### PR TITLE
Document example of `SHOW COLUMNS` result

### DIFF
--- a/docs/src/main/sphinx/sql/show-columns.rst
+++ b/docs/src/main/sphinx/sql/show-columns.rst
@@ -12,10 +12,29 @@ Synopsis
 Description
 -----------
 
-List the columns in a ``table`` along with their data type and other attributes.
+List the columns in a ``table`` along with their data type and other attributes::
+
+    SHOW COLUMNS FROM nation;
+
+.. code-block:: text
+
+      Column   |     Type     | Extra | Comment
+    -----------+--------------+-------+---------
+     nationkey | bigint       |       |
+     name      | varchar(25)  |       |
+     regionkey | bigint       |       |
+     comment   | varchar(152) |       |
+
 
 :ref:`Specify a pattern <like_operator>` in the optional ``LIKE`` clause to
 filter the results to the desired subset. For example, the following query
 allows you to find columns ending in ``key``::
 
-    SHOW COLUMNS FROM nation LIKE '%key'
+    SHOW COLUMNS FROM nation LIKE '%key';
+
+.. code-block:: text
+
+      Column   |     Type     | Extra | Comment
+    -----------+--------------+-------+---------
+     nationkey | bigint       |       |
+     regionkey | bigint       |       |


### PR DESCRIPTION
## Description

Document example of `SHOW COLUMNS` result
<img width="788" alt="Screenshot 2023-05-08 at 10 56 17" src="https://user-images.githubusercontent.com/6237050/236717173-a1152f3e-302f-42ec-8465-05e6c8768a4c.png">

## Release notes

(x) This is not user-visible or docs only and no release notes are required.