### PR TITLE
Add initial Azure TrinoFileSystem

### DIFF
--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>420-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-filesystem-azure</artifactId>
+    <name>trino-filesystem-azure</name>
+    <description>Trino Filesystem - Azure</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-memory-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.nimbusds</groupId>
+                    <artifactId>oauth2-oidc-sdk</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-blob</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-xml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-storage-file-datalake</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuth.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuth.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+
+public interface AzureAuth
+{
+    void setAuth(String storageAccount, BlobContainerClientBuilder builder);
+
+    void setAuth(String storageAccount, DataLakeServiceClientBuilder builder);
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKey.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKey.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class AzureAuthAccessKey
+        implements AzureAuth
+{
+    private final String accessKey;
+
+    @Inject
+    public AzureAuthAccessKey(AzureAuthAccessKeyConfig config)
+    {
+        this(config.getAccessKey());
+    }
+
+    public AzureAuthAccessKey(String accessKey)
+    {
+        this.accessKey = requireNonNull(accessKey, "accessKey is null");
+    }
+
+    @Override
+    public void setAuth(String storageAccount, BlobContainerClientBuilder builder)
+    {
+        builder.credential(new StorageSharedKeyCredential(storageAccount, accessKey));
+    }
+
+    @Override
+    public void setAuth(String storageAccount, DataLakeServiceClientBuilder builder)
+    {
+        builder.credential(new StorageSharedKeyCredential(storageAccount, accessKey));
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKeyConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKeyConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import javax.validation.constraints.NotEmpty;
+
+public class AzureAuthAccessKeyConfig
+{
+    private String accessKey;
+
+    @NotEmpty
+    public String getAccessKey()
+    {
+        return accessKey;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.access-key")
+    public AzureAuthAccessKeyConfig setAccessKey(String accessKey)
+    {
+        this.accessKey = accessKey;
+        return this;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKeyModule.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthAccessKeyModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class AzureAuthAccessKeyModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(AzureAuthAccessKeyConfig.class);
+        binder.bind(AzureAuth.class).to(AzureAuthAccessKey.class).in(Scopes.SINGLETON);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthConfig.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import javax.validation.constraints.NotEmpty;
+
+public class AzureAuthOAuthConfig
+{
+    private String clientEndpoint;
+    private String clientId;
+    private String clientSecret;
+
+    @NotEmpty
+    public String getClientEndpoint()
+    {
+        return clientEndpoint;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.oauth.endpoint")
+    public AzureAuthOAuthConfig setClientEndpoint(String clientEndpoint)
+    {
+        this.clientEndpoint = clientEndpoint;
+        return this;
+    }
+
+    @NotEmpty
+    public String getClientId()
+    {
+        return clientId;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.oauth.client-id")
+    public AzureAuthOAuthConfig setClientId(String clientId)
+    {
+        this.clientId = clientId;
+        return this;
+    }
+
+    @NotEmpty
+    public String getClientSecret()
+    {
+        return clientSecret;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.oauth.secret")
+    public AzureAuthOAuthConfig setClientSecret(String clientSecret)
+    {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthModule.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthModule.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class AzureAuthOAuthModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(AzureAuthOAuthConfig.class);
+        binder.bind(AzureAuth.class).to(AzureAuthOauth.class).in(Scopes.SINGLETON);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOauth.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOauth.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+
+import javax.inject.Inject;
+
+public class AzureAuthOauth
+        implements AzureAuth
+{
+    private final ClientSecretCredential credential;
+
+    @Inject
+    public AzureAuthOauth(AzureAuthOAuthConfig config)
+    {
+        this(config.getClientEndpoint(), config.getClientId(), config.getClientSecret());
+    }
+
+    public AzureAuthOauth(String clientEndpoint, String clientId, String clientSecret)
+    {
+        credential = new ClientSecretCredentialBuilder()
+                .authorityHost(clientEndpoint)
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build();
+    }
+
+    @Override
+    public void setAuth(String storageAccount, BlobContainerClientBuilder builder)
+    {
+        builder.credential(credential);
+    }
+
+    @Override
+    public void setAuth(String storageAccount, DataLakeServiceClientBuilder builder)
+    {
+        builder.credential(credential);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureBlobFileIterator.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureBlobFileIterator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.models.BlobItem;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Optional;
+
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.util.Objects.requireNonNull;
+
+final class AzureBlobFileIterator
+        implements FileIterator
+{
+    private final AzureLocation location;
+    private final Iterator<BlobItem> iterator;
+    private final String base;
+
+    AzureBlobFileIterator(AzureLocation location, Iterator<BlobItem> iterator)
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.iterator = requireNonNull(iterator, "iterator is null");
+        this.base = "abfs://%s%s.dfs.core.windows.net".formatted(
+                location.container().map(container -> container + "@").orElse(""),
+                location.account());
+    }
+
+    @Override
+    public boolean hasNext()
+            throws IOException
+    {
+        try {
+            return iterator.hasNext();
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", location);
+        }
+    }
+
+    @Override
+    public FileEntry next()
+            throws IOException
+    {
+        try {
+            BlobItem blobItem = iterator.next();
+            return new FileEntry(
+                    Location.of(base + "/" + blobItem.getName()),
+                    blobItem.getProperties().getContentLength(),
+                    blobItem.getProperties().getLastModified().toInstant(),
+                    Optional.empty());
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", location);
+        }
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureDataLakeFileIterator.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureDataLakeFileIterator.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.file.datalake.models.PathItem;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Optional;
+
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+
+final class AzureDataLakeFileIterator
+        implements FileIterator
+{
+    private final AzureLocation location;
+    private final Iterator<PathItem> iterator;
+    private final String base;
+
+    AzureDataLakeFileIterator(AzureLocation location, Iterator<PathItem> iterator)
+    {
+        this.location = location;
+        this.iterator = iterator;
+        this.base = "abfs://%s%s.dfs.core.windows.net".formatted(
+                location.container().map(container -> container + "@").orElse(""),
+                location.account());
+    }
+
+    @Override
+    public boolean hasNext()
+            throws IOException
+    {
+        try {
+            return iterator.hasNext();
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", location);
+        }
+    }
+
+    @Override
+    public FileEntry next()
+            throws IOException
+    {
+        try {
+            PathItem pathItem = iterator.next();
+            return new FileEntry(
+                    Location.of(base + "/" + pathItem.getName()),
+                    pathItem.getContentLength(),
+                    pathItem.getLastModified().toInstant(),
+                    Optional.empty());
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", location);
+        }
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.core.http.HttpClient;
+import com.azure.core.http.rest.PagedIterable;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.AccountKind;
+import com.azure.storage.blob.models.BlobItem;
+import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.models.StorageAccountInfo;
+import com.azure.storage.common.Utility;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import com.azure.storage.file.datalake.models.DataLakeRequestConditions;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.azure.storage.common.implementation.Constants.HeaderConstants.ETAG_WILDCARD;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
+
+public class AzureFileSystem
+        implements TrinoFileSystem
+{
+    private final HttpClient httpClient;
+    private final AzureAuth azureAuth;
+    private final int readBlockSizeBytes;
+    private final long writeBlockSizeBytes;
+    private final int maxWriteConcurrency;
+    private final long maxSingleUploadSizeBytes;
+
+    public AzureFileSystem(HttpClient httpClient, AzureAuth azureAuth, DataSize readBlockSize, DataSize writeBlockSize, int maxWriteConcurrency, DataSize maxSingleUploadSize)
+    {
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.azureAuth = requireNonNull(azureAuth, "azureAuth is null");
+        this.readBlockSizeBytes = toIntExact(readBlockSize.toBytes());
+        this.writeBlockSizeBytes = writeBlockSize.toBytes();
+        checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
+        this.maxWriteConcurrency = maxWriteConcurrency;
+        this.maxSingleUploadSizeBytes = maxSingleUploadSize.toBytes();
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location)
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        BlobClient client = createBlobClient(azureLocation);
+        return new AzureInputFile(azureLocation, OptionalLong.empty(), client, readBlockSizeBytes);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length)
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        BlobClient client = createBlobClient(azureLocation);
+        return new AzureInputFile(azureLocation, OptionalLong.of(length), client, readBlockSizeBytes);
+    }
+
+    @Override
+    public TrinoOutputFile newOutputFile(Location location)
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        BlobClient client = createBlobClient(azureLocation);
+        return new AzureOutputFile(azureLocation, client, writeBlockSizeBytes, maxWriteConcurrency, maxSingleUploadSizeBytes);
+    }
+
+    @Override
+    public void deleteFile(Location location)
+            throws IOException
+    {
+        location.verifyValidFileLocation();
+        AzureLocation azureLocation = new AzureLocation(location);
+        BlobClient client = createBlobClient(azureLocation);
+        try {
+            client.delete();
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "deleting file", azureLocation);
+        }
+    }
+
+    @Override
+    public void deleteDirectory(Location location)
+            throws IOException
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        try {
+            if (isHierarchicalNamespaceEnabled(azureLocation)) {
+                deleteGen2Directory(azureLocation);
+            }
+            else {
+                deleteBlobDirectory(azureLocation);
+            }
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "deleting directory", azureLocation);
+        }
+    }
+
+    private void deleteGen2Directory(AzureLocation location)
+            throws IOException
+    {
+        DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location);
+        DataLakePathDeleteOptions deleteRecursiveOptions = new DataLakePathDeleteOptions().setIsRecursive(true);
+        if (location.path().isEmpty()) {
+            for (PathItem pathItem : fileSystemClient.listPaths()) {
+                if (pathItem.isDirectory()) {
+                    fileSystemClient.deleteDirectoryIfExistsWithResponse(pathItem.getName(), deleteRecursiveOptions, null, null);
+                }
+                else {
+                    fileSystemClient.deleteFileIfExists(pathItem.getName());
+                }
+            }
+        }
+        else {
+            DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(location.path());
+            if (directoryClient.exists()) {
+                if (!directoryClient.getProperties().isDirectory()) {
+                    throw new IOException("Location is not a directory: " + location);
+                }
+                directoryClient.deleteIfExistsWithResponse(deleteRecursiveOptions, null, null);
+            }
+        }
+    }
+
+    private void deleteBlobDirectory(AzureLocation location)
+    {
+        String path = location.path();
+        if (!path.isEmpty() && !path.endsWith("/")) {
+            path += "/";
+        }
+        BlobContainerClient blobContainerClient = createBlobContainerClient(location);
+        PagedIterable<BlobItem> blobItems = blobContainerClient.listBlobs(new ListBlobsOptions().setPrefix(path), null);
+        for (BlobItem item : blobItems) {
+            String blobUrl = Utility.urlEncode(item.getName());
+            blobContainerClient.getBlobClient(blobUrl).deleteIfExists();
+        }
+    }
+
+    @Override
+    public void renameFile(Location source, Location target)
+            throws IOException
+    {
+        source.verifyValidFileLocation();
+        target.verifyValidFileLocation();
+
+        AzureLocation sourceLocation = new AzureLocation(source);
+        AzureLocation targetLocation = new AzureLocation(target);
+        if (!sourceLocation.account().equals(targetLocation.account())) {
+            throw new IOException("Cannot rename across storage accounts");
+        }
+        if (!Objects.equals(sourceLocation.container(), targetLocation.container())) {
+            throw new IOException("Cannot rename across storage account containers");
+        }
+
+        // DFS rename file works with all storage types
+        renameGen2File(sourceLocation, targetLocation);
+    }
+
+    private void renameGen2File(AzureLocation source, AzureLocation target)
+            throws IOException
+    {
+        try {
+            DataLakeFileSystemClient fileSystemClient = createFileSystemClient(source);
+            DataLakeFileClient dataLakeFileClient = fileSystemClient.getFileClient(source.path());
+            if (dataLakeFileClient.getProperties().isDirectory()) {
+                throw new IOException("Rename file from %s to %s, source is a directory".formatted(source, target));
+            }
+
+            fileSystemClient.createDirectoryIfNotExists(target.location().parentDirectory().path());
+            dataLakeFileClient.renameWithResponse(
+                    null,
+                    target.path(),
+                    null,
+                    new DataLakeRequestConditions().setIfNoneMatch(ETAG_WILDCARD),
+                    null,
+                    null);
+        }
+        catch (RuntimeException e) {
+            throw new IOException("Rename file from %s to %s failed".formatted(source, target), e);
+        }
+    }
+
+    @Override
+    public FileIterator listFiles(Location location)
+            throws IOException
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        try {
+            // blob api returns directories as blobs, so it can not be used when Gen2 is enabled
+            if (isHierarchicalNamespaceEnabled(azureLocation)) {
+                return listGen2Files(azureLocation);
+            }
+            else {
+                return listBlobFiles(azureLocation);
+            }
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "listing files", azureLocation);
+        }
+    }
+
+    private FileIterator listGen2Files(AzureLocation location)
+            throws IOException
+    {
+        DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location);
+        PagedIterable<PathItem> pathItems;
+        if (location.path().isEmpty()) {
+            pathItems = fileSystemClient.listPaths(new ListPathsOptions().setRecursive(true), null);
+        }
+        else {
+            DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(location.path());
+            if (!directoryClient.exists()) {
+                return FileIterator.empty();
+            }
+            if (!directoryClient.getProperties().isDirectory()) {
+                throw new IOException("Location is not a directory: " + location);
+            }
+            pathItems = directoryClient.listPaths(true, false, null, null);
+        }
+        return new AzureDataLakeFileIterator(
+                location,
+                pathItems.stream()
+                        .filter(not(PathItem::isDirectory))
+                        .iterator());
+    }
+
+    private AzureBlobFileIterator listBlobFiles(AzureLocation location)
+    {
+        String path = location.path();
+        if (!path.isEmpty() && !path.endsWith("/")) {
+            path += "/";
+        }
+        PagedIterable<BlobItem> blobItems = createBlobContainerClient(location).listBlobs(new ListBlobsOptions().setPrefix(path), null);
+        return new AzureBlobFileIterator(location, blobItems.iterator());
+    }
+
+    @Override
+    public Optional<Boolean> directoryExists(Location location)
+            throws IOException
+    {
+        AzureLocation azureLocation = new AzureLocation(location);
+        if (location.path().isEmpty()) {
+            return Optional.of(true);
+        }
+        if (!isHierarchicalNamespaceEnabled(azureLocation)) {
+            if (listFiles(location).hasNext()) {
+                return Optional.of(true);
+            }
+            return Optional.empty();
+        }
+
+        try {
+            DataLakeFileSystemClient fileSystemClient = createFileSystemClient(azureLocation);
+            DataLakeFileClient fileClient = fileSystemClient.getFileClient(azureLocation.path());
+            return Optional.of(fileClient.getProperties().isDirectory());
+        }
+        catch (DataLakeStorageException e) {
+            if (e.getStatusCode() == 404) {
+                return Optional.of(false);
+            }
+            throw handleAzureException(e, "checking directory existence", azureLocation);
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "checking directory existence", azureLocation);
+        }
+    }
+
+    private boolean isHierarchicalNamespaceEnabled(AzureLocation location)
+            throws IOException
+    {
+        StorageAccountInfo accountInfo = createBlobContainerClient(location).getServiceClient().getAccountInfo();
+
+        AccountKind accountKind = accountInfo.getAccountKind();
+        if (accountKind == AccountKind.BLOB_STORAGE) {
+            return false;
+        }
+        if (accountKind != AccountKind.STORAGE_V2) {
+            throw new IOException("Unsupported account kind '%s': %s".formatted(accountKind, location));
+        }
+        return accountInfo.isHierarchicalNamespaceEnabled();
+    }
+
+    private BlobClient createBlobClient(AzureLocation location)
+    {
+        // encode the path using the Azure url encoder utility
+        String path = Utility.urlEncode(location.path());
+        return createBlobContainerClient(location).getBlobClient(path);
+    }
+
+    private BlobContainerClient createBlobContainerClient(AzureLocation location)
+    {
+        requireNonNull(location, "location is null");
+
+        BlobContainerClientBuilder builder = new BlobContainerClientBuilder()
+                .httpClient(httpClient)
+                .endpoint(String.format("https://%s.blob.core.windows.net", location.account()));
+        azureAuth.setAuth(location.account(), builder);
+        location.container().ifPresent(builder::containerName);
+        return builder.buildClient();
+    }
+
+    private DataLakeFileSystemClient createFileSystemClient(AzureLocation location)
+    {
+        requireNonNull(location, "location is null");
+
+        DataLakeServiceClientBuilder builder = new DataLakeServiceClientBuilder()
+                .httpClient(httpClient)
+                .endpoint(String.format("https://%s.dfs.core.windows.net", location.account()));
+        azureAuth.setAuth(location.account(), builder);
+        DataLakeServiceClient client = builder.buildClient();
+        DataLakeFileSystemClient fileSystemClient = client.getFileSystemClient(location.container().orElseThrow());
+        if (!fileSystemClient.exists()) {
+            throw new IllegalArgumentException();
+        }
+        return fileSystemClient;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+
+import javax.validation.constraints.NotNull;
+
+public class AzureFileSystemConfig
+{
+    public enum AuthType
+    {
+        ACCESS_KEY,
+        OAUTH,
+        NONE
+    }
+
+    private AuthType authType = AuthType.NONE;
+
+    private DataSize readBlockSize = DataSize.of(4, Unit.MEGABYTE);
+    private DataSize writeBlockSize = DataSize.of(4, Unit.MEGABYTE);
+    private int maxWriteConcurrency = 8;
+    private DataSize maxSingleUploadSize = DataSize.of(4, Unit.MEGABYTE);
+
+    @NotNull
+    public AuthType getAuthType()
+    {
+        return authType;
+    }
+
+    @Config("azure.auth-type")
+    public AzureFileSystemConfig setAuthType(AuthType authType)
+    {
+        this.authType = authType;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getReadBlockSize()
+    {
+        return readBlockSize;
+    }
+
+    @Config("azure.read-block-size")
+    public AzureFileSystemConfig setReadBlockSize(DataSize readBlockSize)
+    {
+        this.readBlockSize = readBlockSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getWriteBlockSize()
+    {
+        return writeBlockSize;
+    }
+
+    @Config("azure.write-block-size")
+    public AzureFileSystemConfig setWriteBlockSize(DataSize writeBlockSize)
+    {
+        this.writeBlockSize = writeBlockSize;
+        return this;
+    }
+
+    @NotNull
+    public int getMaxWriteConcurrency()
+    {
+        return maxWriteConcurrency;
+    }
+
+    @Config("azure.max-write-concurrency")
+    public AzureFileSystemConfig setMaxWriteConcurrency(int maxWriteConcurrency)
+    {
+        this.maxWriteConcurrency = maxWriteConcurrency;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxSingleUploadSize()
+    {
+        return maxSingleUploadSize;
+    }
+
+    @Config("azure.max-single-upload-size")
+    public AzureFileSystemConfig setMaxSingleUploadSize(DataSize maxSingleUploadSize)
+    {
+        this.maxSingleUploadSize = maxSingleUploadSize;
+        return this;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.core.http.HttpClient;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+
+import javax.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class AzureFileSystemFactory
+        implements TrinoFileSystemFactory
+{
+    // All file systems share a single HTTP client
+    private final HttpClient httpClient = HttpClient.createDefault();
+
+    private final AzureAuth auth;
+    private final DataSize readBlockSize;
+    private final DataSize writeBlockSize;
+    private final int maxWriteConcurrency;
+    private final DataSize maxSingleUploadSize;
+
+    @Inject
+    public AzureFileSystemFactory(AzureAuth azureAuth, AzureFileSystemConfig config)
+    {
+        this(
+                azureAuth,
+                config.getReadBlockSize(),
+                config.getWriteBlockSize(),
+                config.getMaxWriteConcurrency(),
+                config.getMaxSingleUploadSize());
+    }
+
+    public AzureFileSystemFactory(AzureAuth azureAuth, DataSize readBlockSize, DataSize writeBlockSize, int maxWriteConcurrency, DataSize maxSingleUploadSize)
+    {
+        this.auth = requireNonNull(azureAuth, "azureAuth is null");
+        this.readBlockSize = requireNonNull(readBlockSize, "readBlockSize is null");
+        this.writeBlockSize = requireNonNull(writeBlockSize, "writeBlockSize is null");
+        checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
+        this.maxWriteConcurrency = maxWriteConcurrency;
+        this.maxSingleUploadSize = requireNonNull(maxSingleUploadSize, "maxSingleUploadSize is null");
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity)
+    {
+        return new AzureFileSystem(httpClient, auth, readBlockSize, writeBlockSize, maxWriteConcurrency, maxSingleUploadSize);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemModule.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemModule.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+
+public class AzureFileSystemModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        Module module = switch (buildConfigObject(AzureFileSystemConfig.class).getAuthType()) {
+            case ACCESS_KEY -> new AzureAuthAccessKeyModule();
+            case OAUTH -> new AzureAuthOAuthModule();
+            case NONE -> EMPTY_MODULE;
+        };
+        install(module);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInput.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInput.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobRange;
+import com.azure.storage.blob.options.BlobInputStreamOptions;
+import com.azure.storage.blob.specialized.BlobInputStream;
+import io.trino.filesystem.TrinoInput;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+class AzureInput
+        implements TrinoInput
+{
+    private final AzureLocation location;
+    private final BlobClient blobClient;
+    private final int readBlockSize;
+    private OptionalLong length;
+    private boolean closed;
+
+    public AzureInput(AzureLocation location, BlobClient blobClient, int readBlockSize, OptionalLong length)
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.blobClient = requireNonNull(blobClient, "blobClient is null");
+        checkArgument(readBlockSize >= 0, "readBlockSize is negative");
+        this.readBlockSize = readBlockSize;
+        this.length = requireNonNull(length, "length is null");
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+        if (bufferLength == 0) {
+            return;
+        }
+
+        BlobInputStreamOptions options = new BlobInputStreamOptions()
+                .setRange(new BlobRange(position, (long) bufferLength))
+                .setBlockSize(readBlockSize);
+        try (BlobInputStream blobInputStream = blobClient.openInputStream(options)) {
+            long fileSize = blobInputStream.getProperties().getBlobSize();
+            if (position >= fileSize) {
+                throw new IOException("Cannot read at %s. File size is %s: %s".formatted(position, fileSize, location));
+            }
+
+            int readSize = blobInputStream.readNBytes(buffer, bufferOffset, bufferLength);
+            if (readSize != bufferLength) {
+                throw new EOFException("End of file reached before reading fully: " + location);
+            }
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "reading file", location);
+        }
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+
+        try {
+            if (length.isEmpty()) {
+                length = OptionalLong.of(blobClient.getProperties().getBlobSize());
+            }
+            BlobInputStreamOptions options = new BlobInputStreamOptions()
+                    .setRange(new BlobRange(length.orElseThrow() - bufferLength))
+                    .setBlockSize(readBlockSize);
+            try (BlobInputStream blobInputStream = blobClient.openInputStream(options)) {
+                return blobInputStream.readNBytes(buffer, bufferOffset, bufferLength);
+            }
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "reading file", location);
+        }
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Output stream closed: " + location);
+        }
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+    }
+
+    @Override
+    public String toString()
+    {
+        return location.toString();
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputFile.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobProperties;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.util.Objects.requireNonNull;
+
+class AzureInputFile
+        implements TrinoInputFile
+{
+    private final AzureLocation location;
+    private final BlobClient blobClient;
+    private final int readBlockSizeBytes;
+
+    private OptionalLong length;
+    private Optional<Instant> lastModified = Optional.empty();
+
+    public AzureInputFile(AzureLocation location, OptionalLong length, BlobClient blobClient, int readBlockSizeBytes)
+    {
+        this.location = requireNonNull(location, "location is null");
+        location.location().verifyValidFileLocation();
+        this.length = requireNonNull(length, "length is null");
+        this.blobClient = requireNonNull(blobClient, "blobClient is null");
+        checkArgument(readBlockSizeBytes >= 0, "readBlockSizeBytes is negative");
+        this.readBlockSizeBytes = readBlockSizeBytes;
+    }
+
+    @Override
+    public Location location()
+    {
+        return location.location();
+    }
+
+    @Override
+    public boolean exists()
+    {
+        return blobClient.exists();
+    }
+
+    @Override
+    public TrinoInputStream newStream()
+            throws IOException
+    {
+        return new AzureInputStream(location, blobClient, readBlockSizeBytes);
+    }
+
+    @Override
+    public TrinoInput newInput()
+            throws IOException
+    {
+        try {
+            return new AzureInput(location, blobClient, readBlockSizeBytes, length);
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "opening file", location);
+        }
+    }
+
+    @Override
+    public Instant lastModified()
+            throws IOException
+    {
+        if (lastModified.isEmpty()) {
+            loadProperties();
+        }
+        return lastModified.orElseThrow();
+    }
+
+    @Override
+    public long length()
+            throws IOException
+    {
+        if (length.isEmpty()) {
+            loadProperties();
+        }
+        return length.orElseThrow();
+    }
+
+    private void loadProperties()
+            throws IOException
+    {
+        BlobProperties properties;
+        try {
+            properties = blobClient.getProperties();
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "fetching properties for file", location);
+        }
+        if (length.isEmpty()) {
+            length = OptionalLong.of(properties.getBlobSize());
+        }
+        if (lastModified.isEmpty()) {
+            lastModified = Optional.of(properties.getLastModified().toInstant());
+        }
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputStream.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureInputStream.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobRange;
+import com.azure.storage.blob.options.BlobInputStreamOptions;
+import com.azure.storage.blob.specialized.BlobInputStream;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.primitives.Longs.constrainToRange;
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+class AzureInputStream
+        extends TrinoInputStream
+{
+    private final AzureLocation location;
+    private final BlobClient blobClient;
+    private final int readBlockSizeBytes;
+    private final long fileSize;
+
+    private BlobInputStream stream;
+    private long currentPosition;
+    private long nextPosition;
+    private boolean closed;
+
+    public AzureInputStream(AzureLocation location, BlobClient blobClient, int readBlockSizeBytes)
+            throws IOException
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.blobClient = requireNonNull(blobClient, "blobClient is null");
+        checkArgument(readBlockSizeBytes >= 0, "readBlockSizeBytes is negative");
+        this.readBlockSizeBytes = readBlockSizeBytes;
+        openStream(0);
+        fileSize = stream.getProperties().getBlobSize();
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+        repositionStream();
+        return stream.available();
+    }
+
+    @Override
+    public long getPosition()
+    {
+        return nextPosition;
+    }
+
+    @Override
+    public void seek(long newPosition)
+            throws IOException
+    {
+        ensureOpen();
+        if (newPosition < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (newPosition > fileSize) {
+            throw new IOException("Cannot seek to %s. File size is %s: %s".formatted(newPosition, fileSize, location));
+        }
+        nextPosition = newPosition;
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+        repositionStream();
+
+        try {
+            int value = stream.read();
+            if (value >= 0) {
+                currentPosition++;
+                nextPosition++;
+            }
+            return value;
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "reading file", location);
+        }
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        checkFromIndexSize(offset, length, buffer.length);
+
+        ensureOpen();
+        repositionStream();
+
+        try {
+            int readSize = stream.read(buffer, offset, length);
+            if (readSize > 0) {
+                currentPosition += readSize;
+                nextPosition += readSize;
+            }
+            return readSize;
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "reading file", location);
+        }
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        ensureOpen();
+
+        long skipSize = constrainToRange(n, 0, fileSize - nextPosition);
+        nextPosition += skipSize;
+        return skipSize;
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        ensureOpen();
+        if (n <= 0) {
+            return;
+        }
+
+        long position = nextPosition + n;
+        if ((position < 0) || (position > fileSize)) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, nextPosition, fileSize, location));
+        }
+        nextPosition = position;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Output stream closed: " + location);
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            try {
+                stream.close();
+            }
+            catch (RuntimeException e) {
+                throw handleAzureException(e, "closing file", location);
+            }
+        }
+    }
+
+    private void openStream(long offset)
+            throws IOException
+    {
+        try {
+            BlobInputStreamOptions options = new BlobInputStreamOptions()
+                    .setRange(new BlobRange(offset))
+                    .setBlockSize(readBlockSizeBytes);
+            stream = blobClient.openInputStream(options);
+            currentPosition = offset;
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "reading file", location);
+        }
+    }
+
+    private void repositionStream()
+            throws IOException
+    {
+        if (nextPosition == currentPosition) {
+            return;
+        }
+
+        if (nextPosition > currentPosition) {
+            long bytesToSkip = nextPosition - currentPosition;
+            // this always works because the client simply moves a counter forward and
+            // preforms the reposition on the next actual read
+            stream.skipNBytes(bytesToSkip);
+        }
+        else {
+            stream.close();
+            openStream(nextPosition);
+        }
+
+        currentPosition = nextPosition;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureLocation.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.common.base.CharMatcher;
+import io.trino.filesystem.Location;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+class AzureLocation
+{
+    private static final String INVALID_LOCATION_MESSAGE = "Invalid Azure location. Expected form is 'abfs://[<containerName>@]<accountName>.dfs.core.windows.net/<filePath>': %s";
+
+    // https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
+    private static final CharMatcher CONTAINER_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9')).or(CharMatcher.is('-'));
+    private static final CharMatcher STORAGE_ACCOUNT_VALID_CHARACTERS = CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9'));
+
+    private final Location location;
+    private final String account;
+
+    public AzureLocation(Location location)
+    {
+        this.location = requireNonNull(location, "location is null");
+        // abfss is also supported but not documented
+        String scheme = location.scheme().orElseThrow(() -> new IllegalArgumentException(String.format(INVALID_LOCATION_MESSAGE, location)));
+        checkArgument("abfs".equals(scheme) || "abfss".equals(scheme), INVALID_LOCATION_MESSAGE, location);
+
+        // container is interpolated into the URL path, so perform extra checks
+        location.userInfo().ifPresent(container -> {
+            checkArgument(!container.isEmpty(), INVALID_LOCATION_MESSAGE, location);
+            checkArgument(
+                    CONTAINER_VALID_CHARACTERS.matchesAllOf(container),
+                    "Invalid Azure storage container name. Valid characters are 'a-z', '0-9', and '-': %s",
+                    location);
+            checkArgument(
+                    !container.startsWith("-") && !container.endsWith("-"),
+                    "Invalid Azure storage container name. Cannot start or end with a hyphen: %s",
+                    location);
+            checkArgument(
+                    !container.contains("--"),
+                    "Invalid Azure storage container name. Cannot contain consecutive hyphens: %s",
+                    location);
+        });
+
+        // storage account is the first label of the host
+        checkArgument(location.host().isPresent(), INVALID_LOCATION_MESSAGE, location);
+        String host = location.host().get();
+        int accountSplit = host.indexOf('.');
+        checkArgument(
+                accountSplit > 0,
+                INVALID_LOCATION_MESSAGE,
+                this.location);
+        this.account = host.substring(0, accountSplit);
+
+        // host must end with ".dfs.core.windows.net"
+        checkArgument(host.substring(accountSplit).equals(".dfs.core.windows.net"), INVALID_LOCATION_MESSAGE, location);
+
+        // storage account is interpolated into URL host name, so perform extra checks
+        checkArgument(STORAGE_ACCOUNT_VALID_CHARACTERS.matchesAllOf(account),
+                "Invalid Azure storage account name. Valid characters are 'a-z' and '0-9': %s",
+                location);
+    }
+
+    /**
+     * Creates a new {@link AzureLocation} based on the storage account, container and blob path parsed from the location.
+     * <p>
+     * Locations follow the conventions used by
+     * <a href="https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri">ABFS URI</a>
+     * that follows the following convention
+     * <pre>{@code abfs://<container-name>@<storage-account-name>.dfs.core.windows.net/<blob_path>}</pre>
+     */
+    public static AzureLocation from(String location)
+    {
+        return new AzureLocation(Location.of(location));
+    }
+
+    public Location location()
+    {
+        return location;
+    }
+
+    public Optional<String> container()
+    {
+        return location.userInfo();
+    }
+
+    public String account()
+    {
+        return account;
+    }
+
+    public String path()
+    {
+        return location.path();
+    }
+
+    @Override
+    public String toString()
+    {
+        return location.toString();
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobClient;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.FileAlreadyExistsException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+class AzureOutputFile
+        implements TrinoOutputFile
+{
+    private final AzureLocation location;
+    private final BlobClient blobClient;
+    private final long writeBlockSizeBytes;
+    private final int maxWriteConcurrency;
+    private final long maxSingleUploadSizeBytes;
+
+    public AzureOutputFile(AzureLocation location, BlobClient blobClient, long writeBlockSizeBytes, int maxWriteConcurrency, long maxSingleUploadSizeBytes)
+    {
+        this.location = requireNonNull(location, "location is null");
+        location.location().verifyValidFileLocation();
+        this.blobClient = requireNonNull(blobClient, "blobClient is null");
+        checkArgument(writeBlockSizeBytes >= 0, "writeBlockSizeBytes is negative");
+        this.writeBlockSizeBytes = writeBlockSizeBytes;
+        checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
+        this.maxWriteConcurrency = maxWriteConcurrency;
+        checkArgument(maxSingleUploadSizeBytes >= 0, "maxSingleUploadSizeBytes is negative");
+        this.maxSingleUploadSizeBytes = maxSingleUploadSizeBytes;
+    }
+
+    public boolean exists()
+    {
+        return blobClient.exists();
+    }
+
+    @Override
+    public OutputStream create(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        // Azure can enforce that the file is not overwritten, but it only enforces this during data upload.
+        // Check here and then set the stream to check again when data is uploaded just to be sure.
+        if (exists()) {
+            throw new FileAlreadyExistsException(location.toString());
+        }
+        return createOutputStream(memoryContext, false);
+    }
+
+    @Override
+    public OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        return createOutputStream(memoryContext, true);
+    }
+
+    private AzureOutputStream createOutputStream(AggregatedMemoryContext memoryContext, boolean overwrite)
+            throws IOException
+    {
+        return new AzureOutputStream(location, blobClient, overwrite, memoryContext, writeBlockSizeBytes, maxWriteConcurrency, maxSingleUploadSizeBytes);
+    }
+
+    @Override
+    public Location location()
+    {
+        return location.location();
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputStream.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputStream.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.ParallelTransferOptions;
+import com.azure.storage.blob.options.BlockBlobOutputStreamOptions;
+import com.azure.storage.common.implementation.Constants.HeaderConstants;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.filesystem.azure.AzureUtils.handleAzureException;
+import static java.lang.Math.min;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+class AzureOutputStream
+        extends OutputStream
+{
+    private static final int BUFFER_SIZE = 8192;
+
+    private final AzureLocation location;
+    private final long writeBlockSizeBytes;
+    private final OutputStream stream;
+    private final LocalMemoryContext memoryContext;
+    private long writtenBytes;
+    private boolean closed;
+
+    public AzureOutputStream(
+            AzureLocation location,
+            BlobClient blobClient,
+            boolean overwrite,
+            AggregatedMemoryContext memoryContext,
+            long writeBlockSizeBytes,
+            int maxWriteConcurrency,
+            long maxSingleUploadSizeBytes)
+            throws IOException
+    {
+        requireNonNull(location, "location is null");
+        requireNonNull(blobClient, "blobClient is null");
+        checkArgument(writeBlockSizeBytes >= 0, "writeBlockSizeBytes is negative");
+        checkArgument(maxWriteConcurrency >= 0, "maxWriteConcurrency is negative");
+        checkArgument(maxSingleUploadSizeBytes >= 0, "maxSingleUploadSizeBytes is negative");
+
+        this.location = location;
+        this.writeBlockSizeBytes = writeBlockSizeBytes;
+        BlockBlobOutputStreamOptions streamOptions = new BlockBlobOutputStreamOptions();
+        streamOptions.setParallelTransferOptions(new ParallelTransferOptions()
+                .setBlockSizeLong(writeBlockSizeBytes)
+                .setMaxConcurrency(maxWriteConcurrency)
+                .setMaxSingleUploadSizeLong(maxSingleUploadSizeBytes));
+        if (!overwrite) {
+            // This is not enforced until data is written
+            streamOptions.setRequestConditions(new BlobRequestConditions().setIfNoneMatch(HeaderConstants.ETAG_WILDCARD));
+        }
+
+        try {
+            // TODO It is not clear if the buffered stream helps or hurts... the underlying implementation seems to copy every write to a byte buffer so small writes will suffer
+            stream = new BufferedOutputStream(blobClient.getBlockBlobClient().getBlobOutputStream(streamOptions), BUFFER_SIZE);
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "creating file", location);
+        }
+
+        // TODO to track memory we will need to fork com.azure.storage.blob.specialized.BlobOutputStream.BlockBlobOutputStream
+        this.memoryContext = memoryContext.newLocalMemoryContext(AzureOutputStream.class.getSimpleName());
+        this.memoryContext.setBytes(BUFFER_SIZE);
+    }
+
+    @Override
+    public void write(int b)
+            throws IOException
+    {
+        ensureOpen();
+        try {
+            stream.write(b);
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "writing file", location);
+        }
+        recordBytesWritten(1);
+    }
+
+    @Override
+    public void write(byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        checkFromIndexSize(offset, length, buffer.length);
+
+        ensureOpen();
+        try {
+            stream.write(buffer, offset, length);
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "writing file", location);
+        }
+        recordBytesWritten(length);
+    }
+
+    @Override
+    public void flush()
+            throws IOException
+    {
+        ensureOpen();
+        try {
+            stream.flush();
+        }
+        catch (RuntimeException e) {
+            throw handleAzureException(e, "writing file", location);
+        }
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Output stream closed: " + location);
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            try {
+                stream.close();
+            }
+            catch (IOException e) {
+                // Azure close sometimes rethrows IOExceptions from worker threads, so the
+                // stack traces are disconnected from this call. Wrapping here solves that problem.
+                throw new IOException("Error closing file: " + location, e);
+            }
+            finally {
+                memoryContext.close();
+            }
+        }
+    }
+
+    private void recordBytesWritten(int size)
+    {
+        if (writtenBytes < writeBlockSizeBytes) {
+            // assume that there is only one pending block buffer, and that it grows as written bytes grow
+            memoryContext.setBytes(BUFFER_SIZE + min(writtenBytes + size, writeBlockSizeBytes));
+        }
+        writtenBytes += size;
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureUtils.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.core.exception.AzureException;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+final class AzureUtils
+{
+    private AzureUtils() {}
+
+    public static IOException handleAzureException(RuntimeException exception, String action, AzureLocation location)
+            throws IOException
+    {
+        if (exception instanceof BlobStorageException blobStorageException) {
+            if (BlobErrorCode.BLOB_NOT_FOUND.equals(blobStorageException.getErrorCode())) {
+                throw new FileNotFoundException(location.toString());
+            }
+        }
+        if (exception instanceof DataLakeStorageException dataLakeStorageException) {
+            if ("PathNotFound".equals(dataLakeStorageException.getErrorCode())) {
+                throw new FileNotFoundException(location.toString());
+            }
+        }
+        if (exception instanceof AzureException) {
+            throw new IOException("Azure service error %s file: %s".formatted(action, location), exception);
+        }
+        throw new IOException("Error %s file: %s".formatted(action, location), exception);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.StorageAccountInfo;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.IOException;
+
+import static com.azure.storage.common.Utility.urlEncode;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Locale.ROOT;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public abstract class AbstractTestAzureFileSystem
+        extends AbstractTestTrinoFileSystem
+{
+    protected static String getRequiredEnvironmentVariable(String name)
+    {
+        return requireNonNull(System.getenv(name), "Environment variable not set: " + name);
+    }
+
+    enum AccountKind
+    {
+        HIERARCHICAL, FLAT, BLOB
+    }
+
+    private String account;
+    private StorageSharedKeyCredential credential;
+    private AccountKind accountKind;
+    private String containerName;
+    private Location rootLocation;
+    private BlobContainerClient blobContainerClient;
+    private TrinoFileSystem fileSystem;
+
+    protected void initialize(String account, String accountKey, AccountKind expectedAccountKind)
+            throws IOException
+    {
+        this.account = account;
+        credential = new StorageSharedKeyCredential(account, accountKey);
+
+        String blobEndpoint = "https://%s.blob.core.windows.net".formatted(account);
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .endpoint(blobEndpoint)
+                .credential(credential)
+                .buildClient();
+        accountKind = getAccountKind(blobServiceClient);
+        checkState(accountKind == expectedAccountKind, "Expected %s account, but found %s".formatted(expectedAccountKind, accountKind));
+
+        containerName = "test-%s-%s".formatted(accountKind.name().toLowerCase(ROOT), randomUUID());
+        rootLocation = Location.of("abfs://%s@%s.dfs.core.windows.net".formatted(containerName, account));
+
+        blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
+        // this will fail if the container already exists, which is what we want
+        blobContainerClient.create();
+
+        fileSystem = new AzureFileSystemFactory(new AzureAuthAccessKey(accountKey), new AzureFileSystemConfig()).create(ConnectorIdentity.ofUser("test"));
+
+        cleanupFiles();
+    }
+
+    private static AccountKind getAccountKind(BlobServiceClient blobServiceClient)
+            throws IOException
+    {
+        StorageAccountInfo accountInfo = blobServiceClient.getAccountInfo();
+        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.STORAGE_V2) {
+            if (accountInfo.isHierarchicalNamespaceEnabled()) {
+                return AccountKind.HIERARCHICAL;
+            }
+            return AccountKind.FLAT;
+        }
+        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.BLOB_STORAGE) {
+            return AccountKind.BLOB;
+        }
+        throw new IOException("Unsupported account kind '%s'".formatted(accountInfo.getAccountKind()));
+    }
+
+    @AfterAll
+    void tearDown()
+    {
+        credential = null;
+        fileSystem = null;
+        if (blobContainerClient != null) {
+            blobContainerClient.deleteIfExists();
+            blobContainerClient = null;
+        }
+    }
+
+    @AfterEach
+    void afterEach()
+    {
+        cleanupFiles();
+    }
+
+    private void cleanupFiles()
+    {
+        if (accountKind == AccountKind.HIERARCHICAL) {
+            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClientBuilder()
+                    .endpoint("https://%s.dfs.core.windows.net".formatted(account))
+                    .fileSystemName(containerName)
+                    .credential(credential)
+                    .buildClient();
+
+            DataLakePathDeleteOptions deleteRecursiveOptions = new DataLakePathDeleteOptions().setIsRecursive(true);
+            for (PathItem pathItem : fileSystemClient.listPaths()) {
+                if (pathItem.isDirectory()) {
+                    fileSystemClient.deleteDirectoryIfExistsWithResponse(pathItem.getName(), deleteRecursiveOptions, null, null);
+                }
+                else {
+                    fileSystemClient.deleteFileIfExists(pathItem.getName());
+                }
+            }
+        }
+        else {
+            blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(urlEncode(item.getName())).deleteIfExists());
+        }
+    }
+
+    @Override
+    protected final boolean isHierarchical()
+    {
+        return accountKind == AccountKind.HIERARCHICAL;
+    }
+
+    @Override
+    protected final TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected final Location getRootLocation()
+    {
+        return rootLocation;
+    }
+
+    @Override
+    protected final void verifyFileSystemIsEmpty()
+    {
+        assertThat(blobContainerClient.listBlobs()).isEmpty();
+    }
+
+    @Test
+    void testPaths()
+            throws IOException
+    {
+        // Azure file paths are always hierarchical
+        testPathHierarchical();
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthAccessKeyConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthAccessKeyConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+class TestAzureAuthAccessKeyConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AzureAuthAccessKeyConfig.class)
+                .setAccessKey(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("azure.access-key", "secret")
+                .buildOrThrow();
+
+        AzureAuthAccessKeyConfig expected = new AzureAuthAccessKeyConfig()
+                .setAccessKey("secret");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthOAuthConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthOAuthConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+class TestAzureAuthOAuthConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AzureAuthOAuthConfig.class)
+                .setClientEndpoint(null)
+                .setClientId(null)
+                .setClientSecret(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("azure.oauth.endpoint", "endpoint")
+                .put("azure.oauth.client-id", "clientId")
+                .put("azure.oauth.secret", "secret")
+                .buildOrThrow();
+
+        AzureAuthOAuthConfig expected = new AzureAuthOAuthConfig()
+                .setClientEndpoint("endpoint")
+                .setClientId("clientId")
+                .setClientSecret("secret");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemBlob.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemBlob.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.IOException;
+
+import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.BLOB;
+
+@EnabledIfEnvironmentVariable(named = "ABFS_BLOB_ACCOUNT", matches = ".+")
+@TestInstance(Lifecycle.PER_CLASS)
+class TestAzureFileSystemBlob
+        extends AbstractTestAzureFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        initialize(getRequiredEnvironmentVariable("ABFS_BLOB_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_BLOB_ACCESS_KEY"), BLOB);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+import io.trino.filesystem.azure.AzureFileSystemConfig.AuthType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+class TestAzureFileSystemConfig
+{
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AzureFileSystemConfig.class)
+                .setAuthType(AuthType.NONE)
+                .setReadBlockSize(DataSize.of(4, Unit.MEGABYTE))
+                .setWriteBlockSize(DataSize.of(4, Unit.MEGABYTE))
+                .setMaxWriteConcurrency(8)
+                .setMaxSingleUploadSize(DataSize.of(4, Unit.MEGABYTE)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("azure.auth-type", "oauth")
+                .put("azure.read-block-size", "3MB")
+                .put("azure.write-block-size", "5MB")
+                .put("azure.max-write-concurrency", "7")
+                .put("azure.max-single-upload-size", "7MB")
+                .buildOrThrow();
+
+        AzureFileSystemConfig expected = new AzureFileSystemConfig()
+                .setAuthType(AuthType.OAUTH)
+                .setReadBlockSize(DataSize.of(3, Unit.MEGABYTE))
+                .setWriteBlockSize(DataSize.of(5, Unit.MEGABYTE))
+                .setMaxWriteConcurrency(7)
+                .setMaxSingleUploadSize(DataSize.of(7, Unit.MEGABYTE));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.IOException;
+
+import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.FLAT;
+
+@EnabledIfEnvironmentVariable(named = "ABFS_FLAT_ACCOUNT", matches = ".+")
+@TestInstance(Lifecycle.PER_CLASS)
+class TestAzureFileSystemGen2Flat
+        extends AbstractTestAzureFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        initialize(getRequiredEnvironmentVariable("ABFS_FLAT_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_FLAT_ACCESS_KEY"), FLAT);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import java.io.IOException;
+
+import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.HIERARCHICAL;
+
+@EnabledIfEnvironmentVariable(named = "ABFS_ACCOUNT", matches = ".+")
+@TestInstance(Lifecycle.PER_CLASS)
+class TestAzureFileSystemGen2Hierarchical
+        extends AbstractTestAzureFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        initialize(getRequiredEnvironmentVariable("ABFS_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_ACCESS_KEY"), HIERARCHICAL);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureLocation.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import io.trino.filesystem.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestAzureLocation
+{
+    @Test
+    void test()
+    {
+        assertValid("abfs://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file");
+        assertValid("abfss://container@account.dfs.core.windows.net/some/path/file", "account", "container", "some/path/file");
+
+        assertValid("abfs://container-stuff@account.dfs.core.windows.net/some/path/file", "account", "container-stuff", "some/path/file");
+        assertValid("abfs://container2@account.dfs.core.windows.net/some/path/file", "account", "container2", "some/path/file");
+        assertValid("abfs://account.dfs.core.windows.net/some/path/file", "account", null, "some/path/file");
+
+        assertValid("abfs://container@account.dfs.core.windows.net/file", "account", "container", "file");
+        assertValid("abfs://container@account0.dfs.core.windows.net///f///i///l///e///", "account0", "container", "//f///i///l///e///");
+
+        // only abfs and abfss schemes allowed
+        assertInvalid("https://container@account.dfs.core.windows.net/some/path/file");
+        // host must have at least to labels
+        assertInvalid("abfs://container@account/some/path/file");
+        assertInvalid("abfs://container@/some/path/file");
+
+        // schema and authority are required
+        assertInvalid("abfs:///some/path/file");
+        assertInvalid("/some/path/file");
+
+        // container is only a-z, 0-9, and dash, and cannot start or end with dash or contain consecutive dashes
+        assertInvalid("abfs://ConTainer@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://con_tainer@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://con$tainer@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://-container@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://container-@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://con---tainer@account.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://con--tainer@account.dfs.core.windows.net/some/path/file");
+        // account is only a-z and 0-9
+        assertInvalid("abfs://container@ac-count.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://container@ac_count.dfs.core.windows.net/some/path/file");
+        assertInvalid("abfs://container@ac$count.dfs.core.windows.net/some/path/file");
+        // host must end with .dfs.core.windows.net
+        assertInvalid("abfs://container@account.example.com/some/path/file");
+        // host must be just account.dfs.core.windows.net
+        assertInvalid("abfs://container@account.fake.dfs.core.windows.net/some/path/file");
+    }
+
+    private static void assertValid(String uri, String expectedAccount, String expectedContainer, String expectedPath)
+    {
+        Location location = Location.of(uri);
+        AzureLocation azureLocation = new AzureLocation(location);
+        assertThat(azureLocation.location()).isEqualTo(location);
+        assertThat(azureLocation.account()).isEqualTo(expectedAccount);
+        assertThat(azureLocation.container()).isEqualTo(Optional.ofNullable(expectedContainer));
+        assertThat(azureLocation.path()).contains(expectedPath);
+    }
+
+    private static void assertInvalid(String uri)
+    {
+        Location location = Location.of(uri);
+        assertThatThrownBy(() -> new AzureLocation(location))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(uri);
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -538,7 +538,7 @@ public abstract class AbstractTestTrinoFileSystem
         // file outside of root is not allowed
         // the check is over the entire statement, because some file system delay path checks until the data is uploaded
         assertThatThrownBy(() -> getFileSystem().newOutputFile(createLocation("../file")).createOrOverwrite().close())
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOfAny(IOException.class, IllegalArgumentException.class)
                 .hasMessageContaining(createLocation("../file").toString());
 
         try (TempBlob absolute = new TempBlob(createLocation("b"))) {

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -14,20 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <azurejavasdk.version>1.2.11</azurejavasdk.version>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>com.azure</groupId>
-                <artifactId>azure-sdk-bom</artifactId>
-                <type>pom</type>
-                <version>${azurejavasdk.version}</version>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <module>lib/trino-array</module>
         <module>lib/trino-collect</module>
         <module>lib/trino-filesystem</module>
+        <module>lib/trino-filesystem-azure</module>
         <module>lib/trino-filesystem-manager</module>
         <module>lib/trino-filesystem-s3</module>
         <module>lib/trino-geospatial-toolkit</module>
@@ -331,6 +332,12 @@
                 <groupId>io.trino</groupId>
                 <artifactId>trino-filesystem</artifactId>
                 <type>test-jar</type>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-filesystem-azure</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1070,6 +1070,14 @@
             </dependency>
 
             <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-sdk-bom</artifactId>
+                <type>pom</type>
+                <version>1.2.13</version>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>com.clearspring.analytics</groupId>
                 <artifactId>stream</artifactId>
                 <version>2.9.5</version>


### PR DESCRIPTION
## Description
Add a starting implementation of TrinoFileSystem for Azure which supports Blob and Gen2 without or without hierarchical namespace enabled.  The tests only cover access key authentication, and will need secrets for the 3 file system implementations.  Also, the Guice modules have not been tested.


This is part of #15921 

## Release notes

(X) This is not user-visible or docs only and no release notes are required.
