### PR TITLE
Fix TestDbResourceGroupsPostgresqlFlywayMigration flakiness

### DIFF
--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
@@ -28,4 +28,12 @@ public class TestDbResourceGroupsPostgresqlFlywayMigration
         container.start();
         return container;
     }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
+    }
 }


### PR DESCRIPTION
The test is supposed to run single-threaded.
