### PR TITLE
Avoid boxing booleans for equals on primitive types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
@@ -171,13 +171,10 @@ class PolymorphicScalarFunction
 
     private static Class<?> getNullAwareContainerType(Class<?> clazz, InvocationReturnConvention returnConvention)
     {
-        switch (returnConvention) {
-            case NULLABLE_RETURN:
-                return Primitives.wrap(clazz);
-            case FAIL_ON_NULL:
-                return clazz;
-        }
-        throw new UnsupportedOperationException("Unknown return convention: " + returnConvention);
+        return switch (returnConvention) {
+            case NULLABLE_RETURN -> Primitives.wrap(clazz);
+            case DEFAULT_ON_NULL, FAIL_ON_NULL -> clazz;
+        };
     }
 
     static final class PolymorphicScalarFunctionChoice

--- a/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/JoinCompiler.java
@@ -91,8 +91,8 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.setStatic;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.operator.join.JoinUtils.getSingleBigintJoinChannel;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
@@ -1031,14 +1031,13 @@ public class JoinCompiler
             BytecodeExpression rightBlock,
             BytecodeExpression rightBlockPosition)
     {
-        MethodHandle equalOperator = typeOperators.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
-        BytecodeExpression equalInvocation = invokeDynamic(
+        MethodHandle equalOperator = typeOperators.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
+        return invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(callSiteBinder.bind(equalOperator).getBindingId()),
                 "equal",
                 equalOperator.type(),
                 leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
-        return BytecodeExpressions.equal(equalInvocation, getStatic(Boolean.class, "TRUE"));
     }
 
     public static class LookupSourceSupplierFactory

--- a/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
@@ -36,8 +36,8 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.collect.cache.SafeCaches.buildNonEvictableCacheWithWeakInvalidateAll;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
@@ -47,7 +47,7 @@ import static java.util.Objects.requireNonNull;
 
 public final class BlockTypeOperators
 {
-    private static final InvocationConvention BLOCK_EQUAL_CONVENTION = simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION);
+    private static final InvocationConvention BLOCK_EQUAL_CONVENTION = simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
     private static final InvocationConvention HASH_CODE_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION);
     private static final InvocationConvention XX_HASH_64_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION);
     private static final InvocationConvention IS_DISTINCT_FROM_CONVENTION = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
@@ -80,7 +80,7 @@ public final class BlockTypeOperators
 
     public interface BlockPositionEqual
     {
-        Boolean equal(Block left, int leftPosition, Block right, int rightPosition);
+        boolean equal(Block left, int leftPosition, Block right, int rightPosition);
 
         default boolean equalNullSafe(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
         {

--- a/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
+++ b/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
@@ -57,6 +57,7 @@ import static io.trino.spi.connector.SortOrder.DESC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_LAST;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
@@ -274,6 +275,10 @@ public abstract class AbstractTestType
                     .hasMessageContaining("is not comparable");
 
             assertThatThrownBy(() -> typeOperators.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION)))
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("is not comparable");
+
+            assertThatThrownBy(() -> typeOperators.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION)))
                     .isInstanceOf(UnsupportedOperationException.class)
                     .hasMessageContaining("is not comparable");
 

--- a/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
@@ -155,6 +155,7 @@ public class InvocationConvention
     public enum InvocationReturnConvention
     {
         FAIL_ON_NULL(false),
+        DEFAULT_ON_NULL(false),
         NULLABLE_RETURN(true);
 
         private final boolean nullable;

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
@@ -37,8 +37,8 @@ import java.util.stream.Stream;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
 import static io.trino.spi.predicate.Utils.handleThrowable;
@@ -451,7 +451,7 @@ public class EquatableValueSet
             if (block.getPositionCount() != 1) {
                 throw new IllegalArgumentException("Block should only have one position");
             }
-            this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
+            this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
             this.hashCodeOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION));
         }
 
@@ -502,14 +502,14 @@ public class EquatableValueSet
                 return false;
             }
 
-            Boolean result;
+            boolean result;
             try {
-                result = (Boolean) equalOperator.invokeExact(this.block, 0, other.block, 0);
+                result = (boolean) equalOperator.invokeExact(this.block, 0, other.block, 0);
             }
             catch (Throwable throwable) {
                 throw handleThrowable(throwable);
             }
-            return Boolean.TRUE.equals(result);
+            return result;
         }
 
         public long getRetainedSizeInBytes()

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/NullableValue.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/NullableValue.java
@@ -23,8 +23,8 @@ import java.lang.invoke.MethodType;
 import java.util.Objects;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
 import static io.trino.spi.predicate.Utils.handleThrowable;
@@ -51,8 +51,8 @@ public final class NullableValue
         this.value = value;
 
         if (type.isComparable()) {
-            this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL))
-                    .asType(MethodType.methodType(Boolean.class, Object.class, Object.class));
+            this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, NEVER_NULL, NEVER_NULL))
+                    .asType(MethodType.methodType(boolean.class, Object.class, Object.class));
             this.hashCodeOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL))
                     .asType(MethodType.methodType(long.class, Object.class));
         }
@@ -147,7 +147,7 @@ public final class NullableValue
     private boolean valueEquals(Object otherValue)
     {
         try {
-            return ((Boolean) equalOperator.invokeExact(value, otherValue)) == Boolean.TRUE;
+            return (boolean) equalOperator.invokeExact(value, otherValue);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -40,8 +40,8 @@ import java.util.stream.Stream;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
 import static io.trino.spi.predicate.Utils.handleThrowable;
@@ -49,7 +49,6 @@ import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.TypeUtils.isFloatingPointNaN;
 import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
-import static java.lang.Boolean.TRUE;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -86,7 +85,7 @@ public final class SortedRangeSet
             throw new IllegalArgumentException("Type is not orderable: " + type);
         }
         this.type = type;
-        this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
+        this.equalOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getEqualOperator(type, simpleConvention(DEFAULT_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
         this.hashCodeOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION));
         // choice of placing unordered values first or last does not matter for this code
         this.comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonUnorderedLastOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
@@ -871,14 +870,14 @@ public final class SortedRangeSet
             // TODO this should probably use IS NOT DISTINCT FROM
             return leftIsNull == rightIsNull;
         }
-        Boolean equal;
+        boolean equal;
         try {
-            equal = (Boolean) equalOperator.invokeExact(leftBlock, leftPosition, rightBlock, rightPosition);
+            equal = (boolean) equalOperator.invokeExact(leftBlock, leftPosition, rightBlock, rightPosition);
         }
         catch (Throwable throwable) {
             throw handleThrowable(throwable);
         }
-        return TRUE.equals(equal);
+        return equal;
     }
 
     private static int compareValues(MethodHandle comparisonOperator, Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)


### PR DESCRIPTION
## Description

PagesHashStrategy#positionEqualsPositionIgnoreNulls can avoid the overhead of ValueConversions.boxBoolean for primitive types.
This PR introduces a new DEFAULT_ON_NULL method return convention which is used to create an adapted equals method handle where equals methods with nullable return value are adapted to return `false` on java `null` and equals methods with primitive return value are used without adaptation.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
