### PR TITLE
Allow disabling caching missing tables in CachingMetastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -161,6 +161,7 @@ public class CachingHiveMetastore
                 .maximumSize(maximumSize)
                 .statsRecording(StatsRecording.DISABLED)
                 .cacheMissing(true)
+                .partitionCacheEnabled(true)
                 .build();
     }
 
@@ -177,7 +178,7 @@ public class CachingHiveMetastore
         private Long maximumSize;
         private StatsRecording statsRecording = StatsRecording.ENABLED;
         private Boolean cacheMissing;
-        private boolean partitionCacheEnabled = true;
+        private Boolean partitionCacheEnabled;
 
         public CachingHiveMetastoreBuilder() {}
 
@@ -192,7 +193,7 @@ public class CachingHiveMetastore
                 Long maximumSize,
                 StatsRecording statsRecording,
                 Boolean cacheMissing,
-                boolean partitionCacheEnabled)
+                Boolean partitionCacheEnabled)
         {
             this.delegate = delegate;
             this.executor = executor;
@@ -300,6 +301,7 @@ public class CachingHiveMetastore
             requireNonNull(delegate, "delegate not set");
             requireNonNull(maximumSize, "maximumSize not set");
             requireNonNull(cacheMissing, "cacheMissing not set");
+            requireNonNull(partitionCacheEnabled, "partitionCacheEnabled not set");
             return new CachingHiveMetastore(
                     delegate,
                     metadataCacheEnabled,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -80,6 +80,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.cache.CacheLoader.asyncReloading;
@@ -113,6 +114,7 @@ public class CachingHiveMetastore
     }
 
     protected final HiveMetastore delegate;
+    private final boolean cacheMissing;
     private final LoadingCache<String, Optional<Database>> databaseCache;
     private final LoadingCache<String, List<String>> databaseNamesCache;
     private final LoadingCache<HiveTableName, Optional<Table>> tableCache;
@@ -146,6 +148,7 @@ public class CachingHiveMetastore
                 other.refreshMills,
                 other.maximumSize,
                 other.statsRecording,
+                other.cacheMissing,
                 other.partitionCacheEnabled);
     }
 
@@ -157,6 +160,7 @@ public class CachingHiveMetastore
                 .statsCacheEnabled(true)
                 .maximumSize(maximumSize)
                 .statsRecording(StatsRecording.DISABLED)
+                .cacheMissing(true)
                 .build();
     }
 
@@ -172,6 +176,7 @@ public class CachingHiveMetastore
         private OptionalLong refreshMills = OptionalLong.empty();
         private Long maximumSize;
         private StatsRecording statsRecording = StatsRecording.ENABLED;
+        private Boolean cacheMissing;
         private boolean partitionCacheEnabled = true;
 
         public CachingHiveMetastoreBuilder() {}
@@ -186,6 +191,7 @@ public class CachingHiveMetastore
                 OptionalLong refreshMills,
                 Long maximumSize,
                 StatsRecording statsRecording,
+                Boolean cacheMissing,
                 boolean partitionCacheEnabled)
         {
             this.delegate = delegate;
@@ -197,6 +203,7 @@ public class CachingHiveMetastore
             this.refreshMills = refreshMills;
             this.maximumSize = maximumSize;
             this.statsRecording = statsRecording;
+            this.cacheMissing = cacheMissing;
             this.partitionCacheEnabled = partitionCacheEnabled;
         }
 
@@ -273,6 +280,13 @@ public class CachingHiveMetastore
         }
 
         @CanIgnoreReturnValue
+        public CachingHiveMetastoreBuilder cacheMissing(boolean cacheMissing)
+        {
+            this.cacheMissing = cacheMissing;
+            return this;
+        }
+
+        @CanIgnoreReturnValue
         public CachingHiveMetastoreBuilder partitionCacheEnabled(boolean partitionCacheEnabled)
         {
             this.partitionCacheEnabled = partitionCacheEnabled;
@@ -285,6 +299,7 @@ public class CachingHiveMetastore
             requireNonNull(statsCacheEnabled, "statsCacheEnabled is null");
             requireNonNull(delegate, "delegate not set");
             requireNonNull(maximumSize, "maximumSize not set");
+            requireNonNull(cacheMissing, "cacheMissing not set");
             return new CachingHiveMetastore(
                     delegate,
                     metadataCacheEnabled,
@@ -295,6 +310,7 @@ public class CachingHiveMetastore
                     executor,
                     maximumSize,
                     statsRecording,
+                    cacheMissing,
                     partitionCacheEnabled);
         }
     }
@@ -309,10 +325,12 @@ public class CachingHiveMetastore
             Optional<Executor> executor,
             long maximumSize,
             StatsRecording statsRecording,
+            boolean cacheMissing,
             boolean partitionCacheEnabled)
     {
         checkArgument(metadataCacheEnabled || statsCacheEnabled, "Cache not enabled");
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.cacheMissing = cacheMissing;
         requireNonNull(executor, "executor is null");
 
         CacheFactory cacheFactory;
@@ -401,6 +419,28 @@ public class CachingHiveMetastore
     private static <K, V> V get(LoadingCache<K, V> cache, K key)
     {
         try {
+            V value = cache.getUnchecked(key);
+            checkState(!(value instanceof Optional), "This must not be used for caches with Optional values, as it doesn't implement cacheMissing logic. Use getOptional()");
+            return value;
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), TrinoException.class);
+            throw e;
+        }
+    }
+
+    private <K, V> Optional<V> getOptional(LoadingCache<K, Optional<V>> cache, K key)
+    {
+        try {
+            Optional<V> value = cache.getIfPresent(key);
+            @SuppressWarnings("OptionalAssignedToNull")
+            boolean valueIsPresent = value != null;
+            if (valueIsPresent) {
+                if (value.isPresent() || cacheMissing) {
+                    return value;
+                }
+                cache.invalidate(key);
+            }
             return cache.getUnchecked(key);
         }
         catch (UncheckedExecutionException e) {
@@ -524,7 +564,7 @@ public class CachingHiveMetastore
     @Override
     public Optional<Database> getDatabase(String databaseName)
     {
-        return get(databaseCache, databaseName);
+        return getOptional(databaseCache, databaseName);
     }
 
     private Optional<Database> loadDatabase(String databaseName)
@@ -552,7 +592,7 @@ public class CachingHiveMetastore
     @Override
     public Optional<Table> getTable(String databaseName, String tableName)
     {
-        return get(tableCache, hiveTableName(databaseName, tableName));
+        return getOptional(tableCache, hiveTableName(databaseName, tableName));
     }
 
     @Override
@@ -943,7 +983,7 @@ public class CachingHiveMetastore
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)
     {
-        return get(partitionFilterCache, partitionFilter(databaseName, tableName, columnNames, partitionKeysFilter));
+        return getOptional(partitionFilterCache, partitionFilter(databaseName, tableName, columnNames, partitionKeysFilter));
     }
 
     private Optional<List<String>> loadPartitionNamesByFilter(PartitionFilter partitionFilter)
@@ -1168,7 +1208,7 @@ public class CachingHiveMetastore
     @Override
     public Optional<String> getConfigValue(String name)
     {
-        return get(configValuesCache, name);
+        return getOptional(configValuesCache, name);
     }
 
     private Optional<String> loadConfigValue(String name)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -34,6 +34,7 @@ public class CachingHiveMetastoreConfig
     private Optional<Duration> metastoreRefreshInterval = Optional.empty();
     private long metastoreCacheMaximumSize = 10000;
     private int maxMetastoreRefreshThreads = 10;
+    private boolean cacheMissing = true;
     private boolean partitionCacheEnabled = true;
 
     @NotNull
@@ -98,6 +99,18 @@ public class CachingHiveMetastoreConfig
     public CachingHiveMetastoreConfig setMaxMetastoreRefreshThreads(int maxMetastoreRefreshThreads)
     {
         this.maxMetastoreRefreshThreads = maxMetastoreRefreshThreads;
+        return this;
+    }
+
+    public boolean isCacheMissing()
+    {
+        return cacheMissing;
+    }
+
+    @Config("hive.metastore-cache.cache-missing")
+    public CachingHiveMetastoreConfig setCacheMissing(boolean cacheMissing)
+    {
+        this.cacheMissing = cacheMissing;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -97,6 +97,7 @@ public class SharedHiveMetastoreCache
                 .statsCacheTtl(statsCacheTtl)
                 .refreshInterval(config.getMetastoreRefreshInterval())
                 .maximumSize(config.getMetastoreCacheMaximumSize())
+                .cacheMissing(config.isCacheMissing())
                 .partitionCacheEnabled(config.isPartitionCacheEnabled());
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -807,6 +807,7 @@ public abstract class AbstractTestHive
                 .cacheTtl(new Duration(1, MINUTES))
                 .refreshInterval(new Duration(15, SECONDS))
                 .maximumSize(10000)
+                .cacheMissing(new CachingHiveMetastoreConfig().isCacheMissing())
                 .partitionCacheEnabled(new CachingHiveMetastoreConfig().isPartitionCacheEnabled())
                 .build();
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -35,6 +35,7 @@ public class TestCachingHiveMetastoreConfig
                 .setMetastoreRefreshInterval(null)
                 .setMetastoreCacheMaximumSize(10000)
                 .setMaxMetastoreRefreshThreads(10)
+                .setCacheMissing(true)
                 .setPartitionCacheEnabled(true));
     }
 
@@ -48,6 +49,7 @@ public class TestCachingHiveMetastoreConfig
                 .put("hive.metastore-cache-maximum-size", "5000")
                 .put("hive.metastore-refresh-max-threads", "2500")
                 .put("hive.metastore-cache.cache-partitions", "false")
+                .put("hive.metastore-cache.cache-missing", "false")
                 .buildOrThrow();
 
         CachingHiveMetastoreConfig expected = new CachingHiveMetastoreConfig()
@@ -56,6 +58,7 @@ public class TestCachingHiveMetastoreConfig
                 .setMetastoreRefreshInterval(new Duration(30, TimeUnit.MINUTES))
                 .setMetastoreCacheMaximumSize(5000)
                 .setMaxMetastoreRefreshThreads(2500)
+                .setCacheMissing(false)
                 .setPartitionCacheEnabled(false);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -83,6 +83,7 @@ public class MockThriftMetastoreClient
     private final Map<SchemaTableName, Map<String, Map<String, ColumnStatisticsObj>>> databaseTablePartitionColumnStatistics = new HashMap<>();
 
     private boolean throwException;
+    private boolean returnTable = true;
 
     public MockThriftMetastoreClient()
     {
@@ -143,6 +144,11 @@ public class MockThriftMetastoreClient
     public void setThrowException(boolean throwException)
     {
         this.throwException = throwException;
+    }
+
+    public void setReturnTable(boolean returnTable)
+    {
+        this.returnTable = returnTable;
     }
 
     public int getAccessCount()
@@ -207,7 +213,7 @@ public class MockThriftMetastoreClient
         if (throwException) {
             throw new RuntimeException();
         }
-        if (!dbName.equals(TEST_DATABASE) || !tableName.equals(TEST_TABLE)) {
+        if (!returnTable || !dbName.equals(TEST_DATABASE) || !tableName.equals(TEST_TABLE)) {
             throw new NoSuchObjectException();
         }
         return new Table(


### PR DESCRIPTION
Table absence is harder to less interesting to cache and sometimes undesirable at all. This is similar to `metadata.cache-missing` config we have for JDBC connectors.
