### PR TITLE
Add wildcard example to GRANT sql statement

### DIFF
--- a/docs/src/main/sphinx/sql/grant.rst
+++ b/docs/src/main/sphinx/sql/grant.rst
@@ -48,6 +48,19 @@ Grant ``SELECT`` privilege on the table ``orders`` to everyone::
 
     GRANT SELECT ON orders TO ROLE PUBLIC;
 
+Grant ``SELECT`` privilege on all tables in a schema to user ``bob`` with a wildcard::
+
+    USE "catalog"."finance";
+    GRANT SELECT ON "*" TO ROLE bob;
+
+Grant ``SELECT`` privilege on all tables in a schema to user ``bob`` with a wildcard (alternate syntax)::
+
+    GRANT SELECT ON "catalog"."finance"."*" TO ROLE bob;
+
+GRANT ``SELECT`` privilege on all schemas in a cluster to user ``alice`` with a wildcard::
+
+    GRANT SELECT ON "catalog"."*"."*" TO ROLE alice;
+
 Limitations
 -----------
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I added a wildcard example to the documentation for the GRANT SQL statement.
It looks like wildcards also works on the REVOKE and DENY statements...
I'm wondering if this should be documented more globally, instead of on these individual pages. Maybe in the "SQL language" section? 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
