### PR TITLE
Use decimals by default in tpch connector

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkBlockSerde.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BenchmarkBlockSerde.java
@@ -403,7 +403,7 @@ public class BenchmarkBlockSerde
             PageSerializer serializer = serdeFactory.createSerializer(Optional.empty());
             PageDeserializer deserializer = serdeFactory.createDeserializer(Optional.empty());
 
-            List<Page> pages = ImmutableList.copyOf(getTablePages("lineitem", 0.1, DecimalTypeMapping.DOUBLE));
+            List<Page> pages = ImmutableList.copyOf(getTablePages("lineitem", 0.1, DecimalTypeMapping.DECIMAL));
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(0);
             writePages(serializer, new OutputStreamSliceOutput(sliceOutput), pages.listIterator());
             setup(sliceOutput.slice(), serializer, deserializer, pages);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.sql.planner.LogicalPlanner;
@@ -77,7 +78,7 @@ public class BasePlanTest
         LocalQueryRunner queryRunner = LocalQueryRunner.create(sessionBuilder.build());
 
         queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(),
-                new TpchConnectorFactory(1),
+                new TpchConnectorFactory(1, true, DecimalTypeMapping.DOUBLE),
                 ImmutableMap.of());
         return queryRunner;
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -90,14 +90,14 @@ public class TestJsonRepresentation
                         "6",
                         "Output",
                         ImmutableMap.of("columnNames", "[quantity]"),
-                        ImmutableList.of(typedSymbol("quantity", "double")),
+                        ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
                                 "98",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
-                                ImmutableList.of(typedSymbol("quantity", "double")),
+                                ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
@@ -108,18 +108,18 @@ public class TestJsonRepresentation
                                                 "isReplicateNullsAndAny", "",
                                                 "hashColumn", "[]",
                                                 "arguments", "[]"),
-                                        ImmutableList.of(typedSymbol("quantity", "double")),
+                                        ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                                         ImmutableList.of(),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 0, 0, 0)),
                                         ImmutableList.of(new JsonRenderedNode(
                                                 "0",
                                                 "TableScan",
                                                 ImmutableMap.of("table", "tpch:tiny:lineitem"),
-                                                ImmutableList.of(typedSymbol("quantity", "double")),
+                                                ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                                                 ImmutableList.of("quantity := tpch:quantity"),
                                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                                 ImmutableList.of()))))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2058))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2086))
                 .row(DISTRIBUTED_PLAN_JSON_CODEC.toJson(distributedPlan))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);
@@ -133,14 +133,14 @@ public class TestJsonRepresentation
                 "6",
                 "Output",
                 ImmutableMap.of("columnNames", "[quantity]"),
-                ImmutableList.of(typedSymbol("quantity", "double")),
+                ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                 ImmutableList.of(),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
                         "98",
                         "Limit",
                         ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
-                        ImmutableList.of(typedSymbol("quantity", "double")),
+                        ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
@@ -151,18 +151,18 @@ public class TestJsonRepresentation
                                         "isReplicateNullsAndAny", "",
                                         "hashColumn", "[]",
                                         "arguments", "[]"),
-                                ImmutableList.of(typedSymbol("quantity", "double")),
+                                ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 0, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
                                         "0",
                                         "TableScan",
                                         ImmutableMap.of("table", "tpch:tiny:lineitem"),
-                                        ImmutableList.of(typedSymbol("quantity", "double")),
+                                        ImmutableList.of(typedSymbol("quantity", "decimal(12,2)")),
                                         ImmutableList.of("quantity := tpch:quantity"),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                         ImmutableList.of())))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1884))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1912))
                 .row(JSON_RENDERED_NODE_CODEC.toJson(expectedJsonNode))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);

--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkColumnReaders.java
@@ -1208,8 +1208,8 @@ public class BenchmarkColumnReaders
                 throws Exception
         {
             setup(
-                    getTableColumns("lineitem", DecimalTypeMapping.DOUBLE),
-                    getTablePages("lineitem", 0.1, DecimalTypeMapping.DOUBLE));
+                    getTableColumns("lineitem", DecimalTypeMapping.DECIMAL),
+                    getTablePages("lineitem", 0.1, DecimalTypeMapping.DECIMAL));
         }
     }
 

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/AccumuloQueryRunner.java
@@ -20,6 +20,7 @@ import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.accumulo.conf.AccumuloConfig;
 import io.trino.plugin.accumulo.serializers.LexicoderRowSerializer;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -30,6 +31,7 @@ import org.intellij.lang.annotations.Language;
 import java.util.Map;
 
 import static io.airlift.units.Duration.nanosSince;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -52,7 +54,10 @@ public final class AccumuloQueryRunner
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         TestingAccumuloServer server = TestingAccumuloServer.getInstance();
         queryRunner.installPlugin(new AccumuloPlugin());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Module;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -28,6 +29,7 @@ import java.sql.Statement;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -76,7 +78,10 @@ public final class H2QueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             createSchema(properties, "tpch");
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -25,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.trino.plugin.cassandra.CassandraTestingUtils.createKeyspace;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -51,7 +53,10 @@ public final class CassandraQueryRunner
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         // note: additional copy via ImmutableList so that if fails on nulls
         connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/ClickHouseQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -26,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -56,7 +58,10 @@ public final class ClickHouseQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -20,6 +20,7 @@ import io.trino.Session;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.plugin.tpcds.TpcdsPlugin;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -34,6 +35,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.deltalake.DeltaLakeConnectorFactory.CONNECTOR_NAME;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -99,7 +101,10 @@ public final class DeltaLakeQueryRunner
             DistributedQueryRunner queryRunner = super.build();
             try {
                 queryRunner.installPlugin(new TpchPlugin());
-                queryRunner.createCatalog("tpch", "tpch");
+                queryRunner.createCatalog(
+                        "tpch",
+                        "tpch",
+                        ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
                 queryRunner.installPlugin(new TpcdsPlugin());
                 queryRunner.createCatalog("tpcds", "tpcds");

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchQueryRunner.java
@@ -18,6 +18,7 @@ import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.jmx.JmxPlugin;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -32,6 +33,7 @@ import java.util.Map;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.elasticsearch.ElasticsearchServer.ELASTICSEARCH_7_IMAGE;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -80,7 +82,10 @@ public final class ElasticsearchQueryRunner
             queryRunner.createCatalog("jmx", "jmx");
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             ElasticsearchConnectorFactory testFactory = new ElasticsearchConnectorFactory();
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -22,6 +22,7 @@ import io.airlift.log.Logging;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.containers.HiveMinioDataLake;
 import io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.containers.Minio;
@@ -45,6 +46,7 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.containers.Minio.MINIO_ACCESS_KEY;
 import static io.trino.testing.containers.Minio.MINIO_SECRET_KEY;
@@ -130,7 +132,10 @@ public final class IcebergQueryRunner
             DistributedQueryRunner queryRunner = super.build();
             try {
                 queryRunner.installPlugin(new TpchPlugin());
-                queryRunner.createCatalog("tpch", "tpch");
+                queryRunner.createCatalog(
+                        "tpch",
+                        "tpch",
+                        ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
                 queryRunner.installPlugin(new IcebergPlugin());
                 Map<String, String> icebergProperties = new HashMap<>(this.icebergProperties.buildOrThrow());

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/IgniteQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -50,7 +52,10 @@ public final class IgniteQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("connection-url", server.getJdbcUrl());

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/KuduQueryRunnerFactory.java
@@ -19,6 +19,7 @@ import com.google.common.net.HostAndPort;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -29,6 +30,7 @@ import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.Session.SessionBuilder;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -100,7 +102,10 @@ public final class KuduQueryRunnerFactory
                     .build();
 
             runner.installPlugin(new TpchPlugin());
-            runner.createCatalog("tpch", "tpch");
+            runner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             installKuduConnector(kuduServer.getMasterAddress(), runner, kuduSchema, kuduSchemaEmulationPrefix);
 

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/MariaDbQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.mariadb;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -46,7 +48,10 @@ public final class MariaDbQueryRunner
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/MemoryQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -93,7 +95,10 @@ public final class MemoryQueryRunner
                 queryRunner.createCatalog(CATALOG, "memory", memoryProperties.buildOrThrow());
 
                 queryRunner.installPlugin(new TpchPlugin());
-                queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+                queryRunner.createCatalog(
+                        "tpch",
+                        "tpch",
+                        ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
                 copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), initialTables);
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -19,6 +19,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -29,6 +30,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -69,7 +71,10 @@ public final class MongoQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("mongodb.connection-url", server.getConnectionString().toString());

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MySqlQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -69,7 +71,10 @@ public final class MySqlQueryRunner
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/OracleQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.oracle;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -26,6 +27,7 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -48,7 +50,10 @@ public final class OracleQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             queryRunner.installPlugin(new OraclePlugin());
             queryRunner.createCatalog("oracle", "oracle", connectorProperties);

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.tpch.TpchTable.LINE_ITEM;
@@ -55,7 +57,10 @@ public final class PhoenixQueryRunner
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("phoenix.connection-url", server.getJdbcUrl())

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.plugin.jmx.JmxPlugin;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -65,7 +67,10 @@ public final class PostgreSqlQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/RaptorQueryRunner.java
@@ -24,6 +24,7 @@ import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.raptor.legacy.storage.StorageManagerConfig;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.DistributedQueryRunner;
@@ -37,6 +38,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static io.airlift.units.Duration.nanosSince;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingHandles.createTestCatalogHandle;
@@ -61,7 +63,10 @@ public final class RaptorQueryRunner
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         queryRunner.installPlugin(new RaptorPlugin());
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().toFile();

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorMySqlConnectorTest.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.raptor.legacy;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -25,6 +26,7 @@ import java.util.Map;
 
 import static io.trino.plugin.raptor.legacy.RaptorQueryRunner.copyTables;
 import static io.trino.plugin.raptor.legacy.RaptorQueryRunner.createSession;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static java.lang.String.format;
 
 public class TestRaptorMySqlConnectorTest
@@ -62,7 +64,10 @@ public class TestRaptorMySqlConnectorTest
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession("tpch")).build();
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         queryRunner.installPlugin(new RaptorPlugin());
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().toFile();

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/RedisQueryRunner.java
@@ -21,6 +21,7 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.redis.util.CodecSupplier;
 import io.trino.plugin.redis.util.RedisServer;
 import io.trino.plugin.redis.util.RedisTestUtils;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.type.TypeManager;
@@ -34,6 +35,7 @@ import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.redis.util.RedisTestUtils.installRedisPlugin;
 import static io.trino.plugin.redis.util.RedisTestUtils.loadTpchTableDescription;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Locale.ENGLISH;
@@ -61,7 +63,10 @@ public final class RedisQueryRunner
                     .build();
 
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             Map<SchemaTableName, RedisTableDescription> tableDescriptions = createTpchTableDescriptions(queryRunner.getCoordinator().getTypeManager(), tables, dataFormat);
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.sqlserver;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.security.Identity;
 import io.trino.testing.DistributedQueryRunner;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -67,7 +69,10 @@ public final class SqlServerQueryRunner
                 .build();
         try {
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
             // note: additional copy via ImmutableList so that if fails on nulls
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -37,6 +37,7 @@ import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.thrift.ThriftPlugin;
 import io.trino.plugin.thrift.server.ThriftIndexedTpchService;
 import io.trino.plugin.thrift.server.ThriftTpchService;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.ErrorType;
@@ -62,6 +63,7 @@ import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -148,7 +150,10 @@ public final class ThriftQueryRunner
         queryRunner.createCatalog("thrift", "trino_thrift", connectorProperties);
 
         queryRunner.installPlugin(new TpchPlugin());
-        queryRunner.createCatalog("tpch", "tpch");
+        queryRunner.createCatalog(
+                "tpch",
+                "tpch",
+                ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
 
         return queryRunner;
     }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -34,6 +34,7 @@ import static io.trino.plugin.base.Versions.checkSpiVersion;
 import static java.lang.Boolean.FALSE;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class TpchConnectorFactory
         implements ConnectorFactory
@@ -50,6 +51,7 @@ public class TpchConnectorFactory
 
     private final int defaultSplitsPerNode;
     private final boolean predicatePushdownEnabled;
+    private final DecimalTypeMapping decimalTypeMapping;
 
     public TpchConnectorFactory()
     {
@@ -63,8 +65,14 @@ public class TpchConnectorFactory
 
     public TpchConnectorFactory(int defaultSplitsPerNode, boolean predicatePushdownEnabled)
     {
+        this(defaultSplitsPerNode, predicatePushdownEnabled, DecimalTypeMapping.DECIMAL);
+    }
+
+    public TpchConnectorFactory(int defaultSplitsPerNode, boolean predicatePushdownEnabled, DecimalTypeMapping decimalTypeMapping)
+    {
         this.defaultSplitsPerNode = defaultSplitsPerNode;
         this.predicatePushdownEnabled = predicatePushdownEnabled;
+        this.decimalTypeMapping = requireNonNull(decimalTypeMapping, "decimalTypeMapping is null");
     }
 
     @Override
@@ -80,7 +88,7 @@ public class TpchConnectorFactory
 
         int splitsPerNode = getSplitsPerNode(properties);
         ColumnNaming columnNaming = ColumnNaming.valueOf(properties.getOrDefault(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()).toUpperCase(ENGLISH));
-        DecimalTypeMapping decimalTypeMapping = DecimalTypeMapping.valueOf(properties.getOrDefault(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()).toUpperCase(ENGLISH));
+        DecimalTypeMapping decimalTypeMapping = DecimalTypeMapping.valueOf(properties.getOrDefault(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, this.decimalTypeMapping.name()).toUpperCase(ENGLISH));
         boolean partitioningEnabled = Boolean.parseBoolean(properties.getOrDefault(TPCH_PARTITIONING_ENABLED, "true"));
         NodeManager nodeManager = context.getNodeManager();
 

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
@@ -423,15 +423,15 @@ public class TestTpchMetadata
         requireNonNull(column, "column is null");
         requireNonNull(value, "value is null");
         return TupleDomain.fromFixedValues(
-                ImmutableMap.of(tpchMetadata.toColumnHandle(column), new NullableValue(getTrinoType(column, DecimalTypeMapping.DOUBLE), value)));
+                ImmutableMap.of(tpchMetadata.toColumnHandle(column), new NullableValue(getTrinoType(column, DecimalTypeMapping.DECIMAL), value)));
     }
 
     private static TupleDomain<ColumnHandle> fixedValueTupleDomain(TpchMetadata tpchMetadata, TpchColumn<?> column1, Object value1, TpchColumn<?> column2, Object value2)
     {
         return TupleDomain.fromFixedValues(
                 ImmutableMap.of(
-                        tpchMetadata.toColumnHandle(column1), new NullableValue(getTrinoType(column1, DecimalTypeMapping.DOUBLE), value1),
-                        tpchMetadata.toColumnHandle(column2), new NullableValue(getTrinoType(column2, DecimalTypeMapping.DOUBLE), value2)));
+                        tpchMetadata.toColumnHandle(column1), new NullableValue(getTrinoType(column1, DecimalTypeMapping.DECIMAL), value1),
+                        tpchMetadata.toColumnHandle(column2), new NullableValue(getTrinoType(column2, DecimalTypeMapping.DECIMAL), value2)));
     }
 
     private ColumnStatistics noColumnStatistics()

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -333,10 +333,10 @@ public class TestHiveStorageFormats
                         "   partkey       BIGINT," +
                         "   suppkey       BIGINT," +
                         "   linenumber    INTEGER," +
-                        "   quantity      DOUBLE," +
-                        "   extendedprice DOUBLE," +
-                        "   discount      DOUBLE," +
-                        "   tax           DOUBLE," +
+                        "   quantity      DECIMAL(12,2)," +
+                        "   extendedprice DECIMAL(12,2)," +
+                        "   discount      DECIMAL(12,2)," +
+                        "   tax           DECIMAL(12,2)," +
                         "   linestatus    VARCHAR," +
                         "   shipinstruct  VARCHAR," +
                         "   shipmode      VARCHAR," +
@@ -404,10 +404,10 @@ public class TestHiveStorageFormats
                         "   partkey       BIGINT," +
                         "   suppkey       BIGINT," +
                         "   linenumber    INTEGER," +
-                        "   quantity      DOUBLE," +
-                        "   extendedprice DOUBLE," +
-                        "   discount      DOUBLE," +
-                        "   tax           DOUBLE," +
+                        "   quantity      DECIMAL(12,2)," +
+                        "   extendedprice DECIMAL(12,2)," +
+                        "   discount      DECIMAL(12,2)," +
+                        "   tax           DECIMAL(12,2)," +
                         "   linestatus    VARCHAR," +
                         "   shipinstruct  VARCHAR," +
                         "   shipmode      VARCHAR," +

--- a/testing/trino-server-dev/etc/catalog/tpch.properties
+++ b/testing/trino-server-dev/etc/catalog/tpch.properties
@@ -8,4 +8,3 @@
 connector.name=tpch
 tpch.splits-per-node=4
 tpch.column-naming=STANDARD
-tpch.double-type-mapping=DECIMAL

--- a/testing/trino-server-dev/etc/catalog/tpch.properties
+++ b/testing/trino-server-dev/etc/catalog/tpch.properties
@@ -7,4 +7,3 @@
 
 connector.name=tpch
 tpch.splits-per-node=4
-tpch.column-naming=STANDARD

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1162,14 +1162,14 @@ public class TestEventListenerBasic
                         "6",
                         "Output",
                         ImmutableMap.of("columnNames", "[column_1]"),
-                        ImmutableList.of(typedSymbol("symbol_1", "double")),
+                        ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                         ImmutableList.of(),
                         ImmutableList.of(),
                         ImmutableList.of(new JsonRenderedNode(
                                 "98",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
-                                ImmutableList.of(typedSymbol("symbol_1", "double")),
+                                ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                                 ImmutableList.of(),
                                 ImmutableList.of(),
                                 ImmutableList.of(new JsonRenderedNode(
@@ -1180,14 +1180,14 @@ public class TestEventListenerBasic
                                                 "isReplicateNullsAndAny", "",
                                                 "hashColumn", "[]",
                                                 "arguments", "[]"),
-                                        ImmutableList.of(typedSymbol("symbol_1", "double")),
+                                        ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                                         ImmutableList.of(),
                                         ImmutableList.of(),
                                         ImmutableList.of(new JsonRenderedNode(
                                                 "138",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
-                                                ImmutableList.of(typedSymbol("symbol_1", "double")),
+                                                ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                                                 ImmutableList.of(),
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
@@ -1198,7 +1198,7 @@ public class TestEventListenerBasic
                                 "count", "10",
                                 "withTies", "",
                                 "inputPreSortedBy", "[]"),
-                        ImmutableList.of(typedSymbol("symbol_1", "double")),
+                        ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                         ImmutableList.of(),
                         ImmutableList.of(),
                         ImmutableList.of(new JsonRenderedNode(
@@ -1206,7 +1206,7 @@ public class TestEventListenerBasic
                                 "TableScan",
                                 ImmutableMap.of(
                                         "table", "[table = catalog_1.schema_1.table_1, connector = tpch]"),
-                                ImmutableList.of(typedSymbol("symbol_1", "double")),
+                                ImmutableList.of(typedSymbol("symbol_1", "decimal(12,2)")),
                                 ImmutableList.of("symbol_1 := column_2"),
                                 ImmutableList.of(),
                                 ImmutableList.of()))));

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -725,7 +725,7 @@ public class TestAccessControl
                         // orderkey column is filtered
                         "('custkey', 'bigint', '', '')," +
                         "('orderstatus', 'varchar(1)', '', '')," +
-                        "('totalprice', 'double', '', '')," +
+                        "('totalprice', 'decimal(12,2)', '', '')," +
                         "('orderdate', 'date', '', '')," +
                         "('orderpriority', 'varchar(15)', '', '')," +
                         "('clerk', 'varchar(15)', '', '')," +
@@ -746,7 +746,7 @@ public class TestAccessControl
                         // orderkey column is filtered
                         "('custkey', 'bigint', '', '')," +
                         "('orderstatus', 'varchar(1)', '', '')," +
-                        "('totalprice', 'double', '', '')," +
+                        "('totalprice', 'decimal(12,2)', '', '')," +
                         "('orderdate', 'date', '', '')," +
                         "('orderpriority', 'varchar(15)', '', '')," +
                         "('clerk', 'varchar(15)', '', '')," +

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedQueriesNoHashGeneration.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedQueriesNoHashGeneration.java
@@ -14,6 +14,7 @@
 package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.QueryRunner;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
@@ -27,6 +28,7 @@ public class TestDistributedQueriesNoHashGeneration
     {
         return TpchQueryRunnerBuilder.builder()
                 .setCoordinatorProperties(ImmutableMap.of("optimizer.optimize-hash-generation", "false"))
+                .withTpchDecimalTypeMapping(DecimalTypeMapping.DOUBLE)
                 .build();
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedSpilledQueries.java
@@ -16,12 +16,14 @@ package io.trino.tests;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.DistributedQueryRunner;
 
 import java.nio.file.Paths;
 
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.UUID.randomUUID;
@@ -61,7 +63,10 @@ public class TestDistributedSpilledQueries
 
         try {
             queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
+            queryRunner.createCatalog(
+                    "tpch",
+                    "tpch",
+                    ImmutableMap.of(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, DecimalTypeMapping.DOUBLE.name()));
             return queryRunner;
         }
         catch (Exception e) {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
@@ -15,6 +15,7 @@ package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.LocalQueryRunner;
@@ -54,7 +55,7 @@ public class TestLocalQueries
         // local queries run directly against the generator
         localQueryRunner.createCatalog(
                 defaultSession.getCatalog().get(),
-                new TpchConnectorFactory(1),
+                new TpchConnectorFactory(1, true, DecimalTypeMapping.DOUBLE),
                 ImmutableMap.of());
 
         localQueryRunner.addFunctions(CUSTOM_FUNCTIONS);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
@@ -15,6 +15,7 @@ package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.spi.type.Type;
 import io.trino.testing.AbstractTestQueries;
@@ -66,7 +67,7 @@ public class TestQueryPlanDeterminism
         // local queries run directly against the generator
         localQueryRunner.createCatalog(
                 defaultSession.getCatalog().get(),
-                new TpchConnectorFactory(1),
+                new TpchConnectorFactory(1, true, DecimalTypeMapping.DOUBLE),
                 ImmutableMap.of());
 
         localQueryRunner.addFunctions(CUSTOM_FUNCTIONS);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestWindowQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestWindowQueries.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests;
 
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.testing.AbstractTestWindowQueries;
 import io.trino.testing.QueryRunner;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
@@ -24,6 +25,8 @@ public class TestWindowQueries
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        return TpchQueryRunnerBuilder.builder().build();
+        return TpchQueryRunnerBuilder.builder()
+                .withTpchDecimalTypeMapping(DecimalTypeMapping.DOUBLE)
+                .build();
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunnerBuilder.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TpchQueryRunnerBuilder.java
@@ -15,18 +15,22 @@ package io.trino.tests.tpch;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.tpch.DecimalTypeMapping;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static io.trino.plugin.tpch.DecimalTypeMapping.DOUBLE;
+import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_DOUBLE_TYPE_MAPPING_PROPERTY;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_MAX_ROWS_PER_PAGE_PROPERTY;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_PRODUCE_PAGES;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_SPLITS_PER_NODE;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_TABLE_SCAN_REDIRECTION_CATALOG;
 import static io.trino.plugin.tpch.TpchConnectorFactory.TPCH_TABLE_SCAN_REDIRECTION_SCHEMA;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
 
 public final class TpchQueryRunnerBuilder
         extends DistributedQueryRunner.Builder<TpchQueryRunnerBuilder>
@@ -42,6 +46,7 @@ public final class TpchQueryRunnerBuilder
     private Optional<String> destinationCatalog = Optional.empty();
     private Optional<String> destinationSchema = Optional.empty();
     private OptionalInt splitsPerNode = OptionalInt.empty();
+    private DecimalTypeMapping tpchDecimalTypeMapping = DOUBLE;
 
     private TpchQueryRunnerBuilder()
     {
@@ -78,6 +83,12 @@ public final class TpchQueryRunnerBuilder
         return this;
     }
 
+    public TpchQueryRunnerBuilder withTpchDecimalTypeMapping(DecimalTypeMapping tpchDecimalTypeMapping)
+    {
+        this.tpchDecimalTypeMapping = requireNonNull(tpchDecimalTypeMapping, "tpchDecimalTypeMapping is null");
+        return this;
+    }
+
     public static TpchQueryRunnerBuilder builder()
     {
         return new TpchQueryRunnerBuilder();
@@ -95,6 +106,7 @@ public final class TpchQueryRunnerBuilder
             destinationCatalog.ifPresent(value -> properties.put(TPCH_TABLE_SCAN_REDIRECTION_CATALOG, value));
             destinationSchema.ifPresent(value -> properties.put(TPCH_TABLE_SCAN_REDIRECTION_SCHEMA, value));
             splitsPerNode.ifPresent(value -> properties.put(TPCH_SPLITS_PER_NODE, Integer.toString(value)));
+            properties.put(TPCH_DOUBLE_TYPE_MAPPING_PROPERTY, tpchDecimalTypeMapping.name());
             queryRunner.createCatalog("tpch", "tpch", properties.buildOrThrow());
             return queryRunner;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Use decimals by default in tpch connector
Use simplified naming convention in tpch dev catalog


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# TPC-H
* Use SQL `decimal` type for floating point values. ({issue}`17344`)
```
