### PR TITLE
Run trino-hdfs tests single-threaded

### DIFF
--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -14,6 +14,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <!-- e.g. TestFileSystemCache asserts on static global state -->
+        <air.test.thread-count>1</air.test.thread-count>
     </properties>
 
     <dependencies>

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
@@ -38,7 +38,6 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-@Test(singleThreaded = true) // e.g. test methods operate on shared, mutated tempFile
 public class TestFSDataInputStreamTail
 {
     private File tempRoot;

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
@@ -42,7 +42,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 
-@Test(singleThreaded = true)
 public class TestFileSystemCache
 {
     @BeforeMethod(alwaysRun = true)


### PR DESCRIPTION
The tests verify global (static) state, e.g.
`TrinoFileSystemCache.INSTANCE.getFileSystemCacheStats().getCacheSize()`, so test classes cannot be run in parallel.

This also removes `@Test(singleThreaded = true)` from test classes. This becomes redundant, and may create false impression as to how test concurrency is managed in this module.

hopefully fixes https://github.com/trinodb/trino/issues/17158 