### PR TITLE
Remove deprecated getStartTime method from ConnectorSession

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSession.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSession.java
@@ -39,15 +39,6 @@ public interface ConnectorSession
 
     Optional<String> getTraceToken();
 
-    /**
-     * @deprecated use {@link #getStart()} instead
-     */
-    @Deprecated
-    default long getStartTime()
-    {
-        return getStart().toEpochMilli();
-    }
-
     Instant getStart();
 
     <T> T getProperty(String name, Class<T> type);


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
