### PR TITLE
Document unsigned numeric type MySQL/MariaDB to Trino mapping

### DIFF
--- a/docs/src/main/sphinx/connector/mariadb.rst
+++ b/docs/src/main/sphinx/connector/mariadb.rst
@@ -105,14 +105,26 @@ to the following table:
   * - ``TINYINT``
     - ``TINYINT``
     -
+  * - ``TINYINT UNSIGNED``
+    - ``SMALLINT``
+    -
   * - ``SMALLINT``
     - ``SMALLINT``
+    -
+  * - ``SMALLINT UNSIGNED``
+    - ``INTEGER``
     -
   * - ``INT``
     - ``INTEGER``
     -
+  * - ``INT UNSIGNED``
+    - ``BIGINT``
+    -
   * - ``BIGINT``
     - ``BIGINT``
+    -
+  * - ``BIGINT UNSIGNED``
+    - ``DECIMAL(20, 0)``
     -
   * - ``FLOAT``
     - ``REAL``

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -132,14 +132,26 @@ this table:
   * - ``TINYINT``
     - ``TINYINT``
     -
+  * - ``TINYINT UNSIGNED``
+    - ``SMALLINT``
+    -
   * - ``SMALLINT``
     - ``SMALLINT``
+    -
+  * - ``SMALLINT UNSIGNED``
+    - ``INTEGER``
     -
   * - ``INTEGER``
     - ``INTEGER``
     -
+  * - ``INTEGER UNSIGNED``
+    - ``BIGINT``
+    -
   * - ``BIGINT``
     - ``BIGINT``
+    -
+  * - ``BIGINT UNSIGNED``
+    - ``DECIMAL(20, 0)``
     -
   * - ``DOUBLE PRECISION``
     - ``DOUBLE``


### PR DESCRIPTION
## Description
Document how unsigned numeric types from MySQL and MariaDB are mapped to Trino.

## Additional context and related issues
As discussed in https://github.com/trinodb/trino/discussions/14679
https://github.com/trinodb/trino/blob/1be256c678f78e58a18adf519ba87cbfc1605e5c/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbClient.java#L616-L634
https://github.com/trinodb/trino/blob/1be256c678f78e58a18adf519ba87cbfc1605e5c/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java#L371-L379

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
