### PR TITLE
Support table comment for redshift connector

### DIFF
--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -66,12 +66,9 @@ public class TestRedshiftConnectorTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         switch (connectorBehavior) {
-            case SUPPORTS_COMMENT_ON_TABLE:
-                return false;
             case SUPPORTS_COMMENT_ON_COLUMN:
                 return true;
 
-            case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
                 return false;
 


### PR DESCRIPTION
## Description
Fix https://github.com/trinodb/trino/issues/16900

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Redshift
* Add support for creating a table with a table comment. ({issue}`16900`)
* Add support for [`COMMENT ON TABLE`](/sql/comment). ({issue}`16900`)
```
