### PR TITLE
Add Protobuf 'any' type support to Kafka connector

### DIFF
--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -17,6 +17,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -63,6 +69,12 @@
             <artifactId>slice</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-cache</artifactId>
+        </dependency>
+
+        <!-- Trino SPI -->
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
@@ -116,6 +128,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-provider</artifactId>
+            <!-- This is under Confluent Community License and it should not be used with compile scope -->
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/DescriptorProvider.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/DescriptorProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.decoder.protobuf;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import io.trino.spi.TrinoException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Optional;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public interface DescriptorProvider
+{
+    Optional<Descriptor> getDescriptorFromTypeUrl(String url);
+
+    default String getContents(String url)
+    {
+        requireNonNull(url, "url is null");
+        ByteArrayOutputStream typeBytes = new ByteArrayOutputStream();
+        try (InputStream stream = new URL(url).openStream()) {
+            stream.transferTo(typeBytes);
+        }
+        catch (IOException e) {
+            throw new TrinoException(GENERIC_USER_ERROR, "Failed to read schema from URL", e);
+        }
+        return typeBytes.toString(UTF_8);
+    }
+}

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/DummyDescriptorProvider.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/DummyDescriptorProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.decoder.protobuf;
+
+import com.google.protobuf.Descriptors.Descriptor;
+
+import java.util.Optional;
+
+public class DummyDescriptorProvider
+        implements DescriptorProvider
+{
+    @Override
+    public Optional<Descriptor> getDescriptorFromTypeUrl(String url)
+    {
+        return Optional.empty();
+    }
+}

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/FileDescriptorProvider.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/FileDescriptorProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.decoder.protobuf;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.Descriptor;
+import io.trino.spi.TrinoException;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.decoder.protobuf.ProtobufErrorCode.INVALID_PROTO_FILE;
+import static io.trino.decoder.protobuf.ProtobufRowDecoderFactory.DEFAULT_MESSAGE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class FileDescriptorProvider
+        implements DescriptorProvider
+{
+    private final LoadingCache<String, Descriptor> protobufTypeUrlCache;
+
+    public FileDescriptorProvider()
+    {
+        protobufTypeUrlCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder().maximumSize(1000),
+                CacheLoader.from(this::loadDescriptorFromType));
+    }
+
+    @Override
+    public Optional<Descriptor> getDescriptorFromTypeUrl(String url)
+    {
+        try {
+            requireNonNull(url, "url is null");
+            return Optional.of(protobufTypeUrlCache.get(url));
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Descriptor loadDescriptorFromType(String url)
+    {
+        try {
+            Descriptor descriptor = ProtobufUtils.getFileDescriptor(getContents(url)).findMessageTypeByName(DEFAULT_MESSAGE);
+            checkState(descriptor != null, format("Message %s not found", DEFAULT_MESSAGE));
+            return descriptor;
+        }
+        catch (Descriptors.DescriptorValidationException e) {
+            throw new TrinoException(INVALID_PROTO_FILE, "Unable to parse protobuf schema", e);
+        }
+    }
+}

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufColumnDecoder.java
@@ -13,13 +13,19 @@
  */
 package io.trino.decoder.protobuf;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.OneofDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.decoder.DecoderColumnHandle;
@@ -45,10 +51,12 @@ import io.trino.spi.type.VarcharType;
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -60,6 +68,9 @@ import static java.util.Objects.requireNonNull;
 
 public class ProtobufColumnDecoder
 {
+    // Trino JSON types are expected to be sorted by key
+    private static final ObjectMapper mapper = JsonMapper.builder().configure(ORDER_MAP_ENTRIES_BY_KEYS, true).build();
+    private static final String ANY_TYPE_NAME = "google.protobuf.Any";
     private static final Slice EMPTY_JSON = Slices.utf8Slice("{}");
 
     private static final Set<Type> SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(
@@ -76,13 +87,15 @@ public class ProtobufColumnDecoder
     private final String columnMapping;
     private final String columnName;
     private final TypeManager typeManager;
+    private final DescriptorProvider descriptorProvider;
     private final Type jsonType;
 
-    public ProtobufColumnDecoder(DecoderColumnHandle columnHandle, TypeManager typeManager)
+    public ProtobufColumnDecoder(DecoderColumnHandle columnHandle, TypeManager typeManager, DescriptorProvider descriptorProvider)
     {
         try {
             requireNonNull(columnHandle, "columnHandle is null");
             this.typeManager = requireNonNull(typeManager, "typeManager is null");
+            this.descriptorProvider = requireNonNull(descriptorProvider, "descriptorProvider is null");
             this.jsonType = typeManager.getType(new TypeSignature(JSON));
             this.columnType = columnHandle.getType();
             this.columnMapping = columnHandle.getMapping();
@@ -141,7 +154,7 @@ public class ProtobufColumnDecoder
     }
 
     @Nullable
-    private static Object locateField(DynamicMessage message, String columnMapping)
+    private Object locateField(DynamicMessage message, String columnMapping)
     {
         Object value = message;
         Optional<Descriptor> valueDescriptor = Optional.of(message.getDescriptorForType());
@@ -160,6 +173,11 @@ public class ProtobufColumnDecoder
             value = ((DynamicMessage) value).getField(fieldDescriptor);
             valueDescriptor = getDescriptor(fieldDescriptor);
         }
+
+        if (valueDescriptor.isPresent() && valueDescriptor.get().getFullName().equals(ANY_TYPE_NAME)) {
+            return createAnyJson((Message) value, valueDescriptor.get());
+        }
+
         return value;
     }
 
@@ -205,5 +223,35 @@ public class ProtobufColumnDecoder
             }
         }
         return EMPTY_JSON;
+    }
+
+    private Object createAnyJson(Message value, Descriptor valueDescriptor)
+    {
+        try {
+            String typeUrl = (String) value.getField(valueDescriptor.findFieldByName("type_url"));
+            Optional<Descriptor> descriptor = descriptorProvider.getDescriptorFromTypeUrl(typeUrl);
+            if (descriptor.isPresent()) {
+                return Slices.utf8Slice(sorted(JsonFormat.printer()
+                        .usingTypeRegistry(TypeRegistry.newBuilder().add(descriptor.get()).build())
+                        .omittingInsignificantWhitespace()
+                        .print(value)));
+            }
+            return null;
+        }
+        catch (InvalidProtocolBufferException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to print JSON from 'any' message type", e);
+        }
+    }
+
+    private static String sorted(String json)
+    {
+        try {
+            // Trino JSON types are expected to be sorted by key
+            // This routine takes an input JSON string and sorts the entire tree by key, including nested maps
+            return mapper.writeValueAsString(mapper.treeToValue(mapper.readTree(json), Map.class));
+        }
+        catch (JsonProcessingException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to process JSON", e);
+        }
     }
 }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufDecoderModule.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufDecoderModule.java
@@ -27,6 +27,7 @@ public class ProtobufDecoderModule
     public void configure(Binder binder)
     {
         binder.bind(DynamicMessageProvider.Factory.class).to(FixedSchemaDynamicMessageProvider.Factory.class).in(SINGLETON);
+        binder.bind(DescriptorProvider.class).to(DummyDescriptorProvider.class).in(SINGLETON);
         newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(ProtobufRowDecoder.NAME).to(ProtobufRowDecoderFactory.class).in(SINGLETON);
     }
 }

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoder.java
@@ -35,13 +35,13 @@ public class ProtobufRowDecoder
     private final DynamicMessageProvider dynamicMessageProvider;
     private final Map<DecoderColumnHandle, ProtobufColumnDecoder> columnDecoders;
 
-    public ProtobufRowDecoder(DynamicMessageProvider dynamicMessageProvider, Set<DecoderColumnHandle> columns, TypeManager typeManager)
+    public ProtobufRowDecoder(DynamicMessageProvider dynamicMessageProvider, Set<DecoderColumnHandle> columns, TypeManager typeManager, DescriptorProvider descriptorProvider)
     {
         this.dynamicMessageProvider = requireNonNull(dynamicMessageProvider, "dynamicMessageSupplier is null");
         this.columnDecoders = columns.stream()
                 .collect(toImmutableMap(
                         identity(),
-                        column -> new ProtobufColumnDecoder(column, typeManager)));
+                        column -> new ProtobufColumnDecoder(column, typeManager, descriptorProvider)));
     }
 
     @Override

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoderFactory.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/protobuf/ProtobufRowDecoderFactory.java
@@ -33,12 +33,14 @@ public class ProtobufRowDecoderFactory
 
     private final Factory dynamicMessageProviderFactory;
     private final TypeManager typeManager;
+    private final DescriptorProvider descriptorProvider;
 
     @Inject
-    public ProtobufRowDecoderFactory(Factory dynamicMessageProviderFactory, TypeManager typeManager)
+    public ProtobufRowDecoderFactory(Factory dynamicMessageProviderFactory, TypeManager typeManager, DescriptorProvider descriptorProvider)
     {
         this.dynamicMessageProviderFactory = requireNonNull(dynamicMessageProviderFactory, "dynamicMessageProviderFactory is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.descriptorProvider = requireNonNull(descriptorProvider, "descriptorProvider is null");
     }
 
     @Override
@@ -47,6 +49,7 @@ public class ProtobufRowDecoderFactory
         return new ProtobufRowDecoder(
                 dynamicMessageProviderFactory.create(Optional.ofNullable(decoderParams.get("dataSchema"))),
                 columns,
-                typeManager);
+                typeManager,
+                descriptorProvider);
     }
 }

--- a/lib/trino-record-decoder/src/test/java/io/trino/decoder/protobuf/TestProtobufDecoder.java
+++ b/lib/trino-record-decoder/src/test/java/io/trino/decoder/protobuf/TestProtobufDecoder.java
@@ -13,11 +13,13 @@
  */
 package io.trino.decoder.protobuf;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
+import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Timestamp;
@@ -39,6 +41,8 @@ import io.trino.testing.TestingSession;
 import io.trino.type.JsonType;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -69,10 +73,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestProtobufDecoder
 {
-    private static final ProtobufRowDecoderFactory DECODER_FACTORY = new ProtobufRowDecoderFactory(new FixedSchemaDynamicMessageProvider.Factory(), TESTING_TYPE_MANAGER);
+    private static final ProtobufRowDecoderFactory DECODER_FACTORY = new ProtobufRowDecoderFactory(new FixedSchemaDynamicMessageProvider.Factory(), TESTING_TYPE_MANAGER, new FileDescriptorProvider());
 
     @Test(dataProvider = "allTypesDataProvider", dataProviderClass = ProtobufDataProviders.class)
     public void testAllDataTypes(String stringData, Integer integerData, Long longData, Double doubleData, Float floatData, Boolean booleanData, String enumData, SqlTimestamp sqlTimestamp, byte[] bytesData)
@@ -267,7 +272,7 @@ public class TestProtobufDecoder
         final var message = messageBuilder.setField(messageBuilder.getDescriptorForType().findFieldByName("column"), "value").build();
 
         final var descriptor = ProtobufSchemaUtils.getSchema(message).toDescriptor();
-        final var decoder = new ProtobufRowDecoder(new FixedSchemaDynamicMessageProvider(descriptor), ImmutableSet.of(testColumnHandle, testOneofColumn), TESTING_TYPE_MANAGER);
+        final var decoder = new ProtobufRowDecoder(new FixedSchemaDynamicMessageProvider(descriptor), ImmutableSet.of(testColumnHandle, testOneofColumn), TESTING_TYPE_MANAGER, new FileDescriptorProvider());
 
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = decoder
                 .decodeRow(message.toByteArray())
@@ -280,6 +285,87 @@ public class TestProtobufDecoder
 
         assertEquals(decodedRow.get(testColumnHandle).getSlice().toStringUtf8(), "value");
         assertEquals(decodedRow.get(testOneofColumn).getSlice().toStringUtf8(), expected);
+    }
+
+    @Test
+    public void testAnyTypeWithDummyDescriptor()
+            throws Exception
+    {
+        String stringData = "Trino";
+
+        Descriptor allDataTypesDescriptor = getDescriptor("all_datatypes.proto");
+        DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(allDataTypesDescriptor);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("stringColumn"), stringData);
+
+        Descriptor anyTypeDescriptor = getDescriptor("test_any.proto");
+        DynamicMessage.Builder testAnyBuilder = DynamicMessage.newBuilder(anyTypeDescriptor);
+        testAnyBuilder.setField(anyTypeDescriptor.findFieldByName("id"), 1);
+        testAnyBuilder.setField(anyTypeDescriptor.findFieldByName("anyMessage"), Any.pack(messageBuilder.build()));
+        DynamicMessage testAny = testAnyBuilder.build();
+
+        DecoderTestColumnHandle testAnyColumn = new DecoderTestColumnHandle(0, "anyMessage", JsonType.JSON, "anyMessage", null, null, false, false, false);
+        ProtobufRowDecoder decoder = new ProtobufRowDecoder(new FixedSchemaDynamicMessageProvider(anyTypeDescriptor), ImmutableSet.of(testAnyColumn), TESTING_TYPE_MANAGER, new DummyDescriptorProvider());
+
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = decoder
+                .decodeRow(testAny.toByteArray())
+                .orElseThrow(AssertionError::new);
+
+        assertTrue(decodedRow.get(testAnyColumn).isNull());
+    }
+
+    @Test
+    public void testAnyTypeWithFileDescriptor()
+            throws Exception
+    {
+        String stringData = "Trino";
+        int integerData = 1;
+        long longData = 493857959588286460L;
+        double doubleData = PI;
+        float floatData = 3.14f;
+        boolean booleanData = true;
+        String enumData = "ONE";
+        SqlTimestamp sqlTimestamp = sqlTimestampOf(3, LocalDateTime.parse("2020-12-12T15:35:45.923"));
+        byte[] bytesData = "X'65683F'".getBytes(UTF_8);
+
+        Descriptor allDataTypesDescriptor = getDescriptor("all_datatypes.proto");
+        DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(allDataTypesDescriptor);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("stringColumn"), stringData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("integerColumn"), integerData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("longColumn"), longData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("doubleColumn"), doubleData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("floatColumn"), floatData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("booleanColumn"), booleanData);
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("numberColumn"), allDataTypesDescriptor.findEnumTypeByName("Number").findValueByName(enumData));
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("timestampColumn"), getTimestamp(sqlTimestamp));
+        messageBuilder.setField(allDataTypesDescriptor.findFieldByName("bytesColumn"), bytesData);
+
+        // Get URI of parent directory of the descriptor file
+        // Any.pack concatenates the message type's full name to the given prefix
+        URI anySchemaTypeUrl = new File(Resources.getResource("decoder/protobuf/any/all_datatypes/schema").getFile()).getParentFile().toURI();
+        Descriptor descriptor = getDescriptor("test_any.proto");
+        DynamicMessage.Builder testAnyBuilder = DynamicMessage.newBuilder(descriptor);
+        testAnyBuilder.setField(descriptor.findFieldByName("id"), 1);
+        testAnyBuilder.setField(descriptor.findFieldByName("anyMessage"), Any.pack(messageBuilder.build(), anySchemaTypeUrl.toString()));
+        DynamicMessage testAny = testAnyBuilder.build();
+
+        DecoderTestColumnHandle testOneOfColumn = new DecoderTestColumnHandle(0, "anyMessage", JsonType.JSON, "anyMessage", null, null, false, false, false);
+        ProtobufRowDecoder decoder = new ProtobufRowDecoder(new FixedSchemaDynamicMessageProvider(descriptor), ImmutableSet.of(testOneOfColumn), TESTING_TYPE_MANAGER, new FileDescriptorProvider());
+
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = decoder
+                .decodeRow(testAny.toByteArray())
+                .orElseThrow(AssertionError::new);
+
+        JsonNode actual = new ObjectMapper().readTree(decodedRow.get(testOneOfColumn).getSlice().toStringUtf8());
+        assertTrue(actual.get("@type").textValue().contains("schema"));
+        assertEquals(actual.get("stringColumn").textValue(), stringData);
+        assertEquals(actual.get("integerColumn").intValue(), integerData);
+        assertEquals(actual.get("longColumn").textValue(), Long.toString(longData));
+        assertEquals(actual.get("doubleColumn").doubleValue(), doubleData);
+        assertEquals(actual.get("floatColumn").floatValue(), floatData);
+        assertEquals(actual.get("booleanColumn").booleanValue(), booleanData);
+        assertEquals(actual.get("numberColumn").textValue(), enumData);
+        assertEquals(actual.get("timestampColumn").textValue(), "2020-12-12T15:35:45.923Z");
+        assertEquals(actual.get("bytesColumn").binaryValue(), bytesData);
     }
 
     @Test(dataProvider = "allTypesDataProvider", dataProviderClass = ProtobufDataProviders.class)

--- a/lib/trino-record-decoder/src/test/resources/decoder/protobuf/any/all_datatypes/schema
+++ b/lib/trino-record-decoder/src/test/resources/decoder/protobuf/any/all_datatypes/schema
@@ -1,0 +1,21 @@
+// Copy of all_datatypes.proto which is a resolvable URL when packed into a google.protobuf.Any type
+
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message schema {
+  string stringColumn = 1 ;
+  uint32 integerColumn = 2;
+  uint64 longColumn = 3;
+  double doubleColumn = 4;
+  float floatColumn = 5;
+  bool booleanColumn = 6;
+  enum Number {
+    ZERO = 0;
+    ONE = 1;
+  };
+  Number numberColumn = 7;
+  google.protobuf.Timestamp timestampColumn = 8;
+  bytes bytesColumn = 9;
+}

--- a/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_any.proto
+++ b/lib/trino-record-decoder/src/test/resources/decoder/protobuf/test_any.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+
+message schema {
+    int32 id = 1;
+    google.protobuf.Any anyMessage = 2;
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/ProtobufAnySupportConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/ProtobufAnySupportConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class ProtobufAnySupportConfig
+{
+    private boolean protobufAnySupportEnabled;
+
+    public boolean isProtobufAnySupportEnabled()
+    {
+        return protobufAnySupportEnabled;
+    }
+
+    @Config("kafka.protobuf-any-support-enabled")
+    @ConfigDescription("True to enable supporting encoding google.protobuf.Any types as JSON")
+    public ProtobufAnySupportConfig setProtobufAnySupportEnabled(boolean protobufAnySupportEnabled)
+    {
+        this.protobufAnySupportEnabled = protobufAnySupportEnabled;
+        return this;
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentDescriptorProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentDescriptorProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.protobuf.Descriptors.Descriptor;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.trino.decoder.protobuf.DescriptorProvider;
+import io.trino.spi.TrinoException;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static io.trino.cache.SafeCaches.buildNonEvictableCache;
+import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class ConfluentDescriptorProvider
+        implements DescriptorProvider
+{
+    private final LoadingCache<String, Descriptor> protobufTypeUrlCache;
+
+    public ConfluentDescriptorProvider()
+    {
+        protobufTypeUrlCache = buildNonEvictableCache(
+                CacheBuilder.newBuilder().maximumSize(1000),
+                CacheLoader.from(this::loadDescriptorFromType));
+    }
+
+    @Override
+    public Optional<Descriptor> getDescriptorFromTypeUrl(String url)
+    {
+        try {
+            requireNonNull(url, "url is null");
+            return Optional.of(protobufTypeUrlCache.get(url));
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Descriptor loadDescriptorFromType(String url)
+    {
+        try {
+            return ((ProtobufSchema) new ProtobufSchemaProvider()
+                    .parseSchema(getContents(url), List.of(), true)
+                    .orElseThrow())
+                    .toDescriptor();
+        }
+        catch (NoSuchElementException e) {
+            throw new TrinoException(GENERIC_USER_ERROR, "Failed to parse protobuf schema");
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -40,6 +40,8 @@ import io.trino.decoder.avro.AvroReaderSupplier;
 import io.trino.decoder.avro.AvroRowDecoderFactory;
 import io.trino.decoder.dummy.DummyRowDecoder;
 import io.trino.decoder.dummy.DummyRowDecoderFactory;
+import io.trino.decoder.protobuf.DescriptorProvider;
+import io.trino.decoder.protobuf.DummyDescriptorProvider;
 import io.trino.decoder.protobuf.DynamicMessageProvider;
 import io.trino.decoder.protobuf.ProtobufRowDecoder;
 import io.trino.decoder.protobuf.ProtobufRowDecoderFactory;
@@ -50,6 +52,7 @@ import io.trino.plugin.kafka.encoder.avro.AvroRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufRowEncoder;
 import io.trino.plugin.kafka.encoder.protobuf.ProtobufSchemaParser;
 import io.trino.plugin.kafka.schema.ContentSchemaReader;
+import io.trino.plugin.kafka.schema.ProtobufAnySupportConfig;
 import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
 import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
@@ -68,6 +71,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.kafka.encoder.EncoderModule.encoderFactory;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -132,7 +136,7 @@ public class ConfluentModule
                 classLoader);
     }
 
-    private static class ConfluentDecoderModule
+    private class ConfluentDecoderModule
             implements Module
     {
         @Override
@@ -144,6 +148,12 @@ public class ConfluentModule
             newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(ProtobufRowDecoder.NAME).to(ProtobufRowDecoderFactory.class).in(Scopes.SINGLETON);
             newMapBinder(binder, String.class, RowDecoderFactory.class).addBinding(DummyRowDecoder.NAME).to(DummyRowDecoderFactory.class).in(SINGLETON);
             binder.bind(DispatchingRowDecoderFactory.class).in(SINGLETON);
+
+            configBinder(binder).bindConfig(ProtobufAnySupportConfig.class);
+            install(conditionalModule(ProtobufAnySupportConfig.class,
+                    ProtobufAnySupportConfig::isProtobufAnySupportEnabled,
+                    new ConfluentDesciptorProviderModule(),
+                    new DummyDescriptorProviderModule()));
         }
     }
 
@@ -215,15 +225,35 @@ public class ConfluentModule
         private final Supplier<SchemaParser> delegate;
 
         @Inject
-        public LazyLoadedProtobufSchemaParser(TypeManager typeManager)
+        public LazyLoadedProtobufSchemaParser(TypeManager typeManager, ProtobufAnySupportConfig config)
         {
-            this.delegate = Suppliers.memoize(() -> new ProtobufSchemaParser(requireNonNull(typeManager, "typeManager is null")));
+            this.delegate = Suppliers.memoize(() -> new ProtobufSchemaParser(requireNonNull(typeManager, "typeManager is null"), config));
         }
 
         @Override
         protected SchemaParser delegate()
         {
             return delegate.get();
+        }
+    }
+
+    private static class ConfluentDesciptorProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(DescriptorProvider.class).to(ConfluentDescriptorProvider.class).in(SINGLETON);
+        }
+    }
+
+    private static class DummyDescriptorProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(DescriptorProvider.class).to(DummyDescriptorProvider.class).in(SINGLETON);
         }
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplierModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/file/FileTableDescriptionSupplierModule.java
@@ -14,13 +14,19 @@
 package io.trino.plugin.kafka.schema.file;
 
 import com.google.inject.Binder;
+import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.decoder.DecoderModule;
+import io.trino.decoder.protobuf.DescriptorProvider;
+import io.trino.decoder.protobuf.FileDescriptorProvider;
 import io.trino.plugin.kafka.encoder.EncoderModule;
 import io.trino.plugin.kafka.schema.ContentSchemaReader;
+import io.trino.plugin.kafka.schema.ProtobufAnySupportConfig;
 import io.trino.plugin.kafka.schema.TableDescriptionSupplier;
 
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class FileTableDescriptionSupplierModule
@@ -34,5 +40,20 @@ public class FileTableDescriptionSupplierModule
         install(new DecoderModule());
         install(new EncoderModule());
         binder.bind(ContentSchemaReader.class).to(FileContentSchemaReader.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(ProtobufAnySupportConfig.class);
+        install(conditionalModule(ProtobufAnySupportConfig.class,
+                ProtobufAnySupportConfig::isProtobufAnySupportEnabled,
+                new FileDescriptorProviderModule()));
+    }
+
+    private static class FileDescriptorProviderModule
+            implements Module
+    {
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(DescriptorProvider.class).to(FileDescriptorProvider.class).in(SINGLETON);
+        }
     }
 }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/KafkaWithConfluentSchemaRegistryQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/KafkaWithConfluentSchemaRegistryQueryRunner.java
@@ -47,6 +47,7 @@ public final class KafkaWithConfluentSchemaRegistryQueryRunner
             Map<String, String> properties = new HashMap<>(extraKafkaProperties);
             properties.putIfAbsent("kafka.table-description-supplier", "confluent");
             properties.putIfAbsent("kafka.confluent-schema-registry-url", testingKafka.getSchemaRegistryConnectString());
+            properties.putIfAbsent("kafka.protobuf-any-support-enabled", "true");
             setExtraKafkaProperties(properties);
         }
     }

--- a/plugin/trino-kafka/src/test/resources/protobuf/any/structural_datatypes/schema
+++ b/plugin/trino-kafka/src/test/resources/protobuf/any/structural_datatypes/schema
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+message schema {
+    repeated string list = 1;
+    map<string, string> map = 2;
+    enum Number {
+        ZERO = 0;
+        ONE = 1;
+        TWO = 2;
+    };
+    message Row {
+        string string_column = 1;
+        uint32 integer_column = 2;
+        uint64 long_column = 3;
+        double double_column = 4;
+        float float_column = 5;
+        bool boolean_column = 6;
+        Number number_column = 7;
+        google.protobuf.Timestamp timestamp_column = 8;
+        bytes bytes_column = 9;
+    };
+    Row row = 3;
+    message NestedRow {
+        repeated Row nested_list = 1;
+        map<string, Row> nested_map = 2;
+        Row row = 3;
+    };
+    NestedRow nested_row = 4;
+}

--- a/plugin/trino-kafka/src/test/resources/protobuf/test_any.proto
+++ b/plugin/trino-kafka/src/test/resources/protobuf/test_any.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+import "google/protobuf/any.proto";
+
+message schema {
+    int32 id = 1;
+    google.protobuf.Any anyMessage = 2;
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This adds support for the `any` Protobuf data type, converting the message type to JSON. The default implementation uses the `ProtobufUtils` mechanism for parsing the `Descriptor`. There is a separate implementation that uses Confluent's `ProtobufSchemaProvider` which is used instead when the `ConfluentModule` is enabled and uses caching when accessing the types.

This PR needs user-facing documentation which will be added as another commit.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The Protobuf `any` type contains two fields, one `type_url` field and another being any serialized Protobuf message. The `type_url` is expected to be a URL that resolves to a serialized descriptor of the message. This change uses a `java.net.URL` of the `type_url` to open a stream and read the bytes of the descriptor which is then converted into a `Descriptor` object. We then pass this to a JSON printer to serialize the message. Afterwards, we have to sort all of the keys, including nested keys, as the Trino JSON type expects all keys to be ordered.

This requires users to ensure that the URL is resolvable from the Coordinator and Worker hosts, either by being a locally installed `file://` on each machine or a remote `https://` service.

Expands on #16836 which added `oneof` support

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Kafka Connector
* Added support for `Any` Protobuf types for file-based and Confluent table descriptors
```
