### PR TITLE
Add config to reject Iceberg queries without partition filter

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -157,6 +157,10 @@ implementation is used:
   * - ``iceberg.register-table-procedure.enabled``
     - Enable to allow user to call ``register_table`` procedure.
     - ``false``
+  * - ``iceberg.query-partition-filter-required``
+    - Set to ``true`` to force a query to use a partition filter. 
+      You can use the ``query_partition_filter_required`` catalog session property for temporary, catalog specific use. 
+    - ``false``
 ```
 
 ## Type mapping

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -73,6 +73,7 @@ public class IcebergConfig
     private double minimumAssignedSplitWeight = 0.05;
     private Optional<String> materializedViewsStorageSchema = Optional.empty();
     private boolean sortedWritingEnabled = true;
+    private boolean queryPartitionFilterRequired;
 
     public CatalogType getCatalogType()
     {
@@ -366,5 +367,18 @@ public class IcebergConfig
     {
         this.sortedWritingEnabled = sortedWritingEnabled;
         return this;
+    }
+
+    @Config("iceberg.query-partition-filter-required")
+    @ConfigDescription("Require a filter on at least one partition column")
+    public IcebergConfig setQueryPartitionFilterRequired(boolean queryPartitionFilterRequired)
+    {
+        this.queryPartitionFilterRequired = queryPartitionFilterRequired;
+        return this;
+    }
+
+    public boolean isQueryPartitionFilterRequired()
+    {
+        return queryPartitionFilterRequired;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -88,6 +88,7 @@ public final class IcebergSessionProperties
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "remove_orphan_files_min_retention";
     private static final String MERGE_MANIFESTS_ON_WRITE = "merge_manifests_on_write";
     private static final String SORTED_WRITING_ENABLED = "sorted_writing_enabled";
+    private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -299,6 +300,11 @@ public final class IcebergSessionProperties
                         "Enable sorted writing to tables with a specified sort order",
                         icebergConfig.isSortedWritingEnabled(),
                         false))
+                .add(booleanProperty(
+                        QUERY_PARTITION_FILTER_REQUIRED,
+                        "Require filter on partition column",
+                        icebergConfig.isQueryPartitionFilterRequired(),
+                        false))
                 .build();
     }
 
@@ -488,5 +494,10 @@ public final class IcebergSessionProperties
     public static boolean isSortedWritingEnabled(ConnectorSession session)
     {
         return session.getProperty(SORTED_WRITING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
+    {
+        return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -637,6 +637,24 @@ public abstract class BaseIcebergConnectorSmokeTest
         }
     }
 
+    @Test
+    public void testPartitionFilterRequired()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty("iceberg", "query_partition_filter_required", "true")
+                .build();
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        String query = "SELECT id FROM " + tableName + " WHERE a = 'a'";
+        String failureMessage = "Filter required for tpch.*\\." + tableName + " on at least one of the partition columns: ds";
+        assertQueryFails(session, query, failureMessage);
+        assertQueryFails(session, "EXPLAIN " + query, failureMessage);
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
     protected abstract boolean isFileSorted(Location path, String sortColumnName);
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -6984,6 +6984,222 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @Test
+    public void testIdentityPartitionFilterMissing()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQueryFails(session, "SELECT id FROM " + tableName + " WHERE ds IS NOT null OR true", "Filter required for tpch\\." + tableName + " on at least one of the partition columns: ds");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testBucketPartitionFilterMissing()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['bucket(ds, 16)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQueryFails(session, "SELECT id FROM " + tableName + " WHERE ds IS NOT null OR true", "Filter required for tpch\\." + tableName + " on at least one of the partition columns: ds");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testIdentityPartitionFilterIncluded()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        String query = "SELECT id FROM " + tableName + " WHERE ds = 'a'";
+        assertQuery(session, query, "VALUES 1");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testBucketPartitionFilterIncluded()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['bucket(ds, 16)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a'), (2, 'b', 'b')", 2);
+        String query = "SELECT id FROM " + tableName + " WHERE ds = 'a'";
+        assertQuery(session, query, "VALUES 1");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testMultiPartitionedTableFilterIncluded()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['id', 'bucket(ds, 16)'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a'), (2, 'b', 'b')", 2);
+        // include predicate only on 'id', not on 'ds'
+        String query = "SELECT id, ds FROM " + tableName + " WHERE id = 2";
+        assertQuery(session, query, "VALUES (2, 'b')");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testIdentityPartitionIsNotNullFilter()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQuery(session, "SELECT id FROM " + tableName + " WHERE ds IS NOT null", "VALUES 1");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testJoinPartitionFilterIncluded()
+    {
+        String tableName1 = "test_partition_" + randomNameSuffix();
+        String tableName2 = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName1 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName1 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertUpdate(session, "CREATE TABLE " + tableName2 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName2 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQuery(session, "SELECT a.id, b.id FROM " + tableName1 + " a JOIN " + tableName2 + " b ON (a.ds = b.ds) WHERE a.ds = 'a'", "VALUES (1, 1)");
+        assertUpdate(session, "DROP TABLE " + tableName1);
+        assertUpdate(session, "DROP TABLE " + tableName2);
+    }
+
+    @Test
+    public void testJoinWithMissingPartitionFilter()
+    {
+        String tableName1 = "test_partition_" + randomNameSuffix();
+        String tableName2 = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName1 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName1 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertUpdate(session, "CREATE TABLE " + tableName2 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName2 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQueryFails(session, "SELECT a.id, b.id FROM " + tableName1 + " a JOIN " + tableName2 + " b ON (a.id = b.id) WHERE a.ds = 'a'", "Filter required for tpch\\." + tableName2 + " on at least one of the partition columns: ds");
+        assertUpdate(session, "DROP TABLE " + tableName1);
+        assertUpdate(session, "DROP TABLE " + tableName2);
+    }
+
+    @Test
+    public void testJoinWithPartitionFilterOnPartitionedTable()
+    {
+        String tableName1 = "test_partition_" + randomNameSuffix();
+        String tableName2 = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName1 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName1 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertUpdate(session, "CREATE TABLE " + tableName2 + " (id integer, a varchar, b varchar, ds varchar)");
+        assertUpdate(session, "INSERT INTO " + tableName2 + " (id, a, ds) VALUES (1, 'a', 'a')", 1);
+        assertQuery(session, "SELECT a.id, b.id FROM " + tableName1 + " a JOIN " + tableName2 + " b ON (a.id = b.id) WHERE a.ds = 'a'", "VALUES (1, 1)");
+        assertUpdate(session, "DROP TABLE " + tableName1);
+        assertUpdate(session, "DROP TABLE " + tableName2);
+    }
+
+    @Test
+    public void testPartitionPredicateWithCasting()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, '1', '1')", 1);
+        String query = "SELECT id FROM " + tableName + " WHERE cast(ds as integer) = 1";
+        assertQuery(session, query, "VALUES 1");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testNestedQueryWithInnerPartitionPredicate()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, '1', '1')", 1);
+        String query = "SELECT id FROM (SELECT * FROM " + tableName + " WHERE cast(ds as integer) = 1) WHERE cast(a as integer) = 1";
+        assertQuery(session, query, "VALUES 1");
+        assertUpdate(session, "DROP TABLE " + tableName + "");
+    }
+
+    @Test
+    public void testPredicateOnNonPartitionColumn()
+    {
+        String tableName = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName + " (id, a, ds) VALUES (1, '1', '1')", 1);
+        String query = "SELECT id FROM " + tableName + " WHERE cast(b as integer) = 1";
+        assertQueryFails(session, query, "Filter required for tpch\\." + tableName + " on at least one of the partition columns: ds");
+        assertUpdate(session, "DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testNonSelectStatementsWithPartitionFilterRequired()
+    {
+        String tableName1 = "test_partition_" + randomNameSuffix();
+        String tableName2 = "test_partition_" + randomNameSuffix();
+
+        Session session = withPartitionFilterRequired(getSession());
+
+        assertUpdate(session, "CREATE TABLE " + tableName1 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "CREATE TABLE " + tableName2 + " (id integer, a varchar, b varchar, ds varchar) WITH (partitioning = ARRAY['ds'])");
+        assertUpdate(session, "INSERT INTO " + tableName1 + " (id, a, ds) VALUES (1, '1', '1'), (2, '2', '2')", 2);
+        assertUpdate(session, "INSERT INTO " + tableName2 + " (id, a, ds) VALUES (1, '1', '1'), (3, '3', '3')", 2);
+
+        // These non-SELECT statements fail without a partition filter
+        String errorMessage = "Filter required for tpch\\." + tableName1 + " on at least one of the partition columns: ds";
+        assertQueryFails(session, "ALTER TABLE " + tableName1 + " EXECUTE optimize", errorMessage);
+        assertQueryFails(session, "UPDATE " + tableName1 + " SET a = 'New'", errorMessage);
+        assertQueryFails(session, "MERGE INTO " + tableName1 + " AS a USING " + tableName2 + " AS b ON (a.ds = b.ds) WHEN MATCHED THEN UPDATE SET a = 'New'", errorMessage);
+        assertQueryFails(session, "DELETE FROM " + tableName1 + " WHERE a = '1'", errorMessage);
+
+        // Adding partition filters to each solves the problem
+        assertQuerySucceeds(session, "ALTER TABLE " + tableName1 + " EXECUTE optimize WHERE ds in ('2', '4')");
+        assertQuerySucceeds(session, "UPDATE " + tableName1 + " SET a = 'New' WHERE ds = '2'");
+        assertQuerySucceeds(session, "MERGE INTO " + tableName1 + " AS a USING (SELECT * FROM " + tableName2 + " WHERE ds = '1') AS b ON (a.ds = b.ds) WHEN MATCHED THEN UPDATE SET a = 'New'");
+        assertQuerySucceeds(session, "DELETE FROM " + tableName1 + " WHERE ds = '1'");
+
+        // Analyze should always succeed, since currently it cannot take a partition argument like Hive
+        assertQuerySucceeds(session, "ANALYZE " + tableName1);
+        assertQuerySucceeds(session, "ANALYZE " + tableName2 + " WITH (columns = ARRAY['id', 'a'])");
+
+        assertUpdate(session, "DROP TABLE " + tableName1);
+        assertUpdate(session, "DROP TABLE " + tableName2);
+    }
+
+    private static Session withPartitionFilterRequired(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty("iceberg", "query_partition_filter_required", "true")
+                .build();
+    }
+
     @Override
     protected void verifyTableNameLengthFailurePermissible(Throwable e)
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -61,7 +61,8 @@ public class TestIcebergConfig
                 .setMinimumAssignedSplitWeight(0.05)
                 .setMaterializedViewsStorageSchema(null)
                 .setRegisterTableProcedureEnabled(false)
-                .setSortedWritingEnabled(true));
+                .setSortedWritingEnabled(true)
+                .setQueryPartitionFilterRequired(false));
     }
 
     @Test
@@ -89,6 +90,7 @@ public class TestIcebergConfig
                 .put("iceberg.materialized-views.storage-schema", "mv_storage_schema")
                 .put("iceberg.register-table-procedure.enabled", "true")
                 .put("iceberg.sorted-writing-enabled", "false")
+                .put("iceberg.query-partition-filter-required", "true")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -112,7 +114,8 @@ public class TestIcebergConfig
                 .setMinimumAssignedSplitWeight(0.01)
                 .setMaterializedViewsStorageSchema("mv_storage_schema")
                 .setRegisterTableProcedureEnabled(true)
-                .setSortedWritingEnabled(false);
+                .setSortedWritingEnabled(false)
+                .setQueryPartitionFilterRequired(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -186,6 +186,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                         tablePath,
                         ImmutableMap.of(),
                         false,
+                        Optional.empty(),
+                        ImmutableSet.of(),
                         Optional.empty()),
                 transaction);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -139,6 +139,8 @@ public class TestIcebergSplitSource
                 nationTable.location(),
                 nationTable.properties(),
                 false,
+                Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty());
 
         try (IcebergSplitSource splitSource = new IcebergSplitSource(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -170,6 +170,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 "",
                 ImmutableMap.of(),
                 false,
+                Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
@@ -252,6 +254,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 "",
                 ImmutableMap.of(),
                 false,
+                Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
@@ -301,6 +305,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 "",
                 ImmutableMap.of(),
                 false,
+                Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
@@ -361,6 +367,8 @@ public class TestConnectorPushdownRulesWithIceberg
                 "",
                 ImmutableMap.of(),
                 false,
+                Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty());
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

For iceberg partitioned tables, we should reject the table scan produced by the planner when the query does not have partition field.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/17239

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add an option to require all scans on partitioned tables to have a filter on a partitioned column. This can be enabled by setting the 
  ``iceberg.query-partition-filter-required`` catalog config property or the ``query_partition_filter_required`` catalog session property to ``true``.
```
