### PR TITLE
Remove `ANALYZE` call on materialized view

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftTableStatisticsReader.java
@@ -240,7 +240,6 @@ public class TestRedshiftTableStatisticsReader
             executeInRedshift("CREATE MATERIALIZED VIEW " + schemaAndTable +
                     " AS SELECT custkey, mktsegment, comment FROM " + TEST_SCHEMA + ".customer");
             executeInRedshift("REFRESH MATERIALIZED VIEW " + schemaAndTable);
-            executeInRedshift("ANALYZE VERBOSE " + schemaAndTable);
             TableStatistics tableStatistics = statsReader.readTableStatistics(
                     SESSION,
                     new JdbcTableHandle(


### PR DESCRIPTION
Materialized Views are analyzed automatically in AWS Redshift now.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
