### PR TITLE
Refactor internal http client usage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/failuredetector/FailureDetectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/failuredetector/FailureDetectorModule.java
@@ -14,22 +14,22 @@
 package io.trino.failuredetector;
 
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
 import org.weakref.jmx.guice.ExportBinder;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static io.trino.server.InternalCommunicationHttpClientModule.internalHttpClientModule;
 
 public class FailureDetectorModule
-        implements Module
+        extends AbstractConfigurationAwareModule
 {
     @Override
-    public void configure(Binder binder)
+    protected void setup(Binder binder)
     {
-        httpClientBinder(binder)
-                .bindHttpClient("failure-detector", ForFailureDetector.class)
-                .withTracing();
+        install(internalHttpClientModule("failure-detector", ForFailureDetector.class)
+                .withTracing()
+                .build());
 
         configBinder(binder).bindConfig(FailureDetectorConfig.class);
 

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationHttpClientModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationHttpClientModule.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.http.client.HttpClientBinder.HttpClientBindingBuilder;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.HttpRequestFilter;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
+import static java.util.Objects.requireNonNull;
+
+public class InternalCommunicationHttpClientModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String clientName;
+    private final Class<? extends Annotation> annotation;
+    private final boolean withTracing;
+    private final Consumer<HttpClientConfig> configDefaults;
+    private final List<Class<? extends HttpRequestFilter>> filters;
+
+    private InternalCommunicationHttpClientModule(
+            String clientName,
+            Class<? extends Annotation> annotation,
+            boolean withTracing,
+            Consumer<HttpClientConfig> configDefaults,
+            List<Class<? extends HttpRequestFilter>> filters)
+    {
+        this.clientName = requireNonNull(clientName, "clientName is null");
+        this.annotation = requireNonNull(annotation, "annotation is null");
+        this.withTracing = withTracing;
+        this.configDefaults = requireNonNull(configDefaults, "configDefaults is null");
+        this.filters = ImmutableList.copyOf(requireNonNull(filters, "filters is null"));
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        HttpClientBindingBuilder httpClientBindingBuilder = httpClientBinder(binder).bindHttpClient(clientName, annotation);
+        InternalCommunicationConfig internalCommunicationConfig = buildConfigObject(InternalCommunicationConfig.class);
+        httpClientBindingBuilder.withConfigDefaults(httpConfig -> {
+            configureClient(httpConfig, internalCommunicationConfig);
+            configDefaults.accept(httpConfig);
+        });
+
+        httpClientBindingBuilder.addFilterBinding().to(InternalAuthenticationManager.class);
+
+        if (withTracing) {
+            httpClientBindingBuilder.withTracing();
+        }
+
+        filters.forEach(httpClientBindingBuilder::withFilter);
+    }
+
+    static void configureClient(HttpClientConfig httpConfig, InternalCommunicationConfig internalCommunicationConfig)
+    {
+        httpConfig.setHttp2Enabled(internalCommunicationConfig.isHttp2Enabled());
+        if (internalCommunicationConfig.isHttpsRequired() && internalCommunicationConfig.getKeyStorePath() == null && internalCommunicationConfig.getTrustStorePath() == null) {
+            configureClientForAutomaticHttps(httpConfig, internalCommunicationConfig);
+        }
+        else {
+            configureClientForManualHttps(httpConfig, internalCommunicationConfig);
+        }
+    }
+
+    private static void configureClientForAutomaticHttps(HttpClientConfig httpConfig, InternalCommunicationConfig internalCommunicationConfig)
+    {
+        String sharedSecret = internalCommunicationConfig.getSharedSecret()
+                .orElseThrow(() -> new IllegalArgumentException("Internal shared secret must be set when internal HTTPS is enabled"));
+        httpConfig.setAutomaticHttpsSharedSecret(sharedSecret);
+    }
+
+    private static void configureClientForManualHttps(HttpClientConfig httpConfig, InternalCommunicationConfig internalCommunicationConfig)
+    {
+        httpConfig.setKeyStorePath(internalCommunicationConfig.getKeyStorePath());
+        httpConfig.setKeyStorePassword(internalCommunicationConfig.getKeyStorePassword());
+        httpConfig.setTrustStorePath(internalCommunicationConfig.getTrustStorePath());
+        httpConfig.setTrustStorePassword(internalCommunicationConfig.getTrustStorePassword());
+        httpConfig.setAutomaticHttpsSharedSecret(null);
+    }
+
+    public static class Builder
+    {
+        private final String clientName;
+        private final Class<? extends Annotation> annotation;
+        private boolean withTracing;
+        private Consumer<HttpClientConfig> configDefaults = config -> {};
+        private final List<Class<? extends HttpRequestFilter>> filters = new ArrayList<>();
+
+        private Builder(String clientName, Class<? extends Annotation> annotation)
+        {
+            this.clientName = requireNonNull(clientName, "clientName is null");
+            this.annotation = requireNonNull(annotation, "annotation is null");
+        }
+
+        public Builder withTracing()
+        {
+            this.withTracing = true;
+            return this;
+        }
+
+        public Builder withConfigDefaults(Consumer<HttpClientConfig> configDefaults)
+        {
+            this.configDefaults = requireNonNull(configDefaults, "configDefaults is null");
+            return this;
+        }
+
+        public Builder withFilter(Class<? extends HttpRequestFilter> requestFilter)
+        {
+            this.filters.add(requestFilter);
+            return this;
+        }
+
+        public InternalCommunicationHttpClientModule build()
+        {
+            return new InternalCommunicationHttpClientModule(clientName, annotation, withTracing, configDefaults, filters);
+        }
+    }
+
+    public static InternalCommunicationHttpClientModule.Builder internalHttpClientModule(String clientName, Class<? extends Annotation> annotation)
+    {
+        return new Builder(clientName, annotation);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
@@ -14,9 +14,9 @@
 package io.trino.server;
 
 import com.google.inject.Binder;
+import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.client.ForDiscoveryClient;
-import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.HttpRequestFilter;
 import io.airlift.http.client.Request;
 import io.airlift.http.server.HttpsConfig;
@@ -30,7 +30,6 @@ import java.net.UnknownHostException;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static io.airlift.node.AddressToHostname.encodeAddressAsHostname;
 import static io.airlift.node.NodeConfig.AddressSource.IP_ENCODED_AS_HOSTNAME;
 
@@ -40,38 +39,17 @@ public class InternalCommunicationModule
     @Override
     protected void setup(Binder binder)
     {
-        // Set defaults for all HttpClients in the same guice context
-        // so in case of any additions or alternations here an update in:
-        //   io.trino.server.security.jwt.JwtAuthenticatorSupportModule.JwkModule.configure
-        // and
-        //   io.trino.server.security.oauth2.OAuth2ServiceModule.setup
-        // may also be required.
         InternalCommunicationConfig internalCommunicationConfig = buildConfigObject(InternalCommunicationConfig.class);
+        Multibinder<HttpRequestFilter> discoveryFilterBinder = newSetBinder(binder, HttpRequestFilter.class, ForDiscoveryClient.class);
         if (internalCommunicationConfig.isHttpsRequired() && internalCommunicationConfig.getKeyStorePath() == null && internalCommunicationConfig.getTrustStorePath() == null) {
             String sharedSecret = internalCommunicationConfig.getSharedSecret()
                     .orElseThrow(() -> new IllegalArgumentException("Internal shared secret must be set when internal HTTPS is enabled"));
             configBinder(binder).bindConfigDefaults(HttpsConfig.class, config -> config.setAutomaticHttpsSharedSecret(sharedSecret));
-            configBinder(binder).bindConfigGlobalDefaults(HttpClientConfig.class, config -> {
-                config.setHttp2Enabled(internalCommunicationConfig.isHttp2Enabled());
-                config.setAutomaticHttpsSharedSecret(sharedSecret);
-            });
             configBinder(binder).bindConfigGlobalDefaults(NodeConfig.class, config -> config.setInternalAddressSource(IP_ENCODED_AS_HOSTNAME));
-            // rewrite discovery client requests to use IP encoded as hostname
-            newSetBinder(binder, HttpRequestFilter.class, ForDiscoveryClient.class).addBinding().to(DiscoveryEncodeAddressAsHostname.class);
+            discoveryFilterBinder.addBinding().to(DiscoveryEncodeAddressAsHostname.class);
         }
-        else {
-            configBinder(binder).bindConfigGlobalDefaults(HttpClientConfig.class, config -> {
-                config.setHttp2Enabled(internalCommunicationConfig.isHttp2Enabled());
-                config.setKeyStorePath(internalCommunicationConfig.getKeyStorePath());
-                config.setKeyStorePassword(internalCommunicationConfig.getKeyStorePassword());
-                config.setTrustStorePath(internalCommunicationConfig.getTrustStorePath());
-                config.setTrustStorePassword(internalCommunicationConfig.getTrustStorePassword());
-                config.setAutomaticHttpsSharedSecret(null);
-            });
-        }
-
+        discoveryFilterBinder.addBinding().to(InternalAuthenticationManager.class);
         binder.bind(InternalAuthenticationManager.class);
-        httpClientBinder(binder).bindGlobalFilter(InternalAuthenticationManager.class);
     }
 
     private static class DiscoveryEncodeAddressAsHostname

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -54,19 +54,7 @@ public class JwtAuthenticatorSupportModule
         @Override
         public void configure(Binder binder)
         {
-            httpClientBinder(binder)
-                    .bindHttpClient("jwk", ForJwt.class)
-                    // Reset HttpClient default configuration to override InternalCommunicationModule changes.
-                    // Setting a keystore and/or a truststore for internal communication changes the default SSL configuration
-                    // for all clients in the same guice context. This, however, does not make sense for this client which will
-                    // very rarely use the same SSL setup as internal communication, so using the system default truststore
-                    // makes more sense.
-                    .withConfigDefaults(config -> config
-                            .setKeyStorePath(null)
-                            .setKeyStorePassword(null)
-                            .setTrustStorePath(null)
-                            .setTrustStorePassword(null)
-                            .setAutomaticHttpsSharedSecret(null));
+            httpClientBinder(binder).bindHttpClient("jwk", ForJwt.class);
         }
 
         @Provides

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -50,18 +50,7 @@ public class OAuth2ServiceModule
                 .in(Scopes.SINGLETON);
         install(conditionalModule(OAuth2Config.class, OAuth2Config::isEnableDiscovery, this::bindOidcDiscovery, this::bindStaticConfiguration));
         install(conditionalModule(OAuth2Config.class, OAuth2Config::isEnableRefreshTokens, this::enableRefreshTokens, this::disableRefreshTokens));
-        httpClientBinder(binder)
-                .bindHttpClient("oauth2-jwk", ForOAuth2.class)
-                // Reset to defaults to override InternalCommunicationModule changes to this client default configuration.
-                // Setting a keystore and/or a truststore for internal communication changes the default SSL configuration
-                // for all clients in this guice context. This does not make sense for this client which will very rarely
-                // use the same SSL configuration, so using the system default truststore makes more sense.
-                .withConfigDefaults(config -> config
-                        .setKeyStorePath(null)
-                        .setKeyStorePassword(null)
-                        .setTrustStorePath(null)
-                        .setTrustStorePassword(null)
-                        .setAutomaticHttpsSharedSecret(null));
+        httpClientBinder(binder).bindHttpClient("oauth2-jwk", ForOAuth2.class);
     }
 
     private void enableRefreshTokens(Binder binder)

--- a/core/trino-main/src/test/java/io/trino/failuredetector/TestHeartbeatFailureDetector.java
+++ b/core/trino-main/src/test/java/io/trino/failuredetector/TestHeartbeatFailureDetector.java
@@ -30,6 +30,7 @@ import io.airlift.tracetoken.TraceTokenModule;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.failuredetector.HeartbeatFailureDetector.Stats;
 import io.trino.server.InternalCommunicationConfig;
+import io.trino.server.security.SecurityConfig;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.GET;
@@ -61,6 +62,7 @@ public class TestHeartbeatFailureDetector
                 new JaxrsModule(),
                 new FailureDetectorModule(),
                 binder -> {
+                    configBinder(binder).bindConfig(SecurityConfig.class);
                     configBinder(binder).bindConfig(InternalCommunicationConfig.class);
                     configBinder(binder).bindConfig(QueryManagerConfig.class);
                     discoveryBinder(binder).bindSelector("trino");

--- a/core/trino-main/src/test/java/io/trino/server/TestGenerateTokenFilter.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestGenerateTokenFilter.java
@@ -66,9 +66,9 @@ public class TestGenerateTokenFilter
 
         // extract the filter
         List<HttpRequestFilter> filters = httpClient.getRequestFilters();
-        assertEquals(filters.size(), 3);
-        assertInstanceOf(filters.get(2), GenerateTraceTokenRequestFilter.class);
-        filter = (GenerateTraceTokenRequestFilter) filters.get(2);
+        assertEquals(filters.size(), 2);
+        assertInstanceOf(filters.get(1), GenerateTraceTokenRequestFilter.class);
+        filter = (GenerateTraceTokenRequestFilter) filters.get(1);
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
The previous approach was dangerous, as it was modifying configuration for all HTTP clients and adding global filters even for HTTP clients there were not supposed to be used for internal communication.

With this change, it's now intentional which HTTP clients are supposed to use secured internal communication.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
