### PR TITLE
Inline $ref with other metadata tables

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -1099,7 +1099,7 @@ The output of the query has the following columns:
     - The set of field IDs used for equality comparison in equality delete files
 
 ``$refs`` table
-^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 The ``$refs`` table provides information about Iceberg references including branches and tags.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Inline `$ref` with other metadata tables, same as [`$files` above it](https://github.com/trinodb/trino/blame/master/docs/src/main/sphinx/connector/iceberg.rst#L1029-L1030)

Its currently out of alignment:
<img width="291" alt="Screenshot 2023-04-29 at 9 11 15 AM" src="https://user-images.githubusercontent.com/9057843/235312488-e5de4d4f-47dc-4776-8a3d-6af5991195d7.png">


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
