### PR TITLE
Handle missing StorageDescriptor in Hive Glue materialized views

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.PATH_PROPERTY;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -86,8 +86,8 @@ public class HiveMetastoreBackedDeltaLakeMetastore
 
     public static void verifyDeltaLakeTable(Table table)
     {
-        if (isHiveOrPrestoView(table)) {
-            // this is a Hive view, hence not a table
+        if (isViewOrMaterializedView(table)) {
+            // this is a view, hence not a table
             throw new NotADeltaLakeTableException(table.getDatabaseName(), table.getTableName());
         }
         if (!TABLE_PROVIDER_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_PROVIDER_PROPERTY))) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -263,8 +263,8 @@ import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.ViewReaderUtil.createViewReader;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.acid.AcidTransaction.forCreateTable;
@@ -1445,7 +1445,7 @@ public class HiveMetadata
     {
         Table view = metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
-        if (translateHiveViews && !isPrestoView(view)) {
+        if (translateHiveViews && !isTrinoView(view)) {
             throw new HiveViewNotSupportedException(viewName);
         }
         return view;
@@ -2611,7 +2611,7 @@ public class HiveMetadata
 
         Optional<Table> existing = metastore.getTable(viewName.getSchemaName(), viewName.getTableName());
         if (existing.isPresent()) {
-            if (!replace || !isPrestoView(existing.get())) {
+            if (!replace || !isTrinoView(existing.get())) {
                 throw new ViewAlreadyExistsException(viewName);
             }
 
@@ -2728,7 +2728,7 @@ public class HiveMetadata
         return table
                 .filter(view -> isViewOrMaterializedView(view) && !isTrinoMaterializedView(view))
                 .map(view -> {
-                    if (!translateHiveViews && !isPrestoView(view)) {
+                    if (!translateHiveViews && !isTrinoView(view)) {
                         throw new HiveViewNotSupportedException(viewName);
                     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
@@ -38,7 +38,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.TrinoViewUtil.createViewProperties;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
@@ -86,7 +86,7 @@ public final class TrinoViewHiveMetastore
 
         Optional<io.trino.plugin.hive.metastore.Table> existing = metastore.getTable(schemaViewName.getSchemaName(), schemaViewName.getTableName());
         if (existing.isPresent()) {
-            if (!replace || !isPrestoView(existing.get())) {
+            if (!replace || !isTrinoView(existing.get())) {
                 throw new ViewAlreadyExistsException(schemaViewName);
             }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
@@ -28,8 +28,8 @@ import static io.trino.plugin.hive.HiveMetadata.PRESTO_VIEW_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_CREATED_BY;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 
 public final class TrinoViewUtil
 {
@@ -70,7 +70,7 @@ public final class TrinoViewUtil
 
     private static boolean isView(String tableType, Map<String, String> tableParameters)
     {
-        return isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT));
+        return isViewOrMaterializedView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT));
     }
 
     public static Map<String, String> createViewProperties(ConnectorSession session, String trinoVersion, String connectorName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
@@ -28,7 +28,7 @@ import static io.trino.plugin.hive.HiveMetadata.PRESTO_VIEW_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_CREATED_BY;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 
 public final class TrinoViewUtil
@@ -47,7 +47,7 @@ public final class TrinoViewUtil
             return Optional.empty();
         }
 
-        if (!isPrestoView(tableParameters)) {
+        if (!isTrinoView(tableParameters)) {
             // Hive views are not compatible
             throw new HiveViewNotSupportedException(viewName);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -150,12 +150,6 @@ public final class ViewReaderUtil
         return isPrestoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
     }
 
-    public static boolean canDecodeView(Table table)
-    {
-        // we can decode Hive or Presto view
-        return table.getTableType().equals(VIRTUAL_VIEW.name());
-    }
-
     public static boolean isViewOrMaterializedView(Table table)
     {
         return isViewOrMaterializedView(table.getTableType());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -82,7 +82,7 @@ public final class ViewReaderUtil
             boolean runHiveViewRunAsInvoker,
             HiveTimestampPrecision hiveViewsTimestampPrecision)
     {
-        if (isPrestoView(table)) {
+        if (isTrinoView(table)) {
             return new PrestoViewReader();
         }
         if (isHiveViewsLegacyTranslation(session)) {
@@ -130,12 +130,12 @@ public final class ViewReaderUtil
     private static final JsonCodec<ConnectorViewDefinition> VIEW_CODEC =
             new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(ConnectorViewDefinition.class);
 
-    public static boolean isPrestoView(Table table)
+    public static boolean isTrinoView(Table table)
     {
-        return isPrestoView(table.getParameters());
+        return isTrinoView(table.getParameters());
     }
 
-    public static boolean isPrestoView(Map<String, String> tableParameters)
+    public static boolean isTrinoView(Map<String, String> tableParameters)
     {
         return "true".equals(tableParameters.get(PRESTO_VIEW_FLAG));
     }
@@ -147,7 +147,7 @@ public final class ViewReaderUtil
 
     public static boolean isTrinoMaterializedView(Map<String, String> tableParameters)
     {
-        return isPrestoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
+        return isTrinoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
     }
 
     public static boolean isViewOrMaterializedView(Table table)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -140,25 +140,30 @@ public final class ViewReaderUtil
         return "true".equals(tableParameters.get(PRESTO_VIEW_FLAG));
     }
 
-    public static boolean isHiveOrPrestoView(Table table)
+    public static boolean isTrinoMaterializedView(Table table)
     {
-        return isHiveOrPrestoView(table.getTableType());
+        return isTrinoMaterializedView(table.getParameters());
     }
 
-    public static boolean isHiveOrPrestoView(String tableType)
+    public static boolean isTrinoMaterializedView(Map<String, String> tableParameters)
     {
-        return tableType.equals(VIRTUAL_VIEW.name());
-    }
-
-    public static boolean isTrinoMaterializedView(String tableType, Map<String, String> tableParameters)
-    {
-        return isHiveOrPrestoView(tableType) && isPrestoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
+        return isPrestoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
     }
 
     public static boolean canDecodeView(Table table)
     {
         // we can decode Hive or Presto view
         return table.getTableType().equals(VIRTUAL_VIEW.name());
+    }
+
+    public static boolean isViewOrMaterializedView(Table table)
+    {
+        return isViewOrMaterializedView(table.getTableType());
+    }
+
+    public static boolean isViewOrMaterializedView(String tableType)
+    {
+        return tableType.equals(VIRTUAL_VIEW.name());
     }
 
     public static String encodeViewData(ConnectorViewDefinition definition)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -105,7 +105,7 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_TABLE_DROPPED_DURING_QUERY
 import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
@@ -3274,7 +3274,7 @@ public class SemiTransactionalHiveMetastore
             }
             tableCreated = true;
 
-            if (created && !isPrestoView(newTable)) {
+            if (created && !isTrinoView(newTable)) {
                 metastore.updateTableStatistics(newTable.getDatabaseName(), newTable.getTableName(), transaction, ignored -> statistics);
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueToTrinoConverter.java
@@ -41,6 +41,7 @@ import static io.trino.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlu
 import static io.trino.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestPartition;
 import static io.trino.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestStorageDescriptor;
 import static io.trino.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestTable;
+import static io.trino.plugin.hive.metastore.glue.TestingMetastoreObjects.getGlueTestTrinoMaterializedView;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableTypeNullable;
 import static io.trino.plugin.hive.util.HiveUtil.DELTA_LAKE_PROVIDER;
 import static io.trino.plugin.hive.util.HiveUtil.ICEBERG_TABLE_TYPE_NAME;
@@ -257,6 +258,15 @@ public class TestGlueToTrinoConverter
                 testTable.getStorageDescriptor().getColumns().stream()
                         .map(com.amazonaws.services.glue.model.Column::getName)
                         .collect(toImmutableSet()));
+    }
+
+    @Test
+    public void testIcebergMaterializedViewNullStorageDescriptor()
+    {
+        Table testMaterializedView = getGlueTestTrinoMaterializedView(testDatabase.getName());
+        assertNull(testMaterializedView.getStorageDescriptor());
+        io.trino.plugin.hive.metastore.Table trinoTable = GlueToTrinoConverter.convertTable(testMaterializedView, testDatabase.getName());
+        assertEquals(trinoTable.getDataColumns().size(), 1);
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -80,6 +80,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -89,9 +90,13 @@ import static io.trino.plugin.hive.HiveColumnStatisticType.MAX_VALUE;
 import static io.trino.plugin.hive.HiveColumnStatisticType.MIN_VALUE;
 import static io.trino.plugin.hive.HiveColumnStatisticType.NUMBER_OF_DISTINCT_VALUES;
 import static io.trino.plugin.hive.HiveColumnStatisticType.NUMBER_OF_NON_NULL_VALUES;
+import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.HiveStorageFormat.TEXTFILE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
+import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
@@ -118,6 +123,7 @@ import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
+import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -1293,17 +1299,21 @@ public class TestHiveGlueMetastore
     }
 
     @Test
-    public void testTableWithoutStorageDescriptor()
+    public void testGlueObjectsWithoutStorageDescriptor()
     {
-        // StorageDescriptor is an Optional field for Glue tables. Iceberg and Delta Lake tables may not have it set.
+        // StorageDescriptor is an Optional field for Glue tables.
         SchemaTableName table = temporaryTable("test_missing_storage_descriptor");
         DeleteTableRequest deleteTableRequest = new DeleteTableRequest()
                 .withDatabaseName(table.getSchemaName())
                 .withName(table.getTableName());
+
         try {
-            TableInput tableInput = new TableInput()
+            Supplier<TableInput> resetTableInput = () -> new TableInput()
+                    .withStorageDescriptor(null)
                     .withName(table.getTableName())
                     .withTableType(EXTERNAL_TABLE.name());
+
+            TableInput tableInput = resetTableInput.get();
             glueClient.createTable(new CreateTableRequest()
                     .withDatabaseName(database)
                     .withTableInput(tableInput));
@@ -1313,7 +1323,7 @@ public class TestHiveGlueMetastore
             glueClient.deleteTable(deleteTableRequest);
 
             // Iceberg table
-            tableInput = tableInput.withParameters(ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE));
+            tableInput = resetTableInput.get().withParameters(ImmutableMap.of(ICEBERG_TABLE_TYPE_NAME, ICEBERG_TABLE_TYPE_VALUE));
             glueClient.createTable(new CreateTableRequest()
                     .withDatabaseName(database)
                     .withTableInput(tableInput));
@@ -1321,11 +1331,30 @@ public class TestHiveGlueMetastore
             glueClient.deleteTable(deleteTableRequest);
 
             // Delta Lake table
-            tableInput = tableInput.withParameters(ImmutableMap.of(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER));
+            tableInput = resetTableInput.get().withParameters(ImmutableMap.of(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER));
             glueClient.createTable(new CreateTableRequest()
                     .withDatabaseName(database)
                     .withTableInput(tableInput));
             assertTrue(isDeltaLakeTable(metastore.getTable(table.getSchemaName(), table.getTableName()).orElseThrow()));
+            glueClient.deleteTable(deleteTableRequest);
+
+            // Iceberg materialized view
+            tableInput = resetTableInput.get().withTableType(VIRTUAL_VIEW.name())
+                    .withViewOriginalText("/* %s: base64encodedquery */".formatted(ICEBERG_MATERIALIZED_VIEW_COMMENT))
+                    .withViewExpandedText(ICEBERG_MATERIALIZED_VIEW_COMMENT)
+                    .withParameters(ImmutableMap.of(
+                            PRESTO_VIEW_FLAG, "true",
+                            TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT));
+            glueClient.createTable(new CreateTableRequest()
+                    .withDatabaseName(database)
+                    .withTableInput(tableInput));
+            assertTrue(isTrinoMaterializedView(metastore.getTable(table.getSchemaName(), table.getTableName()).orElseThrow()));
+            try (Transaction transaction = newTransaction()) {
+                ConnectorSession session = newSession();
+                ConnectorMetadata metadata = transaction.getMetadata();
+                // Not a view
+                assertThat(metadata.getView(session, table)).isEmpty();
+            }
         }
         finally {
             // Table cannot be dropped through HiveMetastore since a TableHandle cannot be created

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingMetastoreObjects.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingMetastoreObjects.java
@@ -32,6 +32,9 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Consumer;
 
+import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
+import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static java.lang.String.format;
 
 public final class TestingMetastoreObjects
@@ -61,6 +64,20 @@ public final class TestingMetastoreObjects
                 .withTableType(TableType.EXTERNAL_TABLE.name())
                 .withViewOriginalText("originalText")
                 .withViewExpandedText("expandedText");
+    }
+
+    public static Table getGlueTestTrinoMaterializedView(String dbName)
+    {
+        return new Table()
+                .withDatabaseName(dbName)
+                .withName("test-mv" + generateRandom())
+                .withOwner("owner")
+                .withParameters(ImmutableMap.of(PRESTO_VIEW_FLAG, "true", TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT))
+                .withPartitionKeys()
+                .withStorageDescriptor(null)
+                .withTableType(TableType.VIRTUAL_VIEW.name())
+                .withViewOriginalText("/* %s: base64encodedquery */".formatted(ICEBERG_MATERIALIZED_VIEW_COMMENT))
+                .withViewExpandedText(ICEBERG_MATERIALIZED_VIEW_COMMENT);
     }
 
     public static Column getGlueTestColumn()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -43,8 +43,8 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Verify.verify;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableType;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
@@ -85,8 +85,8 @@ public class GlueIcebergTableOperations
         glueVersionId = table.getVersionId();
 
         Map<String, String> parameters = firstNonNull(table.getParameters(), ImmutableMap.of());
-        if (isPrestoView(parameters) && isHiveOrPrestoView(getTableType(table))) {
-            // this is a Presto Hive view, hence not a table
+        if (isPrestoView(parameters) && isViewOrMaterializedView(getTableType(table))) {
+            // this is a Presto view or materialized view, hence not a table
             throw new TableNotFoundException(getSchemaTableName());
         }
         if (!isIcebergTable(parameters)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Verify.verify;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableType;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
@@ -85,7 +85,7 @@ public class GlueIcebergTableOperations
         glueVersionId = table.getVersionId();
 
         Map<String, String> parameters = firstNonNull(table.getParameters(), ImmutableMap.of());
-        if (isPrestoView(parameters) && isViewOrMaterializedView(getTableType(table))) {
+        if (isTrinoView(parameters) && isViewOrMaterializedView(getTableType(table))) {
             // this is a Presto view or materialized view, hence not a table
             throw new TableNotFoundException(getSchemaTableName());
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -88,7 +88,7 @@ import static io.trino.plugin.hive.HiveMetadata.STORAGE_TABLE;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.TrinoViewUtil.createViewProperties;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.metastore.glue.AwsSdkUtil.getPaginatedResults;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableType;
@@ -515,7 +515,7 @@ public class TrinoGlueCatalog
                     LOG.warn(e, "Failed to cache materialized view from %s", schemaTableName);
                 }
             }
-            else if (isPrestoView(parameters) && !viewCache.containsKey(schemaTableName)) {
+            else if (isTrinoView(parameters) && !viewCache.containsKey(schemaTableName)) {
                 if (materializedViewCache.containsKey(schemaTableName) || tableMetadataCache.containsKey(schemaTableName)) {
                     throw new TrinoException(GENERIC_INTERNAL_ERROR, "Glue table cache inconsistency. View cannot also be a materialized view or table");
                 }
@@ -611,7 +611,7 @@ public class TrinoGlueCatalog
     {
         Optional<com.amazonaws.services.glue.model.Table> existing = getTable(session, schemaViewName);
         if (existing.isPresent()) {
-            if (!replace || !isPrestoView(firstNonNull(existing.get().getParameters(), ImmutableMap.of()))) {
+            if (!replace || !isTrinoView(firstNonNull(existing.get().getParameters(), ImmutableMap.of()))) {
                 // TODO: ViewAlreadyExists is misleading if the name is used by a table https://github.com/trinodb/trino/issues/10037
                 throw new ViewAlreadyExistsException(schemaViewName);
             }
@@ -707,7 +707,7 @@ public class TrinoGlueCatalog
                             stats.getGetTables())
                             .map(GetTablesResult::getTableList)
                             .flatMap(List::stream)
-                            .filter(table -> isPrestoView(firstNonNull(table.getParameters(), ImmutableMap.of())))
+                            .filter(table -> isTrinoView(firstNonNull(table.getParameters(), ImmutableMap.of())))
                             .map(table -> new SchemaTableName(glueNamespace, table.getName()))
                             .collect(toImmutableList()));
                 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
@@ -73,8 +73,8 @@ public abstract class AbstractMetastoreTableOperations
         }
         Table table = getTable();
 
-        if (isPrestoView(table) && isHiveOrPrestoView(table)) {
-            // this is a Hive view, hence not a table
+        if (isPrestoView(table) && isViewOrMaterializedView(table)) {
+            // this is a view or a materialized view, hence not a table
             throw new TableNotFoundException(getSchemaTableName());
         }
         if (!isIcebergTable(table)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
@@ -73,7 +73,7 @@ public abstract class AbstractMetastoreTableOperations
         }
         Table table = getTable();
 
-        if (isPrestoView(table) && isViewOrMaterializedView(table)) {
+        if (isTrinoView(table) && isViewOrMaterializedView(table)) {
             // this is a view or a materialized view, hence not a table
             throw new TableNotFoundException(getSchemaTableName());
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -72,8 +72,8 @@ import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
+import static io.trino.plugin.hive.ViewReaderUtil.isViewOrMaterializedView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
@@ -504,7 +504,7 @@ public class TrinoHiveCatalog
         Optional<io.trino.plugin.hive.metastore.Table> existing = metastore.getTable(viewName.getSchemaName(), viewName.getTableName());
 
         if (existing.isPresent()) {
-            if (!isTrinoMaterializedView(existing.get().getTableType(), existing.get().getParameters())) {
+            if (!isTrinoMaterializedView(existing.get().getParameters())) {
                 throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Existing table is not a Materialized View: " + viewName);
             }
             if (!replace) {
@@ -558,7 +558,7 @@ public class TrinoHiveCatalog
         io.trino.plugin.hive.metastore.Table view = metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .orElseThrow(() -> new MaterializedViewNotFoundException(viewName));
 
-        if (!isTrinoMaterializedView(view.getTableType(), view.getParameters())) {
+        if (!isTrinoMaterializedView(view.getParameters())) {
             throw new TrinoException(UNSUPPORTED_TABLE_TYPE, "Not a Materialized View: " + viewName);
         }
 
@@ -585,7 +585,7 @@ public class TrinoHiveCatalog
         }
 
         io.trino.plugin.hive.metastore.Table table = tableOptional.get();
-        if (!isTrinoMaterializedView(table.getTableType(), table.getParameters())) {
+        if (!isTrinoMaterializedView(table.getParameters())) {
             return Optional.empty();
         }
 
@@ -656,7 +656,7 @@ public class TrinoHiveCatalog
 
         Optional<io.trino.plugin.hive.metastore.Table> table = metastore.getTable(tableNameBase.getSchemaName(), tableNameBase.getTableName());
 
-        if (table.isEmpty() || isHiveOrPrestoView(table.get().getTableType())) {
+        if (table.isEmpty() || isViewOrMaterializedView(table.get().getTableType())) {
             return Optional.empty();
         }
         if (!isIcebergTable(table.get())) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes: https://github.com/trinodb/trino/issues/17274


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related PR that fixed some of the issues with null storage descriptors with glue, but did not handle materialized views: https://github.com/trinodb/trino/pull/11092/files


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Allow the Hive Glue Metastore to redirect Iceberg Materialized Views which are missing a StorageDescriptor
```
