### PR TITLE
Drop Delta cache without metastore communication

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Streams;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.trino.metadata.AnalyzeMetadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
@@ -2184,48 +2185,56 @@ public class Analysis
 
             private Builder() {}
 
+            @CanIgnoreReturnValue
             public Builder withArgumentName(String argumentName)
             {
                 this.argumentName = argumentName;
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withName(QualifiedName name)
             {
                 this.name = Optional.of(name);
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withRelation(Relation relation)
             {
                 this.relation = relation;
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withPartitionBy(List<Expression> partitionBy)
             {
                 this.partitionBy = Optional.of(partitionBy);
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withOrderBy(OrderBy orderBy)
             {
                 this.orderBy = Optional.of(orderBy);
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withPruneWhenEmpty(boolean pruneWhenEmpty)
             {
                 this.pruneWhenEmpty = pruneWhenEmpty;
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withRowSemantics(boolean rowSemantics)
             {
                 this.rowSemantics = rowSemantics;
                 return this;
             }
 
+            @CanIgnoreReturnValue
             public Builder withPassThroughColumns(boolean passThroughColumns)
             {
                 this.passThroughColumns = passThroughColumns;

--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -27,7 +27,6 @@ import io.trino.spi.block.DictionaryId;
 import io.trino.spi.block.MapHashTables;
 import io.trino.spi.block.SingleRowBlockWriter;
 import io.trino.spi.block.TestingBlockEncodingSerde;
-import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Array;
@@ -56,7 +55,6 @@ import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
-@Test
 public abstract class AbstractTestBlock
 {
     private static final BlockEncodingSerde BLOCK_ENCODING_SERDE = new TestingBlockEncodingSerde(TESTING_TYPE_MANAGER::getType);

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -58,7 +58,6 @@ import io.trino.testing.TestingMetadata.TestingTableHandle;
 import io.trino.transaction.TransactionManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -90,7 +89,6 @@ import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 
-@Test
 public abstract class BaseDataDefinitionTaskTest
 {
     public static final String SCHEMA = "schema";

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -18,14 +18,12 @@ import io.trino.spi.Plugin;
 import io.trino.testing.LocalQueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 
-@Test
 public abstract class BaseRuleTest
 {
     private RuleTester tester;

--- a/lib/trino-collect/src/main/java/io/trino/collect/cache/CacheUtils.java
+++ b/lib/trino-collect/src/main/java/io/trino/collect/cache/CacheUtils.java
@@ -15,8 +15,12 @@ package io.trino.collect.cache;
 
 import com.google.common.cache.Cache;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public final class CacheUtils
 {
@@ -31,5 +35,13 @@ public final class CacheUtils
             // this can not happen because a supplier can not throw a checked exception
             throw new RuntimeException("Unexpected checked exception from cache load", e);
         }
+    }
+
+    public static <K> void invalidateAllIf(Cache<K, ?> cache, Predicate<? super K> filterFunction)
+    {
+        List<K> cacheKeys = cache.asMap().keySet().stream()
+                .filter(filterFunction)
+                .collect(toImmutableList());
+        cache.invalidateAll(cacheKeys);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -579,7 +579,7 @@ public class CachingJdbcClient
     @Deprecated
     public void onDataChanged(JdbcTableHandle handle)
     {
-        invalidateCache(statisticsCache, key -> key.equals(handle));
+        statisticsCache.invalidate(handle);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
@@ -14,10 +14,12 @@
 package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.util.List;
 
@@ -63,6 +65,12 @@ public class DeltaLakeInsertTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonIgnore
+    public SchemaTableName getSchemaTableName()
+    {
+        return new SchemaTableName(schemaName, tableName);
     }
 
     @JsonProperty

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInsertTableHandle.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -28,8 +27,7 @@ import static java.util.Objects.requireNonNull;
 public class DeltaLakeInsertTableHandle
         implements ConnectorInsertTableHandle
 {
-    private final String schemaName;
-    private final String tableName;
+    private final SchemaTableName tableName;
     private final String location;
     private final MetadataEntry metadataEntry;
     private final List<DeltaLakeColumnHandle> inputColumns;
@@ -38,15 +36,13 @@ public class DeltaLakeInsertTableHandle
 
     @JsonCreator
     public DeltaLakeInsertTableHandle(
-            @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName,
+            @JsonProperty("tableName") SchemaTableName tableName,
             @JsonProperty("location") String location,
             @JsonProperty("metadataEntry") MetadataEntry metadataEntry,
             @JsonProperty("inputColumns") List<DeltaLakeColumnHandle> inputColumns,
             @JsonProperty("readVersion") long readVersion,
             @JsonProperty("retriesEnabled") boolean retriesEnabled)
     {
-        this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.metadataEntry = requireNonNull(metadataEntry, "metadataEntry is null");
         this.inputColumns = ImmutableList.copyOf(inputColumns);
@@ -56,21 +52,9 @@ public class DeltaLakeInsertTableHandle
     }
 
     @JsonProperty
-    public String getSchemaName()
-    {
-        return schemaName;
-    }
-
-    @JsonProperty
-    public String getTableName()
+    public SchemaTableName getTableName()
     {
         return tableName;
-    }
-
-    @JsonIgnore
-    public SchemaTableName getSchemaTableName()
-    {
-        return new SchemaTableName(schemaName, tableName);
     }
 
     @JsonProperty
@@ -106,6 +90,6 @@ public class DeltaLakeInsertTableHandle
     @Override
     public String toString()
     {
-        return schemaName + "." + tableName + "[" + location + "]";
+        return tableName + "[" + location + "]";
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1440,8 +1440,7 @@ public class DeltaLakeMetadata
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
             return new DeltaLakeInsertTableHandle(
-                    table.getSchemaName(),
-                    table.getTableName(),
+                    table.getSchemaTableName(),
                     tableLocation,
                     table.getMetadataEntry(),
                     inputColumns,
@@ -1511,7 +1510,7 @@ public class DeltaLakeMetadata
 
             transactionLogWriter.flush();
             writeCommitted = true;
-            writeCheckpointIfNeeded(session, new SchemaTableName(handle.getSchemaName(), handle.getTableName()), handle.getLocation(), checkpointInterval, commitVersion);
+            writeCheckpointIfNeeded(session, handle.getTableName(), handle.getLocation(), checkpointInterval, commitVersion);
 
             if (isCollectExtendedStatisticsColumnStatisticsOnWrite(session) && !computedStatistics.isEmpty() && !dataFileInfos.isEmpty()) {
                 // TODO (https://github.com/trinodb/trino/issues/16088) Add synchronization when version conflict for INSERT is resolved.
@@ -1522,7 +1521,7 @@ public class DeltaLakeMetadata
                 updateTableStatistics(
                         session,
                         Optional.empty(),
-                        handle.getSchemaTableName(),
+                        handle.getTableName(),
                         handle.getLocation(),
                         maxFileModificationTime,
                         computedStatistics,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -845,8 +845,8 @@ public class DeltaLakeMetadata
 
         PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
         // As a precaution, clear the caches
-        statisticsAccess.invalidateCache(location);
-        transactionLogAccess.invalidateCaches(location);
+        statisticsAccess.invalidateCache(schemaTableName, Optional.of(location));
+        transactionLogAccess.invalidateCache(schemaTableName, Optional.of(location));
         metastore.createTable(
                 session,
                 table,
@@ -1048,7 +1048,8 @@ public class DeltaLakeMetadata
                 .map(dataFileInfoCodec::fromJson)
                 .collect(toImmutableList());
 
-        Table table = buildTable(session, schemaTableName(schemaName, tableName), location, handle.isExternal());
+        SchemaTableName schemaTableName = schemaTableName(schemaName, tableName);
+        Table table = buildTable(session, schemaTableName, location, handle.isExternal());
         // Ensure the table has queryId set. This is relied on for exception handling
         String queryId = session.getQueryId();
         verify(
@@ -1095,6 +1096,7 @@ public class DeltaLakeMetadata
                 updateTableStatistics(
                         session,
                         Optional.empty(),
+                        schemaTableName,
                         location,
                         maxFileModificationTime,
                         computedStatistics,
@@ -1104,8 +1106,8 @@ public class DeltaLakeMetadata
             PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
 
             // As a precaution, clear the caches
-            statisticsAccess.invalidateCache(location);
-            transactionLogAccess.invalidateCaches(location);
+            statisticsAccess.invalidateCache(schemaTableName, Optional.of(location));
+            transactionLogAccess.invalidateCache(schemaTableName, Optional.of(location));
             try {
                 metastore.createTable(session, table, principalPrivileges);
             }
@@ -1520,6 +1522,7 @@ public class DeltaLakeMetadata
                 updateTableStatistics(
                         session,
                         Optional.empty(),
+                        handle.getSchemaTableName(),
                         handle.getLocation(),
                         maxFileModificationTime,
                         computedStatistics,
@@ -2046,8 +2049,8 @@ public class DeltaLakeMetadata
             }
         }
         // As a precaution, clear the caches
-        statisticsAccess.invalidateCache(handle.location());
-        transactionLogAccess.invalidateCaches(handle.location());
+        statisticsAccess.invalidateCache(handle.schemaTableName(), Optional.of(handle.location()));
+        transactionLogAccess.invalidateCache(handle.schemaTableName(), Optional.of(handle.location()));
     }
 
     @Override
@@ -2554,7 +2557,7 @@ public class DeltaLakeMetadata
 
         Optional<ExtendedStatistics> statistics = Optional.empty();
         if (analyzeMode == INCREMENTAL) {
-            statistics = statisticsAccess.readExtendedStatistics(session, handle.getLocation());
+            statistics = statisticsAccess.readExtendedStatistics(session, handle.getSchemaTableName(), handle.getLocation());
         }
 
         Optional<Instant> alreadyAnalyzedModifiedTimeMax = statistics.map(ExtendedStatistics::getAlreadyAnalyzedModifiedTimeMax);
@@ -2634,7 +2637,7 @@ public class DeltaLakeMetadata
         Optional<Set<String>> analyzeColumnNames = Optional.empty();
         String tableLocation = getLocation(tableMetadata.getProperties());
         if (tableLocation != null) {
-            analyzeColumnNames = statisticsAccess.readExtendedStatistics(session, tableLocation)
+            analyzeColumnNames = statisticsAccess.readExtendedStatistics(session, tableMetadata.getTable(), tableLocation)
                     .flatMap(ExtendedStatistics::getAnalyzedColumns);
         }
 
@@ -2702,6 +2705,7 @@ public class DeltaLakeMetadata
         updateTableStatistics(
                 session,
                 Optional.of(analyzeHandle),
+                tableHandle.getSchemaTableName(),
                 tableHandle.getLocation(),
                 maxFileModificationTime,
                 computedStatistics,
@@ -2711,6 +2715,7 @@ public class DeltaLakeMetadata
     private void updateTableStatistics(
             ConnectorSession session,
             Optional<AnalyzeHandle> analyzeHandle,
+            SchemaTableName schemaTableName,
             String location,
             Optional<Instant> maxFileModificationTime,
             Collection<ComputedStatistics> computedStatistics,
@@ -2719,7 +2724,7 @@ public class DeltaLakeMetadata
         Optional<ExtendedStatistics> oldStatistics = Optional.empty();
         boolean loadExistingStats = analyzeHandle.isEmpty() || analyzeHandle.get().getAnalyzeMode() == INCREMENTAL;
         if (loadExistingStats) {
-            oldStatistics = statisticsAccess.readExtendedStatistics(session, location);
+            oldStatistics = statisticsAccess.readExtendedStatistics(session, schemaTableName, location);
         }
 
         // more elaborate logic for handling statistics model evaluation may need to be introduced in the future
@@ -2782,7 +2787,7 @@ public class DeltaLakeMetadata
                 mergedColumnStatistics,
                 analyzedColumns);
 
-        statisticsAccess.updateExtendedStatistics(session, location, mergedExtendedStatistics);
+        statisticsAccess.updateExtendedStatistics(session, schemaTableName, location, mergedExtendedStatistics);
     }
 
     private static String toPhysicalColumnName(String columnName, Optional<Map<String, String>> physicalColumnNameMapping)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
@@ -84,6 +84,6 @@ public class DropExtendedStatsProcedure
             throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", name));
         }
         accessControl.checkCanInsertIntoTable(null, name);
-        statsAccess.deleteExtendedStatistics(session, tableHandle.location());
+        statsAccess.deleteExtendedStatistics(session, name, tableHandle.location());
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/FlushMetadataCacheProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/FlushMetadataCacheProcedure.java
@@ -16,15 +16,11 @@ package io.trino.plugin.deltalake.procedure;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import io.trino.plugin.deltalake.DeltaLakeMetadata;
-import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
-import io.trino.plugin.deltalake.LocatedTableHandle;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
 import io.trino.spi.TrinoException;
 import io.trino.spi.classloader.ThreadContextClassLoader;
-import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.procedure.Procedure;
 
@@ -48,26 +44,23 @@ public class FlushMetadataCacheProcedure
 
     static {
         try {
-            FLUSH_METADATA_CACHE = lookup().unreflect(FlushMetadataCacheProcedure.class.getMethod("flushMetadataCache", ConnectorSession.class, String.class, String.class));
+            FLUSH_METADATA_CACHE = lookup().unreflect(FlushMetadataCacheProcedure.class.getMethod("flushMetadataCache", String.class, String.class));
         }
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
     }
 
-    private final DeltaLakeMetadataFactory metadataFactory;
     private final Optional<CachingHiveMetastore> cachingHiveMetastore;
     private final TransactionLogAccess transactionLogAccess;
     private final CachingExtendedStatisticsAccess extendedStatisticsAccess;
 
     @Inject
     public FlushMetadataCacheProcedure(
-            DeltaLakeMetadataFactory metadataFactory,
             Optional<CachingHiveMetastore> cachingHiveMetastore,
             TransactionLogAccess transactionLogAccess,
             CachingExtendedStatisticsAccess extendedStatisticsAccess)
     {
-        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
         this.cachingHiveMetastore = requireNonNull(cachingHiveMetastore, "cachingHiveMetastore is null");
         this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
         this.extendedStatisticsAccess = requireNonNull(extendedStatisticsAccess, "extendedStatisticsAccess is null");
@@ -86,14 +79,14 @@ public class FlushMetadataCacheProcedure
                 true);
     }
 
-    public void flushMetadataCache(ConnectorSession session, String schemaName, String tableName)
+    public void flushMetadataCache(String schemaName, String tableName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doFlushMetadataCache(session, Optional.ofNullable(schemaName), Optional.ofNullable(tableName));
+            doFlushMetadataCache(Optional.ofNullable(schemaName), Optional.ofNullable(tableName));
         }
     }
 
-    private void doFlushMetadataCache(ConnectorSession session, Optional<String> schemaName, Optional<String> tableName)
+    private void doFlushMetadataCache(Optional<String> schemaName, Optional<String> tableName)
     {
         if (schemaName.isEmpty() && tableName.isEmpty()) {
             cachingHiveMetastore.ifPresent(CachingHiveMetastore::flushCache);
@@ -101,15 +94,10 @@ public class FlushMetadataCacheProcedure
             extendedStatisticsAccess.invalidateCache();
         }
         else if (schemaName.isPresent() && tableName.isPresent()) {
-            DeltaLakeMetadata metadata = metadataFactory.create(session.getIdentity());
             SchemaTableName schemaTableName = new SchemaTableName(schemaName.get(), tableName.get());
-            // This may insert into a cache, but this will get invalidated below. TODO fix Delta so that flush_metadata_cache doesn't have to read from metastore
-            LocatedTableHandle tableHandle = metadata.getTableHandle(session, schemaTableName);
-            cachingHiveMetastore.ifPresent(caching -> caching.invalidateTable(schemaName.get(), tableName.get()));
-
-            Optional<String> tableLocation = Optional.ofNullable(tableHandle).map(LocatedTableHandle::location);
-            tableLocation.ifPresent(transactionLogAccess::invalidateCaches);
-            tableLocation.ifPresent(extendedStatisticsAccess::invalidateCache);
+            cachingHiveMetastore.ifPresent(cachingMetastore -> cachingMetastore.invalidateTable(schemaName.get(), tableName.get()));
+            transactionLogAccess.invalidateCache(schemaTableName, Optional.empty());
+            extendedStatisticsAccess.invalidateCache(schemaTableName, Optional.empty());
         }
         else {
             throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Illegal parameter set passed");

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -36,6 +36,7 @@ import io.trino.spi.procedure.Procedure;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandle;
+import java.util.Optional;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
@@ -155,8 +156,8 @@ public class RegisterTableProcedure
         Table table = buildTable(session, schemaTableName, tableLocation, true);
 
         PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
-        statisticsAccess.invalidateCache(tableLocation);
-        transactionLogAccess.invalidateCaches(tableLocation);
+        statisticsAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
+        transactionLogAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
         // Verify we're registering a location with a valid table
         try {
             TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(table.getSchemaTableName(), tableLocation, session);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/UnregisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/UnregisterTableProcedure.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.procedure.Procedure;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Optional;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
@@ -102,7 +103,7 @@ public class UnregisterTableProcedure
         }
         metadata.getMetastore().dropTable(session, schemaTableName, tableHandle.location(), false);
         // As a precaution, clear the caches
-        statisticsAccess.invalidateCache(tableHandle.location());
-        transactionLogAccess.invalidateCaches(tableHandle.location());
+        statisticsAccess.invalidateCache(schemaTableName, Optional.of(tableHandle.location()));
+        transactionLogAccess.invalidateCache(schemaTableName, Optional.of(tableHandle.location()));
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/CachingExtendedStatisticsAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/CachingExtendedStatisticsAccess.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import io.trino.collect.cache.EvictableCacheBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -27,6 +28,7 @@ import java.time.Duration;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static io.trino.collect.cache.CacheUtils.invalidateAllIf;
 import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.annotation.ElementType.FIELD;
@@ -43,7 +45,7 @@ public class CachingExtendedStatisticsAccess
     private static final long CACHE_MAX_SIZE = 1000;
 
     private final ExtendedStatisticsAccess delegate;
-    private final Cache<String, Optional<ExtendedStatistics>> cache = EvictableCacheBuilder.newBuilder()
+    private final Cache<CacheKey, Optional<ExtendedStatistics>> cache = EvictableCacheBuilder.newBuilder()
             .expireAfterWrite(CACHE_EXPIRATION)
             .maximumSize(CACHE_MAX_SIZE)
             .build();
@@ -55,10 +57,10 @@ public class CachingExtendedStatisticsAccess
     }
 
     @Override
-    public Optional<ExtendedStatistics> readExtendedStatistics(ConnectorSession session, String tableLocation)
+    public Optional<ExtendedStatistics> readExtendedStatistics(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation)
     {
         try {
-            return uncheckedCacheGet(cache, tableLocation, () -> delegate.readExtendedStatistics(session, tableLocation));
+            return uncheckedCacheGet(cache, new CacheKey(schemaTableName, tableLocation), () -> delegate.readExtendedStatistics(session, schemaTableName, tableLocation));
         }
         catch (UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
@@ -67,17 +69,17 @@ public class CachingExtendedStatisticsAccess
     }
 
     @Override
-    public void updateExtendedStatistics(ConnectorSession session, String tableLocation, ExtendedStatistics statistics)
+    public void updateExtendedStatistics(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation, ExtendedStatistics statistics)
     {
-        delegate.updateExtendedStatistics(session, tableLocation, statistics);
-        cache.invalidate(tableLocation);
+        delegate.updateExtendedStatistics(session, schemaTableName, tableLocation, statistics);
+        cache.invalidate(new CacheKey(schemaTableName, tableLocation));
     }
 
     @Override
-    public void deleteExtendedStatistics(ConnectorSession session, String tableLocation)
+    public void deleteExtendedStatistics(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation)
     {
-        delegate.deleteExtendedStatistics(session, tableLocation);
-        cache.invalidate(tableLocation);
+        delegate.deleteExtendedStatistics(session, schemaTableName, tableLocation);
+        cache.invalidate(new CacheKey(schemaTableName, tableLocation));
     }
 
     public void invalidateCache()
@@ -85,14 +87,26 @@ public class CachingExtendedStatisticsAccess
         cache.invalidateAll();
     }
 
-    public void invalidateCache(String tableLocation)
+    // for explicit cache invalidation
+    public void invalidateCache(SchemaTableName schemaTableName, Optional<String> tableLocation)
     {
-        // for explicit cache invalidation
-        cache.invalidate(tableLocation);
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        // Invalidate by location in case one table (location) unregistered and re-register under different name
+        tableLocation.ifPresent(location -> invalidateAllIf(cache, cacheKey -> cacheKey.location().equals(location)));
+        invalidateAllIf(cache, cacheKey -> cacheKey.tableName().equals(schemaTableName));
     }
 
     @Retention(RUNTIME)
     @Target({FIELD, PARAMETER, METHOD})
     @BindingAnnotation
     public @interface ForCachingExtendedStatisticsAccess {}
+
+    private record CacheKey(SchemaTableName tableName, String location)
+    {
+        CacheKey
+        {
+            requireNonNull(tableName, "tableName is null");
+            requireNonNull(location, "location is null");
+        }
+    }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/ExtendedStatisticsAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/ExtendedStatisticsAccess.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake.statistics;
 
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.util.Optional;
 
@@ -21,14 +22,17 @@ public interface ExtendedStatisticsAccess
 {
     Optional<ExtendedStatistics> readExtendedStatistics(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             String tableLocation);
 
     void updateExtendedStatistics(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             String tableLocation,
             ExtendedStatistics statistics);
 
     void deleteExtendedStatistics(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             String tableLocation);
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
@@ -181,7 +181,7 @@ public class FileBasedTableStatisticsProvider
 
         Optional<ExtendedStatistics> statistics = Optional.empty();
         if (isExtendedStatisticsEnabled(session)) {
-            statistics = statisticsAccess.readExtendedStatistics(session, tableHandle.getLocation());
+            statistics = statisticsAccess.readExtendedStatistics(session, tableHandle.getSchemaTableName(), tableHandle.getLocation());
         }
 
         for (DeltaLakeColumnHandle column : columns) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/MetaDirStatisticsAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/MetaDirStatisticsAccess.java
@@ -21,6 +21,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.SchemaTableName;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -58,6 +59,7 @@ public class MetaDirStatisticsAccess
     @Override
     public Optional<ExtendedStatistics> readExtendedStatistics(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             String tableLocation)
     {
         Location location = Location.of(tableLocation);
@@ -85,6 +87,7 @@ public class MetaDirStatisticsAccess
     @Override
     public void updateExtendedStatistics(
             ConnectorSession session,
+            SchemaTableName schemaTableName,
             String tableLocation,
             ExtendedStatistics statistics)
     {
@@ -108,7 +111,7 @@ public class MetaDirStatisticsAccess
     }
 
     @Override
-    public void deleteExtendedStatistics(ConnectorSession session, String tableLocation)
+    public void deleteExtendedStatistics(ConnectorSession session, SchemaTableName schemaTableName, String tableLocation)
     {
         Location statisticsPath = Location.of(tableLocation).appendPath(STATISTICS_META_DIR).appendPath(STATISTICS_FILE);
         try {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -69,6 +69,8 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.collect.cache.CacheUtils.invalidateAllIf;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
@@ -89,8 +91,8 @@ public class TransactionLogAccess
     private final FileFormatDataSourceStats fileFormatDataSourceStats;
     private final TrinoFileSystemFactory fileSystemFactory;
     private final ParquetReaderOptions parquetReaderOptions;
-    private final Cache<String /* table location */, TableSnapshot> tableSnapshots;
-    private final Cache<String /* table location */, DeltaLakeDataFileCacheEntry> activeDataFileCache;
+    private final Cache<CacheKey, TableSnapshot> tableSnapshots;
+    private final Cache<CacheKey, DeltaLakeDataFileCacheEntry> activeDataFileCache;
     private final boolean checkpointRowStatisticsWritingEnabled;
     private final int domainCompactionThreshold;
 
@@ -118,7 +120,7 @@ public class TransactionLogAccess
                 .recordStats()
                 .build();
         activeDataFileCache = EvictableCacheBuilder.newBuilder()
-                .weigher((Weigher<String, DeltaLakeDataFileCacheEntry>) (key, value) -> Ints.saturatedCast(estimatedSizeOf(key) + value.getRetainedSizeInBytes()))
+                .weigher((Weigher<CacheKey, DeltaLakeDataFileCacheEntry>) (key, value) -> Ints.saturatedCast(key.getRetainedSizeInBytes() + value.getRetainedSizeInBytes()))
                 .maximumWeight(deltaLakeConfig.getDataFileCacheSize().toBytes())
                 .expireAfterWrite(deltaLakeConfig.getDataFileCacheTtl().toMillis(), TimeUnit.MILLISECONDS)
                 .shareNothingWhenDisabled()
@@ -143,12 +145,13 @@ public class TransactionLogAccess
     public TableSnapshot loadSnapshot(SchemaTableName table, String tableLocation, ConnectorSession session)
             throws IOException
     {
-        TableSnapshot cachedSnapshot = tableSnapshots.getIfPresent(tableLocation);
+        CacheKey cacheKey = new CacheKey(table, tableLocation);
+        TableSnapshot cachedSnapshot = tableSnapshots.getIfPresent(cacheKey);
         TableSnapshot snapshot;
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         if (cachedSnapshot == null) {
             try {
-                snapshot = tableSnapshots.get(tableLocation, () ->
+                snapshot = tableSnapshots.get(cacheKey, () ->
                         TableSnapshot.load(
                                 table,
                                 fileSystem,
@@ -166,7 +169,7 @@ public class TransactionLogAccess
             Optional<TableSnapshot> updatedSnapshot = cachedSnapshot.getUpdatedSnapshot(fileSystem);
             if (updatedSnapshot.isPresent()) {
                 snapshot = updatedSnapshot.get();
-                tableSnapshots.asMap().replace(tableLocation, cachedSnapshot, snapshot);
+                tableSnapshots.asMap().replace(cacheKey, cachedSnapshot, snapshot);
             }
             else {
                 snapshot = cachedSnapshot;
@@ -181,10 +184,16 @@ public class TransactionLogAccess
         activeDataFileCache.invalidateAll();
     }
 
-    public void invalidateCaches(String tableLocation)
+    public void invalidateCache(SchemaTableName schemaTableName, Optional<String> tableLocation)
     {
-        tableSnapshots.invalidate(tableLocation);
-        activeDataFileCache.invalidate(tableLocation);
+        requireNonNull(schemaTableName, "schemaTableName is null");
+        // Invalidate by location in case one table (location) unregistered and re-register under different name
+        tableLocation.ifPresent(location -> {
+            invalidateAllIf(tableSnapshots, cacheKey -> cacheKey.location().equals(location));
+            invalidateAllIf(activeDataFileCache, cacheKey -> cacheKey.location().equals(location));
+        });
+        invalidateAllIf(tableSnapshots, cacheKey -> cacheKey.tableName().equals(schemaTableName));
+        invalidateAllIf(activeDataFileCache, cacheKey -> cacheKey.tableName().equals(schemaTableName));
     }
 
     public MetadataEntry getMetadataEntry(TableSnapshot tableSnapshot, ConnectorSession session)
@@ -208,8 +217,8 @@ public class TransactionLogAccess
     public List<AddFileEntry> getActiveFiles(TableSnapshot tableSnapshot, ConnectorSession session)
     {
         try {
-            String tableLocation = tableSnapshot.getTableLocation();
-            DeltaLakeDataFileCacheEntry cachedTable = activeDataFileCache.get(tableLocation, () -> {
+            CacheKey cacheKey = new CacheKey(tableSnapshot.getTable(), tableSnapshot.getTableLocation());
+            DeltaLakeDataFileCacheEntry cachedTable = activeDataFileCache.get(cacheKey, () -> {
                 List<AddFileEntry> activeFiles = loadActiveFiles(tableSnapshot, session);
                 return new DeltaLakeDataFileCacheEntry(tableSnapshot.getVersion(), activeFiles);
             });
@@ -234,7 +243,7 @@ public class TransactionLogAccess
                     updatedCacheEntry = new DeltaLakeDataFileCacheEntry(tableSnapshot.getVersion(), activeFiles);
                 }
 
-                activeDataFileCache.asMap().replace(tableLocation, cachedTable, updatedCacheEntry);
+                activeDataFileCache.asMap().replace(cacheKey, cachedTable, updatedCacheEntry);
                 cachedTable = updatedCacheEntry;
             }
             return cachedTable.getActiveFiles();
@@ -478,5 +487,23 @@ public class TransactionLogAccess
                 .collect(toImmutableMap(
                         entry -> entry.getKey().getOriginalName(),
                         Map.Entry::getValue));
+    }
+
+    private record CacheKey(SchemaTableName tableName, String location)
+    {
+        private static final int INSTANCE_SIZE = instanceSize(CacheKey.class);
+
+        CacheKey
+        {
+            requireNonNull(tableName, "tableName is null");
+            requireNonNull(location, "location is null");
+        }
+
+        long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE +
+                    tableName.getRetainedSizeInBytes() +
+                    estimatedSizeOf(location);
+        }
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
@@ -27,7 +27,7 @@ public abstract class BaseDeltaLakeAwsConnectorSmokeTest
     @Override
     protected HiveMinioDataLake createHiveMinioDataLake()
     {
-        hiveMinioDataLake = new HiveMinioDataLake(bucketName);
+        hiveMinioDataLake = new HiveMinioDataLake(bucketName); // closed by superclass
         hiveMinioDataLake.start();
         return hiveMinioDataLake;
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -93,7 +93,7 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
                 ImmutableMap.of("/etc/hadoop/conf/core-site.xml", hadoopCoreSiteXmlTempFile.normalize().toAbsolutePath().toString()),
                 HiveHadoop.HIVE3_IMAGE);
         hiveMinioDataLake.start();
-        return hiveMinioDataLake;
+        return hiveMinioDataLake;  // closed by superclass
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlushMetadataCacheProcedure.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlushMetadataCacheProcedure.java
@@ -106,22 +106,20 @@ public class TestDeltaLakeFlushMetadataCacheProcedure
     public void testFlushMetadataCacheAfterTableCreated()
     {
         String schema = getSession().getSchema().orElseThrow();
-        String tableName = "flush_metadata_after_table_created";
-        String intermediateTableName = "test_flush_intermediate_" + randomNameSuffix();
 
-        String location = "s3://%s/%s".formatted(bucketName, intermediateTableName);
-        assertUpdate("CREATE TABLE " + intermediateTableName + " WITH (location = '" + location + "') AS TABLE tpch.tiny.region", 5);
+        String location = "s3://%s/test_flush_intermediate_tmp_table".formatted(bucketName);
+        assertUpdate("CREATE TABLE test_flush_intermediate_tmp_table WITH (location = '" + location + "') AS TABLE tpch.tiny.region", 5);
 
         // This may cause the connector to cache the fact that the table does not exist
-        assertQueryFails("TABLE " + tableName, "\\Qline 1:1: Table 'delta.default.flush_metadata_after_table_created' does not exist");
+        assertQueryFails("TABLE flush_metadata_after_table_created", "\\Qline 1:1: Table 'delta.default.flush_metadata_after_table_created' does not exist");
 
-        metastore.renameTable(schema, intermediateTableName, schema, tableName);
+        metastore.renameTable(schema, "test_flush_intermediate_tmp_table", schema, "flush_metadata_after_table_created");
 
         // Verify cached state (we currently cache missing objects in CachingMetastore)
-        assertQueryFails("TABLE " + tableName, "\\Qline 1:1: Table 'delta.default.flush_metadata_after_table_created' does not exist");
+        assertQueryFails("TABLE flush_metadata_after_table_created", "\\Qline 1:1: Table 'delta.default.flush_metadata_after_table_created' does not exist");
 
-        assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "')");
-        assertThat(query("TABLE " + tableName))
+        assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => 'flush_metadata_after_table_created')");
+        assertThat(query("TABLE flush_metadata_after_table_created"))
                 .skippingTypesCheck() // Delta has no parametric varchar
                 .matches("TABLE tpch.tiny.region");
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlushMetadataCacheProcedure.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFlushMetadataCacheProcedure.java
@@ -22,8 +22,6 @@ import io.trino.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createS3DeltaLakeQueryRunner;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
@@ -41,7 +39,7 @@ public class TestDeltaLakeFlushMetadataCacheProcedure
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        HiveMinioDataLake hiveMinioDataLake = new HiveMinioDataLake(bucketName, HIVE3_IMAGE);
+        HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         metastore = new BridgingHiveMetastore(
                 testingThriftHiveMetastoreBuilder()
@@ -58,7 +56,6 @@ public class TestDeltaLakeFlushMetadataCacheProcedure
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
-            throws IOException
     {
         metastore = null;
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -131,7 +131,7 @@ public class TestDeltaLakeGcsConnectorSmokeTest
                         "/etc/hadoop/conf/gcp-credentials.json", gcpCredentialsFile.toAbsolutePath().toString()),
                 HIVE3_IMAGE);
         dataLake.start();
-        return dataLake;
+        return dataLake; // closed by superclass
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeReadTimestamps.java
@@ -49,7 +49,6 @@ import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.YEAR;
 import static java.util.stream.Collectors.joining;
 
-@Test
 public class TestDeltaLakeReadTimestamps
         extends AbstractTestQueryFramework
 {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
@@ -456,7 +456,8 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
 
     private Optional<ExtendedStatistics> readExtendedStatisticsFromTableResource(String tableLocationResourceName)
     {
+        SchemaTableName name = new SchemaTableName("some_ignored_schema", "some_ignored_name");
         String tableLocation = Resources.getResource(tableLocationResourceName).toExternalForm();
-        return statistics.readExtendedStatistics(SESSION, tableLocation);
+        return statistics.readExtendedStatistics(SESSION, name, tableLocation);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/statistics/TestDeltaLakeFileBasedTableStatisticsProvider.java
@@ -398,8 +398,7 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
     public void testExtendedStatisticsWithoutDataSize()
     {
         // Read extended_stats.json that was generated before supporting data_size
-        String tableLocation = Resources.getResource("statistics/extended_stats_without_data_size").toExternalForm();
-        Optional<ExtendedStatistics> extendedStatistics = statistics.readExtendedStatistics(SESSION, tableLocation);
+        Optional<ExtendedStatistics> extendedStatistics = readExtendedStatisticsFromTableResource("statistics/extended_stats_without_data_size");
         assertThat(extendedStatistics).isNotEmpty();
         Map<String, DeltaLakeColumnStatistics> columnStatistics = extendedStatistics.get().getColumnStatistics();
         assertThat(columnStatistics).hasSize(3);
@@ -409,8 +408,7 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
     public void testExtendedStatisticsWithDataSize()
     {
         // Read extended_stats.json that was generated after supporting data_size
-        String tableLocation = Resources.getResource("statistics/extended_stats_with_data_size").toExternalForm();
-        Optional<ExtendedStatistics> extendedStatistics = statistics.readExtendedStatistics(SESSION, tableLocation);
+        Optional<ExtendedStatistics> extendedStatistics = readExtendedStatisticsFromTableResource("statistics/extended_stats_with_data_size");
         assertThat(extendedStatistics).isNotEmpty();
         Map<String, DeltaLakeColumnStatistics> columnStatistics = extendedStatistics.get().getColumnStatistics();
         assertThat(columnStatistics).hasSize(3);
@@ -423,8 +421,8 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
     public void testMergeExtendedStatisticsWithoutAndWithDataSize()
     {
         // Merge two extended stats files. The first file doesn't have totalSizeInBytes field and the second file has totalSizeInBytes field
-        Optional<ExtendedStatistics> statisticsWithoutDataSize = statistics.readExtendedStatistics(SESSION, Resources.getResource("statistics/extended_stats_without_data_size").toExternalForm());
-        Optional<ExtendedStatistics> statisticsWithDataSize = statistics.readExtendedStatistics(SESSION, Resources.getResource("statistics/extended_stats_with_data_size").toExternalForm());
+        Optional<ExtendedStatistics> statisticsWithoutDataSize = readExtendedStatisticsFromTableResource("statistics/extended_stats_without_data_size");
+        Optional<ExtendedStatistics> statisticsWithDataSize = readExtendedStatisticsFromTableResource("statistics/extended_stats_with_data_size");
         assertThat(statisticsWithoutDataSize).isNotEmpty();
         assertThat(statisticsWithDataSize).isNotEmpty();
 
@@ -454,5 +452,11 @@ public class TestDeltaLakeFileBasedTableStatisticsProvider
             throw new RuntimeException(e);
         }
         return tableStatisticsProvider.getTableStatistics(session, tableHandle, tableSnapshot);
+    }
+
+    private Optional<ExtendedStatistics> readExtendedStatisticsFromTableResource(String tableLocationResourceName)
+    {
+        String tableLocation = Resources.getResource(tableLocationResourceName).toExternalForm();
+        return statistics.readExtendedStatistics(SESSION, tableLocation);
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -73,7 +73,6 @@ import static io.trino.util.DateTimeUtils.parseDate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-@Test
 public class TestCheckpointWriter
 {
     private final TypeManager typeManager = TESTING_TYPE_MANAGER;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -964,7 +964,8 @@ public class CachingHiveMetastore
 
     public void invalidateTable(String databaseName, String tableName)
     {
-        invalidateTableCache(databaseName, tableName);
+        HiveTableName hiveTableName = new HiveTableName(databaseName, tableName);
+        tableCache.invalidate(hiveTableName);
         tableNamesCache.invalidate(databaseName);
         allTableNamesCache.invalidateAll();
         viewNamesCache.invalidate(databaseName);
@@ -972,23 +973,9 @@ public class CachingHiveMetastore
         tablePrivilegesCache.asMap().keySet().stream()
                 .filter(userTableKey -> userTableKey.matches(databaseName, tableName))
                 .forEach(tablePrivilegesCache::invalidate);
-        invalidateTableStatisticsCache(databaseName, tableName);
+        tableStatisticsCache.invalidate(hiveTableName);
         invalidateTablesWithParameterCache(databaseName, tableName);
         invalidatePartitionCache(databaseName, tableName);
-    }
-
-    private void invalidateTableCache(String databaseName, String tableName)
-    {
-        tableCache.asMap().keySet().stream()
-                .filter(table -> table.getDatabaseName().equals(databaseName) && table.getTableName().equals(tableName))
-                .forEach(tableCache::invalidate);
-    }
-
-    private void invalidateTableStatisticsCache(String databaseName, String tableName)
-    {
-        tableStatisticsCache.asMap().keySet().stream()
-                .filter(table -> table.getDatabaseName().equals(databaseName) && table.getTableName().equals(tableName))
-                .forEach(tableStatisticsCache::invalidate);
     }
 
     private void invalidateTablesWithParameterCache(String databaseName, String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -89,6 +89,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static io.trino.collect.cache.CacheUtils.invalidateAllIf;
 import static io.trino.collect.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.plugin.hive.metastore.HivePartitionName.hivePartitionName;
 import static io.trino.plugin.hive.metastore.HiveTableName.hiveTableName;
@@ -970,9 +971,7 @@ public class CachingHiveMetastore
         allTableNamesCache.invalidateAll();
         viewNamesCache.invalidate(databaseName);
         allViewNamesCache.invalidateAll();
-        tablePrivilegesCache.asMap().keySet().stream()
-                .filter(userTableKey -> userTableKey.matches(databaseName, tableName))
-                .forEach(tablePrivilegesCache::invalidate);
+        invalidateAllIf(tablePrivilegesCache, userTableKey -> userTableKey.matches(databaseName, tableName));
         tableStatisticsCache.invalidate(hiveTableName);
         invalidateTablesWithParameterCache(databaseName, tableName);
         invalidatePartitionCache(databaseName, tableName);
@@ -1178,15 +1177,9 @@ public class CachingHiveMetastore
         Predicate<HivePartitionName> hivePartitionPredicate = partitionName -> partitionName.getHiveTableName().equals(hiveTableName) &&
                 partitionPredicate.test(partitionName.getPartitionName());
 
-        partitionCache.asMap().keySet().stream()
-                .filter(hivePartitionPredicate)
-                .forEach(partitionCache::invalidate);
-        partitionFilterCache.asMap().keySet().stream()
-                .filter(partitionFilter -> partitionFilter.getHiveTableName().equals(hiveTableName))
-                .forEach(partitionFilterCache::invalidate);
-        partitionStatisticsCache.asMap().keySet().stream()
-                .filter(hivePartitionPredicate)
-                .forEach(partitionStatisticsCache::invalidate);
+        invalidateAllIf(partitionCache, hivePartitionPredicate);
+        invalidateAllIf(partitionFilterCache, partitionFilter -> partitionFilter.getHiveTableName().equals(hiveTableName));
+        invalidateAllIf(partitionStatisticsCache, hivePartitionPredicate);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -988,7 +988,7 @@ public class CachingHiveMetastore
     {
         tableStatisticsCache.asMap().keySet().stream()
                 .filter(table -> table.getDatabaseName().equals(databaseName) && table.getTableName().equals(tableName))
-                .forEach(tableCache::invalidate);
+                .forEach(tableStatisticsCache::invalidate);
     }
 
     private void invalidateTablesWithParameterCache(String databaseName, String tableName)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -24,6 +24,7 @@ import io.airlift.units.Duration;
 import io.trino.hive.thrift.metastore.ColumnStatisticsData;
 import io.trino.hive.thrift.metastore.ColumnStatisticsObj;
 import io.trino.hive.thrift.metastore.LongColumnStatsData;
+import io.trino.plugin.hive.HiveBasicStatistics;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.PartitionStatistics;
@@ -125,6 +126,7 @@ public class TestCachingHiveMetastore
     private static final Logger log = Logger.get(TestCachingHiveMetastore.class);
 
     private static final PartitionStatistics TEST_STATS = PartitionStatistics.builder()
+            .setBasicStatistics(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(2398040535435L), OptionalLong.empty(), OptionalLong.empty()))
             .setColumnStatistics(ImmutableMap.of(TEST_COLUMN, createIntegerColumnStatistics(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty())))
             .build();
     private static final SchemaTableName TEST_SCHEMA_TABLE = new SchemaTableName(TEST_DATABASE, TEST_TABLE);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -575,6 +575,22 @@ public class TestCachingHiveMetastore
         assertThat(metastore.getTableStatistics(tableCol23).getColumnStatistics())
                 .containsEntry("col2", intColumnStats(2))
                 .containsEntry("col3", intColumnStats(3));
+
+        metastore.getTableStatistics(table); // ensure cached
+        assertEquals(mockClient.getAccessCount(), 5);
+        ColumnStatisticsData newStats = new ColumnStatisticsData();
+        newStats.setLongStats(new LongColumnStatsData(327843, 4324));
+        mockClient.mockColumnStats(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_COLUMN, newStats));
+        metastore.invalidateTable(TEST_DATABASE, TEST_TABLE);
+        assertEquals(metastore.getTableStatistics(table), PartitionStatistics.builder()
+                .setBasicStatistics(TEST_STATS.getBasicStatistics())
+                .setColumnStatistics(ImmutableMap.of(TEST_COLUMN, createIntegerColumnStatistics(
+                        OptionalLong.empty(),
+                        OptionalLong.empty(),
+                        OptionalLong.of(newStats.getLongStats().getNumNulls()),
+                        OptionalLong.of(newStats.getLongStats().getNumDVs() - 1))))
+                .build());
+        assertEquals(mockClient.getAccessCount(), 6);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -132,16 +132,6 @@ public class MockThriftMetastoreClient
         return data;
     }
 
-    private static ColumnStatisticsObj createTestStats()
-    {
-        ColumnStatisticsObj stats = new ColumnStatisticsObj();
-        ColumnStatisticsData data = new ColumnStatisticsData();
-        data.setLongStats(new LongColumnStatsData());
-        stats.setStatsData(data);
-        stats.setColName(TEST_COLUMN);
-        return stats;
-    }
-
     public void setThrowException(boolean throwException)
     {
         this.throwException = throwException;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -243,7 +243,7 @@ public class MockThriftMetastoreClient
                 0,
                 DEFAULT_STORAGE_DESCRIPTOR,
                 ImmutableList.of(new FieldSchema("key", "string", null)),
-                ImmutableMap.of(),
+                ImmutableMap.of("numRows", "2398040535435"),
                 "",
                 "",
                 TableType.MANAGED_TABLE.name());
@@ -363,7 +363,7 @@ public class MockThriftMetastoreClient
                 !ImmutableSet.of(TEST_PARTITION_VALUES1, TEST_PARTITION_VALUES2, TEST_PARTITION_VALUES3).contains(partitionValues)) {
             throw new NoSuchObjectException();
         }
-        return new Partition(partitionValues, TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of());
+        return new Partition(partitionValues, TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of("numRows", "2398040535435"));
     }
 
     @Override

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportIllNamedTest.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportIllNamedTest.java
@@ -18,7 +18,7 @@ import org.testng.ITestClass;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static io.trino.testng.services.Listeners.reportListenerFailure;
-import static io.trino.testng.services.ReportUnannotatedMethods.isTemptoClass;
+import static io.trino.testng.services.ReportBadTestAnnotations.isTemptoClass;
 
 public class ReportIllNamedTest
         implements IClassListener

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,8 +1,8 @@
 io.trino.testng.services.ManageTestResources
 io.trino.testng.services.ReportAfterMethodNotAlwaysRun
+io.trino.testng.services.ReportBadTestAnnotations
 io.trino.testng.services.ReportOrphanedExecutors
 io.trino.testng.services.ReportPrivateMethods
-io.trino.testng.services.ReportUnannotatedMethods
 io.trino.testng.services.ReportIllNamedTest
 io.trino.testng.services.ReportMultiThreadedBeforeOrAfterMethod
 io.trino.testng.services.LogTestDurationListener

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestFlakyAnnotationVerifier.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestFlakyAnnotationVerifier.java
@@ -73,7 +73,7 @@ public class TestFlakyAnnotationVerifier
     private static class TestNotTestMethodWithFlaky
     {
         @Flaky(issue = "Blah", match = "Blah")
-        @ReportUnannotatedMethods.Suppress
+        @ReportBadTestAnnotations.Suppress
         public void test() {}
     }
 

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportBadTestAnnotations.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportBadTestAnnotations.java
@@ -22,13 +22,14 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
-import static io.trino.testng.services.ReportUnannotatedMethods.findUnannotatedTestMethods;
-import static io.trino.testng.services.ReportUnannotatedMethods.isTemptoClass;
+import static io.trino.testng.services.ReportBadTestAnnotations.classWithMeaninglessTestAnnotation;
+import static io.trino.testng.services.ReportBadTestAnnotations.findUnannotatedTestMethods;
+import static io.trino.testng.services.ReportBadTestAnnotations.isTemptoClass;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class TestReportUnannotatedMethods
+public class TestReportBadTestAnnotations
 {
     @Test
     public void testTest()
@@ -73,6 +74,17 @@ public class TestReportUnannotatedMethods
                 .isEmpty();
         assertThat(findUnannotatedTestMethods(TestingTestWithSuppressedPublicMethodInInterface.class))
                 .isEmpty();
+    }
+
+    @Test
+    public void testClassLevelTestAnnotation()
+    {
+        assertThat(classWithMeaninglessTestAnnotation(TestingTestWithClassLevelTrivialAnnotation.class))
+                .contains(TestingTestWithClassLevelTrivialAnnotation.class);
+        assertThat(classWithMeaninglessTestAnnotation(TestingTestWithClassLevelUsefulAnnotation.class))
+                .isEmpty();
+        assertThat(classWithMeaninglessTestAnnotation(TestingTestInheritingFromBaseWithClassLevelTrivialAnnotation.class))
+                .contains(BaseClassWithClassLevelTrivialAnnotation.class);
     }
 
     private static class TestingTest
@@ -150,7 +162,7 @@ public class TestReportUnannotatedMethods
         @Test
         public void test() {}
 
-        @ReportUnannotatedMethods.Suppress
+        @ReportBadTestAnnotations.Suppress
         public void method() {}
     }
 
@@ -163,7 +175,34 @@ public class TestReportUnannotatedMethods
 
     private interface InterfaceWithSuppressedPublicMethod
     {
-        @ReportUnannotatedMethods.Suppress
+        @ReportBadTestAnnotations.Suppress
         default void method() {}
     }
+
+    @Test
+    @ReportBadTestAnnotations.Suppress
+    private static class TestingTestWithClassLevelTrivialAnnotation
+    {
+        @Test
+        public void test() {}
+    }
+
+    @Test(singleThreaded = true)
+    @ReportBadTestAnnotations.Suppress
+    private static class TestingTestWithClassLevelUsefulAnnotation
+    {
+        @Test
+        public void test() {}
+    }
+
+    @Test
+    private abstract static class BaseClassWithClassLevelTrivialAnnotation
+    {
+        @Test
+        public void test() {}
+    }
+
+    @ReportBadTestAnnotations.Suppress
+    private static class TestingTestInheritingFromBaseWithClassLevelTrivialAnnotation
+            extends BaseClassWithClassLevelTrivialAnnotation {}
 }


### PR DESCRIPTION
Refactor Delta flush_metadata_cache procedure so that it doesn't have to
rely on external state (the metastore) to drop the caches.

Follow-up to https://github.com/trinodb/trino/pull/17174#discussion_r1174008917
