### PR TITLE
Make 'parquet_use_bloom_filter' session property descriptions consistent

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -393,7 +393,7 @@ public final class HiveSessionProperties
                         false),
                 booleanProperty(
                         PARQUET_USE_BLOOM_FILTER,
-                        "Use Parquet bloomfilter",
+                        "Use Parquet Bloom filters",
                         parquetReaderConfig.isUseBloomFilter(),
                         false),
                 dataSizeProperty(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -144,7 +144,7 @@ public class ParquetReaderConfig
     }
 
     @Config("parquet.use-bloom-filter")
-    @ConfigDescription("Enable using Parquet bloom filter")
+    @ConfigDescription("Use Parquet Bloom filters")
     public ParquetReaderConfig setUseBloomFilter(boolean useBloomFilter)
     {
         options = options.withBloomFilter(useBloomFilter);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -200,7 +200,7 @@ public final class IcebergSessionProperties
                         false))
                 .add(booleanProperty(
                         PARQUET_USE_BLOOM_FILTER,
-                        "Parquet: Enable using Parquet bloom filter",
+                        "Use Parquet Bloom filters",
                         parquetReaderConfig.isUseBloomFilter(),
                         false))
                 .add(integerProperty(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
These descriptions across iceberg/hive control the same logical configuration, make them consistent. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* N/A.
```
