### PR TITLE
Remove deprecated ConnectorMetadata.getSchemaTableName

### DIFF
--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -216,16 +216,6 @@ public class TracingConnectorMetadata
         }
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public SchemaTableName getSchemaTableName(ConnectorSession session, ConnectorTableHandle table)
-    {
-        Span span = startSpan("getSchemaTableName", table);
-        try (var ignored = scopedSpan(span)) {
-            return delegate.getSchemaTableName(session, table);
-        }
-    }
-
     @Override
     public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -218,18 +218,6 @@ public interface ConnectorMetadata
     }
 
     /**
-     * Return schema table name for the specified table handle.
-     * This method is useful when requiring only {@link SchemaTableName} without other objects.
-     *
-     * @throws RuntimeException if table handle is no longer valid
-     */
-    @Deprecated // ... and optimized implementations already removed
-    default SchemaTableName getSchemaTableName(ConnectorSession session, ConnectorTableHandle table)
-    {
-        return getTableSchema(session, table).getTable();
-    }
-
-    /**
      * Return table schema definition for the specified table handle.
      * This method is useful when getting full table metadata is expensive.
      *

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -250,14 +250,6 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public SchemaTableName getSchemaTableName(ConnectorSession session, ConnectorTableHandle table)
-    {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaTableName(session, table);
-        }
-    }
-
-    @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
Deprecated since 646286ca3662b27fde03b9b875a72554bc16b79b (Trino 406).
