### PR TITLE
Allow web ui authentication type in uppercase

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiAuthenticationModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiAuthenticationModule.java
@@ -109,7 +109,7 @@ public class WebUiAuthenticationModule
         {
             String authentication = buildConfigObject(WebUiAuthenticationConfig.class).getAuthentication();
             if (authentication != null) {
-                return authentication;
+                return authentication.toLowerCase(ENGLISH);
             }
 
             // no authenticator explicitly set for the web ui, so choose a default:

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -212,7 +212,8 @@ public class TestWebUi
         try (TestingTrinoServer server = TestingTrinoServer.builder()
                 .setProperties(ImmutableMap.<String, String>builder()
                         .putAll(SECURE_PROPERTIES)
-                        .put("http-server.authentication.type", "password")
+                        // using mixed case to test uppercase and lowercase
+                        .put("http-server.authentication.type", "PaSSworD")
                         .put("password-authenticator.config-files", passwordConfigDummy.toString())
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())


### PR DESCRIPTION
## Description

Just a quick update to allow uppercase setup as well. Maybe we want to add some test case as well.

Essentially I would also like to standardize for the authentication type to be standardized in the documentation to be either uppercase or lowercase .. is there a preferred choice @martint ?

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* Fixes #17334

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Web UI

* Allow uppercase or mixed case for `web-ui.authentication.type` ({issue}`17334`)
```
