### PR TITLE
Fix over read in TEXTFILE struct reader

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/StructEncoding.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/StructEncoding.java
@@ -81,6 +81,11 @@ public class StructEncoding
                     // no need to process the remaining bytes as they are all assigned to the last column
                     break;
                 }
+                if (fieldIndex == structFields.size()) {
+                    // this was the last field, so there is no more data to process
+                    builder.closeEntry();
+                    return;
+                }
             }
             else if (isEscapeByte(currentByte)) {
                 // ignore the char after escape_char


### PR DESCRIPTION
The text reader for structs does not exit once all fields has been read and additional fields are simply read into the existing row builder. The additional fields are supposed to be ignored.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix over read in TEXTFILE decoder for structs that contain more columns in the file than are mapped in the schema.
```
