### PR TITLE
Add support for EXECUTE IMMEDIATE statement

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryPreparer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryPreparer.java
@@ -61,21 +61,21 @@ public class QueryPreparer
     {
         Statement statement = wrappedStatement;
         Optional<String> prepareSql = Optional.empty();
-        if (statement instanceof Execute) {
-            prepareSql = Optional.of(session.getPreparedStatementFromExecute((Execute) statement));
+        if (statement instanceof Execute executeStatement) {
+            prepareSql = Optional.of(session.getPreparedStatementFromExecute(executeStatement));
             statement = sqlParser.createStatement(prepareSql.get(), createParsingOptions(session));
         }
 
-        if (statement instanceof ExplainAnalyze) {
-            Statement innerStatement = ((ExplainAnalyze) statement).getStatement();
+        if (statement instanceof ExplainAnalyze explainAnalyzeStatement) {
+            Statement innerStatement = explainAnalyzeStatement.getStatement();
             Optional<QueryType> innerQueryType = getQueryType(innerStatement);
             if (innerQueryType.isEmpty() || innerQueryType.get() == QueryType.DATA_DEFINITION) {
                 throw new TrinoException(NOT_SUPPORTED, "EXPLAIN ANALYZE doesn't support statement type: " + innerStatement.getClass().getSimpleName());
             }
         }
         List<Expression> parameters = ImmutableList.of();
-        if (wrappedStatement instanceof Execute) {
-            parameters = ((Execute) wrappedStatement).getParameters();
+        if (wrappedStatement instanceof Execute executeStatement) {
+            parameters = executeStatement.getParameters();
         }
         validateParameters(statement, parameters);
         return new PreparedQuery(statement, parameters, prepareSql);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -150,6 +150,7 @@ import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.EmptyTableTreatment;
 import io.trino.sql.tree.Except;
 import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Expression;
@@ -1315,6 +1316,12 @@ class StatementAnalyzer
 
         @Override
         protected Scope visitExecute(Execute node, Optional<Scope> scope)
+        {
+            return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitExecuteImmediate(ExecuteImmediate node, Optional<Scope> scope)
         {
             return createAndAssignScope(node, scope);
         }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExecuteImmediate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExecuteImmediate.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.sql.parser.ParsingException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestExecuteImmediate
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testNoParameters()
+    {
+        assertThat(assertions.query("EXECUTE IMMEDIATE 'SELECT * FROM (VALUES 1, 2, 3)'"))
+                .matches("VALUES 1,2,3");
+    }
+
+    @Test
+    public void testParameterInLambda()
+    {
+        assertThat(assertions.query("EXECUTE IMMEDIATE 'SELECT * FROM (VALUES ARRAY[1,2,3], ARRAY[4,5,6]) t(a) WHERE any_match(t.a, v -> v = ?)' USING 1"))
+                .matches("VALUES ARRAY[1,2,3]");
+    }
+
+    @Test
+    public void testQuotesInStatement()
+    {
+        assertThat(assertions.query("EXECUTE IMMEDIATE 'SELECT ''foo'''"))
+                .matches("VALUES 'foo'");
+    }
+
+    @Test
+    public void testSyntaxError()
+    {
+        assertThatThrownBy(() -> assertions.query("EXECUTE IMMEDIATE 'SELECT ''foo'"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessageMatching("line 1:27: mismatched input '''. Expecting: .*");
+        assertThatThrownBy(() -> assertions.query("EXECUTE IMMEDIATE\n'SELECT ''foo'"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessageMatching("line 2:8: mismatched input '''. Expecting: .*");
+    }
+
+    @Test
+    public void testSemanticError()
+    {
+        assertTrinoExceptionThrownBy(() -> assertions.query("EXECUTE IMMEDIATE 'SELECT * FROM tiny.tpch.orders'"))
+                .hasMessageMatching("line 1:34: Catalog 'tiny' does not exist");
+        assertTrinoExceptionThrownBy(() -> assertions.query("EXECUTE IMMEDIATE\n'SELECT *\nFROM tiny.tpch.orders'"))
+                .hasMessageMatching("line 3:6: Catalog 'tiny' does not exist");
+    }
+}

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -171,6 +171,7 @@ statement
     | PREPARE identifier FROM statement                                #prepare
     | DEALLOCATE PREPARE identifier                                    #deallocate
     | EXECUTE identifier (USING expression (',' expression)*)?         #execute
+    | EXECUTE IMMEDIATE string (USING expression (',' expression)*)?   #executeImmediate
     | DESCRIBE INPUT identifier                                        #describeInput
     | DESCRIBE OUTPUT identifier                                       #describeOutput
     | SET PATH pathSpecification                                       #setPath
@@ -846,7 +847,7 @@ nonReserved
     | FETCH | FILTER | FINAL | FIRST | FOLLOWING | FORMAT | FUNCTIONS
     | GRACE | GRANT | GRANTED | GRANTS | GRAPHVIZ | GROUPS
     | HOUR
-    | IF | IGNORE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ISOLATION
+    | IF | IGNORE | IMMEDIATE | INCLUDING | INITIAL | INPUT | INTERVAL | INVOKER | IO | ISOLATION
     | JSON
     | KEEP | KEY | KEYS
     | LAST | LATERAL | LEADING | LEVEL | LIMIT | LOCAL | LOGICAL
@@ -962,6 +963,7 @@ HAVING: 'HAVING';
 HOUR: 'HOUR';
 IF: 'IF';
 IGNORE: 'IGNORE';
+IMMEDIATE: 'IMMEDIATE';
 IN: 'IN';
 INCLUDING: 'INCLUDING';
 INITIAL: 'INITIAL';

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -47,6 +47,7 @@ import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.Except;
 import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.ExplainFormat;
@@ -401,6 +402,21 @@ public final class SqlFormatter
             List<Expression> parameters = node.getParameters();
             if (!parameters.isEmpty()) {
                 builder.append(" USING ");
+                builder.append(parameters.stream()
+                        .map(SqlFormatter::formatExpression)
+                        .collect(joining(", ")));
+            }
+            return null;
+        }
+
+        @Override
+        protected Void visitExecuteImmediate(ExecuteImmediate node, Integer indent)
+        {
+            append(indent, "EXECUTE IMMEDIATE\n")
+                    .append(formatStringLiteral(node.getStatement().getValue()));
+            List<Expression> parameters = node.getParameters();
+            if (!parameters.isEmpty()) {
+                builder.append("\nUSING ");
                 builder.append(parameters.stream()
                         .map(SqlFormatter::formatExpression)
                         .collect(joining(", ")));

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -80,6 +80,7 @@ import io.trino.sql.tree.EmptyTableTreatment.Treatment;
 import io.trino.sql.tree.Except;
 import io.trino.sql.tree.ExcludedPattern;
 import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.ExistsPredicate;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
@@ -939,6 +940,15 @@ class AstBuilder
         return new Execute(
                 getLocation(context),
                 (Identifier) visit(context.identifier()),
+                visit(context.expression(), Expression.class));
+    }
+
+    @Override
+    public Node visitExecuteImmediate(SqlBaseParser.ExecuteImmediateContext context)
+    {
+        return new ExecuteImmediate(
+                getLocation(context),
+                ((StringLiteral) visit(context.string())),
                 visit(context.expression(), Expression.class));
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -16,6 +16,7 @@ package io.trino.sql.parser;
 import io.trino.sql.tree.DataType;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.PathSpecification;
 import io.trino.sql.tree.RowPattern;
 import io.trino.sql.tree.Statement;
@@ -37,6 +38,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -84,6 +86,11 @@ public class SqlParser
         return (Statement) invokeParser("statement", sql, SqlBaseParser::singleStatement, parsingOptions);
     }
 
+    public Statement createStatement(String sql, NodeLocation location, ParsingOptions parsingOptions)
+    {
+        return (Statement) invokeParser("statement", sql, Optional.ofNullable(location), SqlBaseParser::singleStatement, parsingOptions);
+    }
+
     public Expression createExpression(String expression, ParsingOptions parsingOptions)
     {
         return (Expression) invokeParser("expression", expression, SqlBaseParser::standaloneExpression, parsingOptions);
@@ -105,6 +112,11 @@ public class SqlParser
     }
 
     private Node invokeParser(String name, String sql, Function<SqlBaseParser, ParserRuleContext> parseFunction, ParsingOptions parsingOptions)
+    {
+        return invokeParser(name, sql, Optional.empty(), parseFunction, parsingOptions);
+    }
+
+    private Node invokeParser(String name, String sql, Optional<NodeLocation> location, Function<SqlBaseParser, ParserRuleContext> parseFunction, ParsingOptions parsingOptions)
     {
         try {
             SqlBaseLexer lexer = new SqlBaseLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
@@ -149,8 +161,20 @@ public class SqlParser
                 parser.getInterpreter().setPredictionMode(PredictionMode.LL);
                 tree = parseFunction.apply(parser);
             }
+            catch (ParsingException e) {
+                location.ifPresent(statementLocation -> {
+                    int line = statementLocation.getLineNumber();
+                    int column = statementLocation.getColumnNumber();
+                    throw new ParsingException(
+                            e.getErrorMessage(),
+                            (RecognitionException) e.getCause(),
+                            e.getLineNumber() + line - 1,
+                            e.getColumnNumber() + (line == 1 ? column : 0));
+                });
+                throw e;
+            }
 
-            return new AstBuilder(parsingOptions).visit(tree);
+            return new AstBuilder(location, parsingOptions).visit(tree);
         }
         catch (StackOverflowError e) {
             throw new ParsingException(name + " is too large (stack overflow while parsing)");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -102,6 +102,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitExecuteImmediate(ExecuteImmediate node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitDescribeOutput(DescribeOutput node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExecuteImmediate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExecuteImmediate.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ExecuteImmediate
+        extends Statement
+{
+    private final StringLiteral statement;
+    private final List<Expression> parameters;
+
+    public ExecuteImmediate(NodeLocation location, StringLiteral statement, List<Expression> parameters)
+    {
+        super(Optional.of(location));
+        this.statement = requireNonNull(statement, "statement is null");
+        this.parameters = ImmutableList.copyOf(parameters);
+    }
+
+    public StringLiteral getStatement()
+    {
+        return statement;
+    }
+
+    public List<Expression> getParameters()
+    {
+        return parameters;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitExecuteImmediate(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.<Node>builder().addAll(parameters).add(statement).build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(statement, parameters);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ExecuteImmediate o = (ExecuteImmediate) obj;
+        return Objects.equals(statement, o.statement) &&
+                Objects.equals(parameters, o.parameters);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("statement", statement)
+                .add("parameters", parameters)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -66,6 +66,7 @@ import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.EmptyPattern;
 import io.trino.sql.tree.EmptyTableTreatment;
 import io.trino.sql.tree.Execute;
+import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.ExistsPredicate;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
@@ -3159,6 +3160,28 @@ public class TestSqlParser
     {
         assertStatement("EXECUTE myquery USING 1, 'abc', ARRAY ['hello']",
                 new Execute(identifier("myquery"), ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new Array(ImmutableList.of(new StringLiteral("hello"))))));
+    }
+
+    @Test
+    public void testExecuteImmediate()
+    {
+        assertStatement(
+                "EXECUTE IMMEDIATE 'SELECT * FROM foo'",
+                new ExecuteImmediate(
+                        new NodeLocation(1, 1),
+                        new StringLiteral(new NodeLocation(1, 19), "SELECT * FROM foo"),
+                        emptyList()));
+    }
+
+    @Test
+    public void testExecuteImmediateWithUsing()
+    {
+        assertStatement(
+                "EXECUTE IMMEDIATE 'SELECT ?, ? FROM foo' USING 1, 'abc', ARRAY ['hello']",
+                new ExecuteImmediate(
+                        new NodeLocation(1, 1),
+                        new StringLiteral(new NodeLocation(1, 19), "SELECT ?, ? FROM foo"),
+                        ImmutableList.of(new LongLiteral("1"), new StringLiteral("abc"), new Array(ImmutableList.of(new StringLiteral("hello"))))));
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
@@ -121,6 +121,24 @@ public class TestPreparedStatements
     }
 
     @Test(groups = JDBC)
+    @Requires(ImmutableAllTypesTable.class)
+    public void executeImmediateSelectSql()
+            throws SQLException
+    {
+        int testValue = 2147483647;
+        String executeSql = "EXECUTE IMMEDIATE 'SELECT c_int FROM " + TABLE_NAME + " WHERE c_int = ?' USING ";
+
+        try (Connection conn = connection(); Statement statement = conn.createStatement()) {
+            assertThat(QueryResult.forResultSet(statement.executeQuery(executeSql + testValue)))
+                    .containsOnly(row(testValue));
+            assertThat(QueryResult.forResultSet(statement.executeQuery(executeSql + "NULL")))
+                    .hasNoRows();
+            assertThat(QueryResult.forResultSet(statement.executeQuery(executeSql + 2)))
+                    .hasNoRows();
+        }
+    }
+
+    @Test(groups = JDBC)
     @Requires(MutableAllTypesTable.class)
     public void preparedInsertVarbinaryApi()
     {
@@ -263,96 +281,116 @@ public class TestPreparedStatements
         String selectSqlWithTable = format(SELECT_STAR_SQL, tableNameInDatabase);
         String executeSql = "EXECUTE ps1 using ";
 
-        try (Statement statement = connection().createStatement()) {
+        try (Connection conn = connection(); Statement statement = conn.createStatement()) {
             statement.execute(insertSqlWithTable);
-            statement.execute(executeSql +
-                    "cast(127 as tinyint), " +
-                    "cast(32767 as smallint), " +
-                    "2147483647, " +
-                    "9223372036854775807, " +
-                    "cast(123.345 as real), " +
-                    "cast(234.567 as double), " +
-                    "cast(345 as decimal(10)), " +
-                    "cast(345.678 as decimal(10,5)), " +
-                    "timestamp '2015-05-10 12:15:35', " +
-                    "date '2015-05-10', " +
-                    "'ala ma kota', " +
-                    "'ala ma kot', " +
-                    "cast('ala ma' as char(10)), " +
-                    "true, " +
-                    "X'00010203002AF9'");
-
-            statement.execute(executeSql +
-                    "cast(1 as tinyint), " +
-                    "cast(2 as smallint), " +
-                    "3, " +
-                    "4, " +
-                    "cast(5.6 as real), " +
-                    "cast(7.8 as double), " +
-                    "cast(9 as decimal(10)), " +
-                    "cast(2.3 as decimal(10,5)), " +
-                    "timestamp '2012-05-10 1:35:15', " +
-                    "date '2014-03-10', " +
-                    "'abc', " +
-                    "'def', " +
-                    "cast('ghi' as char(10)), " +
-                    "false, " +
-                    "varbinary 'jkl'");
-
-            statement.execute(executeSql +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null");
-
-            QueryResult result = onTrino().executeQuery(selectSqlWithTable);
-            assertColumnTypes(result);
-            assertThat(result).containsOnly(
-                    row(
-                            127,
-                            32767,
-                            2147483647,
-                            Long.valueOf("9223372036854775807"),
-                            Float.valueOf("123.345"),
-                            234.567,
-                            BigDecimal.valueOf(345),
-                            new BigDecimal("345.67800"),
-                            Timestamp.valueOf("2015-05-10 12:15:35"),
-                            Date.valueOf("2015-05-10"),
-                            "ala ma kota",
-                            "ala ma kot",
-                            "ala ma    ",
-                            Boolean.TRUE,
-                            new byte[] {0, 1, 2, 3, 0, 42, -7}),
-                    row(
-                            1,
-                            2,
-                            3,
-                            4,
-                            Float.valueOf("5.6"),
-                            7.8,
-                            BigDecimal.valueOf(9),
-                            new BigDecimal("2.30000"),
-                            Timestamp.valueOf("2012-05-10 1:35:15"),
-                            Date.valueOf("2014-03-10"),
-                            "abc",
-                            "def",
-                            "ghi       ",
-                            Boolean.FALSE,
-                            "jkl".getBytes(UTF_8)),
-                    row(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
+            insertAndVerify(statement, executeSql, selectSqlWithTable);
         }
+    }
+
+    @Test(groups = JDBC)
+    @Requires(MutableAllTypesTable.class)
+    public void executeImmediateInsertSql()
+            throws SQLException
+    {
+        String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
+        String selectSqlWithTable = format(SELECT_STAR_SQL, tableNameInDatabase);
+        String executeInsertSql = format("EXECUTE IMMEDIATE '%s' using ", format(INSERT_SQL, tableNameInDatabase));
+
+        try (Connection conn = connection(); Statement statement = conn.createStatement()) {
+            insertAndVerify(statement, executeInsertSql, selectSqlWithTable);
+        }
+    }
+
+    private void insertAndVerify(Statement statement, String insertSql, String verifySql)
+            throws SQLException
+    {
+        statement.execute(insertSql +
+                "cast(127 as tinyint), " +
+                "cast(32767 as smallint), " +
+                "2147483647, " +
+                "9223372036854775807, " +
+                "cast(123.345 as real), " +
+                "cast(234.567 as double), " +
+                "cast(345 as decimal(10)), " +
+                "cast(345.678 as decimal(10,5)), " +
+                "timestamp '2015-05-10 12:15:35', " +
+                "date '2015-05-10', " +
+                "'ala ma kota', " +
+                "'ala ma kot', " +
+                "cast('ala ma' as char(10)), " +
+                "true, " +
+                "X'00010203002AF9'");
+
+        statement.execute(insertSql +
+                "cast(1 as tinyint), " +
+                "cast(2 as smallint), " +
+                "3, " +
+                "4, " +
+                "cast(5.6 as real), " +
+                "cast(7.8 as double), " +
+                "cast(9 as decimal(10)), " +
+                "cast(2.3 as decimal(10,5)), " +
+                "timestamp '2012-05-10 1:35:15', " +
+                "date '2014-03-10', " +
+                "'abc', " +
+                "'def', " +
+                "cast('ghi' as char(10)), " +
+                "false, " +
+                "varbinary 'jkl'");
+
+        statement.execute(insertSql +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null");
+
+        QueryResult result = onTrino().executeQuery(verifySql);
+        assertColumnTypes(result);
+        assertThat(result).containsOnly(
+                row(
+                        127,
+                        32767,
+                        2147483647,
+                        Long.valueOf("9223372036854775807"),
+                        Float.valueOf("123.345"),
+                        234.567,
+                        BigDecimal.valueOf(345),
+                        new BigDecimal("345.67800"),
+                        Timestamp.valueOf("2015-05-10 12:15:35"),
+                        Date.valueOf("2015-05-10"),
+                        "ala ma kota",
+                        "ala ma kot",
+                        "ala ma    ",
+                        Boolean.TRUE,
+                        new byte[] {0, 1, 2, 3, 0, 42, -7}),
+                row(
+                        1,
+                        2,
+                        3,
+                        4,
+                        Float.valueOf("5.6"),
+                        7.8,
+                        BigDecimal.valueOf(9),
+                        new BigDecimal("2.30000"),
+                        Timestamp.valueOf("2012-05-10 1:35:15"),
+                        Date.valueOf("2014-03-10"),
+                        "abc",
+                        "def",
+                        "ghi       ",
+                        Boolean.FALSE,
+                        "jkl".getBytes(UTF_8)),
+                row(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
     }
 
     @Test(groups = JDBC)
@@ -367,29 +405,51 @@ public class TestPreparedStatements
 
         try (Statement statement = connection().createStatement()) {
             statement.execute(insertSqlWithTable);
-            statement.execute(executeSql +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "null, " +
-                    "X'00010203002AF9'");
-
-            QueryResult result = onTrino().executeQuery(selectSqlWithTable);
-            assertColumnTypes(result);
-            assertThat(result).containsOnly(
-                    row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                            new byte[] {0, 1, 2, 3, 0, 42, -7}));
+            insertAndVerifyVarbinary(statement, executeSql, selectSqlWithTable);
         }
+    }
+
+    @Test(groups = JDBC)
+    @Requires(MutableAllTypesTable.class)
+    public void executeImmediateVarbinarySql()
+            throws SQLException
+    {
+        String tableNameInDatabase = mutableTablesState().get(TABLE_NAME_MUTABLE).getNameInDatabase();
+        String insertSqlWithTable = "PREPARE ps1 from " + format(INSERT_SQL, tableNameInDatabase);
+        String selectSqlWithTable = format(SELECT_STAR_SQL, tableNameInDatabase);
+        String executeSql = format("EXECUTE IMMEDIATE '%s' using ", format(INSERT_SQL, tableNameInDatabase));
+
+        try (Connection conn = connection(); Statement statement = conn.createStatement()) {
+            statement.execute(insertSqlWithTable);
+            insertAndVerifyVarbinary(statement, executeSql, selectSqlWithTable);
+        }
+    }
+
+    private void insertAndVerifyVarbinary(Statement statement, String insertSql, String verifySql)
+            throws SQLException
+    {
+        statement.execute(insertSql +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "null, " +
+                "X'00010203002AF9'");
+
+        QueryResult result = onTrino().executeQuery(verifySql);
+        assertColumnTypes(result);
+        assertThat(result).containsOnly(
+                row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                        new byte[] {0, 1, 2, 3, 0, 42, -7}));
     }
 
     private void assertColumnTypes(QueryResult queryResult)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
@@ -105,7 +105,7 @@ public class TestPreparedStatements
             throws SQLException
     {
         String prepareSql = "PREPARE ps1 from SELECT c_int FROM " + TABLE_NAME + " WHERE c_int = ?";
-        final int testValue = 2147483647;
+        int testValue = 2147483647;
         String executeSql = "EXECUTE ps1 using ";
 
         try (Statement statement = connection().createStatement()) {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -1605,6 +1605,23 @@ public abstract class AbstractTestEngineOnlyQueries
     }
 
     @Test
+    public void testExecuteImmediateWithSubqueries()
+    {
+        List<QueryTemplate.Parameter> leftValues = parameter("left").of(
+                "", "1 = ",
+                "EXISTS",
+                "1 IN",
+                "1 = ANY", "1 = ALL",
+                "2 <> ANY", "2 <> ALL",
+                "0 < ALL", "0 < ANY",
+                "1 <= ALL", "1 <= ANY");
+
+        queryTemplate("SELECT %left% (SELECT 1 WHERE 2 = ?)")
+                .replaceAll(leftValues)
+                .forEach(query -> assertQuery("EXECUTE IMMEDIATE '" + query + "' USING 2", "SELECT true"));
+    }
+
+    @Test
     public void testFunctionNotRegistered()
     {
         assertQueryFails(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #17353 

Syntax:
```
EXECUTE IMMEDIATE
'SELECT * FROM t WHERE a = ? and b = ?'
USING 'foo', 42
```

The semantics are the same as:
```
PREPARE stmt1 FROM SELECT * FROM t WHERE a = ? and b = ?
EXECUTE stmt1 USING 'foo', 42
DEALLOCATE PREPARE stmt1
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
