### PR TITLE
Upgrade Databricks JDBC driver to 2.6.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
             <dependency>
                 <groupId>com.databricks</groupId>
                 <artifactId>databricks-jdbc</artifactId>
-                <version>2.6.29</version>
+                <version>2.6.32</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

The version resolves security issue:
> [SPARKJ-632] The credentials leaked by the driver are passed into error messages.

I haven't observed such credential leak in Trino CI, but it would be better to upgrade the driver. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.