### PR TITLE
Fix under-sizing of parquet pages in writer 

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -19,7 +19,6 @@ import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.airlift.units.DataSize;
 import io.trino.parquet.Field;
 import io.trino.parquet.ParquetCorruptionException;
 import io.trino.parquet.ParquetDataSource;
@@ -59,7 +58,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.parquet.ParquetTypeUtils.constructField;
 import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
@@ -68,7 +66,6 @@ import static io.trino.parquet.ParquetWriteValidation.ParquetWriteValidationBuil
 import static io.trino.parquet.writer.ParquetDataOutput.createDataOutput;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
@@ -79,8 +76,6 @@ public class ParquetWriter
         implements Closeable
 {
     private static final int INSTANCE_SIZE = instanceSize(ParquetWriter.class);
-
-    private static final int CHUNK_MAX_BYTES = toIntExact(DataSize.of(128, MEGABYTE).toBytes());
 
     private final OutputStreamSliceOutput outputStream;
     private final ParquetWriterOptions writerOption;
@@ -128,7 +123,7 @@ public class ParquetWriter
         recordValidation(validation -> validation.setColumns(messageType.getColumns()));
         recordValidation(validation -> validation.setCreatedBy(createdBy));
         initColumnWriters();
-        this.chunkMaxLogicalBytes = max(1, CHUNK_MAX_BYTES / 2);
+        this.chunkMaxLogicalBytes = max(1, writerOption.getMaxRowGroupSize() / 2);
     }
 
     public long getWrittenBytes()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -160,7 +160,10 @@ public class ParquetWriter
 
         while (page != null) {
             int chunkRows = min(page.getPositionCount(), writerOption.getBatchSize());
-            Page chunk = page.getRegion(0, chunkRows);
+            Page chunk = page;
+            if (chunkRows < page.getPositionCount()) {
+                chunk = chunk.getRegion(0, chunkRows);
+            }
 
             // avoid chunk with huge logical size
             while (chunkRows > 1 && chunk.getLogicalSizeInBytes() > chunkMaxLogicalBytes) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -40,7 +40,7 @@ public class ParquetWriterOptions
         this.batchSize = batchSize;
     }
 
-    public long getMaxRowGroupSize()
+    public int getMaxRowGroupSize()
     {
         return maxRowGroupSize;
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.parquet.writer.ParquetSchemaConverter;
+import io.trino.parquet.writer.ParquetWriter;
+import io.trino.parquet.writer.ParquetWriterOptions;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import org.apache.parquet.format.CompressionCodec;
+import org.joda.time.DateTimeZone;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+
+public class ParquetTestUtils
+{
+    private ParquetTestUtils() {}
+
+    public static Slice writeParquetFile(ParquetWriterOptions writerOptions, List<Type> types, List<String> columnNames, List<io.trino.spi.Page> inputPages)
+            throws IOException
+    {
+        checkArgument(types.size() == columnNames.size());
+        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, false, false);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ParquetWriter writer = new ParquetWriter(
+                outputStream,
+                schemaConverter.getMessageType(),
+                schemaConverter.getPrimitiveTypes(),
+                writerOptions,
+                CompressionCodec.SNAPPY,
+                "test-version",
+                false,
+                Optional.of(DateTimeZone.getDefault()),
+                Optional.empty());
+
+        for (io.trino.spi.Page inputPage : inputPages) {
+            checkArgument(types.size() == inputPage.getChannelCount());
+            writer.write(inputPage);
+        }
+        writer.close();
+        return Slices.wrappedBuffer(outputStream.toByteArray());
+    }
+
+    public static List<io.trino.spi.Page> generateInputPages(List<Type> types, int positionsPerPage, int pageCount)
+    {
+        ImmutableList.Builder<io.trino.spi.Page> pagesBuilder = ImmutableList.builder();
+        for (int i = 0; i < pageCount; i++) {
+            List<Block> blocks = types.stream()
+                    .map(type -> generateBlock(type, positionsPerPage))
+                    .collect(toImmutableList());
+            pagesBuilder.add(new Page(blocks.toArray(Block[]::new)));
+        }
+        return pagesBuilder.build();
+    }
+
+    private static Block generateBlock(Type type, int positions)
+    {
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, positions);
+        for (int i = 0; i < positions; i++) {
+            writeNativeValue(type, blockBuilder, (long) i);
+        }
+        return blockBuilder.build();
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
@@ -14,43 +14,33 @@
 package io.trino.parquet.reader;
 
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.parquet.Field;
 import io.trino.parquet.ParquetDataSource;
 import io.trino.parquet.ParquetReaderOptions;
-import io.trino.parquet.writer.ParquetSchemaConverter;
-import io.trino.parquet.writer.ParquetWriter;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.spi.Page;
-import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.LazyBlock;
 import io.trino.spi.type.Type;
-import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.MessageColumnIO;
-import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.ParquetTestUtils.generateInputPages;
+import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
 import static io.trino.parquet.ParquetTypeUtils.constructField;
 import static io.trino.parquet.ParquetTypeUtils.getColumnIO;
 import static io.trino.parquet.ParquetTypeUtils.lookupColumnByName;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.util.Collections.nCopies;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.joda.time.DateTimeZone.UTC;
@@ -65,7 +55,15 @@ public class TestParquetReaderMemoryUsage
         List<String> columnNames = ImmutableList.of("columnA", "columnB");
         List<Type> types = ImmutableList.of(INTEGER, BIGINT);
 
-        ParquetDataSource dataSource = new TestingParquetDataSource(writeParquetFile(types, columnNames), new ParquetReaderOptions());
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxBlockSize(DataSize.ofBytes(1000))
+                                .build(),
+                        types,
+                        columnNames,
+                        generateInputPages(types, 100, 5)),
+                new ParquetReaderOptions());
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThan(1);
         // Verify file has only non-dictionary encodings as dictionary memory usage is already tested in TestFlatColumnReader#testMemoryUsage
@@ -107,54 +105,6 @@ public class TestParquetReaderMemoryUsage
 
         reader.close();
         assertThat(memoryContext.getBytes()).isEqualTo(0);
-    }
-
-    private static Slice writeParquetFile(List<Type> types, List<String> columnNames)
-            throws IOException
-    {
-        checkArgument(types.size() == columnNames.size());
-        ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(types, columnNames, false, false);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ParquetWriter writer = new ParquetWriter(
-                outputStream,
-                schemaConverter.getMessageType(),
-                schemaConverter.getPrimitiveTypes(),
-                ParquetWriterOptions.builder()
-                        .setMaxBlockSize(DataSize.ofBytes(1000))
-                        .build(),
-                CompressionCodec.SNAPPY,
-                "test-version",
-                false,
-                Optional.of(DateTimeZone.getDefault()),
-                Optional.empty());
-
-        for (io.trino.spi.Page inputPage : generateInputPages(types, 100, 5)) {
-            checkArgument(types.size() == inputPage.getChannelCount());
-            writer.write(inputPage);
-        }
-        writer.close();
-        return Slices.wrappedBuffer(outputStream.toByteArray());
-    }
-
-    private static List<io.trino.spi.Page> generateInputPages(List<Type> types, int positionsPerPage, int pageCount)
-    {
-        ImmutableList.Builder<io.trino.spi.Page> pagesBuilder = ImmutableList.builder();
-        for (int i = 0; i < pageCount; i++) {
-            List<Block> blocks = types.stream()
-                    .map(type -> generateBlock(type, positionsPerPage))
-                    .collect(toImmutableList());
-            pagesBuilder.add(new Page(blocks.toArray(Block[]::new)));
-        }
-        return pagesBuilder.build();
-    }
-
-    private static Block generateBlock(Type type, int positions)
-    {
-        BlockBuilder blockBuilder = type.createBlockBuilder(null, positions);
-        for (int i = 0; i < positions; i++) {
-            writeNativeValue(type, blockBuilder, (long) i);
-        }
-        return blockBuilder.build();
     }
 
     private static ParquetReader createParquetReader(

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetReaderMemoryUsage.java
@@ -120,8 +120,7 @@ public class TestParquetReaderMemoryUsage
                 schemaConverter.getMessageType(),
                 schemaConverter.getPrimitiveTypes(),
                 ParquetWriterOptions.builder()
-                        .setMaxPageSize(DataSize.ofBytes(100))
-                        .setMaxBlockSize(DataSize.ofBytes(1))
+                        .setMaxBlockSize(DataSize.ofBytes(1000))
                         .build(),
                 CompressionCodec.SNAPPY,
                 "test-version",

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -13,11 +13,37 @@
  */
 package io.trino.parquet.writer;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import io.airlift.units.DataSize;
+import io.trino.parquet.DataPage;
+import io.trino.parquet.DiskRange;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetReaderOptions;
+import io.trino.parquet.reader.ChunkedInputStream;
+import io.trino.parquet.reader.MetadataReader;
+import io.trino.parquet.reader.PageReader;
+import io.trino.parquet.reader.TestingParquetDataSource;
+import io.trino.spi.type.Type;
 import org.apache.parquet.VersionParser;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.schema.PrimitiveType;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.parquet.ParquetTestUtils.generateInputPages;
+import static io.trino.parquet.ParquetTestUtils.writeParquetFile;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestParquetWriter
@@ -36,5 +62,52 @@ public class TestParquetWriter
         assertThat(version.application).isEqualTo("parquet-mr-trino");
         assertThat(version.version).isEqualTo("test-version");
         assertThat(version.appBuildHash).isEqualTo("n/a");
+    }
+
+    @Test
+    public void testWrittenPageSize()
+            throws IOException
+    {
+        List<String> columnNames = ImmutableList.of("columnA", "columnB");
+        List<Type> types = ImmutableList.of(INTEGER, BIGINT);
+
+        // Write a file with many small input pages and parquet max page size of 20Kb
+        ParquetDataSource dataSource = new TestingParquetDataSource(
+                writeParquetFile(
+                        ParquetWriterOptions.builder()
+                                .setMaxPageSize(DataSize.ofBytes(20 * 1024))
+                                .build(),
+                        types,
+                        columnNames,
+                        generateInputPages(types, 100, 1000)),
+                new ParquetReaderOptions());
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
+        assertThat(parquetMetadata.getBlocks().size()).isEqualTo(1);
+        assertThat(parquetMetadata.getBlocks().get(0).getRowCount()).isEqualTo(100 * 1000);
+
+        ColumnChunkMetaData chunkMetaData = parquetMetadata.getBlocks().get(0).getColumns().get(0);
+        DiskRange range = new DiskRange(chunkMetaData.getStartingPos(), chunkMetaData.getTotalSize());
+        Map<Integer, ChunkedInputStream> chunkReader = dataSource.planRead(ImmutableListMultimap.of(0, range), newSimpleAggregatedMemoryContext());
+
+        PageReader pageReader = PageReader.createPageReader(
+                chunkReader.get(0),
+                chunkMetaData,
+                new ColumnDescriptor(new String[] {"columna"}, new PrimitiveType(REQUIRED, INT32, "columna"), 0, 0),
+                null,
+                Optional.empty());
+
+        pageReader.readDictionaryPage();
+        assertThat(pageReader.hasNext()).isTrue();
+        int pagesRead = 0;
+        DataPage dataPage;
+        while (pageReader.hasNext()) {
+            dataPage = pageReader.readPage();
+            pagesRead++;
+            if (!pageReader.hasNext()) {
+                break; // skip last page size validation
+            }
+            assertThat(dataPage.getValueCount()).isBetween(4500, 5500);
+        }
+        assertThat(pagesRead).isGreaterThan(10);
     }
 }


### PR DESCRIPTION
## Description
Fix calculation of checking for current page size so that
parquet page sizes don't keep reducing with increasing number 
of compressed pages buffered in memory. Small parquet pages
can reduce parquet reader performance by forcing decoding
and decompression on smaller chunks of data.

```
Benchmark                        (benchmarkFileFormat)  (compression)  (dataSet)   Mode  Cnt  Before score    After score
BenchmarkHiveFileFormat.read   TRINO_OPTIMIZED_PARQUET         SNAPPY   LINEITEM  thrpt   20  15.767 ± 0.155  16.652 ± 0.113  ops/s

Before
read  LINEITEM  SNAPPY  TRINO_OPTIMIZED_PARQUET   788.4MB/s ±  7931.1kB/s ( 0.98%) (N = 20, α = 99.9%)

After
read  LINEITEM  SNAPPY  TRINO_OPTIMIZED_PARQUET   832.7MB/s ±  5808.6kB/s ( 0.68%) (N = 20, α = 99.9%)
```
E.g. page sizes before
```
Column: shipmode
--------------------------------------------------------------------------------
  page   type  enc  count   avg size   size       rows     nulls   min / max
  0-D    dict  Z _  7       8.29 B     58 B
  0-1    data  Z R  126991  0.38 B     46.761 kB
  0-2    data  Z R  123519  0.38 B     45.483 kB
  0-3    data  Z R  116706  0.38 B     42.977 kB
  0-4    data  Z R  110477  0.38 B     40.683 kB
  0-5    data  Z R  105683  0.38 B     38.918 kB
  0-6    data  Z R  102963  0.38 B     37.917 kB
  0-7    data  Z R  96078   0.38 B     35.381 kB
  0-8    data  Z R  92639   0.38 B     34.114 kB
  0-9    data  Z R  89242   0.38 B     32.866 kB
  0-10   data  Z R  85820   0.38 B     31.605 kB
  0-11   data  Z R  78934   0.38 B     29.069 kB
  0-12   data  Z R  75509   0.38 B     27.809 kB
  0-13   data  Z R  72057   0.38 B     26.539 kB
  0-14   data  Z R  68657   0.38 B     25.288 kB
  0-15   data  Z R  68668   0.38 B     25.291 kB
  0-16   data  Z R  65214   0.38 B     24.019 kB
  0-17   data  Z R  61749   0.38 B     22.743 kB
  0-18   data  Z R  58357   0.38 B     21.494 kB
  0-19   data  Z R  54919   0.38 B     20.228 kB
  0-20   data  Z R  51487   0.38 B     18.965 kB
  0-21   data  Z R  51485   0.38 B     18.965 kB
  0-22   data  Z R  48028   0.38 B     17.692 kB
  0-23   data  Z R  44600   0.38 B     16.429 kB
  0-24   data  Z R  44605   0.38 B     16.432 kB
  0-25   data  Z R  41188   0.38 B     15.174 kB
  0-26   data  Z R  41186   0.38 B     15.174 kB
  0-27   data  Z R  37737   0.38 B     13.904 kB
  0-28   data  Z R  37756   0.38 B     13.910 kB
  0-29   data  Z R  34312   0.38 B     12.642 kB
  0-30   data  Z R  34339   0.38 B     12.653 kB
  0-31   data  Z R  30896   0.38 B     11.384 kB
  0-32   data  Z R  30873   0.38 B     11.378 kB
  0-33   data  Z R  27458   0.38 B     10.120 kB
  0-34   data  Z R  27468   0.38 B     10.123 kB
  0-35   data  Z R  27467   0.38 B     10.123 kB
  0-36   data  Z R  24013   0.38 B     8.851 kB
  0-37   data  Z R  24039   0.38 B     8.859 kB
  0-38   data  Z R  24015   0.38 B     8.851 kB
  0-39   data  Z R  20585   0.38 B     7.590 kB
  0-40   data  Z R  20591   0.38 B     7.590 kB
  0-41   data  Z R  20597   0.38 B     7.593 kB
  0-42   data  Z R  20608   0.38 B     7.596 kB
  0-43   data  Z R  17149   0.38 B     6.324 kB
  0-44   data  Z R  17156   0.38 B     6.327 kB
  0-45   data  Z R  17146   0.38 B     6.324 kB
  0-46   data  Z R  17166   0.38 B     6.330 kB
  0-47   data  Z R  13733   0.38 B     5.066 kB
  0-48   data  Z R  13726   0.38 B     5.063 kB
  0-49   data  Z R  13730   0.38 B     5.066 kB
  0-50   data  Z R  13734   0.38 B     5.066 kB
  0-51   data  Z R  13748   0.38 B     5.072 kB
  0-52   data  Z R  10290   0.38 B     3.800 kB
  0-53   data  Z R  10305   0.38 B     3.806 kB
  0-54   data  Z R  10296   0.38 B     3.800 kB
  0-55   data  Z R  10289   0.38 B     3.800 kB
  0-56   data  Z R  10292   0.38 B     3.800 kB
  0-57   data  Z R  10291   0.38 B     3.800 kB
  0-58   data  Z R  10291   0.38 B     3.800 kB
  0-59   data  Z R  6866    0.38 B     2.538 kB
  0-60   data  Z R  6853    0.38 B     2.532 kB
  0-61   data  Z R  6863    0.38 B     2.535 kB
  0-62   data  Z R  6865    0.38 B     2.538 kB
  0-63   data  Z R  6860    0.38 B     2.535 kB
  0-64   data  Z R  6868    0.38 B     2.538 kB
  0-65   data  Z R  6867    0.38 B     2.538 kB
  0-66   data  Z R  6859    0.38 B     2.535 kB
  0-67   data  Z R  6858    0.38 B     2.535 kB
  0-68   data  Z R  6870    0.38 B     2.538 kB
  0-69   data  Z R  6853    0.38 B     2.532 kB
  0-70   data  Z R  3434    0.38 B     1.274 kB
  0-71   data  Z R  3433    0.38 B     1.274 kB
  0-72   data  Z R  3429    0.38 B     1.271 kB
  0-73   data  Z R  3429    0.38 B     1.271 kB
  0-74   data  Z R  3434    0.38 B     1.274 kB
  0-75   data  Z R  3434    0.38 B     1.274 kB
  0-76   data  Z R  3428    0.38 B     1.271 kB
  0-77   data  Z R  3429    0.38 B     1.271 kB
  0-78   data  Z R  3436    0.38 B     1.274 kB
  0-79   data  Z R  3432    0.38 B     1.271 kB
  0-80   data  Z R  3433    0.38 B     1.274 kB
  0-81   data  Z R  3429    0.38 B     1.271 kB
  0-82   data  Z R  3436    0.38 B     1.274 kB
  0-83   data  Z R  3429    0.38 B     1.271 kB
  0-84   data  Z R  3431    0.38 B     1.271 kB
  0-85   data  Z R  3436    0.38 B     1.274 kB
  0-86   data  Z R  3435    0.38 B     1.274 kB
  0-87   data  Z R  3430    0.38 B     1.271 kB
  0-88   data  Z R  3432    0.38 B     1.271 kB
  0-89   data  Z R  3431    0.38 B     1.271 kB
  0-90   data  Z R  3427    0.38 B     1.271 kB
  0-91   data  Z R  3428    0.38 B     1.271 kB
  0-92   data  Z R  3434    0.38 B     1.274 kB
  0-93   data  Z R  3436    0.38 B     1.274 kB
```
Page sizes after
```
Column: shipmode
--------------------------------------------------------------------------------
  page   type  enc  count   avg size   size       rows     nulls   min / max
  0-D    dict  Z _  7       8.29 B     58 B
  0-1    data  Z R  126975  0.38 B     46.755 kB
  0-2    data  Z R  126959  0.38 B     46.749 kB
  0-3    data  Z R  126999  0.38 B     46.764 kB
  0-4    data  Z R  126950  0.38 B     46.746 kB
  0-5    data  Z R  126975  0.38 B     46.755 kB
  0-6    data  Z R  126963  0.38 B     46.752 kB
  0-7    data  Z R  126962  0.38 B     46.752 kB
  0-8    data  Z R  127006  0.38 B     46.767 kB
  0-9    data  Z R  127001  0.38 B     46.767 kB
  0-10   data  Z R  126959  0.38 B     46.749 kB
  0-11   data  Z R  127018  0.38 B     46.773 kB
  0-12   data  Z R  126992  0.38 B     46.761 kB
  0-13   data  Z R  127001  0.38 B     46.767 kB
  0-14   data  Z R  126955  0.38 B     46.749 kB
  0-15   data  Z R  126987  0.38 B     46.761 kB
  0-16   data  Z R  126945  0.38 B     46.746 kB
  0-17   data  Z R  127014  0.38 B     46.771 kB
  0-18   data  Z R  126992  0.38 B     46.761 kB
  0-19   data  Z R  126986  0.38 B     46.761 kB
  0-20   data  Z R  126970  0.38 B     46.755 kB
  0-21   data  Z R  127007  0.38 B     46.767 kB
  0-22   data  Z R  126980  0.38 B     46.758 kB
  0-23   data  Z R  126926  0.38 B     46.737 kB
  0-24   data  Z R  127016  0.38 B     46.771 kB
  0-25   data  Z R  126967  0.38 B     46.752 kB
  0-26   data  Z R  126945  0.38 B     46.746 kB
  0-27   data  Z R  126990  0.38 B     46.761 kB
  0-28   data  Z R  127006  0.38 B     46.767 kB
  0-29   data  Z R  126985  0.38 B     46.761 kB
  0-30   data  Z R  126986  0.38 B     46.761 kB
  0-31   data  Z R  126955  0.38 B     46.749 kB
  0-32   data  Z R  126986  0.38 B     46.761 kB
  0-33   data  Z R  127003  0.38 B     46.767 kB
  0-34   data  Z R  127014  0.38 B     46.771 kB
  0-35   data  Z R  126959  0.38 B     46.749 kB
  0-36   data  Z R  126989  0.38 B     46.761 kB
  0-37   data  Z R  126973  0.38 B     46.755 kB
  0-38   data  Z R  126972  0.38 B     46.755 kB
  0-39   data  Z R  34312   0.38 B     12.642 kB
```

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix inefficient packing of data within files written by the optimized parquet writer. ({issue}`17373`)

# Hudi, Delta, Iceberg
* Fix inefficient packing of data within files written by the parquet writer. ({issue}`17373`)
```
