### PR TITLE
Allow accessing external environments in Delta Lake query runner

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -122,12 +122,6 @@ public final class DeltaLakeQueryRunner
         }
     }
 
-    public static DistributedQueryRunner createDeltaLakeQueryRunner(String catalogName)
-            throws Exception
-    {
-        return createDeltaLakeQueryRunner(catalogName, ImmutableMap.of(), ImmutableMap.of());
-    }
-
     public static DistributedQueryRunner createDeltaLakeQueryRunner(String catalogName, Map<String, String> extraProperties, Map<String, String> connectorProperties)
             throws Exception
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -263,20 +263,18 @@ public final class DeltaLakeQueryRunner
         }
     }
 
-    public static class DeltaLakeGlueQueryRunnerMain
+    public static class DeltaLakeExternalQueryRunnerMain
     {
         public static void main(String[] args)
                 throws Exception
         {
-            // Requires AWS credentials, which can be provided any way supported by the DefaultProviderChain
-            // See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
-            DistributedQueryRunner queryRunner = builder(createSession())
+            // Please set Delta Lake connector properties via VM options. e.g. -Dhive.metastore=glue -D..
+            DistributedQueryRunner queryRunner = builder()
                     .setCatalogName(DELTA_CATALOG)
                     .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
-                    .setDeltaProperties(ImmutableMap.of("hive.metastore", "glue"))
                     .build();
 
-            Logger log = Logger.get(DeltaLakeGlueQueryRunnerMain.class);
+            Logger log = Logger.get(DeltaLakeExternalQueryRunnerMain.class);
             log.info("======== SERVER STARTED ========");
             log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
         }


### PR DESCRIPTION
## Description

The main purpose is quickly accessing product test environments using the new `DeltaLakeExternalQueryRunnerMain`.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.