### PR TITLE
Refactor HiveSplitManager

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
@@ -28,7 +28,6 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.type.Type;
 
 import javax.inject.Inject;
 
@@ -45,7 +44,6 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.toPartitionName;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveUtil.parsePartitionValue;
 import static io.trino.plugin.hive.util.HiveUtil.unescapePathName;
-import static java.util.stream.Collectors.toList;
 
 public class HivePartitionManager
 {
@@ -100,10 +98,6 @@ public class HivePartitionManager
                     bucketFilter);
         }
 
-        List<Type> partitionTypes = partitionColumns.stream()
-                .map(HiveColumnHandle::getType)
-                .collect(toList());
-
         Optional<List<String>> partitionNames = Optional.empty();
         Iterable<HivePartition> partitionsIterable;
         Predicate<Map<ColumnHandle, NullableValue>> predicate = constraint.predicate().orElse(value -> true);
@@ -117,7 +111,7 @@ public class HivePartitionManager
                     .orElseGet(() -> getFilteredPartitionNames(metastore, tableName, partitionColumns, compactEffectivePredicate));
             partitionsIterable = () -> partitionNamesList.stream()
                     // Apply extra filters which could not be done by getFilteredPartitionNames
-                    .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, partitionTypes, effectivePredicate, predicate))
+                    .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, effectivePredicate, predicate))
                     .filter(Optional::isPresent)
                     .map(Optional::get)
                     .iterator();
@@ -138,13 +132,9 @@ public class HivePartitionManager
                 .map(HiveColumnHandle::getName)
                 .collect(toImmutableList());
 
-        List<Type> partitionColumnTypes = partitionColumns.stream()
-                .map(HiveColumnHandle::getType)
-                .collect(toImmutableList());
-
         List<HivePartition> partitionList = partitionValuesList.stream()
                 .map(partitionValues -> toPartitionName(partitionColumnNames, partitionValues))
-                .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, partitionColumnTypes, TupleDomain.all(), value -> true))
+                .map(partitionName -> parseValuesAndFilterPartition(tableName, partitionName, partitionColumns, TupleDomain.all(), value -> true))
                 .map(partition -> partition.orElseThrow(() -> new VerifyException("partition must exist")))
                 .collect(toImmutableList());
 
@@ -216,11 +206,10 @@ public class HivePartitionManager
             SchemaTableName tableName,
             String partitionId,
             List<HiveColumnHandle> partitionColumns,
-            List<Type> partitionColumnTypes,
             TupleDomain<ColumnHandle> constraintSummary,
             Predicate<Map<ColumnHandle, NullableValue>> constraint)
     {
-        HivePartition partition = parsePartition(tableName, partitionId, partitionColumns, partitionColumnTypes);
+        HivePartition partition = parsePartition(tableName, partitionId, partitionColumns);
 
         if (partitionMatches(partitionColumns, constraintSummary, constraint, partition)) {
             return Optional.of(partition);
@@ -228,7 +217,7 @@ public class HivePartitionManager
         return Optional.empty();
     }
 
-    private boolean partitionMatches(List<HiveColumnHandle> partitionColumns, TupleDomain<ColumnHandle> constraintSummary, Predicate<Map<ColumnHandle, NullableValue>> constraint, HivePartition partition)
+    private static boolean partitionMatches(List<HiveColumnHandle> partitionColumns, TupleDomain<ColumnHandle> constraintSummary, Predicate<Map<ColumnHandle, NullableValue>> constraint, HivePartition partition)
     {
         return partitionMatches(partitionColumns, constraintSummary, partition) && constraint.test(partition.getKeys());
     }
@@ -263,14 +252,13 @@ public class HivePartitionManager
     public static HivePartition parsePartition(
             SchemaTableName tableName,
             String partitionName,
-            List<HiveColumnHandle> partitionColumns,
-            List<Type> partitionColumnTypes)
+            List<HiveColumnHandle> partitionColumns)
     {
         List<String> partitionValues = extractPartitionValues(partitionName);
-        ImmutableMap.Builder<ColumnHandle, NullableValue> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<ColumnHandle, NullableValue> builder = ImmutableMap.builderWithExpectedSize(partitionColumns.size());
         for (int i = 0; i < partitionColumns.size(); i++) {
             HiveColumnHandle column = partitionColumns.get(i);
-            NullableValue parsedValue = parsePartitionValue(partitionName, partitionValues.get(i), partitionColumnTypes.get(i));
+            NullableValue parsedValue = parsePartitionValue(partitionName, partitionValues.get(i), column.getType());
             builder.put(column, parsedValue);
         }
         Map<ColumnHandle, NullableValue> values = builder.buildOrThrow();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -325,7 +325,7 @@ public class HiveSplitManager
                     tableName.getSchemaName(),
                     tableName.getTableName(),
                     Lists.transform(partitionBatch, HivePartition::getPartitionId));
-            ImmutableMap.Builder<String, Partition> partitionBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, Partition> partitionBuilder = ImmutableMap.builderWithExpectedSize(batch.size());
             for (Map.Entry<String, Optional<Partition>> entry : batch.entrySet()) {
                 if (entry.getValue().isEmpty()) {
                     throw new TrinoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Partition no longer exists: " + entry.getKey());
@@ -337,7 +337,7 @@ public class HiveSplitManager
                 throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Expected %s partitions but found %s", partitionBatch.size(), partitions.size()));
             }
 
-            ImmutableList.Builder<HivePartitionMetadata> results = ImmutableList.builder();
+            ImmutableList.Builder<HivePartitionMetadata> results = ImmutableList.builderWithExpectedSize(partitionBatch.size());
             for (HivePartition hivePartition : partitionBatch) {
                 Partition partition = partitions.get(hivePartition.getPartitionId());
                 if (partition == null) {
@@ -448,7 +448,7 @@ public class HiveSplitManager
 
     private TableToPartitionMapping getTableToPartitionMappingByColumnNames(SchemaTableName tableName, String partName, List<Column> tableColumns, List<Column> partitionColumns, HiveTimestampPrecision hiveTimestampPrecision)
     {
-        ImmutableMap.Builder<String, Integer> partitionColumnIndexesBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Integer> partitionColumnIndexesBuilder = ImmutableMap.builderWithExpectedSize(partitionColumns.size());
         for (int i = 0; i < partitionColumns.size(); i++) {
             partitionColumnIndexesBuilder.put(partitionColumns.get(i).getName().toLowerCase(ENGLISH), i);
         }
@@ -539,7 +539,7 @@ public class HiveSplitManager
                 }
 
                 int count = 0;
-                ImmutableList.Builder<T> builder = ImmutableList.builder();
+                ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(currentSize);
                 while (values.hasNext() && count < currentSize) {
                     builder.add(values.next());
                     ++count;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -218,17 +218,6 @@ public class HiveSplitManager
             throw new HiveNotReadableException(tableName, Optional.empty(), tableNotReadable);
         }
 
-        // get partitions
-        Iterator<HivePartition> partitions = partitionManager.getPartitions(metastore, hiveTable);
-
-        // short circuit if we don't have any partitions
-        if (!partitions.hasNext()) {
-            if (hiveTable.isRecordScannedFiles()) {
-                return new FixedSplitSource(ImmutableList.of(), ImmutableList.of());
-            }
-            return emptySplitSource();
-        }
-
         // get buckets from first partition (arbitrary)
         Optional<HiveBucketFilter> bucketFilter = hiveTable.getBucketFilter();
 
@@ -243,11 +232,21 @@ public class HiveSplitManager
             }
         }
 
+        // get partitions
+        Iterator<HivePartition> partitions = partitionManager.getPartitions(metastore, hiveTable);
+
+        // short circuit if we don't have any partitions
+        if (!partitions.hasNext()) {
+            if (hiveTable.isRecordScannedFiles()) {
+                return new FixedSplitSource(ImmutableList.of(), ImmutableList.of());
+            }
+            return emptySplitSource();
+        }
+
         Iterator<HivePartitionMetadata> hivePartitions = getPartitionMetadata(
                 session,
                 metastore,
                 table,
-                tableName,
                 peekingIterator(partitions),
                 bucketHandle.map(HiveBucketHandle::toTableBucketProperty));
 
@@ -302,7 +301,6 @@ public class HiveSplitManager
             ConnectorSession session,
             SemiTransactionalHiveMetastore metastore,
             Table table,
-            SchemaTableName tableName,
             PeekingIterator<HivePartition> hivePartitions,
             Optional<HiveBucketProperty> bucketProperty)
     {
@@ -317,90 +315,40 @@ public class HiveSplitManager
             return singletonIterator(new HivePartitionMetadata(firstPartition, Optional.empty(), TableToPartitionMapping.empty()));
         }
 
-        Optional<HiveStorageFormat> storageFormat = getHiveStorageFormat(table.getStorage().getStorageFormat());
+        HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
+        boolean propagateTableScanSortingProperties = isPropagateTableScanSortingProperties(session);
+        boolean usePartitionColumnNames = isPartitionUsesColumnNames(session, getHiveStorageFormat(table.getStorage().getStorageFormat()));
 
         Iterator<List<HivePartition>> partitionNameBatches = partitionExponentially(hivePartitions, minPartitionBatchSize, maxPartitionBatchSize);
         Iterator<List<HivePartitionMetadata>> partitionBatches = transform(partitionNameBatches, partitionBatch -> {
-            Map<String, Optional<Partition>> batch = metastore.getPartitionsByNames(
+            SchemaTableName tableName = table.getSchemaTableName();
+            Map<String, Optional<Partition>> partitions = metastore.getPartitionsByNames(
                     tableName.getSchemaName(),
                     tableName.getTableName(),
                     Lists.transform(partitionBatch, HivePartition::getPartitionId));
-            ImmutableMap.Builder<String, Partition> partitionBuilder = ImmutableMap.builderWithExpectedSize(batch.size());
-            for (Map.Entry<String, Optional<Partition>> entry : batch.entrySet()) {
-                if (entry.getValue().isEmpty()) {
-                    throw new TrinoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Partition no longer exists: " + entry.getKey());
-                }
-                partitionBuilder.put(entry.getKey(), entry.getValue().get());
-            }
-            Map<String, Partition> partitions = partitionBuilder.buildOrThrow();
+
             if (partitionBatch.size() != partitions.size()) {
                 throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Expected %s partitions but found %s", partitionBatch.size(), partitions.size()));
             }
 
             ImmutableList.Builder<HivePartitionMetadata> results = ImmutableList.builderWithExpectedSize(partitionBatch.size());
             for (HivePartition hivePartition : partitionBatch) {
-                Partition partition = partitions.get(hivePartition.getPartitionId());
+                Optional<Partition> partition = partitions.get(hivePartition.getPartitionId());
                 if (partition == null) {
                     throw new TrinoException(GENERIC_INTERNAL_ERROR, "Partition not loaded: " + hivePartition);
                 }
-                String partName = makePartitionName(table, partition);
-
-                // verify partition is online
-                verifyOnline(tableName, Optional.of(partName), getProtectMode(partition), partition.getParameters());
-
-                // verify partition is not marked as non-readable
-                String partitionNotReadable = partition.getParameters().get(OBJECT_NOT_READABLE);
-                if (!isNullOrEmpty(partitionNotReadable)) {
-                    throw new HiveNotReadableException(tableName, Optional.of(partName), partitionNotReadable);
+                if (partition.isEmpty()) {
+                    throw new TrinoException(HIVE_PARTITION_DROPPED_DURING_QUERY, "Partition no longer exists: " + hivePartition.getPartitionId());
                 }
-
-                // Verify that the partition schema matches the table schema.
-                // Either adding or dropping columns from the end of the table
-                // without modifying existing partitions is allowed, but every
-                // column that exists in both the table and partition must have
-                // the same type.
-                List<Column> tableColumns = table.getDataColumns();
-                List<Column> partitionColumns = partition.getColumns();
-                if ((tableColumns == null) || (partitionColumns == null)) {
-                    throw new TrinoException(HIVE_INVALID_METADATA, format("Table '%s' or partition '%s' has null columns", tableName, partName));
-                }
-                TableToPartitionMapping tableToPartitionMapping = getTableToPartitionMapping(session, storageFormat, tableName, partName, tableColumns, partitionColumns);
-
-                if (bucketProperty.isPresent()) {
-                    HiveBucketProperty partitionBucketProperty = partition.getStorage().getBucketProperty()
-                            .orElseThrow(() -> new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
-                                    "Hive table (%s) is bucketed but partition (%s) is not bucketed",
-                                    hivePartition.getTableName(),
-                                    hivePartition.getPartitionId())));
-                    int tableBucketCount = bucketProperty.get().getBucketCount();
-                    int partitionBucketCount = partitionBucketProperty.getBucketCount();
-                    List<String> tableBucketColumns = bucketProperty.get().getBucketedBy();
-                    List<String> partitionBucketColumns = partitionBucketProperty.getBucketedBy();
-                    if (!tableBucketColumns.equals(partitionBucketColumns) || !isBucketCountCompatible(tableBucketCount, partitionBucketCount)) {
-                        throw new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
-                                "Hive table (%s) bucketing (columns=%s, buckets=%s) is not compatible with partition (%s) bucketing (columns=%s, buckets=%s)",
-                                hivePartition.getTableName(),
-                                tableBucketColumns,
-                                tableBucketCount,
-                                hivePartition.getPartitionId(),
-                                partitionBucketColumns,
-                                partitionBucketCount));
-                    }
-                    if (isPropagateTableScanSortingProperties(session)) {
-                        List<SortingColumn> tableSortedColumns = bucketProperty.get().getSortedBy();
-                        List<SortingColumn> partitionSortedColumns = partitionBucketProperty.getSortedBy();
-                        if (!isSortingCompatible(tableSortedColumns, partitionSortedColumns)) {
-                            throw new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
-                                    "Hive table (%s) sorting by %s is not compatible with partition (%s) sorting by %s. This restriction can be avoided by disabling propagate_table_scan_sorting_properties.",
-                                    hivePartition.getTableName(),
-                                    tableSortedColumns.stream().map(HiveUtil::sortingColumnToString).collect(toImmutableList()),
-                                    hivePartition.getPartitionId(),
-                                    partitionSortedColumns.stream().map(HiveUtil::sortingColumnToString).collect(toImmutableList())));
-                        }
-                    }
-                }
-
-                results.add(new HivePartitionMetadata(hivePartition, Optional.of(partition), tableToPartitionMapping));
+                results.add(toPartitionMetadata(
+                        typeManager,
+                        hiveTimestampPrecision,
+                        propagateTableScanSortingProperties,
+                        usePartitionColumnNames,
+                        table,
+                        bucketProperty,
+                        hivePartition,
+                        partition.get()));
             }
 
             return results.build();
@@ -410,11 +358,79 @@ public class HiveSplitManager
                 .iterator();
     }
 
-    private TableToPartitionMapping getTableToPartitionMapping(ConnectorSession session, Optional<HiveStorageFormat> storageFormat, SchemaTableName tableName, String partName, List<Column> tableColumns, List<Column> partitionColumns)
+    private static HivePartitionMetadata toPartitionMetadata(
+            TypeManager typeManager,
+            HiveTimestampPrecision hiveTimestampPrecision,
+            boolean propagateTableScanSortingProperties,
+            boolean usePartitionColumnNames,
+            Table table,
+            Optional<HiveBucketProperty> bucketProperty,
+            HivePartition hivePartition,
+            Partition partition)
     {
-        HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
-        if (storageFormat.isPresent() && isPartitionUsesColumnNames(session, storageFormat.get())) {
-            return getTableToPartitionMappingByColumnNames(tableName, partName, tableColumns, partitionColumns, hiveTimestampPrecision);
+        SchemaTableName tableName = table.getSchemaTableName();
+        String partName = makePartitionName(table, partition);
+        // verify partition is online
+        verifyOnline(tableName, Optional.of(partName), getProtectMode(partition), partition.getParameters());
+
+        // verify partition is not marked as non-readable
+        String partitionNotReadable = partition.getParameters().get(OBJECT_NOT_READABLE);
+        if (!isNullOrEmpty(partitionNotReadable)) {
+            throw new HiveNotReadableException(tableName, Optional.of(partName), partitionNotReadable);
+        }
+
+        // Verify that the partition schema matches the table schema.
+        // Either adding or dropping columns from the end of the table
+        // without modifying existing partitions is allowed, but every
+        // column that exists in both the table and partition must have
+        // the same type.
+        List<Column> tableColumns = table.getDataColumns();
+        List<Column> partitionColumns = partition.getColumns();
+        if ((tableColumns == null) || (partitionColumns == null)) {
+            throw new TrinoException(HIVE_INVALID_METADATA, format("Table '%s' or partition '%s' has null columns", tableName, partName));
+        }
+        TableToPartitionMapping tableToPartitionMapping = getTableToPartitionMapping(usePartitionColumnNames, typeManager, hiveTimestampPrecision, tableName, partName, tableColumns, partitionColumns);
+
+        if (bucketProperty.isPresent()) {
+            HiveBucketProperty partitionBucketProperty = partition.getStorage().getBucketProperty()
+                    .orElseThrow(() -> new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
+                            "Hive table (%s) is bucketed but partition (%s) is not bucketed",
+                            tableName,
+                            partName)));
+            int tableBucketCount = bucketProperty.get().getBucketCount();
+            int partitionBucketCount = partitionBucketProperty.getBucketCount();
+            List<String> tableBucketColumns = bucketProperty.get().getBucketedBy();
+            List<String> partitionBucketColumns = partitionBucketProperty.getBucketedBy();
+            if (!tableBucketColumns.equals(partitionBucketColumns) || !isBucketCountCompatible(tableBucketCount, partitionBucketCount)) {
+                throw new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
+                        "Hive table (%s) bucketing (columns=%s, buckets=%s) is not compatible with partition (%s) bucketing (columns=%s, buckets=%s)",
+                        tableName,
+                        tableBucketColumns,
+                        tableBucketCount,
+                        partName,
+                        partitionBucketColumns,
+                        partitionBucketCount));
+            }
+            if (propagateTableScanSortingProperties) {
+                List<SortingColumn> tableSortedColumns = bucketProperty.get().getSortedBy();
+                List<SortingColumn> partitionSortedColumns = partitionBucketProperty.getSortedBy();
+                if (!isSortingCompatible(tableSortedColumns, partitionSortedColumns)) {
+                    throw new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format(
+                            "Hive table (%s) sorting by %s is not compatible with partition (%s) sorting by %s. This restriction can be avoided by disabling propagate_table_scan_sorting_properties.",
+                            tableName,
+                            tableSortedColumns.stream().map(HiveUtil::sortingColumnToString).collect(toImmutableList()),
+                            partName,
+                            partitionSortedColumns.stream().map(HiveUtil::sortingColumnToString).collect(toImmutableList())));
+                }
+            }
+        }
+        return new HivePartitionMetadata(hivePartition, Optional.of(partition), tableToPartitionMapping);
+    }
+
+    private static TableToPartitionMapping getTableToPartitionMapping(boolean usePartitionColumnNames, TypeManager typeManager, HiveTimestampPrecision hiveTimestampPrecision, SchemaTableName tableName, String partName, List<Column> tableColumns, List<Column> partitionColumns)
+    {
+        if (usePartitionColumnNames) {
+            return getTableToPartitionMappingByColumnNames(typeManager, tableName, partName, tableColumns, partitionColumns, hiveTimestampPrecision);
         }
         ImmutableMap.Builder<Integer, HiveTypeName> columnCoercions = ImmutableMap.builder();
         for (int i = 0; i < min(partitionColumns.size(), tableColumns.size()); i++) {
@@ -430,23 +446,20 @@ public class HiveSplitManager
         return mapColumnsByIndex(columnCoercions.buildOrThrow());
     }
 
-    private static boolean isPartitionUsesColumnNames(ConnectorSession session, HiveStorageFormat storageFormat)
+    private static boolean isPartitionUsesColumnNames(ConnectorSession session, Optional<HiveStorageFormat> storageFormat)
     {
-        switch (storageFormat) {
-            case AVRO:
-                return true;
-            case JSON:
-                return true;
-            case ORC:
-                return isUseOrcColumnNames(session);
-            case PARQUET:
-                return isUseParquetColumnNames(session);
-            default:
-                return false;
+        if (storageFormat.isEmpty()) {
+            return false;
         }
+        return switch (storageFormat.get()) {
+            case AVRO, JSON -> true;
+            case ORC -> isUseOrcColumnNames(session);
+            case PARQUET -> isUseParquetColumnNames(session);
+            default -> false;
+        };
     }
 
-    private TableToPartitionMapping getTableToPartitionMappingByColumnNames(SchemaTableName tableName, String partName, List<Column> tableColumns, List<Column> partitionColumns, HiveTimestampPrecision hiveTimestampPrecision)
+    private static TableToPartitionMapping getTableToPartitionMappingByColumnNames(TypeManager typeManager, SchemaTableName tableName, String partName, List<Column> tableColumns, List<Column> partitionColumns, HiveTimestampPrecision hiveTimestampPrecision)
     {
         ImmutableMap.Builder<String, Integer> partitionColumnIndexesBuilder = ImmutableMap.builderWithExpectedSize(partitionColumns.size());
         for (int i = 0; i < partitionColumns.size(); i++) {
@@ -477,7 +490,7 @@ public class HiveSplitManager
         return new TableToPartitionMapping(Optional.of(tableToPartitionColumns.buildOrThrow()), columnCoercions.buildOrThrow());
     }
 
-    private TrinoException tablePartitionColumnMismatchException(SchemaTableName tableName, String partName, String tableColumnName, HiveType tableType, String partitionColumnName, HiveType partitionType)
+    private static TrinoException tablePartitionColumnMismatchException(SchemaTableName tableName, String partName, String tableColumnName, HiveType tableType, String partitionColumnName, HiveType partitionType)
     {
         return new TrinoException(HIVE_PARTITION_SCHEMA_MISMATCH, format("" +
                         "There is a mismatch between the table and partition schemas. " +

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -847,7 +847,7 @@ public class TestMetastoreHiveStatisticsProvider
 
     private static HivePartition partition(String name)
     {
-        return parsePartition(TABLE, name, ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2), ImmutableList.of(VARCHAR, BIGINT));
+        return parsePartition(TABLE, name, ImmutableList.of(PARTITION_COLUMN_1, PARTITION_COLUMN_2));
     }
 
     private static PartitionStatistics rowsCount(long rowsCount)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
@@ -79,11 +79,8 @@ public final class HudiUtil
             List<HiveColumnHandle> partitionColumnHandles,
             TupleDomain<HiveColumnHandle> constraintSummary)
     {
-        List<Type> partitionColumnTypes = partitionColumnHandles.stream()
-                .map(HiveColumnHandle::getType)
-                .collect(toList());
         HivePartition partition = HivePartitionManager.parsePartition(
-                tableName, hivePartitionName, partitionColumnHandles, partitionColumnTypes);
+                tableName, hivePartitionName, partitionColumnHandles);
 
         return partitionMatches(partitionColumnHandles, constraintSummary, partition);
     }


### PR DESCRIPTION
## Description
Refactors `HiveSplitManager`s to avoid redundant repeated work when creating `HivePartitionMetadata` instances for each partition enumerated by eagerly extracting session properties, avoiding unnecessary intermediate collection copies, and making methods static where possible.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

