### PR TITLE
Add support for plural date/time unit forms

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -66,7 +66,6 @@ import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -288,48 +287,37 @@ public final class DateTimeFunctions
         return getDateField(UTC_CHRONOLOGY, unit).getDifferenceAsLong(DAYS.toMillis(date2), DAYS.toMillis(date1));
     }
 
-    private static DateTimeField getDateField(ISOChronology chronology, Slice unit)
+    private static DateTimeField getDateField(ISOChronology chronology, Slice unitString)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        switch (unitString) {
-            case "day":
-                return chronology.dayOfMonth();
-            case "week":
-                return chronology.weekOfWeekyear();
-            case "month":
-                return chronology.monthOfYear();
-            case "quarter":
-                return QUARTER_OF_YEAR.getField(chronology);
-            case "year":
-                return chronology.year();
-        }
-        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid DATE field");
+        DateTimeUnit unit = DateTimeUnit.valueOf(unitString, false)
+                .orElseThrow(() -> new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString.toStringUtf8() + "' is not a valid DATE field"));
+
+        return switch (unit) {
+            case DAY -> chronology.dayOfMonth();
+            case WEEK -> chronology.weekOfWeekyear();
+            case MONTH -> chronology.monthOfYear();
+            case QUARTER -> QUARTER_OF_YEAR.getField(chronology);
+            case YEAR -> chronology.year();
+            default -> throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unit + "' is not a valid DATE field");
+        };
     }
 
-    public static DateTimeField getTimestampField(ISOChronology chronology, Slice unit)
+    public static DateTimeField getTimestampField(ISOChronology chronology, Slice unitString)
     {
-        String unitString = unit.toStringUtf8().toLowerCase(ENGLISH);
-        switch (unitString) {
-            case "millisecond":
-                return chronology.millisOfSecond();
-            case "second":
-                return chronology.secondOfMinute();
-            case "minute":
-                return chronology.minuteOfHour();
-            case "hour":
-                return chronology.hourOfDay();
-            case "day":
-                return chronology.dayOfMonth();
-            case "week":
-                return chronology.weekOfWeekyear();
-            case "month":
-                return chronology.monthOfYear();
-            case "quarter":
-                return QUARTER_OF_YEAR.getField(chronology);
-            case "year":
-                return chronology.year();
-        }
-        throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString + "' is not a valid TIMESTAMP field");
+        DateTimeUnit unit = DateTimeUnit.valueOf(unitString, false)
+                .orElseThrow(() -> new TrinoException(INVALID_FUNCTION_ARGUMENT, "'" + unitString.toStringUtf8() + "' is not a valid TIMESTAMP field"));
+
+        return switch (unit) {
+            case MILLISECOND -> chronology.millisOfSecond();
+            case SECOND -> chronology.secondOfMinute();
+            case MINUTE -> chronology.minuteOfHour();
+            case HOUR -> chronology.hourOfDay();
+            case DAY -> chronology.dayOfMonth();
+            case WEEK -> chronology.weekOfWeekyear();
+            case MONTH -> chronology.monthOfYear();
+            case QUARTER -> QUARTER_OF_YEAR.getField(chronology);
+            case YEAR -> chronology.year();
+        };
     }
 
     @Description("Parses the specified date/time by the given format")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeUnit.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeUnit.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+
+import java.util.Optional;
+
+import static java.util.Locale.ENGLISH;
+
+public enum DateTimeUnit
+{
+    MILLISECOND,
+    SECOND,
+    MINUTE,
+    HOUR,
+    DAY,
+    WEEK,
+    MONTH,
+    QUARTER,
+    YEAR;
+
+    public static Optional<DateTimeUnit> valueOf(Slice unit, boolean acceptPlural)
+    {
+        String unitString = unit.toStringUtf8().toUpperCase(ENGLISH);
+        if (acceptPlural && unitString.endsWith("S")) {
+            unitString = unitString.substring(0, unitString.length() - 1);
+        }
+
+        try {
+            return Optional.of(valueOf(unitString));
+        }
+        catch (IllegalArgumentException ignored) {
+            return Optional.empty();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeUnit.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeUnit.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.operator.scalar.DateTimeUnit.DAY;
+import static io.trino.operator.scalar.DateTimeUnit.HOUR;
+import static io.trino.operator.scalar.DateTimeUnit.MILLISECOND;
+import static io.trino.operator.scalar.DateTimeUnit.MINUTE;
+import static io.trino.operator.scalar.DateTimeUnit.MONTH;
+import static io.trino.operator.scalar.DateTimeUnit.QUARTER;
+import static io.trino.operator.scalar.DateTimeUnit.SECOND;
+import static io.trino.operator.scalar.DateTimeUnit.WEEK;
+import static io.trino.operator.scalar.DateTimeUnit.YEAR;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@Test
+public class TestDateTimeUnit
+{
+    @Test
+    public void testSingleUnitForm()
+    {
+        assertThat(forString("millisecond")).hasValue(MILLISECOND);
+        assertThat(forString("second")).hasValue(SECOND);
+        assertThat(forString("minute")).hasValue(MINUTE);
+        assertThat(forString("hour")).hasValue(HOUR);
+        assertThat(forString("day")).hasValue(DAY);
+        assertThat(forString("week")).hasValue(WEEK);
+        assertThat(forString("month")).hasValue(MONTH);
+        assertThat(forString("quarter")).hasValue(QUARTER);
+        assertThat(forString("year")).hasValue(YEAR);
+    }
+
+    @Test
+    public void testPluralUnitForm()
+    {
+        assertThat(forString("milliseconds")).hasValue(MILLISECOND);
+        assertThat(forString("seconds")).hasValue(SECOND);
+        assertThat(forString("minutes")).hasValue(MINUTE);
+        assertThat(forString("hours")).hasValue(HOUR);
+        assertThat(forString("days")).hasValue(DAY);
+        assertThat(forString("weeks")).hasValue(WEEK);
+        assertThat(forString("months")).hasValue(MONTH);
+        assertThat(forString("quarters")).hasValue(QUARTER);
+        assertThat(forString("years")).hasValue(YEAR);
+    }
+
+    @Test
+    public void testWordCases()
+    {
+        assertThat(forString("Days")).hasValue(DAY);
+        assertThat(forString("days")).hasValue(DAY);
+        assertThat(forString("YEAR")).hasValue(YEAR);
+        assertThat(forString("MoNtHs")).hasValue(MONTH);
+        assertThat(forString("WeekS")).hasValue(WEEK);
+    }
+
+    @Test
+    public void testUnsupportedUnits()
+    {
+        assertThat(forString("eons")).isEmpty();
+        assertThat(forString("notAUnit")).isEmpty();
+        assertThat(forString("d")).isEmpty();
+        assertThat(forString("m")).isEmpty();
+        assertThat(forString("y")).isEmpty();
+    }
+
+    @Test
+    public void testPluralFormNotAccepted()
+    {
+        assertThat(forString("hours", false)).isEmpty();
+        assertThat(forString("SecondS", false)).isEmpty();
+        assertThat(forString("DayS", false)).isEmpty();
+        assertThat(forString("Months", false)).isEmpty();
+        assertThat(forString("years", false)).isEmpty();
+        assertThat(forString("QUARTERS", false)).isEmpty();
+    }
+
+    public static Optional<DateTimeUnit> forString(String value)
+    {
+        return forString(value, true);
+    }
+
+    public static Optional<DateTimeUnit> forString(String value, boolean acceptPlural)
+    {
+        return DateTimeUnit.valueOf(Slices.utf8Slice(value), acceptPlural);
+    }
+}

--- a/docs/src/main/sphinx/functions/datetime.rst
+++ b/docs/src/main/sphinx/functions/datetime.rst
@@ -224,7 +224,7 @@ Date and time functions
 Truncation function
 -------------------
 
-The ``date_trunc`` function supports the following units:
+The ``date_trunc`` function supports the following case-insensitive units:
 
 =========== ===========================
 Unit        Example Truncated Value
@@ -259,7 +259,7 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 Interval functions
 ------------------
 
-The functions in this section support the following interval units:
+The functions in this section support the following case-insensitive interval units:
 
 ================= ==================
 Unit              Description
@@ -274,6 +274,8 @@ Unit              Description
 ``quarter``       Quarters of a year
 ``year``          Years
 ================= ==================
+
+Interval units in plural form are also supported.
 
 .. function:: date_add(unit, value, timestamp) -> [same as input]
 


### PR DESCRIPTION
This PR should improve user experience as most databases/platforms (Snowflake, PostgreSQL) supports a couple of abbreviations for the date/time/interval units, making it easier for those users to switch to Trino with their queries.

For reference:
- https://www.postgresql.org/docs/7.1/datatype-datetime.html
- https://docs.snowflake.com/en/sql-reference/functions-date-time#label-supported-date-time-parts

Examples:
```
SELECT date_add('hours', 9, TIMESTAMP '2020-03-01 00:00:00');
SELECT date_add('minutes', 9, TIMESTAMP '2020-03-01 00:00:00');
SELECT date_diff('milliseconds', TIMESTAMP '2020-06-01 12:30:45.000000000', TIMESTAMP '2020-06-02 12:30:45.123456789');
```

etc.