### PR TITLE
Apply the dereference pushdown at the physical level on parquet in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -49,6 +49,12 @@ public class TestIcebergParquetConnectorTest
                 typeName.equalsIgnoreCase("timestamp(6) with time zone"));
     }
 
+    @Override
+    protected boolean supportsPhysicalPushdown()
+    {
+        return true;
+    }
+
     @Test
     public void testRowGroupResetDictionary()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes Parquet dereference pushdown on the physical level on https://github.com/trinodb/trino/issues/17156

ORC still open



### Implementation overview for dereference pushdown at physical level in Parquet

PoC is the implementation for Hive

https://github.com/trinodb/trino/blob/adef5f4754eb0edbeed23790d8520ead38ae0ad9/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java#L316-L330

What happens in the code:
- only sufficient columns (if doing `SELECT parent.child, child` only `parent` field will actually be selected) will be selected
- for each column, only the necessary information will be selected from the file schema sent to parquet reader

If `nested.nested1level1.field4` gets selected and the column type hierarchy looks like this:

```
    nested
            field 1
            field 2
            nested1level1
                      field3
                      field4
            nested2level1
                      field5
                      field6 
``` 

for creating the paquet schema, there will be used the parquet type having the following hierarchy:

```
    nested
            nested1level1
                      field4
```

- the types are all unioned together to create a parquet `Message` that corresponds to only to the nested columns which are actually  selected from the nested rows.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Corresponding tests which check also that  the dereference pushdown is effective on the storage layer exist already  in `BaseConnectorTest`. See https://github.com/trinodb/trino/commit/6a4e483e#diff-6be05909e810c0224c1951c4102cad6256e9e088feb91e4c260756bfde89b6d5

Lookup for usage of https://github.com/trinodb/trino/blob/adef5f4754eb0edbeed23790d8520ead38ae0ad9/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java#L69


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of reading ROW types from parquet files. ({issue}`17387`)
```
