### PR TITLE
Document ConnectorSplitSource thread-safety requirements

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
@@ -20,6 +20,11 @@ import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Source of splits to be processed.
+ * <p>
+ * Thread-safety: the implementations are not required to be thread-safe.
+ */
 public interface ConnectorSplitSource
         extends Closeable
 {


### PR DESCRIPTION
Note that some existing implementations are not thread-safe. For example `IcebergSplitSource.scannedFiles` is accessed without any synchronization.
