### PR TITLE
Clean up `hadoop.mapred` usages in Hudi

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -16,7 +16,10 @@ package io.trino.plugin.hudi;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
-import io.trino.hdfs.HdfsContext;
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
 import io.trino.plugin.hive.HiveColumnHandle;
@@ -39,7 +42,6 @@ import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.model.HoodieTableType;
 
 import java.io.IOException;
@@ -68,7 +70,6 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static org.apache.hudi.common.fs.FSUtils.getFs;
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 import static org.apache.hudi.common.util.StringUtils.isNullOrEmpty;
 
@@ -79,12 +80,14 @@ public class HudiMetadata
 
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
+    private final TrinoFileSystemFactory fileSystemFactory;
     private final TypeManager typeManager;
 
-    public HudiMetadata(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, TypeManager typeManager)
+    public HudiMetadata(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, TrinoFileSystemFactory fileSystemFactory, TypeManager typeManager)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
@@ -228,7 +231,13 @@ public class HudiMetadata
     {
         String basePath = table.getStorage().getLocation();
         try {
-            if (!getFs(basePath, hdfsEnvironment.getConfiguration(new HdfsContext(session), new Path(basePath))).getFileStatus(new Path(basePath, METAFOLDER_NAME)).isDirectory()) {
+            Location baseLocation = Location.of(basePath);
+            Location metaLocation = baseLocation.appendPath(METAFOLDER_NAME);
+
+            TrinoFileSystem trinoFileSystem = fileSystemFactory.create(session);
+            FileIterator iterator = trinoFileSystem.listFiles(metaLocation);
+            // If there is at least one file in the .hoodie directory, it's a valid Hudi table
+            if (!iterator.hasNext()) {
                 log.warn("Could not find Hudi table at path '%s'.", basePath);
                 return false;
             }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadataFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadataFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hudi;
 
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
@@ -29,19 +30,21 @@ public class HudiMetadataFactory
 {
     private final HiveMetastoreFactory metastoreFactory;
     private final HdfsEnvironment hdfsEnvironment;
+    private final TrinoFileSystemFactory fileSystemFactory;
     private final TypeManager typeManager;
 
     @Inject
-    public HudiMetadataFactory(HiveMetastoreFactory metastoreFactory, HdfsEnvironment hdfsEnvironment, TypeManager typeManager)
+    public HudiMetadataFactory(HiveMetastoreFactory metastoreFactory, HdfsEnvironment hdfsEnvironment, TrinoFileSystemFactory fileSystemFactory, TypeManager typeManager)
     {
         this.metastoreFactory = requireNonNull(metastoreFactory, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     public HudiMetadata create(ConnectorIdentity identity)
     {
         HiveMetastore metastore = metastoreFactory.createMetastore(Optional.of(identity));
-        return new HudiMetadata(metastore, hdfsEnvironment, typeManager);
+        return new HudiMetadata(metastore, hdfsEnvironment, fileSystemFactory, typeManager);
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
@@ -31,11 +31,9 @@ import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
-import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 
 import java.util.List;
 import java.util.Map;
@@ -49,11 +47,6 @@ import static java.util.stream.Collectors.toList;
 public final class HudiUtil
 {
     private HudiUtil() {}
-
-    public static boolean isHudiParquetInputFormat(InputFormat<?, ?> inputFormat)
-    {
-        return inputFormat instanceof HoodieParquetInputFormat;
-    }
 
     public static HoodieFileFormat getHudiFileFormat(String path)
     {

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiUtil.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.HiveColumnHandle;
@@ -31,7 +32,6 @@ import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.fs.Path;
-import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodieFileFormat;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
@@ -50,7 +50,7 @@ public final class HudiUtil
 
     public static HoodieFileFormat getHudiFileFormat(String path)
     {
-        final String extension = FSUtils.getFileExtension(path);
+        String extension = getFileExtension(path);
         if (extension.equals(HoodieFileFormat.PARQUET.getFileExtension())) {
             return HoodieFileFormat.PARQUET;
         }
@@ -64,6 +64,13 @@ public final class HudiUtil
             return HoodieFileFormat.HFILE;
         }
         throw new TrinoException(HUDI_UNSUPPORTED_FILE_FORMAT, "Hoodie InputFormat not implemented for base file of type " + extension);
+    }
+
+    private static String getFileExtension(String fullName)
+    {
+        String fileName = Location.of(fullName).fileName();
+        int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex == -1 ? "" : fileName.substring(dotIndex);
     }
 
     public static boolean partitionMatchesPredicates(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -93,7 +93,7 @@ public class HudiBackgroundSplitLoader
         List<HivePartitionKey> partitionKeys = partition.getHivePartitionKeys();
         List<HudiFileStatus> partitionFiles = hudiDirectoryLister.listStatus(partition);
         partitionFiles.stream()
-                .flatMap(fileStatus -> hudiSplitFactory.createSplits(partitionKeys, fileStatus))
+                .flatMap(fileStatus -> hudiSplitFactory.createSplits(partitionKeys, fileStatus).stream())
                 .map(asyncQueue::offer)
                 .forEachOrdered(MoreFutures::getFutureValue);
     }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiUtil.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiUtil.java
@@ -14,34 +14,15 @@
 package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.testng.annotations.Test;
 
 import java.util.List;
-import java.util.Properties;
 
-import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
-import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
-import static io.trino.plugin.hive.util.HiveUtil.getInputFormat;
-import static io.trino.plugin.hudi.HudiUtil.isHudiParquetInputFormat;
 import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
-import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.FILE_INPUT_FORMAT;
-import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestHudiUtil
 {
-    @Test
-    public void testIsHudiParquetInputFormat()
-    {
-        Properties schema = new Properties();
-        schema.setProperty(FILE_INPUT_FORMAT, HoodieParquetInputFormat.class.getName());
-        schema.setProperty(SERIALIZATION_LIB, PARQUET.getSerde());
-
-        assertTrue(isHudiParquetInputFormat(getInputFormat(newEmptyConfiguration(), schema, false)));
-    }
-
     @Test
     public void testBuildPartitionValues()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This cleans up usages of `FileSplit` and `InputFormat` from `org.apache.hadoop.mapred`. 

Additionally also added a small change to get rid of Hudi's `FsUtils`. Note that `isDirectory` check for the tableLocation is replaced with a check to look for at least one file.

Relates to https://github.com/trinodb/trino/issues/17228

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
