### PR TITLE
Fail the build if a non-existent Maven profile is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2036,6 +2036,7 @@
                                     <include>org.yaml:snakeyaml:*:jar:test</include>
                                 </includes>
                             </bannedDependencies>
+                            <requireProfileIdsExist/>
                         </rules>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
## Description

By default Maven just logs a warning if a non-existent profile is specified with . Enforcer plugin has a rule to fail the build in such cases. This avoids cases where a typo or incorrect ci.yml makes the build appear green even though some expected profile wasn't used.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.

I noticed this while working on https://github.com/trinodb/trino/pull/17167