### PR TITLE
Add aliases to date_add and date_diff functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -271,7 +271,7 @@ public final class DateTimeFunctions
 
     @Description("Add the specified amount of date to the given date")
     @LiteralParameters("x")
-    @ScalarFunction("date_add")
+    @ScalarFunction(value = "date_add", alias = "dateadd")
     @SqlType(StandardTypes.DATE)
     public static long addFieldValueDate(@SqlType("varchar(x)") Slice unit, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DATE) long date)
     {
@@ -280,7 +280,7 @@ public final class DateTimeFunctions
     }
 
     @Description("Difference of the given dates in the given unit")
-    @ScalarFunction("date_diff")
+    @ScalarFunction(value = "date_diff", alias = "datediff")
     @LiteralParameters("x")
     @SqlType(StandardTypes.BIGINT)
     public static long diffDate(@SqlType("varchar(x)") Slice unit, @SqlType(StandardTypes.DATE) long date1, @SqlType(StandardTypes.DATE) long date2)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeFunctions.java
@@ -103,7 +103,7 @@ public class TimeFunctions
 
     @Description("Add the specified amount of time to the given time")
     @LiteralParameters({"x", "p"})
-    @ScalarFunction("date_add")
+    @ScalarFunction(value = "date_add", alias = "dateadd")
     @SqlType("time(p)")
     public static long dateAdd(
             @LiteralParameter("p") long precision,
@@ -141,7 +141,7 @@ public class TimeFunctions
     }
 
     @Description("Difference of the given times in the given unit")
-    @ScalarFunction("date_diff")
+    @ScalarFunction(value = "date_diff", alias = "datediff")
     @LiteralParameters({"x", "p"})
     @SqlType(StandardTypes.BIGINT)
     public static long dateDiff(@SqlType("varchar(x)") Slice unit, @SqlType("time(p)") long time1, @SqlType("time(p)") long time2)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateAdd.java
@@ -31,7 +31,7 @@ import static io.trino.type.DateTimes.scaleEpochMillisToMicros;
 import static java.lang.Math.toIntExact;
 
 @Description("Add the specified amount of time to the given timestamp")
-@ScalarFunction("date_add")
+@ScalarFunction(value = "date_add", alias = "dateadd")
 public class DateAdd
 {
     private DateAdd() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateDiff.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamp/DateDiff.java
@@ -26,7 +26,7 @@ import static io.trino.operator.scalar.DateTimeFunctions.getTimestampField;
 import static io.trino.type.DateTimes.scaleEpochMicrosToMillis;
 
 @Description("Difference of the given times in the given unit")
-@ScalarFunction("date_diff")
+@ScalarFunction(value = "date_diff", alias = "datediff")
 public class DateDiff
 {
     private DateDiff() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateDiff.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateDiff.java
@@ -27,7 +27,7 @@ import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.util.DateTimeZoneIndex.unpackChronology;
 
 @Description("Difference of the given times in the given unit")
-@ScalarFunction("date_diff")
+@ScalarFunction(value = "date_diff", alias = "datediff")
 public class DateDiff
 {
     private DateDiff() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateAdd.java
@@ -43,7 +43,7 @@ import static java.util.Locale.ENGLISH;
 import static org.joda.time.DateTimeConstants.MINUTES_PER_DAY;
 
 @Description("Add the specified amount of time to the given time")
-@ScalarFunction("date_add")
+@ScalarFunction(value = "date_add", alias = "dateadd")
 public class DateAdd
 {
     private DateAdd() {}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateDiff.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timetz/DateDiff.java
@@ -35,7 +35,7 @@ import static io.trino.type.DateTimes.PICOSECONDS_PER_SECOND;
 import static java.util.Locale.ENGLISH;
 
 @Description("Difference of the given times in the given unit")
-@ScalarFunction("date_diff")
+@ScalarFunction(value = "date_diff", alias = "datediff")
 public class DateDiff
 {
     private DateDiff() {}


### PR DESCRIPTION
In Oracle, PostgreSQL, MySQL, and others, these functions do not have underscores

@mosabua do we document the aliases to the function names?