### PR TITLE
Add new scheduler supporting multiple table scans within one stage

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/MultiSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/MultiSourcePartitionedScheduler.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.log.Logger;
+import io.trino.execution.RemoteTask;
+import io.trino.execution.TableExecuteContextManager;
+import io.trino.metadata.InternalNode;
+import io.trino.server.DynamicFilterService;
+import io.trino.split.SplitSource;
+import io.trino.sql.planner.plan.PlanNodeId;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.BooleanSupplier;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static io.trino.execution.scheduler.SourcePartitionedScheduler.newSourcePartitionedSchedulerAsSourceScheduler;
+import static java.util.Objects.requireNonNull;
+
+@NotThreadSafe
+public class MultiSourcePartitionedScheduler
+        implements StageScheduler
+{
+    private static final Logger log = Logger.get(MultiSourcePartitionedScheduler.class);
+
+    private final StageExecution stageExecution;
+    private final Queue<SourceScheduler> sourceSchedulers;
+    private final Map<InternalNode, RemoteTask> scheduledTasks = new HashMap<>();
+    private final DynamicFilterService dynamicFilterService;
+    private final SplitPlacementPolicy splitPlacementPolicy;
+    private final PartitionIdAllocator partitionIdAllocator = new PartitionIdAllocator();
+
+    public MultiSourcePartitionedScheduler(
+            StageExecution stageExecution,
+            Map<PlanNodeId, SplitSource> splitSources,
+            SplitPlacementPolicy splitPlacementPolicy,
+            int splitBatchSize,
+            DynamicFilterService dynamicFilterService,
+            TableExecuteContextManager tableExecuteContextManager,
+            BooleanSupplier anySourceTaskBlocked)
+    {
+        requireNonNull(splitSources, "splitSources is null");
+        checkArgument(splitSources.size() > 1, "It is expected that there will be more than one split sources");
+
+        ImmutableList.Builder<SourceScheduler> sourceSchedulers = ImmutableList.builder();
+        for (PlanNodeId planNodeId : splitSources.keySet()) {
+            SplitSource splitSource = splitSources.get(planNodeId);
+            SourceScheduler sourceScheduler = newSourcePartitionedSchedulerAsSourceScheduler(
+                    stageExecution,
+                    planNodeId,
+                    splitSource,
+                    splitPlacementPolicy,
+                    splitBatchSize,
+                    dynamicFilterService,
+                    tableExecuteContextManager,
+                    anySourceTaskBlocked,
+                    partitionIdAllocator,
+                    scheduledTasks);
+            sourceSchedulers.add(sourceScheduler);
+        }
+        this.stageExecution = requireNonNull(stageExecution, "stageExecution is null");
+        this.sourceSchedulers = new ArrayDeque<>(sourceSchedulers.build());
+        this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        this.splitPlacementPolicy = requireNonNull(splitPlacementPolicy, "splitPlacementPolicy is null");
+    }
+
+    @Override
+    public synchronized void start()
+    {
+        /*
+         * Avoid deadlocks by immediately scheduling a task for collecting dynamic filters because:
+         *  * there can be task in other stage blocked waiting for the dynamic filters, or
+         *  * connector split source for this stage might be blocked waiting the dynamic filters.
+        */
+        if (dynamicFilterService.isCollectingTaskNeeded(stageExecution.getStageId().getQueryId(), stageExecution.getFragment())) {
+            stageExecution.beginScheduling();
+            /*
+             * We can select node randomly because DynamicFilterSourceOperator is not dependent on splits
+             * scheduled by this scheduler.
+             */
+            scheduleTaskOnRandomNode();
+        }
+    }
+
+    @Override
+    public synchronized ScheduleResult schedule()
+    {
+        ImmutableSet.Builder<RemoteTask> newScheduledTasks = ImmutableSet.builder();
+        ListenableFuture<Void> blocked = immediateVoidFuture();
+        Optional<ScheduleResult.BlockedReason> blockedReason = Optional.empty();
+        int splitsScheduled = 0;
+
+        while (!sourceSchedulers.isEmpty()) {
+            SourceScheduler scheduler = sourceSchedulers.peek();
+            ScheduleResult scheduleResult = scheduler.schedule();
+
+            splitsScheduled += scheduleResult.getSplitsScheduled();
+            newScheduledTasks.addAll(scheduleResult.getNewTasks());
+            blocked = scheduleResult.getBlocked();
+            blockedReason = scheduleResult.getBlockedReason();
+
+            // if the source is not done scheduling, stop scheduling for now
+            if (!blocked.isDone() || !scheduleResult.isFinished()) {
+                break;
+            }
+
+            stageExecution.schedulingComplete(scheduler.getPlanNodeId());
+            sourceSchedulers.remove().close();
+        }
+        if (blockedReason.isPresent()) {
+            return new ScheduleResult(sourceSchedulers.isEmpty(), newScheduledTasks.build(), blocked, blockedReason.get(), splitsScheduled);
+        }
+        return new ScheduleResult(sourceSchedulers.isEmpty(), newScheduledTasks.build(), splitsScheduled);
+    }
+
+    @Override
+    public void close()
+    {
+        for (SourceScheduler sourceScheduler : sourceSchedulers) {
+            try {
+                sourceScheduler.close();
+            }
+            catch (Throwable t) {
+                log.warn(t, "Error closing split source");
+            }
+        }
+        sourceSchedulers.clear();
+    }
+
+    private void scheduleTaskOnRandomNode()
+    {
+        checkState(scheduledTasks.isEmpty(), "Stage task is already scheduled on node");
+        List<InternalNode> allNodes = splitPlacementPolicy.allNodes();
+        checkState(allNodes.size() > 0, "No nodes available");
+        InternalNode node = allNodes.get(ThreadLocalRandom.current().nextInt(0, allNodes.size()));
+        Optional<RemoteTask> remoteTask = stageExecution.scheduleTask(node, partitionIdAllocator.getNextId(), ImmutableMultimap.of());
+        remoteTask.ifPresent(task -> scheduledTasks.put(node, task));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/FragmentTableScanCounter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/FragmentTableScanCounter.java
@@ -23,8 +23,6 @@ import java.util.List;
 /**
  * Visitor to count number of tables scanned in the current fragment
  * (fragments separated by ExchangeNodes).
- * <p>
- * TODO: remove this class after we make colocated_join always true
  */
 public final class FragmentTableScanCounter
 {

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
@@ -1,0 +1,725 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
+import io.trino.Session;
+import io.trino.client.NodeVersion;
+import io.trino.cost.StatsAndCosts;
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.execution.MockRemoteTaskFactory;
+import io.trino.execution.NodeTaskMap;
+import io.trino.execution.PartitionedSplitsInfo;
+import io.trino.execution.RemoteTask;
+import io.trino.execution.SqlStage;
+import io.trino.execution.StageId;
+import io.trino.execution.TableExecuteContextManager;
+import io.trino.execution.TableInfo;
+import io.trino.failuredetector.NoOpFailureDetector;
+import io.trino.metadata.FunctionManager;
+import io.trino.metadata.InMemoryNodeManager;
+import io.trino.metadata.InternalNode;
+import io.trino.metadata.InternalNodeManager;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.operator.RetryPolicy;
+import io.trino.server.DynamicFilterService;
+import io.trino.spi.QueryId;
+import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.TypeOperators;
+import io.trino.split.ConnectorAwareSplitSource;
+import io.trino.split.SplitSource;
+import io.trino.sql.DynamicFilters;
+import io.trino.sql.planner.Partitioning;
+import io.trino.sql.planner.PartitioningScheme;
+import io.trino.sql.planner.PlanFragment;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.testing.TestingMetadata.TestingColumnHandle;
+import io.trino.testing.TestingSession;
+import io.trino.testing.TestingSplit;
+import io.trino.util.FinalizerService;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.tracing.Tracing.noopTracer;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.execution.scheduler.NodeSchedulerConfig.SplitsBalancingPolicy.STAGE;
+import static io.trino.execution.scheduler.PipelinedStageExecution.createPipelinedStageExecution;
+import static io.trino.execution.scheduler.ScheduleResult.BlockedReason.SPLIT_QUEUES_FULL;
+import static io.trino.execution.scheduler.ScheduleResult.BlockedReason.WAITING_FOR_SOURCE;
+import static io.trino.execution.scheduler.StageExecution.State.PLANNED;
+import static io.trino.execution.scheduler.StageExecution.State.SCHEDULING;
+import static io.trino.metadata.FunctionManager.createTestingFunctionManager;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.testing.TestingHandles.TEST_TABLE_HANDLE;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestMultiSourcePartitionedScheduler
+{
+    private static final PlanNodeId TABLE_SCAN_1_NODE_ID = new PlanNodeId("1");
+    private static final PlanNodeId TABLE_SCAN_2_NODE_ID = new PlanNodeId("2");
+    private static final QueryId QUERY_ID = new QueryId("query");
+    private static final DynamicFilterId DYNAMIC_FILTER_ID = new DynamicFilterId("filter1");
+
+    private final ExecutorService queryExecutor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%s"));
+    private final InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+    private final FinalizerService finalizerService = new FinalizerService();
+    private final Metadata metadata = createTestMetadataManager();
+    private final FunctionManager functionManager = createTestingFunctionManager();
+    private final TypeOperators typeOperators = new TypeOperators();
+    private final Session session = TestingSession.testSessionBuilder().build();
+    private final PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
+
+    public TestMultiSourcePartitionedScheduler()
+    {
+        nodeManager.addNodes(
+                new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        finalizerService.start();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroyExecutor()
+    {
+        queryExecutor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+        finalizerService.destroy();
+    }
+
+    @Test
+    public void testScheduleSplitsBatchedNoBlocking()
+    {
+        // Test whether two internal schedulers were completely scheduled - no blocking case
+        PlanFragment plan = createFragment();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(60), TABLE_SCAN_2_NODE_ID, createFixedSplitSource(60)),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                7);
+
+        for (int i = 0; i <= (60 / 7) * 2; i++) {
+            ScheduleResult scheduleResult = scheduler.schedule();
+
+            // finishes when last split is fetched
+            if (i == (60 / 7) * 2) {
+                assertEffectivelyFinished(scheduleResult, scheduler);
+            }
+            else {
+                assertFalse(scheduleResult.isFinished());
+            }
+
+            // never blocks
+            assertTrue(scheduleResult.getBlocked().isDone());
+
+            // first three splits create new tasks
+            assertEquals(scheduleResult.getNewTasks().size(), i == 0 ? 3 : 0);
+        }
+
+        for (RemoteTask remoteTask : stage.getAllTasks()) {
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 40);
+        }
+        stage.abort();
+    }
+
+    @Test
+    public void testScheduleSplitsBatchedBlockingSplitSource()
+    {
+        // Test case when one internal scheduler has blocking split source and finally is blocked
+        PlanFragment plan = createFragment();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+        QueuedSplitSource blockingSplitSource = new QueuedSplitSource(TestingSplit::createRemoteSplit);
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(10), TABLE_SCAN_2_NODE_ID, blockingSplitSource),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                5);
+
+        ScheduleResult scheduleResult = scheduler.schedule();
+        assertFalse(scheduleResult.isFinished());
+        assertTrue(scheduleResult.getBlocked().isDone());
+        assertEquals(scheduleResult.getNewTasks().size(), 3);
+
+        scheduleResult = scheduler.schedule();
+        assertFalse(scheduleResult.isFinished());
+        assertFalse(scheduleResult.getBlocked().isDone());
+        assertEquals(scheduleResult.getNewTasks().size(), 0);
+        assertEquals(scheduleResult.getBlockedReason(), Optional.of(WAITING_FOR_SOURCE));
+
+        blockingSplitSource.addSplits(2, true);
+
+        scheduleResult = scheduler.schedule();
+        assertTrue(scheduleResult.getBlocked().isDone());
+        assertEquals(scheduleResult.getSplitsScheduled(), 2);
+        assertEquals(scheduleResult.getNewTasks().size(), 0);
+        assertEquals(scheduleResult.getBlockedReason(), Optional.empty());
+        assertTrue(scheduleResult.isFinished());
+
+        assertPartitionedSplitCount(stage, 12);
+        assertEffectivelyFinished(scheduleResult, scheduler);
+
+        for (RemoteTask remoteTask : stage.getAllTasks()) {
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 4);
+        }
+        stage.abort();
+    }
+
+    @Test
+    public void testScheduleSplitsTasksAreFull()
+    {
+        // Test the case when tasks are full
+        PlanFragment plan = createFragment();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(200), TABLE_SCAN_2_NODE_ID, createFixedSplitSource(200)),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                200);
+
+        ScheduleResult scheduleResult = scheduler.schedule();
+        assertEquals(scheduleResult.getSplitsScheduled(), 300);
+        assertFalse(scheduleResult.isFinished());
+        assertFalse(scheduleResult.getBlocked().isDone());
+        assertEquals(scheduleResult.getNewTasks().size(), 3);
+        assertEquals(scheduleResult.getBlockedReason(), Optional.of(SPLIT_QUEUES_FULL));
+
+        assertEquals(stage.getAllTasks().stream().mapToInt(task -> task.getPartitionedSplitsInfo().getCount()).sum(), 300);
+        stage.abort();
+    }
+
+    @Test
+    public void testBalancedSplitAssignment()
+    {
+        // use private node manager so we can add a node later
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager(
+                new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+
+        // Schedule 15 splits - there are 3 nodes, each node should get 5 splits
+        PlanFragment firstPlan = createFragment();
+        StageExecution firstStage = createStageExecution(firstPlan, nodeTaskMap);
+
+        QueuedSplitSource firstSplitSource = new QueuedSplitSource(TestingSplit::createRemoteSplit);
+        QueuedSplitSource secondSplitSource = new QueuedSplitSource(TestingSplit::createRemoteSplit);
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, firstSplitSource, TABLE_SCAN_2_NODE_ID, secondSplitSource),
+                createSplitPlacementPolicies(session, firstStage, nodeTaskMap, nodeManager),
+                firstStage,
+                15);
+
+        // Only first split source produces splits at that moment
+        firstSplitSource.addSplits(15, true);
+
+        ScheduleResult scheduleResult = scheduler.schedule();
+        assertFalse(scheduleResult.getBlocked().isDone());
+        assertEquals(scheduleResult.getNewTasks().size(), 3);
+        assertEquals(firstStage.getAllTasks().size(), 3);
+        for (RemoteTask remoteTask : firstStage.getAllTasks()) {
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            // All splits were balanced between nodes
+            assertEquals(splitsInfo.getCount(), 5);
+        }
+
+        // Add new node
+        InternalNode additionalNode = new InternalNode("other4", URI.create("http://127.0.0.1:14"), NodeVersion.UNKNOWN, false);
+        nodeManager.addNodes(additionalNode);
+
+        // Second source produced splits now
+        secondSplitSource.addSplits(3, true);
+
+        scheduleResult = scheduler.schedule();
+
+        assertEffectivelyFinished(scheduleResult, scheduler);
+        assertTrue(scheduleResult.getBlocked().isDone());
+        assertTrue(scheduleResult.isFinished());
+        assertEquals(scheduleResult.getNewTasks().size(), 1);
+        assertEquals(firstStage.getAllTasks().size(), 4);
+
+        assertEquals(firstStage.getAllTasks().get(0).getPartitionedSplitsInfo().getCount(), 5);
+        assertEquals(firstStage.getAllTasks().get(1).getPartitionedSplitsInfo().getCount(), 5);
+        assertEquals(firstStage.getAllTasks().get(2).getPartitionedSplitsInfo().getCount(), 5);
+        assertEquals(firstStage.getAllTasks().get(3).getPartitionedSplitsInfo().getCount(), 3);
+
+        // Second source produces
+        PlanFragment secondPlan = createFragment();
+        StageExecution secondStage = createStageExecution(secondPlan, nodeTaskMap);
+        StageScheduler secondScheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(10), TABLE_SCAN_2_NODE_ID, createFixedSplitSource(10)),
+                createSplitPlacementPolicies(session, secondStage, nodeTaskMap, nodeManager),
+                secondStage,
+                10);
+
+        scheduleResult = secondScheduler.schedule();
+        assertEffectivelyFinished(scheduleResult, secondScheduler);
+        assertTrue(scheduleResult.getBlocked().isDone());
+        assertTrue(scheduleResult.isFinished());
+        assertEquals(scheduleResult.getNewTasks().size(), 4);
+        assertEquals(secondStage.getAllTasks().size(), 4);
+
+        for (RemoteTask task : secondStage.getAllTasks()) {
+            assertEquals(task.getPartitionedSplitsInfo().getCount(), 5);
+        }
+        firstStage.abort();
+        secondStage.abort();
+    }
+
+    @Test
+    public void testScheduleEmptySources()
+    {
+        PlanFragment plan = createFragment();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(0), TABLE_SCAN_2_NODE_ID, createFixedSplitSource(0)),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                15);
+
+        ScheduleResult scheduleResult = scheduler.schedule();
+
+        // If both split sources produce no splits then internal schedulers add one split - it can be expected by some operators e.g. AggregationOperator
+        assertEquals(scheduleResult.getNewTasks().size(), 2);
+        assertEffectivelyFinished(scheduleResult, scheduler);
+
+        stage.abort();
+    }
+
+    @Test
+    public void testDynamicFiltersUnblockedOnBlockedBuildSource()
+    {
+        PlanFragment plan = createFragment();
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+        DynamicFilterService dynamicFilterService = new DynamicFilterService(metadata, functionManager, typeOperators, new DynamicFilterConfig());
+        dynamicFilterService.registerQuery(
+                QUERY_ID,
+                TEST_SESSION,
+                ImmutableSet.of(DYNAMIC_FILTER_ID),
+                ImmutableSet.of(DYNAMIC_FILTER_ID),
+                ImmutableSet.of(DYNAMIC_FILTER_ID));
+
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, new QueuedSplitSource(), TABLE_SCAN_2_NODE_ID, new QueuedSplitSource()),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                dynamicFilterService,
+                () -> true,
+                15);
+
+        SymbolAllocator symbolAllocator = new SymbolAllocator();
+        Symbol symbol = symbolAllocator.newSymbol("DF_SYMBOL1", BIGINT);
+        DynamicFilter dynamicFilter = dynamicFilterService.createDynamicFilter(
+                QUERY_ID,
+                ImmutableList.of(new DynamicFilters.Descriptor(DYNAMIC_FILTER_ID, symbol.toSymbolReference())),
+                ImmutableMap.of(symbol, new TestingColumnHandle("probeColumnA")),
+                symbolAllocator.getTypes());
+
+        // make sure dynamic filtering collecting task was created immediately
+        assertEquals(stage.getState(), PLANNED);
+        scheduler.start();
+        assertEquals(stage.getAllTasks().size(), 1);
+        assertEquals(stage.getState(), SCHEDULING);
+
+        // make sure dynamic filter is initially blocked
+        assertFalse(dynamicFilter.isBlocked().isDone());
+
+        // make sure dynamic filter is unblocked due to build side source tasks being blocked
+        ScheduleResult scheduleResult = scheduler.schedule();
+        assertTrue(dynamicFilter.isBlocked().isDone());
+
+        // no new probe splits should be scheduled
+        assertEquals(scheduleResult.getSplitsScheduled(), 0);
+    }
+
+    @Test
+    public void testNoNewTaskScheduledWhenChildStageBufferIsOverUtilized()
+    {
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager(
+                new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
+                new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
+        PlanFragment plan = createFragment();
+        StageExecution stage = createStageExecution(plan, nodeTaskMap);
+
+        // setting over utilized child output buffer
+        StageScheduler scheduler = prepareScheduler(
+                ImmutableMap.of(TABLE_SCAN_1_NODE_ID, createFixedSplitSource(200), TABLE_SCAN_2_NODE_ID, createFixedSplitSource(200)),
+                createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager),
+                stage,
+                new DynamicFilterService(metadata, functionManager, typeOperators, new DynamicFilterConfig()),
+                () -> true,
+                200);
+        // the queues of 3 running nodes should be full
+        ScheduleResult scheduleResult = scheduler.schedule();
+        assertEquals(scheduleResult.getBlockedReason(), Optional.of(SPLIT_QUEUES_FULL));
+        assertEquals(scheduleResult.getNewTasks().size(), 3);
+        assertEquals(scheduleResult.getSplitsScheduled(), 300);
+        for (RemoteTask remoteTask : scheduleResult.getNewTasks()) {
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 100);
+        }
+
+        // new node added but 1 child's output buffer is overutilized - so lockdown the tasks
+        nodeManager.addNodes(new InternalNode("other4", URI.create("http://127.0.0.4:14"), NodeVersion.UNKNOWN, false));
+        scheduleResult = scheduler.schedule();
+        assertEquals(scheduleResult.getBlockedReason(), Optional.of(SPLIT_QUEUES_FULL));
+        assertEquals(scheduleResult.getNewTasks().size(), 0);
+        assertEquals(scheduleResult.getSplitsScheduled(), 0);
+    }
+
+    private static void assertPartitionedSplitCount(StageExecution stage, int expectedPartitionedSplitCount)
+    {
+        assertEquals(stage.getAllTasks().stream().mapToInt(remoteTask -> remoteTask.getPartitionedSplitsInfo().getCount()).sum(), expectedPartitionedSplitCount);
+    }
+
+    private static void assertEffectivelyFinished(ScheduleResult scheduleResult, StageScheduler scheduler)
+    {
+        if (scheduleResult.isFinished()) {
+            assertTrue(scheduleResult.getBlocked().isDone());
+            return;
+        }
+
+        assertTrue(scheduleResult.getBlocked().isDone());
+        ScheduleResult nextScheduleResult = scheduler.schedule();
+        assertTrue(nextScheduleResult.isFinished());
+        assertTrue(nextScheduleResult.getBlocked().isDone());
+        assertEquals(nextScheduleResult.getNewTasks().size(), 0);
+        assertEquals(nextScheduleResult.getSplitsScheduled(), 0);
+    }
+
+    private StageScheduler prepareScheduler(
+            Map<PlanNodeId, ConnectorSplitSource> splitSources,
+            SplitPlacementPolicy splitPlacementPolicy,
+            StageExecution stage,
+            int splitBatchSize)
+    {
+        return prepareScheduler(
+                splitSources,
+                splitPlacementPolicy,
+                stage,
+                new DynamicFilterService(metadata, functionManager, typeOperators, new DynamicFilterConfig()),
+                () -> false,
+                splitBatchSize);
+    }
+
+    private StageScheduler prepareScheduler(
+            Map<PlanNodeId, ConnectorSplitSource> splitSources,
+            SplitPlacementPolicy splitPlacementPolicy,
+            StageExecution stage,
+            DynamicFilterService dynamicFilterService,
+            BooleanSupplier anySourceTaskBlocked,
+            int splitBatchSize)
+    {
+        Map<PlanNodeId, SplitSource> sources = splitSources.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> new ConnectorAwareSplitSource(TEST_CATALOG_HANDLE, e.getValue())));
+        return new MultiSourcePartitionedScheduler(
+                stage,
+                sources,
+                splitPlacementPolicy,
+                splitBatchSize,
+                dynamicFilterService,
+                new TableExecuteContextManager(),
+                anySourceTaskBlocked);
+    }
+
+    private PlanFragment createFragment()
+    {
+        return createFragment(TEST_TABLE_HANDLE, TEST_TABLE_HANDLE);
+    }
+
+    private PlanFragment createFragment(TableHandle firstTableHandle, TableHandle secondTableHandle)
+    {
+        Symbol symbol = new Symbol("column");
+        Symbol buildSymbol = new Symbol("buildColumn");
+
+        TableScanNode tableScanOne = new TableScanNode(
+                TABLE_SCAN_1_NODE_ID,
+                firstTableHandle,
+                ImmutableList.of(symbol),
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
+                false,
+                Optional.empty());
+        FilterNode filterNodeOne = new FilterNode(
+                new PlanNodeId("filter_node_id"),
+                tableScanOne,
+                createDynamicFilterExpression(TEST_SESSION, createTestMetadataManager(), DYNAMIC_FILTER_ID, VARCHAR, symbol.toSymbolReference()));
+        TableScanNode tableScanTwo = new TableScanNode(
+                TABLE_SCAN_2_NODE_ID,
+                secondTableHandle,
+                ImmutableList.of(symbol),
+                ImmutableMap.of(symbol, new TestingColumnHandle("column")),
+                false,
+                Optional.empty());
+        FilterNode filterNodeTwo = new FilterNode(
+                new PlanNodeId("filter_node_id"),
+                tableScanTwo,
+                createDynamicFilterExpression(TEST_SESSION, createTestMetadataManager(), DYNAMIC_FILTER_ID, VARCHAR, symbol.toSymbolReference()));
+
+        RemoteSourceNode remote = new RemoteSourceNode(new PlanNodeId("remote_id"), new PlanFragmentId("plan_fragment_id"), ImmutableList.of(buildSymbol), Optional.empty(), REPLICATE, RetryPolicy.NONE);
+
+        return new PlanFragment(
+                new PlanFragmentId("plan_id"),
+                new JoinNode(
+                        new PlanNodeId("join_id"),
+                        INNER,
+                        new ExchangeNode(
+                                planNodeIdAllocator.getNextId(),
+                                REPARTITION,
+                                LOCAL,
+                                new PartitioningScheme(
+                                        Partitioning.create(FIXED_ARBITRARY_DISTRIBUTION, ImmutableList.of()),
+                                        tableScanOne.getOutputSymbols()),
+                                ImmutableList.of(
+                                        filterNodeOne,
+                                        filterNodeTwo),
+                                ImmutableList.of(tableScanOne.getOutputSymbols(), tableScanTwo.getOutputSymbols()),
+                                Optional.empty()),
+                        remote,
+                        ImmutableList.of(),
+                        tableScanOne.getOutputSymbols(),
+                        remote.getOutputSymbols(),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableMap.of(DYNAMIC_FILTER_ID, buildSymbol),
+                        Optional.empty()),
+                ImmutableMap.of(symbol, VARCHAR),
+                SOURCE_DISTRIBUTION,
+                Optional.empty(),
+                ImmutableList.of(TABLE_SCAN_1_NODE_ID, TABLE_SCAN_2_NODE_ID),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
+                StatsAndCosts.empty(),
+                ImmutableList.of(),
+                Optional.empty());
+    }
+
+    private static ConnectorSplitSource createFixedSplitSource(int splitCount)
+    {
+        return new FixedSplitSource(IntStream.range(0, splitCount).mapToObj(ix -> new TestingSplit(true, ImmutableList.of())).toList());
+    }
+
+    private SplitPlacementPolicy createSplitPlacementPolicies(Session session, StageExecution stage, NodeTaskMap nodeTaskMap, InternalNodeManager nodeManager)
+    {
+        return createSplitPlacementPolicies(session, stage, nodeTaskMap, nodeManager, TEST_CATALOG_HANDLE);
+    }
+
+    private SplitPlacementPolicy createSplitPlacementPolicies(Session session, StageExecution stage, NodeTaskMap nodeTaskMap, InternalNodeManager nodeManager, CatalogHandle catalog)
+    {
+        NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
+                .setIncludeCoordinator(false)
+                .setMaxSplitsPerNode(100)
+                .setMinPendingSplitsPerTask(0)
+                .setSplitsBalancingPolicy(STAGE);
+        NodeScheduler nodeScheduler = new NodeScheduler(new UniformNodeSelectorFactory(nodeManager, nodeSchedulerConfig, nodeTaskMap, new Duration(0, SECONDS)));
+        return new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(catalog)), stage::getAllTasks);
+    }
+
+    private StageExecution createStageExecution(PlanFragment fragment, NodeTaskMap nodeTaskMap)
+    {
+        StageId stageId = new StageId(QUERY_ID, 0);
+        SqlStage stage = SqlStage.createSqlStage(
+                stageId,
+                fragment,
+                ImmutableMap.of(
+                        TABLE_SCAN_1_NODE_ID, new TableInfo(Optional.of("test"), new QualifiedObjectName("test", "test", "test"), TupleDomain.all()),
+                        TABLE_SCAN_2_NODE_ID, new TableInfo(Optional.of("test"), new QualifiedObjectName("test", "test", "test"), TupleDomain.all())),
+                new MockRemoteTaskFactory(queryExecutor, scheduledExecutor),
+                TEST_SESSION,
+                true,
+                nodeTaskMap,
+                queryExecutor,
+                noopTracer(),
+                new SplitSchedulerStats());
+        ImmutableMap.Builder<PlanFragmentId, PipelinedOutputBufferManager> outputBuffers = ImmutableMap.builder();
+        outputBuffers.put(fragment.getId(), new PartitionedPipelinedOutputBufferManager(FIXED_HASH_DISTRIBUTION, 1));
+        fragment.getRemoteSourceNodes().stream()
+                .flatMap(node -> node.getSourceFragmentIds().stream())
+                .forEach(fragmentId -> outputBuffers.put(fragmentId, new PartitionedPipelinedOutputBufferManager(FIXED_HASH_DISTRIBUTION, 10)));
+        return createPipelinedStageExecution(
+                stage,
+                outputBuffers.buildOrThrow(),
+                TaskLifecycleListener.NO_OP,
+                new NoOpFailureDetector(),
+                queryExecutor,
+                Optional.of(new int[] {0}),
+                0);
+    }
+
+    private static class InMemoryNodeManagerByCatalog
+            extends InMemoryNodeManager
+    {
+        private final Function<CatalogHandle, Set<InternalNode>> nodesByCatalogs;
+
+        public InMemoryNodeManagerByCatalog(Set<InternalNode> nodes, Function<CatalogHandle, Set<InternalNode>> nodesByCatalogs)
+        {
+            super(nodes);
+            this.nodesByCatalogs = nodesByCatalogs;
+        }
+
+        @Override
+        public Set<InternalNode> getActiveCatalogNodes(CatalogHandle catalogHandle)
+        {
+            return nodesByCatalogs.apply(catalogHandle);
+        }
+    }
+
+    private static class QueuedSplitSource
+            implements ConnectorSplitSource
+    {
+        private final Supplier<ConnectorSplit> splitFactory;
+        private final LinkedBlockingQueue<ConnectorSplit> queue = new LinkedBlockingQueue<>();
+        private CompletableFuture<?> notEmptyFuture = new CompletableFuture<>();
+        private boolean closed;
+
+        public QueuedSplitSource(Supplier<ConnectorSplit> splitFactory)
+        {
+            this.splitFactory = requireNonNull(splitFactory, "splitFactory is null");
+        }
+
+        public QueuedSplitSource()
+        {
+            this.splitFactory = TestingSplit::createRemoteSplit;
+        }
+
+        synchronized void addSplits(int count, boolean lastSplits)
+        {
+            if (closed) {
+                return;
+            }
+            for (int i = 0; i < count; i++) {
+                queue.add(splitFactory.get());
+            }
+            if (lastSplits) {
+                close();
+            }
+            notEmptyFuture.complete(null);
+        }
+
+        @Override
+        public CompletableFuture<ConnectorSplitBatch> getNextBatch(int maxSize)
+        {
+            return notEmptyFuture
+                    .thenApply(x -> getBatch(maxSize))
+                    .thenApply(splits -> new ConnectorSplitBatch(splits, isFinished()));
+        }
+
+        private synchronized List<ConnectorSplit> getBatch(int maxSize)
+        {
+            // take up to maxSize elements from the queue
+            List<ConnectorSplit> elements = new ArrayList<>(maxSize);
+            queue.drainTo(elements, maxSize);
+
+            // if the queue is empty and the current future is finished, create a new one so
+            // a new readers can be notified when the queue has elements to read
+            if (queue.isEmpty() && !closed) {
+                if (notEmptyFuture.isDone()) {
+                    notEmptyFuture = new CompletableFuture<>();
+                }
+            }
+
+            return ImmutableList.copyOf(elements);
+        }
+
+        @Override
+        public synchronized boolean isFinished()
+        {
+            return closed && queue.isEmpty();
+        }
+
+        @Override
+        public synchronized void close()
+        {
+            closed = true;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
@@ -154,7 +154,7 @@ public class TestAddDynamicFilterSource
                                                         node(
                                                                 DynamicFilterSourceNode.class,
                                                                 exchange(
-                                                                        REMOTE,
+                                                                        LOCAL,
                                                                         Optional.empty(),
                                                                         Optional.empty(),
                                                                         ImmutableList.of(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -19,7 +19,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
+import io.trino.connector.MockConnectorColumnHandle;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.connector.MockConnectorTableHandle;
 import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.BigintType;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy;
 import io.trino.sql.planner.assertions.BasePlanTest;
@@ -30,6 +37,8 @@ import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode.DistributionType;
 import io.trino.sql.planner.plan.MarkDistinctNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.query.QueryAssertions;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.LongLiteral;
@@ -53,6 +62,10 @@ import static io.trino.SystemSessionProperties.USE_EXACT_PARTITIONING;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.PARTITIONED;
 import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyNot;
@@ -976,6 +989,241 @@ public class TestAddExchangesPlans
                         exchange(LOCAL, GATHER,
                                     anyTree(
                                             tableScan("orders")))));
+    }
+
+    @Test
+    public void testBroadcastJoinAboveUnionAll()
+    {
+        // Put union at build side
+        assertDistributedPlan(
+                """
+                    SELECT * FROM region r JOIN (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n ON r.regionkey = n.nationkey
+                """,
+                noJoinReordering(),
+                anyTree(
+                        join(INNER, join -> join
+                                .equiCriteria("regionkey", "nationkey")
+                                .left(
+                                        project(
+                                                node(FilterNode.class,
+                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))
+                                .right(
+                                        exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                        exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                                                project(
+                                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))),
+                                                                project(
+                                                                        tableScan("nation")))))))));
+        // Put union at probe side
+        assertDistributedPlan(
+                """
+                    SELECT * FROM (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n JOIN region r ON r.regionkey = n.nationkey
+                """,
+                noJoinReordering(),
+                anyTree(
+                        join(INNER, join -> join
+                                .equiCriteria("nationkey", "regionkey")
+                                .left(
+                                        exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                                project(
+                                                        node(FilterNode.class,
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))),
+                                                project(
+                                                        node(FilterNode.class,
+                                                                tableScan("nation")))))
+                                .right(
+                                        exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                        project(
+                                                                tableScan("region", ImmutableMap.of("regionkey", "regionkey")))))))));
+    }
+
+    @Test
+    public void testUnionAllAboveBroadcastJoin()
+    {
+        assertDistributedPlan(
+                """
+                    SELECT regionkey FROM nation UNION ALL (SELECT nationkey FROM nation n JOIN region r on r.regionkey = n.nationkey)
+                """,
+                noJoinReordering(),
+                anyTree(
+                        exchange(REMOTE, GATHER, SINGLE_DISTRIBUTION,
+                                tableScan("nation"),
+                                join(INNER, join -> join
+                                        .equiCriteria("nationkey", "regionkey")
+                                        .left(
+                                                project(
+                                                        node(FilterNode.class,
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))
+                                        .right(
+                                                exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                        exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                                project(
+                                                                        tableScan("region", ImmutableMap.of("regionkey", "regionkey"))))))))));
+    }
+
+    @Test
+    public void testGroupedAggregationAboveUnionAllCrossJoined()
+    {
+        assertDistributedPlan(
+                """
+                    SELECT sum(nationkey) FROM (SELECT nationkey FROM nation UNION ALL SELECT nationkey FROM nation), region group by nationkey
+                """,
+                noJoinReordering(),
+                anyTree(
+                        join(INNER, join -> join
+                                .left(
+                                        exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")),
+                                                tableScan("nation")))
+                                .right(
+                                        exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                        tableScan("region")))))));
+    }
+
+    @Test
+    public void testGroupedAggregationAboveUnionAll()
+    {
+        assertDistributedPlan(
+                """
+                    SELECT sum(nationkey) FROM (SELECT nationkey FROM nation UNION ALL SELECT nationkey FROM nation) GROUP BY nationkey
+                """,
+                noJoinReordering(),
+                anyTree(
+                        exchange(LOCAL, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                project(
+                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                project(
+                                                        aggregation(ImmutableMap.of("partial_sum", functionCall("sum", ImmutableList.of("nationkey"))),
+                                                                PARTIAL,
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))),
+                                project(
+                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                project(
+                                                        aggregation(ImmutableMap.of("partial_sum", functionCall("sum", ImmutableList.of("nationkey"))),
+                                                                PARTIAL,
+                                                                tableScan("nation", ImmutableMap.of("nationkey", "nationkey")))))))));
+    }
+
+    @Test
+    public void testUnionAllOnPartitionedAndUnpartitionedSources()
+    {
+        assertDistributedPlan(
+                """
+                     SELECT * FROM (SELECT nationkey FROM nation UNION ALL VALUES (1))
+                """,
+                noJoinReordering(),
+                output(
+                        exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                values("1"),
+                                exchange(REMOTE, GATHER, SINGLE_DISTRIBUTION,
+                                        tableScan("nation")))));
+    }
+
+    @Test
+    public void testNestedUnionAll()
+    {
+        assertDistributedPlan(
+                """
+                     SELECT * FROM ((SELECT nationkey FROM nation) UNION ALL (SELECT nationkey FROM nation)) UNION ALL (SELECT nationkey FROM nation)
+                """,
+                noJoinReordering(),
+                output(
+                        exchange(REMOTE, GATHER, SINGLE_DISTRIBUTION,
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                tableScan("nation"))));
+    }
+
+    @Test
+    public void testUnionAllOnSourceAndHashDistributedChildren()
+    {
+        assertDistributedPlan(
+                """
+                     SELECT * FROM ((SELECT nationkey FROM nation) UNION ALL (SELECT nationkey FROM nation)) UNION ALL (SELECT sum(nationkey) FROM nation GROUP BY nationkey)
+                """,
+                noJoinReordering(),
+                output(
+                        exchange(REMOTE, GATHER, SINGLE_DISTRIBUTION,
+                                tableScan("nation"),
+                                tableScan("nation"),
+                                project(
+                                        anyTree(
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION,
+                                                        project(
+                                                                aggregation(ImmutableMap.of("partial_sum", functionCall("sum", ImmutableList.of("nationkey"))),
+                                                                        PARTIAL,
+                                                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))))))))));
+    }
+
+    @Test
+    public void testUnionAllOnDifferentCatalogs()
+    {
+        MockConnectorFactory connectorFactory = MockConnectorFactory.builder()
+                .withGetColumns(schemaTableName -> ImmutableList.of(
+                        new ColumnMetadata("nationkey", BigintType.BIGINT)))
+                .withGetTableHandle(((session, schemaTableName) -> new MockConnectorTableHandle(
+                        SchemaTableName.schemaTableName("default", "nation"),
+                        TupleDomain.all(),
+                        Optional.of(ImmutableList.of(new MockConnectorColumnHandle("nationkey", BigintType.BIGINT))))))
+                .withName("mock")
+                .build();
+        getQueryRunner().createCatalog("mock", connectorFactory, ImmutableMap.of());
+
+        // Need to use JOIN as parent of UNION ALL to expose replacing remote exchange with local exchange
+        assertDistributedPlan(
+                """
+                         SELECT * FROM (SELECT nationkey FROM nation UNION ALL SELECT nationkey FROM mock.default.nation), region
+                """,
+                noJoinReordering(),
+                output(
+                        join(INNER, join -> join
+                                .left(exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                        tableScan("nation"),
+                                        node(TableScanNode.class)))
+                                .right(
+                                        exchange(LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                        tableScan("region")))))));
+    }
+
+    @Test
+    public void testUnionAllOnInternalCatalog()
+    {
+        // Need to use JOIN as parent of UNION ALL to expose replacing remote exchange with local exchange
+        // TODO: https://starburstdata.atlassian.net/browse/SEP-11273
+        assertDistributedPlan(
+                """
+                         SELECT * FROM (SELECT table_catalog FROM system.information_schema.tables UNION ALL SELECT table_catalog FROM system.information_schema.tables), region
+                """,
+                noJoinReordering(),
+                output(
+                        join(INNER, join -> join
+                                .left(exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                        tableScan("tables"),
+                                        tableScan("tables")))
+                                .right(
+                                        exchange(
+                                                LOCAL, GATHER, SINGLE_DISTRIBUTION,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION,
+                                                        tableScan("region")))))));
+    }
+
+    @Test
+    public void testUnionAllOnTableScanAndValues()
+    {
+        assertDistributedPlan(
+                """
+                         SELECT * FROM (SELECT nationkey FROM nation UNION ALL VALUES(1))
+                """,
+                noJoinReordering(),
+                output(
+                        exchange(LOCAL, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION,
+                                node(ValuesNode.class),
+                                exchange(REMOTE, GATHER, SINGLE_DISTRIBUTION,
+                                        tableScan("nation")))));
     }
 
     private Session spillEnabledWithJoinDistributionType(JoinDistributionType joinDistributionType)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -502,4 +502,10 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE 0=1");
         assertQuery("SELECT * FROM (SELECT count(*) FROM orders) WHERE null");
     }
+
+    @Test
+    public void testUnionAllAboveBroadcastJoin()
+    {
+        assertQuery("SELECT COUNT(*) FROM region r JOIN (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n ON r.regionkey = n.nationkey", "VALUES 10");
+    }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestUnionQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestUnionQueries.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpcds.TpcdsPlugin;
+import io.trino.sql.planner.OptimizerConfig;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tests.tpch.TpchQueryRunnerBuilder;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy.NONE;
+
+public class TestUnionQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build();
+        queryRunner.installPlugin(new TpcdsPlugin());
+        queryRunner.createCatalog("tpcds", "tpcds", ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @Test
+    public void testUnionFromDifferentCatalogs()
+    {
+        @Language("SQL")
+        String query = "SELECT count(*) FROM (SELECT nationkey FROM tpch.tiny.nation UNION ALL SELECT ss_sold_date_sk FROM tpcds.tiny.store_sales) n JOIN tpch.tiny.region r ON n.nationkey = r.regionkey";
+        assertQuery(query, "VALUES(5)");
+    }
+
+    @Test
+    public void testUnionAllOnConnectorPartitionedTables()
+    {
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.name())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, OptimizerConfig.JoinDistributionType.BROADCAST.name()).build();
+
+        @Language("SQL")
+        String query = "SELECT count(*) FROM ((SELECT orderkey FROM orders) union all (SELECT nationkey FROM nation)) o JOIN nation n ON o.orderkey = n.nationkey";
+        assertQuery(session, query, "VALUES(32)");
+    }
+}

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_132"])
                                             partial aggregation over (d_day_name_142, d_week_seq_132)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_85"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_123"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q71.plan.txt
@@ -8,7 +8,7 @@ remote exchange (GATHER, SINGLE, [])
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, ["time_sk"])
                                     join (INNER, REPLICATED):
-                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                             join (INNER, REPLICATED):
                                                 dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                     scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_129"])
                                             partial aggregation over (d_day_name_139, d_week_seq_129)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_51"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_88"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
                                             partial aggregation over (d_day_name_134, d_week_seq_124)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_81"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_117"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
                                             partial aggregation over (d_day_name_134, d_week_seq_124)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_48"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_84"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
                                             partial aggregation over (d_day_name_134, d_week_seq_124)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_81"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_117"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q02.plan.txt
@@ -9,7 +9,7 @@ remote exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["d_week_seq"])
                                     partial aggregation over (d_day_name, d_week_seq)
                                         join (INNER, REPLICATED):
-                                            remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                            local exchange (REPARTITION, ROUND_ROBIN, [])
                                                 dynamic filter (["ws_sold_date_sk"])
                                                     scan web_sales
                                                 dynamic filter (["cs_sold_date_sk"])
@@ -31,7 +31,7 @@ remote exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, ["d_week_seq_124"])
                                             partial aggregation over (d_day_name_134, d_week_seq_124)
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ws_sold_date_sk_48"])
                                                             scan web_sales
                                                         dynamic filter (["cs_sold_date_sk_84"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
@@ -35,7 +35,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 join (INNER, REPLICATED, can skip output duplicates):
                                                                                                     join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                             dynamic filter (["cs_item_sk", "cs_sold_date_sk"])
                                                                                                                 scan catalog_sales
                                                                                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q02.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q02.plan.txt
@@ -12,7 +12,7 @@ remote exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, ["d_day_name", "d_week_seq"])
                                                 partial aggregation over (d_day_name, d_week_seq)
                                                     join (INNER, REPLICATED):
-                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                        local exchange (REPARTITION, ROUND_ROBIN, [])
                                                             dynamic filter (["ws_sold_date_sk"])
                                                                 scan web_sales
                                                             dynamic filter (["cs_sold_date_sk"])
@@ -37,7 +37,7 @@ remote exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPARTITION, HASH, ["d_day_name_134", "d_week_seq_124"])
                                                         partial aggregation over (d_day_name_134, d_week_seq_124)
                                                             join (INNER, REPLICATED):
-                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                     dynamic filter (["ws_sold_date_sk_48"])
                                                                         scan web_sales
                                                                     dynamic filter (["cs_sold_date_sk_84"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q05.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q05.plan.txt
@@ -11,7 +11,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (s_store_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
                                                             scan store_sales
                                                         dynamic filter (["sr_returned_date_sk", "sr_store_sk"])
@@ -28,7 +28,7 @@ local exchange (GATHER, SINGLE, [])
                                         partial aggregation over (cp_catalog_page_id)
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                                         dynamic filter (["cs_catalog_page_sk", "cs_sold_date_sk"])
                                                             scan catalog_sales
                                                         dynamic filter (["cr_catalog_page_sk", "cr_returned_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q54.plan.txt
@@ -22,7 +22,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPARTITION, HASH, ["customer_sk"])
                                                                                         join (INNER, REPLICATED, can skip output duplicates):
                                                                                             join (INNER, REPLICATED, can skip output duplicates):
-                                                                                                remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                local exchange (REPARTITION, ROUND_ROBIN, [])
                                                                                                     dynamic filter (["cs_bill_customer_sk", "cs_bill_customer_sk", "cs_item_sk", "cs_sold_date_sk"])
                                                                                                         scan catalog_sales
                                                                                                     dynamic filter (["ws_bill_customer_sk", "ws_bill_customer_sk", "ws_item_sk", "ws_sold_date_sk"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q71.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q71.plan.txt
@@ -7,7 +7,7 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
                                         join (INNER, REPLICATED):
                                             dynamic filter (["ws_item_sk", "ws_sold_date_sk", "ws_sold_time_sk"])
                                                 scan web_sales


### PR DESCRIPTION
## Description
This PR adds a new scheduler `MultiSourcePartitionedScheduler` that make it possible to run multiple source partitioned table scans within one stage. Some `UNION` queries can take advantage from that, for example:

1. **tpcds/q02**, [orc, unpart, sf1000], before / after:
    - **Duration**:   14.39s / 9.35s
    - **Cpu Time**:  32.45m / 23.36m
    - **Internal Network Data**: 97.4GB /  50.0MB

2. **tpcds/q05**, [orc, unpart, sf1000], before / after:
   - **Duration**:  25.78s / 13s
   - **Cpu Time**: 30.77m / 25.70m
    - **Internal Network Data**: 205GB /  54.5GB


Benchmark results: [benchmarks.pdf](https://github.com/starburstdata/galaxy-trino/files/11177170/benchmarks.pdf)

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(*) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: