### PR TITLE
Fill `QueryCompletedEvent` with relevant `ioMetadata.output` content

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1133,7 +1133,7 @@ public class DeltaLakeMetadata
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
         }
 
-        return Optional.empty();
+        return Optional.of(new DeltaLakeOutputMetadata(new DeltaLakeOutputInfo(!handle.getPartitionedBy().isEmpty())));
     }
 
     private static boolean isCreatedBy(Database database, String queryId)
@@ -1485,6 +1485,7 @@ public class DeltaLakeMetadata
         }
 
         boolean writeCommitted = false;
+        List<String> partitionColumns;
         try {
             TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, handle.getLocation());
 
@@ -1502,7 +1503,7 @@ public class DeltaLakeMetadata
             transactionLogWriter.appendCommitInfoEntry(getCommitInfoEntry(session, commitVersion, createdTime, INSERT_OPERATION, handle.getReadVersion()));
 
             ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
-            List<String> partitionColumns = getPartitionColumns(
+            partitionColumns = getPartitionColumns(
                     handle.getMetadataEntry().getOriginalPartitionColumns(),
                     handle.getInputColumns(),
                     columnMappingMode);
@@ -1535,8 +1536,7 @@ public class DeltaLakeMetadata
             }
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
         }
-
-        return Optional.empty();
+        return Optional.of(new DeltaLakeOutputMetadata(new DeltaLakeOutputInfo(!partitionColumns.isEmpty())));
     }
 
     private static List<String> getPartitionColumns(List<String> originalPartitionColumns, List<DeltaLakeColumnHandle> dataColumns, ColumnMappingMode columnMappingMode)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+public class DeltaLakeOutputInfo
+{
+    private final boolean partitioned;
+
+    @JsonCreator
+    public DeltaLakeOutputInfo(@JsonProperty("partitioned") boolean partitioned)
+    {
+        this.partitioned = partitioned;
+    }
+
+    @JsonProperty
+    public boolean isPartitioned()
+    {
+        return partitioned;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DeltaLakeOutputInfo that)) {
+            return false;
+        }
+        return partitioned == that.partitioned;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(partitioned);
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputMetadata.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package io.trino.plugin.deltalake;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakeOutputMetadata
+    implements ConnectorOutputMetadata
+{
+    private final DeltaLakeOutputInfo outputInfo;
+
+    @JsonCreator
+    public DeltaLakeOutputMetadata(@JsonProperty("outputInfo") DeltaLakeOutputInfo outputInfo)
+    {
+        this.outputInfo = requireNonNull(outputInfo, "outputInfo is null");
+    }
+
+    @Override
+    @JsonProperty
+    public DeltaLakeOutputInfo getInfo()
+    {
+        return outputInfo;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This information can be used to eventually analyze in a finer detail what kind of output had the Trino query.

TODOs

- [ ] All SQL operations that operate on a table should eventually return `Optional<ConnectorOutputMetadata>`.
- [ ] `io.trino.plugin.hive.HiveWrittenPartitions` implementation of  `ConnectorOutputMetadata` is rather simplistic and may need to be changed (breaking change) to something more suitable.
- [ ] Still to verify whether contextual information is to be returned based on the type of the operation (e.g. : MERGE vs DELETE vs CREATE TABLE vs INSERT)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
