### PR TITLE
Enable reading Parquet's bloomfilter statistics for Iceberg connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -1521,3 +1521,9 @@ with Parquet files performed by the Iceberg connector.
         for structural data types. The equivalent catalog session property is
         ``parquet_optimized_nested_reader_enabled``.
       - ``true``
+    * - ``parquet.use-bloom-filter``
+      - Whether bloom filters are used for predicate pushdown when reading
+        Parquet files. Set this property to ``false`` to disable the usage of
+        bloom filters by default. The equivalent catalog session property is
+        ``parquet_use_bloom_filter``.
+      - ``true``

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetWithBloomFilters.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetWithBloomFilters.java
@@ -14,24 +14,22 @@
 package io.trino.plugin.hive.parquet;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.Session;
 import io.trino.plugin.hive.HiveQueryRunner;
-import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.BaseTestParquetWithBloomFilters;
+import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.mapred.JobConf;
 import org.joda.time.DateTimeZone;
-import org.testng.annotations.Test;
 
 import java.io.File;
-import java.nio.file.Files;
-import java.util.Arrays;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.io.MoreFiles.deleteRecursively;
-import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -42,96 +40,36 @@ import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_
 import static org.apache.parquet.format.CompressionCodec.SNAPPY;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.BLOOM_FILTER_ENABLED;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.WRITER_VERSION;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHiveParquetWithBloomFilters
-        extends AbstractTestQueryFramework
+        extends BaseTestParquetWithBloomFilters
 {
-    private static final String COLUMN_NAME = "dataColumn";
-    // containing extreme values, so the row group cannot be eliminated by the column chunk's min/max statistics
-    private static final List<Integer> TEST_VALUES = Arrays.asList(Integer.MIN_VALUE, Integer.MAX_VALUE, 1, 3, 7, 10, 15);
-    private static final int MISSING_VALUE = 0;
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return HiveQueryRunner.builder().build();
+        DistributedQueryRunner queryRunner = HiveQueryRunner.builder().build();
+        dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("hive_data");
+        return queryRunner;
     }
 
-    @Test
-    public void verifyBloomFilterEnabled()
+    @Override
+    protected CatalogSchemaTableName createParquetTableWithBloomFilter(String columnName, List<Integer> testValues)
     {
-        assertThat(query(format("SHOW SESSION LIKE '%s.parquet_use_bloom_filter'", getSession().getCatalog().orElseThrow())))
-                .skippingTypesCheck()
-                .matches(result -> result.getRowCount() == 1)
-                .matches(result -> {
-                    String value = (String) result.getMaterializedRows().get(0).getField(1);
-                    return value.equals("true");
-                });
+        // create the managed table
+        String tableName = "parquet_with_bloom_filters_" + randomNameSuffix();
+        CatalogSchemaTableName catalogSchemaTableName = new CatalogSchemaTableName("hive", new SchemaTableName("tpch", tableName));
+        assertUpdate(format("CREATE TABLE %s (%s INT) WITH (format = 'PARQUET')", catalogSchemaTableName, columnName));
+
+        // directly write data to the managed table
+        Path tableLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableName));
+        Path fileLocation = tableLocation.resolve("bloomFilterFile.parquet");
+        writeParquetFileWithBloomFilter(fileLocation.toFile(), columnName, testValues);
+
+        return catalogSchemaTableName;
     }
 
-    @Test
-    public void testBloomFilterRowGroupPruning()
-            throws Exception
-    {
-        File tmpDir = Files.createTempDirectory("testBloomFilterRowGroupPruning").toFile();
-        try {
-            File parquetFile = new File(tmpDir, randomNameSuffix());
-
-            String tableName = "parquet_with_bloom_filters_" + randomNameSuffix();
-            createParquetBloomFilterSource(parquetFile, COLUMN_NAME, TEST_VALUES);
-            assertUpdate(
-                    format(
-                            "CREATE TABLE %s (%s INT) WITH (format = 'PARQUET', external_location = '%s')",
-                            tableName,
-                            COLUMN_NAME,
-                            tmpDir.getAbsolutePath()));
-
-            // When reading bloom filter is enabled, row groups are pruned when searching for a missing value
-            assertQueryStats(
-                    getSession(),
-                    "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + MISSING_VALUE,
-                    queryStats -> {
-                        assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0);
-                        assertThat(queryStats.getProcessedInputPositions()).isEqualTo(0);
-                    },
-                    results -> assertThat(results.getRowCount()).isEqualTo(0));
-
-            // When reading bloom filter is enabled, row groups are not pruned when searching for a value present in the file
-            assertQueryStats(
-                    getSession(),
-                    "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + TEST_VALUES.get(0),
-                    queryStats -> {
-                        assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
-                        assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
-                    },
-                    results -> assertThat(results.getRowCount()).isEqualTo(1));
-
-            // When reading bloom filter is disabled, row groups are not pruned when searching for a missing value
-            assertQueryStats(
-                    bloomFiltersDisabled(getSession()),
-                    "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + MISSING_VALUE,
-                    queryStats -> {
-                        assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
-                        assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
-                    },
-                    results -> assertThat(results.getRowCount()).isEqualTo(0));
-        }
-        finally {
-            deleteRecursively(tmpDir.toPath(), ALLOW_INSECURE);
-        }
-    }
-
-    private static Session bloomFiltersDisabled(Session session)
-    {
-        return Session.builder(session)
-                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_use_bloom_filter", "false")
-                .build();
-    }
-
-    private static void createParquetBloomFilterSource(File tempFile, String columnName, List<Integer> testValues)
-            throws Exception
+    public static void writeParquetFileWithBloomFilter(File tempFile, String columnName, List<Integer> testValues)
     {
         List<ObjectInspector> objectInspectors = singletonList(javaIntObjectInspector);
         List<String> columnNames = ImmutableList.of(columnName);
@@ -140,15 +78,20 @@ public class TestHiveParquetWithBloomFilters
         jobConf.setEnum(WRITER_VERSION, PARQUET_1_0);
         jobConf.setBoolean(BLOOM_FILTER_ENABLED, true);
 
-        ParquetTester.writeParquetColumn(
-                jobConf,
-                tempFile,
-                SNAPPY,
-                ParquetTester.createTableProperties(columnNames, objectInspectors),
-                getStandardStructObjectInspector(columnNames, objectInspectors),
-                new Iterator<?>[] {testValues.iterator()},
-                Optional.empty(),
-                false,
-                DateTimeZone.getDefault());
+        try {
+            ParquetTester.writeParquetColumn(
+                    jobConf,
+                    tempFile,
+                    SNAPPY,
+                    ParquetTester.createTableProperties(columnNames, objectInspectors),
+                    getStandardStructObjectInspector(columnNames, objectInspectors),
+                    new Iterator<?>[] {testValues.iterator()},
+                    Optional.empty(),
+                    false,
+                    DateTimeZone.getDefault());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -67,6 +67,7 @@ public final class IcebergSessionProperties
     private static final String ORC_WRITER_MAX_STRIPE_ROWS = "orc_writer_max_stripe_rows";
     private static final String ORC_WRITER_MAX_DICTIONARY_MEMORY = "orc_writer_max_dictionary_memory";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
+    private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
     private static final String PARQUET_OPTIMIZED_READER_ENABLED = "parquet_optimized_reader_enabled";
     private static final String PARQUET_OPTIMIZED_NESTED_READER_ENABLED = "parquet_optimized_nested_reader_enabled";
@@ -196,6 +197,11 @@ public final class IcebergSessionProperties
                         PARQUET_MAX_READ_BLOCK_SIZE,
                         "Parquet: Maximum size of a block to read",
                         parquetReaderConfig.getMaxReadBlockSize(),
+                        false))
+                .add(booleanProperty(
+                        PARQUET_USE_BLOOM_FILTER,
+                        "Parquet: Enable using Parquet bloom filter",
+                        parquetReaderConfig.isUseBloomFilter(),
                         false))
                 .add(integerProperty(
                         PARQUET_MAX_READ_BLOCK_ROW_COUNT,
@@ -430,6 +436,11 @@ public final class IcebergSessionProperties
     public static int getParquetWriterBatchSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
+    }
+
+    public static boolean useParquetBloomFilter(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_USE_BLOOM_FILTER, Boolean.class);
     }
 
     public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFilters.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetWithBloomFilters.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.TestingHivePlugin;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.testing.BaseTestParquetWithBloomFilters;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static io.trino.plugin.hive.parquet.TestHiveParquetWithBloomFilters.writeParquetFileWithBloomFilter;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.lang.String.format;
+
+public class TestIcebergParquetWithBloomFilters
+        extends BaseTestParquetWithBloomFilters
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder().build();
+        dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
+
+        // create hive catalog
+        queryRunner.installPlugin(new TestingHivePlugin());
+        queryRunner.createCatalog("hive", "hive", ImmutableMap.<String, String>builder()
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", dataDirectory.toString())
+                .put("hive.security", "allow-all")
+                .buildOrThrow());
+
+        return queryRunner;
+    }
+
+    @Override
+    protected CatalogSchemaTableName createParquetTableWithBloomFilter(String columnName, List<Integer> testValues)
+    {
+        // create the managed table
+        String tableName = "parquet_with_bloom_filters_" + randomNameSuffix();
+        CatalogSchemaTableName hiveCatalogSchemaTableName = new CatalogSchemaTableName("hive", new SchemaTableName("tpch", tableName));
+        CatalogSchemaTableName icebergCatalogSchemaTableName = new CatalogSchemaTableName("iceberg", new SchemaTableName("tpch", tableName));
+        assertUpdate(format("CREATE TABLE %s (%s INT) WITH (format = 'PARQUET')", hiveCatalogSchemaTableName, columnName));
+
+        // directly write data to the managed table
+        Path tableLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableName));
+        Path fileLocation = tableLocation.resolve("bloomFilterFile.parquet");
+        writeParquetFileWithBloomFilter(fileLocation.toFile(), columnName, testValues);
+
+        // migrate the hive table to the iceberg table
+        assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableName + "', 'false')");
+
+        return icebergCatalogSchemaTableName;
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class BaseTestParquetWithBloomFilters
+        extends AbstractTestQueryFramework
+{
+    protected Path dataDirectory;
+    private static final String COLUMN_NAME = "dataColumn";
+    // containing extreme values, so the row group cannot be eliminated by the column chunk's min/max statistics
+    private static final List<Integer> TEST_VALUES = Arrays.asList(Integer.MIN_VALUE, Integer.MAX_VALUE, 1, 3, 7, 10, 15);
+    private static final int MISSING_VALUE = 0;
+
+    @Test
+    public void verifyBloomFilterEnabled()
+    {
+        assertThat(query(format("SHOW SESSION LIKE '%s.parquet_use_bloom_filter'", getSession().getCatalog().orElseThrow())))
+                .skippingTypesCheck()
+                .matches(result -> result.getRowCount() == 1)
+                .matches(result -> {
+                    String value = (String) result.getMaterializedRows().get(0).getField(1);
+                    return value.equals("true");
+                });
+    }
+
+    @Test
+    public void testBloomFilterRowGroupPruning()
+    {
+        CatalogSchemaTableName tableName = createParquetTableWithBloomFilter(COLUMN_NAME, TEST_VALUES);
+
+        // assert table is populated with data
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName,
+                queryStats -> {},
+                results -> assertThat(results.getOnlyColumnAsSet()).isEqualTo(ImmutableSet.copyOf(TEST_VALUES)));
+
+        // When reading bloom filter is enabled, row groups are pruned when searching for a missing value
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + MISSING_VALUE,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isEqualTo(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(0);
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+
+        // When reading bloom filter is enabled, row groups are not pruned when searching for a value present in the file
+        assertQueryStats(
+                getSession(),
+                "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + TEST_VALUES.get(0),
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(1));
+
+        // When reading bloom filter is disabled, row groups are not pruned when searching for a missing value
+        assertQueryStats(
+                bloomFiltersDisabled(getSession()),
+                "SELECT * FROM " + tableName + " WHERE " + COLUMN_NAME + " = " + MISSING_VALUE,
+                queryStats -> {
+                    assertThat(queryStats.getPhysicalInputPositions()).isGreaterThan(0);
+                    assertThat(queryStats.getProcessedInputPositions()).isEqualTo(queryStats.getPhysicalInputPositions());
+                },
+                results -> assertThat(results.getRowCount()).isEqualTo(0));
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    private static Session bloomFiltersDisabled(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(session.getCatalog().orElseThrow(), "parquet_use_bloom_filter", "false")
+                .build();
+    }
+
+    protected abstract CatalogSchemaTableName createParquetTableWithBloomFilter(String columnName, List<Integer> testValues);
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Related HIVE PR: https://github.com/trinodb/trino/pull/14428 and https://github.com/trinodb/trino/pull/15633. 
This brings the same change to the Iceberg connector. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Enable hive connector to read parquet file's bloomfilter statistics. For more details: https://github.com/apache/parquet-format/blob/master/BloomFilter.md. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of queries with filters when bloom filter indexes are present in parquet files. Usage of bloom filters from parquet files can be disabled using the catalog configuration property `parquet.use-bloom-filter` or the catalog session property `parquet_use_bloom_filter`. ({issue}`9471`)
```
