### PR TITLE
Fill TupleDomain and expression in Constraint passed to ConnectorSplitSource

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -175,9 +175,11 @@ public class SplitSourceFactory
             }
 
             Constraint constraint = filterPredicate
-                    .map(predicate -> filterConjuncts(plannerContext.getMetadata(), predicate, expression -> !DynamicFilters.isDynamicFilter(expression)))
-                    .map(predicate -> new LayoutConstraintEvaluator(plannerContext, typeAnalyzer, session, typeProvider, node.getAssignments(), predicate))
-                    .map(evaluator -> new Constraint(TupleDomain.all(), evaluator::isCandidate, evaluator.getArguments())) // we are interested only in functional predicate here, so we set the summary to ALL.
+                    .map(predicate -> {
+                        predicate = filterConjuncts(plannerContext.getMetadata(), predicate, expression -> !DynamicFilters.isDynamicFilter(expression));
+                        LayoutConstraintEvaluator evaluator = new LayoutConstraintEvaluator(plannerContext, typeAnalyzer, session, typeProvider, node.getAssignments(), predicate);
+                        return new Constraint(TupleDomain.all(), evaluator::isCandidate, evaluator.getArguments());
+                    })
                     .orElse(alwaysTrue());
 
             // get dataSource for table

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -65,7 +65,6 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.intersection;
@@ -392,8 +391,7 @@ public class IcebergSplitSource
             Supplier<Map<ColumnHandle, NullableValue>> partitionValues,
             Constraint constraint)
     {
-        // We use Constraint just to pass functional predicate here from DistributedExecutionPlanner
-        verify(constraint.getSummary().isAll());
+        // We ignore constraint.getSummary() on the assumption we have already seen it and is part of IcebergTableHandle.enforcedPredicate or IcebergTableHandle.unenforcedPredicate
 
         if (constraint.predicate().isEmpty() ||
                 intersection(constraint.getPredicateColumns().orElseThrow(), identityPartitionColumns).isEmpty()) {


### PR DESCRIPTION
Passing `Constraint` with ALL domain may be surprising. There is no good
way in ConnectorSplitSource's types to convey that. Instead of trying to
convey this quirk to connector implementors, remove the quirk.

This has potential of affecting connectors, since
`Constraint.predicate` is now narrower, but it considered a good change,
since it now conforms to `Constraint` design (see javadocs on that
class's methods).