### PR TITLE
Add isOnlyNotNull to Domain

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Domain.java
@@ -154,6 +154,11 @@ public final class Domain
         return values.isNone() && nullAllowed;
     }
 
+    public boolean isNotNull()
+    {
+        return values.isAll() && !nullAllowed;
+    }
+
     public Object getSingleValue()
     {
         if (!isSingleValue()) {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -511,7 +511,7 @@ public class KuduClientSession
             else if (!domain.getValues().isNone() && domain.isNullAllowed()) {
                 // no restriction
             }
-            else if (domain.getValues().isAll() && !domain.isNullAllowed()) {
+            else if (domain.isNotNull()) {
                 builder.addPredicate(KuduPredicate.newIsNotNullPredicate(columnSchema));
             }
             else if (domain.isSingleValue()) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -502,7 +502,7 @@ public class MongoSession
         if (domain.getValues().isNone() && domain.isNullAllowed()) {
             return Optional.of(documentOf(name, isNullPredicate()));
         }
-        if (domain.getValues().isAll() && !domain.isNullAllowed()) {
+        if (domain.isNotNull()) {
             return Optional.of(documentOf(name, isNotNullPredicate()));
         }
 


### PR DESCRIPTION
Convenience method for domain.getValues().isAll() && !domain.isNullAllowed(). This translates to IS NOT NULL.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This can be applied to the follow pr as well:
#16979

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
