### PR TITLE
Support check constraints for UPDATE statement in engine and Delta Lake connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -3251,10 +3251,6 @@ class StatementAnalyzer
             if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
                 throw semanticException(NOT_SUPPORTED, update, "Updating a table with a row filter is not supported");
             }
-            if (!tableSchema.getTableSchema().getCheckConstraints().isEmpty()) {
-                // TODO https://github.com/trinodb/trino/issues/15411 Add support for CHECK constraint to UPDATE statement
-                throw semanticException(NOT_SUPPORTED, update, "Updating a table with a check constraint is not supported");
-            }
 
             // TODO: how to deal with connectors that need to see the pre-image of rows to perform the update without
             //       flowing that data through the masking logic
@@ -3281,6 +3277,8 @@ class StatementAnalyzer
 
             Scope tableScope = analyzer.analyzeForUpdate(table, scope, UpdateKind.UPDATE);
             update.getWhere().ifPresent(where -> analyzeWhere(update, tableScope, where));
+            analyzeCheckConstraints(table, tableName, tableScope, tableSchema.getTableSchema().getCheckConstraints());
+            analysis.registerTable(table, redirection.getTableHandle(), tableName, session.getIdentity().getUser(), tableScope);
 
             ImmutableList.Builder<ExpressionAnalysis> analysesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> expressionTypesBuilder = ImmutableList.builder();

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2225,7 +2225,6 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
                     .build();
             analyzeFiltersAndMasks(table, targetTableName, new RelationType(outputFields), accessControlScope);
-            analyzeCheckConstraints(table, targetTableName, accessControlScope, tableSchema.getTableSchema().getCheckConstraints());
             analysis.registerTable(table, tableHandle, targetTableName, session.getIdentity().getUser(), accessControlScope);
 
             Scope tableScope = createAndAssignScope(table, scope, outputFields);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1591,12 +1591,6 @@ public class DeltaLakeMetadata
             throw new TrinoException(NOT_SUPPORTED, "Cannot modify rows from a table with '" + APPEND_ONLY_CONFIGURATION_KEY + "' set to true");
         }
         checkWriteAllowed(session, handle);
-        if (!getColumnInvariants(handle.getMetadataEntry()).isEmpty()) {
-            throw new TrinoException(NOT_SUPPORTED, "Updates are not supported for tables with delta invariants");
-        }
-        if (!getCheckConstraints(handle.getMetadataEntry()).isEmpty()) {
-            throw new TrinoException(NOT_SUPPORTED, "Writing to tables with CHECK constraints is not supported");
-        }
         ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
         if (changeDataFeedEnabled(handle.getMetadataEntry()) && columnMappingMode != NONE) {
             // TODO https://github.com/trinodb/trino/issues/16967 Support CDF for tables with 'id' and 'name' column mapping

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
@@ -187,7 +187,7 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
         assertThatThrownBy(() -> query("INSERT INTO " + tableName + " VALUES(3)"))
                 .hasMessageContaining("Check constraint violation: (\"dummy\" < 3)");
         assertThatThrownBy(() -> query("UPDATE " + tableName + " SET dummy = 3 WHERE dummy = 1"))
-                .hasMessageContaining("Updating a table with a check constraint is not supported");
+                .hasMessageContaining("Check constraint violation: (\"dummy\" < 3)");
 
         assertQuery("SELECT * FROM " + tableName, "VALUES (1), (2)");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckConstraintCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCheckConstraintCompatibility.java
@@ -38,9 +38,9 @@ public class TestDeltaLakeCheckConstraintCompatibility
 {
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS}, dataProvider = "checkConstraints")
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
-    public void testCheckConstraintCompatibility(String columnDefinition, String checkConstraint, String validInput, Row insertedValue, String invalidInput)
+    public void testCheckConstraintInsertCompatibility(String columnDefinition, String checkConstraint, String validInput, Row insertedValue, String invalidInput)
     {
-        String tableName = "test_check_constraint_" + randomNameSuffix();
+        String tableName = "test_check_constraint_insert_" + randomNameSuffix();
 
         onDelta().executeQuery("CREATE TABLE default." + tableName +
                 "(" + columnDefinition + ") " +
@@ -102,6 +102,39 @@ public class TestDeltaLakeCheckConstraintCompatibility
                 // Identifier
                 {"`a.dot` INT", "`a.dot` = 1", "1", row(1), "2"},
         };
+    }
+
+    // TODO: Add DELTA_LAKE_DATABRICKS and DELTA_LAKE_EXCLUDE_73 groups once flakiness on Databricks is resolved
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testCheckConstraintUpdateCompatibility()
+    {
+        String tableName = "test_check_constraint_update_" + randomNameSuffix();
+
+        onDelta().executeQuery("CREATE TABLE default." + tableName +
+                "(a INT) " +
+                "USING DELTA " +
+                "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'");
+
+        try {
+            onDelta().executeQuery("ALTER TABLE default." + tableName + " ADD CONSTRAINT a_constraint CHECK (a < 3)");
+
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES 1");
+            assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .containsOnly(row(1));
+            onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 2");
+            assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .containsOnly(row(2));
+
+            assertThatThrownBy(() -> onDelta().executeQuery("UPDATE default." + tableName + " SET a = 3"))
+                    .hasMessageMatching("(?s).* CHECK constraint .* violated by row with values.*");
+            assertThatThrownBy(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 3"))
+                    .hasMessageContaining("Check constraint violation");
+            assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName))
+                    .containsOnly(row(2));
+        }
+        finally {
+            dropDeltaTableWithRetry("default." + tableName);
+        }
     }
 
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_73, PROFILE_SPECIFIC_TESTS})
@@ -170,10 +203,6 @@ public class TestDeltaLakeCheckConstraintCompatibility
                 "LOCATION 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "'");
         onDelta().executeQuery("ALTER TABLE default." + tableName + " ADD CONSTRAINT aIsPositive CHECK (a > 0)");
         try {
-            assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = 3 WHERE b = 3"))
-                    .hasMessageContaining("Updating a table with a check constraint is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a = 3"))
-                    .hasMessageContaining("Writing to tables with CHECK constraints is not supported");
             assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +
                     "ON (t.a = s.a) WHEN MATCHED THEN UPDATE SET b = 42"))
                     .hasMessageContaining("Cannot merge into a table with check constraints");
@@ -214,14 +243,13 @@ public class TestDeltaLakeCheckConstraintCompatibility
         try {
             // This constraint should be changed to a new one if the connector supports the expression
             onDelta().executeQuery("ALTER TABLE default." + tableName + " ADD CONSTRAINT test_constraint CHECK (a = abs(b))");
-            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, -1)");
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1, -1), (2, -2)");
 
             assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES (1, -1)"))
                     .hasMessageContaining("Failed to convert Delta check constraints to Trino expression");
             assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + tableName + " SET a = -1"))
-                    .hasMessageContaining("Updating a table with a check constraint is not supported");
-            assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a = 1"))
-                    .hasMessageContaining("Writing to tables with CHECK constraints is not supported");
+                    .hasMessageContaining("Failed to convert Delta check constraints to Trino expression");
+            onTrino().executeQuery("DELETE FROM delta.default." + tableName + " WHERE a = 2");
             assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + tableName + " t USING delta.default." + tableName + " s " +
                     "ON (t.a = s.a) WHEN MATCHED THEN UPDATE SET b = -1"))
                     .hasMessageContaining("Cannot merge into a table with check constraints");


### PR DESCRIPTION
## Description

Support check constraints for UPDATE statement in engine and Delta Lake connector

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add support for check constraints in `UPDATE` statement. ({issue}`17195`)

# Delta Lake
* Add support for check constraints and column invariants in `UPDATE` statements. ({issue}`17195`)
```
