### PR TITLE
Improve code readability with QueryTracker#hasQuery

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -146,7 +146,7 @@ public class DispatchManager
         requireNonNull(sessionContext, "sessionContext is null");
         requireNonNull(query, "query is null");
         checkArgument(!query.isEmpty(), "query must not be empty string");
-        checkArgument(queryTracker.tryGetQuery(queryId).isEmpty(), "query %s already exists", queryId);
+        checkArgument(!queryTracker.hasQuery(queryId), "query %s already exists", queryId);
 
         // It is important to return a future implementation which ignores cancellation request.
         // Using NonCancellationPropagatingFuture is not enough; it does not propagate cancel to wrapped future
@@ -295,7 +295,7 @@ public class DispatchManager
 
     public boolean isQueryRegistered(QueryId queryId)
     {
-        return queryTracker.tryGetQuery(queryId).isPresent();
+        return queryTracker.hasQuery(queryId);
     }
 
     public DispatchQuery getQuery(QueryId queryId)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManager.java
@@ -92,6 +92,8 @@ public interface QueryManager
     QueryState getQueryState(QueryId queryId)
             throws NoSuchElementException;
 
+    boolean hasQuery(QueryId queryId);
+
     /**
      * Updates the client heartbeat time, to prevent the query from be automatically purged.
      * If the query does not exist, the call is ignored.

--- a/core/trino-main/src/main/java/io/trino/execution/QueryTracker.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryTracker.java
@@ -147,6 +147,12 @@ public class QueryTracker<T extends TrackedQuery>
                 .orElseThrow(() -> new NoSuchElementException(queryId.toString()));
     }
 
+    public boolean hasQuery(QueryId queryId)
+    {
+        requireNonNull(queryId, "queryId is null");
+        return queries.containsKey(queryId);
+    }
+
     public Optional<T> tryGetQuery(QueryId queryId)
     {
         requireNonNull(queryId, "queryId is null");

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryManager.java
@@ -227,6 +227,12 @@ public class SqlQueryManager
     }
 
     @Override
+    public boolean hasQuery(QueryId queryId)
+    {
+        return queryTracker.hasQuery(queryId);
+    }
+
+    @Override
     public void recordHeartbeat(QueryId queryId)
     {
         queryTracker.tryGetQuery(queryId)

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -120,11 +120,7 @@ public class ExecutingStatementResource
                     try {
                         for (QueryId queryId : queries.keySet()) {
                             // forget about this query if the query manager is no longer tracking it
-                            try {
-                                queryManager.getQueryState(queryId);
-                            }
-                            catch (NoSuchElementException e) {
-                                // query is no longer registered
+                            if (!queryManager.hasQuery(queryId)) {
                                 Query query = queries.remove(queryId);
                                 if (query != null) {
                                     query.dispose();


### PR DESCRIPTION
## Description

Add a method to QueryTracker to test if query is still within history without need to allocate new Optional each time. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

