### PR TITLE
Expand details of per-connector FTE support

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -36,28 +36,23 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
 
 .. warning::
 
-  Setting ``retry-policy`` disables :ref:`write operations
-  <sql-write-operations>` with connectors that do not support fault-tolerant
-  execution of write operations, resulting in a "This connector does not support
-  query retries" error message.
+  Setting ``retry-policy`` may cause queries to fail with connectors that do not
+  explicitly support fault-tolerant execution, resulting in a "This connector
+  does not support query retries" error message.
 
   Support for fault-tolerant execution of SQL statements varies on a
-  per-connector basis:
+  per-connector basis, with more details in the documentation for each
+  connector. The following connectors support fault-tolerant execution:
 
-  * Fault-tolerant execution of :ref:`read operations <sql-read-operations>` is
-    supported by all connectors.
-  * Fault-tolerant execution of :ref:`write operations <sql-write-operations>`
-    is supported by the following connectors:
-
-    * :doc:`/connector/bigquery`
-    * :doc:`/connector/delta-lake`
-    * :doc:`/connector/hive`
-    * :doc:`/connector/iceberg`
-    * :doc:`/connector/mongodb`
-    * :doc:`/connector/mysql`
-    * :doc:`/connector/postgresql`
-    * :doc:`/connector/redshift`
-    * :doc:`/connector/sqlserver`
+  * :ref:`BigQuery connector <bigquery-fte-support>`
+  * :ref:`Delta Lake connector <delta-lake-fte-support>`
+  * :ref:`Hive connector <hive-fte-support>`
+  * :ref:`Iceberg connector <iceberg-fte-support>`
+  * :ref:`MongoDB connector <mongodb-fte-support>`
+  * :ref:`MySQL connector <mysql-fte-support>`
+  * :ref:`PostgreSQL connector <postgresql-fte-support>`
+  * :ref:`Redshift connector <redshift-fte-support>`
+  * :ref:`SQL Server connector <sqlserver-fte-support>`
 
 The following configuration properties control the behavior of fault-tolerant
 execution on a Trino cluster:

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -328,6 +328,14 @@ the following features:
 * :doc:`/sql/drop-schema`
 * :doc:`/sql/comment`
 
+.. _bigquery-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 

--- a/docs/src/main/sphinx/connector/delta-lake.rst
+++ b/docs/src/main/sphinx/connector/delta-lake.rst
@@ -722,6 +722,14 @@ directly or used in conditional statements.
 * ``$file_size``
     Size of the file for this row.
 
+.. _delta-lake-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1370,6 +1370,19 @@ functionality:
 * Support all Hive data types and correct mapping to Trino types
 * Ability to process custom UDFs
 
+.. _hive-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy
+on non-transactional tables.
+
+Read operations are supported with any retry policy on transactional tables.
+Write operations and ``CREATE TABLE ... AS`` operations are not supported with
+any retry policy on transactional tables.
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -1418,6 +1418,14 @@ has no information whether the underlying non-Iceberg tables have changed.
 Dropping a materialized view with :doc:`/sql/drop-materialized-view` removes
 the definition and the storage table.
 
+.. _iceberg-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Performance
 -----------
 

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -488,6 +488,14 @@ The connector supports ``ALTER TABLE RENAME TO``, ``ALTER TABLE ADD COLUMN``
 and ``ALTER TABLE DROP COLUMN`` operations.
 Other uses of ``ALTER TABLE`` are not supported.
 
+.. _mongodb-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -318,6 +318,14 @@ the following statements:
 
 .. include:: sql-delete-limitation.fragment
 
+.. _mysql-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -327,6 +327,14 @@ statements, the connector supports the following features:
 
 .. include:: alter-schema-limitation.fragment
 
+.. _postgresql-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -142,6 +142,14 @@ statements, the connector supports the following features:
 
 .. include:: alter-schema-limitation.fragment
 
+.. _redshift-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -331,6 +331,14 @@ supports the following features:
 
 .. include:: alter-table-limitation.fragment
 
+.. _sqlserver-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The fault-tolerant execution doc's previous assertion that read operations are supported by all connectors is false, as is the assertion that the QUERY retry policy does not cause any queries to fail. This PR adjusts the language for fault-tolerant execution accordingly, and adds sections to connectors describing FTE support (allowing for easier documentation if future connectors only support TASK vs QUERY, or retries of read vs write operations).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
