### PR TITLE
Fix typo in CheckpointWriter

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -457,7 +457,7 @@ public class CheckpointWriter
                 mapBuilder.appendNull();
             }
             else {
-                mapType.getKeyType().writeSlice(mapBuilder, utf8Slice(entry.getValue()));
+                mapType.getValueType().writeSlice(mapBuilder, utf8Slice(entry.getValue()));
             }
         }
         blockBuilder.closeEntry();


### PR DESCRIPTION
It currently probably doesn't fail, because maps being written here are `map(varchar, varchar)` (same key and value type).

thanks @dain for spotting this