### PR TITLE
Support for multiple token issuers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/AzureJwtTokenValidator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/AzureJwtTokenValidator.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.server.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.HttpStatus;
+import io.airlift.http.client.HttpUriBuilder;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.StringResponseHandler;
+import io.airlift.log.Logger;
+import io.trino.spi.TrinoException;
+
+import javax.ws.rs.core.MediaType;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.ACCEPT;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.Request.Builder.prepareGet;
+import static io.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+
+public class AzureJwtTokenValidator
+        extends JwtTokenValidator
+{
+    public static final String AZURE_VALIDATION_URL = "http-server.authentication.azure.validation.url";
+    public static final String AZURE_PARAM_KEY = "http-server.authentication.azure.param.key";
+    public static final String AZURE_PARAM_VALUE = "http-server.authentication.azure.param.value";
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer";
+    private static final Logger log = Logger.get(AzureJwtTokenValidator.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private String azureValidationUrl;
+    private String httpRequestParam;
+    private String httpRequestParamValue;
+
+    @Override
+    public Optional<String> validateAndCreatePrincipal(String token, HttpClient httpClient)
+    {
+        String principalField = this.principalField != null ? this.principalField : "sub";
+        String authToken = TOKEN_PREFIX + " " + token;
+        HttpUriBuilder httpUriBuilder = uriBuilderFrom(URI.create(azureValidationUrl));
+        if (StringUtils.isNotBlank(httpRequestParam) && StringUtils.isBlank(httpRequestParamValue)) {
+            httpUriBuilder.addParameter(httpRequestParam, httpRequestParamValue);
+        }
+        Request request = prepareGet()
+                .addHeader(ACCEPT, MediaType.APPLICATION_JSON)
+                .addHeader(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .addHeader(AUTHORIZATION, authToken)
+                .setUri(httpUriBuilder.build())
+                .build();
+        Optional<String> principal = Optional.empty();
+        try {
+            StringResponseHandler.StringResponse response = httpClient.execute(request, createStringResponseHandler());
+            if (response != null) {
+                if (response.getStatusCode() != HttpStatus.OK.code()) {
+                    log.error("Unexpected response code " + response.getStatusCode() + " from Azure JWT authenticator at " + response.getBody());
+                }
+                else {
+                    Map<String, String> responseMap = StringUtils.isNotBlank(response.getBody()) ? OBJECT_MAPPER.readValue(response.getBody(), Map.class) : null;
+                    principal = (responseMap != null && responseMap.containsKey(principalField)) ? Optional.of(responseMap.get(principalField)) : Optional.empty();
+                }
+            }
+            else {
+                log.error("Unexpected null response received");
+            }
+        }
+        catch (Exception e) {
+            log.error("Error validating azure token using api. Error is : " + e.getMessage());
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, e);
+        }
+
+        return principal;
+    }
+
+    @Override
+    protected void setRequiredProperties(Map<String, Object> properties, File configFile)
+    {
+        super.setRequiredProperties(properties, configFile);
+        String validationUrl = (String) properties.get(AZURE_VALIDATION_URL);
+        checkState(!isNullOrEmpty(validationUrl), "Configuration does not contain '%s' property: %s", AZURE_VALIDATION_URL, configFile);
+        this.azureValidationUrl = validationUrl;
+    }
+
+    @Override
+    protected void setOptionalProperties(Map<String, Object> properties)
+    {
+        super.setOptionalProperties(properties);
+        this.httpRequestParam = (String) properties.get(AZURE_PARAM_KEY);
+        this.httpRequestParamValue = (String) properties.get(AZURE_PARAM_VALUE);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/FileSigningKeyResolver.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/FileSigningKeyResolver.java
@@ -23,7 +23,6 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.SecurityException;
 
 import javax.crypto.spec.SecretKeySpec;
-import javax.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,12 +48,6 @@ public class FileSigningKeyResolver
     private final String keyFile;
     private final LoadedKey staticKey;
     private final ConcurrentMap<String, LoadedKey> keys = new ConcurrentHashMap<>();
-
-    @Inject
-    public FileSigningKeyResolver(JwtAuthenticatorConfig config)
-    {
-        this(config.getKeyFile());
-    }
 
     public FileSigningKeyResolver(String keyFile)
     {

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticator.java
@@ -13,10 +13,10 @@
  */
 package io.trino.server.security.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.JwtParserBuilder;
-import io.jsonwebtoken.SigningKeyResolver;
+import com.google.common.collect.ImmutableList;
+import io.airlift.http.client.HttpClient;
+import io.airlift.log.Logger;
+import io.jsonwebtoken.JwtException;
 import io.trino.server.security.AbstractBearerAuthenticator;
 import io.trino.server.security.AuthenticationException;
 import io.trino.server.security.UserMapping;
@@ -27,83 +27,102 @@ import io.trino.spi.security.Identity;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 
-import java.util.Collection;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
-import static io.jsonwebtoken.Claims.AUDIENCE;
-import static io.trino.server.security.UserMapping.createUserMapping;
-import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
-import static java.lang.String.format;
+import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 
 public class JwtAuthenticator
         extends AbstractBearerAuthenticator
 {
-    private final JwtParser jwtParser;
-    private final String principalField;
-    private final UserMapping userMapping;
-    private final Optional<String> requiredAudience;
+    public static final String JWT_KEY_FILE = "http-server.authentication.jwt.key-file";
+    public static final String JWT_REQUIRED_ISSUER = "http-server.authentication.jwt.required-issuer";
+    public static final String JWT_REQUIRED_AUDIENCE = "http-server.authentication.jwt.required-audience";
+    public static final String JWT_PRINCIPAL_FIELD = "http-server.authentication.jwt.principal-field";
+    public static final String JWT_USER_MAPPING_PATTERN = "http-server.authentication.jwt.user-mapping.pattern";
+    public static final String JWT_USER_MAPPING_FILE = "http-server.authentication.jwt.user-mapping.file";
+    private static final String TOKEN_TYPE = "http-server.token.type";
+    private static final Logger log = Logger.get(JwtAuthenticatorConfig.class);
+
+    private final List<File> configFiles;
+    private List<JwtTokenValidator> tokenValidators;
+    private final HttpClient httpClient;
 
     @Inject
-    public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt SigningKeyResolver signingKeyResolver)
+    public JwtAuthenticator(JwtAuthenticatorConfig config, @ForJwt HttpClient httpClient)
     {
-        principalField = config.getPrincipalField();
-        requiredAudience = Optional.ofNullable(config.getRequiredAudience());
+        this.configFiles = ImmutableList.copyOf(config.getJwtIdpConfigFiles());
+        this.httpClient = httpClient;
+        setTokenIssuers(config);
+    }
 
-        JwtParserBuilder jwtParser = newJwtParserBuilder()
-                .setSigningKeyResolver(signingKeyResolver);
-
-        if (config.getRequiredIssuer() != null) {
-            jwtParser.requireIssuer(config.getRequiredIssuer());
+    private void setTokenIssuers(JwtAuthenticatorConfig config)
+    {
+        List<File> configFiles = this.configFiles;
+        tokenValidators = new ArrayList<>();
+        //TODO: remove the setLegacyConfigurations once deprecated properties are removed
+        if (configFiles.isEmpty()) {
+            JwtTokenValidator jwtTokenValidator = TokenFactory.getJwtToken(TokenTypeEnum.JWT);
+            jwtTokenValidator.setLegacyConfigurations(config);
+            tokenValidators.add(jwtTokenValidator);
         }
-        this.jwtParser = jwtParser.build();
-        userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
+        configFiles.forEach(this::createIdp);
+    }
+
+    private void createIdp(File configFile)
+    {
+        Map<String, Object> properties = loadPropertyFile(configFile);
+        String tokenType = (String) properties.get(TOKEN_TYPE);
+        TokenTypeEnum tokenTypeEnum = TokenTypeEnum.fromTokenType(tokenType);
+        JwtTokenValidator jwtTokenValidator = TokenFactory.getJwtToken(tokenTypeEnum);
+        jwtTokenValidator.setRequiredProperties(properties, configFile);
+        jwtTokenValidator.setOptionalProperties(properties);
+        tokenValidators.add(jwtTokenValidator);
     }
 
     @Override
-    protected Optional<Identity> createIdentity(String token)
-            throws UserMappingException
+    protected Optional<Identity> createIdentity(String givenToken)
+            throws UserMappingException, JwtException
     {
-        Claims claims = jwtParser.parseClaimsJws(token).getBody();
-        validateAudience(claims);
+        Optional<Identity> identity = Optional.empty();
+        PrincipalUserMapping validatedPrincipalUserMapping = tokenValidators.stream()
+                .map(tokenValidator -> new PrincipalUserMapping(tokenValidator.validateAndCreatePrincipal(givenToken, httpClient), Optional.of(tokenValidator.getUserMapping())))
+                .filter(principalUserMapping -> principalUserMapping.getPrincipal().isPresent())
+                .findFirst().orElse(new PrincipalUserMapping(Optional.empty(), Optional.empty()));
 
-        Optional<String> principal = Optional.ofNullable(claims.get(principalField, String.class));
-        if (principal.isEmpty()) {
-            return Optional.empty();
+        Optional<String> principal = validatedPrincipalUserMapping.getPrincipal();
+        if (principal.isPresent()) {
+            UserMapping userMapping = validatedPrincipalUserMapping.getUserMapping().get();
+            identity = Optional.of(Identity.forUser(userMapping.mapUser(principal.get()))
+                    .withPrincipal(new BasicPrincipal(principal.get()))
+                    .build());
         }
-        return Optional.of(Identity.forUser(userMapping.mapUser(principal.get()))
-                .withPrincipal(new BasicPrincipal(principal.get()))
-                .build());
-    }
-
-    private void validateAudience(Claims claims)
-    {
-        if (requiredAudience.isEmpty()) {
-            return;
-        }
-
-        Object tokenAudience = claims.get(AUDIENCE);
-        if (tokenAudience == null) {
-            throw new InvalidClaimException(format("Expected %s claim to be: %s, but was not present in the JWT claims.", AUDIENCE, requiredAudience.get()));
-        }
-
-        if (tokenAudience instanceof String) {
-            if (!requiredAudience.get().equals((String) tokenAudience)) {
-                throw new InvalidClaimException(format("Invalid Audience: %s. Allowed audiences: %s", tokenAudience, requiredAudience.get()));
-            }
-        }
-        else if (tokenAudience instanceof Collection) {
-            if (((Collection<?>) tokenAudience).stream().map(String.class::cast).noneMatch(aud -> requiredAudience.get().equals(aud))) {
-                throw new InvalidClaimException(format("Invalid Audience: %s. Allowed audiences: %s", tokenAudience, requiredAudience.get()));
-            }
-        }
-        else {
-            throw new InvalidClaimException(format("Invalid Audience: %s", tokenAudience));
-        }
+        return identity;
     }
 
     @Override
     protected AuthenticationException needAuthentication(ContainerRequestContext request, Optional<String> currentToken, String message)
     {
         return new AuthenticationException(message, "Bearer realm=\"Trino\", token_type=\"JWT\"");
+    }
+
+    private Map<String, Object> loadPropertyFile(File configFile)
+    {
+        log.info("-- Loading IDP properties %s --", configFile);
+        configFile = configFile.getAbsoluteFile();
+        Map<String, Object> properties;
+        try {
+            properties = new HashMap<>(loadPropertiesFrom(configFile.getPath()));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to read configuration file: " + configFile, e);
+        }
+        return properties;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorConfig.java
@@ -13,14 +13,18 @@
  */
 package io.trino.server.security.jwt;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.configuration.validation.FileExists;
 
-import javax.validation.constraints.NotNull;
-
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
 
 public class JwtAuthenticatorConfig
 {
@@ -30,8 +34,10 @@ public class JwtAuthenticatorConfig
     private String principalField = "sub";
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
+    private List<File> configFiles = ImmutableList.of();
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
-    @NotNull
+    @Deprecated
     public String getKeyFile()
     {
         return keyFile;
@@ -39,12 +45,14 @@ public class JwtAuthenticatorConfig
 
     @Config("http-server.authentication.jwt.key-file")
     @LegacyConfig("http.authentication.jwt.key-file")
+    @Deprecated
     public JwtAuthenticatorConfig setKeyFile(String keyFile)
     {
         this.keyFile = keyFile;
         return this;
     }
 
+    @Deprecated
     public String getRequiredIssuer()
     {
         return requiredIssuer;
@@ -52,12 +60,14 @@ public class JwtAuthenticatorConfig
 
     @Config("http-server.authentication.jwt.required-issuer")
     @LegacyConfig("http.authentication.jwt.required-issuer")
+    @Deprecated
     public JwtAuthenticatorConfig setRequiredIssuer(String requiredIssuer)
     {
         this.requiredIssuer = requiredIssuer;
         return this;
     }
 
+    @Deprecated
     public String getRequiredAudience()
     {
         return requiredAudience;
@@ -65,46 +75,73 @@ public class JwtAuthenticatorConfig
 
     @Config("http-server.authentication.jwt.required-audience")
     @LegacyConfig("http.authentication.jwt.required-audience")
+    @Deprecated
     public JwtAuthenticatorConfig setRequiredAudience(String requiredAudience)
     {
         this.requiredAudience = requiredAudience;
         return this;
     }
 
-    @NotNull
+    @Deprecated
     public String getPrincipalField()
     {
         return principalField;
     }
 
     @Config("http-server.authentication.jwt.principal-field")
+    @Deprecated
     public JwtAuthenticatorConfig setPrincipalField(String principalField)
     {
         this.principalField = principalField;
         return this;
     }
 
+    @Deprecated
     public Optional<String> getUserMappingPattern()
     {
         return userMappingPattern;
     }
 
     @Config("http-server.authentication.jwt.user-mapping.pattern")
+    @Deprecated
     public JwtAuthenticatorConfig setUserMappingPattern(String userMappingPattern)
     {
         this.userMappingPattern = Optional.ofNullable(userMappingPattern);
         return this;
     }
 
+    @Deprecated
     public Optional<@FileExists File> getUserMappingFile()
     {
         return userMappingFile;
     }
 
     @Config("http-server.authentication.jwt.user-mapping.file")
+    @Deprecated
     public JwtAuthenticatorConfig setUserMappingFile(File userMappingFile)
     {
         this.userMappingFile = Optional.ofNullable(userMappingFile);
+        return this;
+    }
+
+    public List<@FileExists File> getJwtIdpConfigFiles()
+    {
+        return configFiles;
+    }
+
+    @Config("http-server.authentication.jwt.config-files")
+    @ConfigDescription("JWT IDP config files")
+    public JwtAuthenticatorConfig setJwtIdpConfigFiles(String configFiles)
+    {
+        this.configFiles = SPLITTER.splitToList(configFiles).stream()
+                .map(File::new)
+                .collect(toImmutableList());
+        return this;
+    }
+
+    public JwtAuthenticatorConfig setJwtIdpConfigFiles(List<File> configFiles)
+    {
+        this.configFiles = ImmutableList.copyOf(configFiles);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -28,7 +28,7 @@ public class JwtAuthenticatorSupportModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(JwtAuthenticatorConfig.class);
-        httpClientBinder(binder).bindHttpClient("jwk", ForJwt.class);
+        httpClientBinder(binder).bindHttpClient(JWK, ForJwt.class);
     }
 
     // this module can be added multiple times, and this prevents multiple processing by Guice

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtTokenValidator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtTokenValidator.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.server.security.jwt;
+
+import io.airlift.http.client.HttpClient;
+import io.airlift.log.Logger;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.JwtParserBuilder;
+import io.jsonwebtoken.SigningKeyResolver;
+import io.trino.server.security.UserMapping;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.server.security.UserMapping.createUserMapping;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_KEY_FILE;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_PRINCIPAL_FIELD;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_REQUIRED_AUDIENCE;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_REQUIRED_ISSUER;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_USER_MAPPING_FILE;
+import static io.trino.server.security.jwt.JwtAuthenticator.JWT_USER_MAPPING_PATTERN;
+import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
+
+public class JwtTokenValidator
+{
+    private static final int JWK_CLOCK_SKEW_SECONDS = 2 * 60; // 2 minutes
+    private static final Logger log = Logger.get(JwtTokenValidator.class);
+
+    protected String keyFile;
+    protected String requiredIssuer;
+    protected String requiredAudience;
+    protected String principalField;
+    protected UserMapping userMapping;
+
+    public UserMapping getUserMapping()
+    {
+        return userMapping;
+    }
+
+    public Optional<String> validateAndCreatePrincipal(String token, HttpClient httpClient)
+    {
+        Optional<String> principal = Optional.empty();
+        JwtParser jwtParser = setJwtParser(httpClient);
+        String principalField = this.principalField != null ? this.principalField : "sub";
+        try {
+            principal = Optional.ofNullable(jwtParser.parseClaimsJws(token)
+                    .getBody()
+                    .get(principalField, String.class));
+        }
+        catch (JwtException e) {
+            log.info("Error occurred validating claim. Verified for the idp " + requiredIssuer + " configured." + e);
+        }
+        return principal;
+    }
+
+    private JwtParser setJwtParser(HttpClient httpClient)
+    {
+        SigningKeyResolver signingKeyResolver;
+        if (keyFile.startsWith("https://") || keyFile.startsWith("http://")) {
+            JwkService jwkService = new JwkService((URI.create(keyFile)), httpClient);
+            signingKeyResolver = new JwkSigningKeyResolver(jwkService);
+        }
+        else {
+            signingKeyResolver = new FileSigningKeyResolver(keyFile);
+        }
+        JwtParserBuilder jwtParserBuilder = newJwtParserBuilder()
+                .setAllowedClockSkewSeconds(JWK_CLOCK_SKEW_SECONDS)
+                .setSigningKeyResolver(signingKeyResolver);
+
+        Optional.ofNullable(requiredIssuer).ifPresent(jwtParserBuilder::requireIssuer);
+        Optional.ofNullable(requiredAudience).ifPresent(jwtParserBuilder::requireAudience);
+        return jwtParserBuilder.build();
+    }
+
+    protected void setRequiredProperties(Map<String, Object> properties, File configFile)
+    {
+        String requiredIssuer = (String) properties.get(JWT_REQUIRED_ISSUER);
+        checkState(!isNullOrEmpty(requiredIssuer), "Configuration does not contain '%s' property: %s", JWT_REQUIRED_ISSUER, configFile);
+        this.requiredIssuer = requiredIssuer;
+
+        String jwtKeyFile = (String) properties.get(JWT_KEY_FILE);
+        checkState(!isNullOrEmpty(jwtKeyFile), "Configuration does not contain '%s' property: %s", JWT_KEY_FILE, configFile);
+        this.keyFile = jwtKeyFile;
+    }
+
+    protected void setOptionalProperties(Map<String, Object> properties)
+    {
+        if (properties.get(JWT_PRINCIPAL_FIELD) != null) {
+            this.principalField = (String) properties.get(JWT_PRINCIPAL_FIELD);
+        }
+        if (properties.get(JWT_REQUIRED_AUDIENCE) != null) {
+            this.requiredAudience = (String) properties.get(JWT_REQUIRED_AUDIENCE);
+        }
+
+        Optional<String> jwtUserMappingPattern = Optional.ofNullable((String) properties.get(JWT_USER_MAPPING_PATTERN));
+        Optional<String> jwtUserMappingFilePath = Optional.ofNullable((String) properties.get(JWT_USER_MAPPING_FILE));
+        Optional<File> jwtUserMappingFile = jwtUserMappingFilePath.isPresent() ? Optional.ofNullable(new File(jwtUserMappingFilePath.get())) : Optional.empty();
+        this.userMapping = createUserMapping(jwtUserMappingPattern, jwtUserMappingFile);
+    }
+
+    //TODO: Remove this method once legacy configs are deprecated & removed.
+    protected void setLegacyConfigurations(JwtAuthenticatorConfig config)
+    {
+        checkState(!isNullOrEmpty(config.getKeyFile()), "http-server.authentication.jwt.key-file must not be null");
+        this.requiredIssuer = config.getRequiredIssuer();
+        this.keyFile = config.getKeyFile();
+        if (config.getPrincipalField() != null) {
+            this.principalField = config.getPrincipalField();
+        }
+        if (config.getRequiredAudience() != null) {
+            this.requiredAudience = config.getRequiredAudience();
+        }
+        this.userMapping = createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/PrincipalUserMapping.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/PrincipalUserMapping.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.server.security.jwt;
+
+import io.trino.server.security.UserMapping;
+
+import java.util.Optional;
+
+public class PrincipalUserMapping
+{
+    private Optional<String> principal;
+    private Optional<UserMapping> userMapping;
+
+    public PrincipalUserMapping(Optional<String> principal, Optional<UserMapping> userMapping)
+    {
+        this.principal = principal;
+        this.userMapping = userMapping;
+    }
+
+    public Optional<String> getPrincipal()
+    {
+        return principal;
+    }
+
+    public void setPrincipal(Optional<String> principal)
+    {
+        this.principal = principal;
+    }
+
+    public Optional<UserMapping> getUserMapping()
+    {
+        return userMapping;
+    }
+
+    public void setUserMapping(Optional<UserMapping> userMapping)
+    {
+        this.userMapping = userMapping;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/TokenFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/TokenFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.server.security.jwt;
+
+public class TokenFactory
+{
+    private TokenFactory()
+    {
+    }
+
+    public static JwtTokenValidator getJwtToken(TokenTypeEnum tokenType)
+    {
+        switch (tokenType) {
+            case AZURE_AD:
+                return new AzureJwtTokenValidator();
+            default:
+                return new JwtTokenValidator();
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/TokenTypeEnum.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/TokenTypeEnum.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.server.security.jwt;
+
+import com.google.common.base.Strings;
+
+import java.util.Arrays;
+
+public enum TokenTypeEnum {
+    JWT("jwt"),
+    AZURE_AD("azure_ad");
+
+    private final String type;
+
+    TokenTypeEnum(String type)
+    {
+        this.type = type;
+    }
+
+    public String getType()
+    {
+        return this.type;
+    }
+
+    public static TokenTypeEnum fromTokenType(String tokenType)
+    {
+        return Strings.isNullOrEmpty(tokenType) ? JWT : Arrays.stream(values())
+                .filter(tokenTypeEnum -> tokenTypeEnum.type.equalsIgnoreCase(tokenType))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Unknown token type"));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -466,7 +466,6 @@ public class TestResourceSecurity
         verifyJwtAuthenticator(Optional.empty(), Optional.empty());
         verifyJwtAuthenticator(Optional.of("custom-principal"), Optional.empty());
         verifyJwtAuthenticator(Optional.empty(), Optional.of(TRINO_AUDIENCE));
-        verifyJwtAuthenticator(Optional.empty(), Optional.of(ImmutableList.of(TRINO_AUDIENCE, ADDITIONAL_AUDIENCE)));
     }
 
     private void verifyJwtAuthenticator(Optional<String> principalField, Optional<Object> audience)

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwtAuthenticatorConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwtAuthenticatorConfig.java
@@ -13,7 +13,9 @@
  */
 package io.trino.server.security.jwt;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.testing.ConfigAssertions;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -22,29 +24,32 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
-import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
-import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 
 public class TestJwtAuthenticatorConfig
 {
+    //TODO: remove unrelated code after deprecated properties are removed.
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(JwtAuthenticatorConfig.class)
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(JwtAuthenticatorConfig.class)
                 .setKeyFile(null)
                 .setRequiredAudience(null)
                 .setRequiredIssuer(null)
                 .setPrincipalField("sub")
                 .setUserMappingPattern(null)
-                .setUserMappingFile(null));
+                .setUserMappingFile(null)
+                .setJwtIdpConfigFiles(""));
     }
 
+    //TODO: remove unrelated code after deprecated properties are removed.
     @Test
     public void testExplicitPropertyMappings()
             throws IOException
     {
         Path jwtKeyFile = Files.createTempFile(null, null);
         Path userMappingFile = Files.createTempFile(null, null);
+        Path idpConfig1 = Files.createTempFile("azuread_idp", ".properties");
+        Path idpConfig2 = Files.createTempFile("keycloak_idp", ".properties");
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("http-server.authentication.jwt.key-file", jwtKeyFile.toString())
@@ -53,6 +58,7 @@ public class TestJwtAuthenticatorConfig
                 .put("http-server.authentication.jwt.principal-field", "some-field")
                 .put("http-server.authentication.jwt.user-mapping.pattern", "(.*)@something")
                 .put("http-server.authentication.jwt.user-mapping.file", userMappingFile.toString())
+                .put("http-server.authentication.jwt.config-files", idpConfig1.toString() + "," + idpConfig2.toString())
                 .buildOrThrow();
 
         JwtAuthenticatorConfig expected = new JwtAuthenticatorConfig()
@@ -61,7 +67,9 @@ public class TestJwtAuthenticatorConfig
                 .setRequiredIssuer("some-issuer")
                 .setPrincipalField("some-field")
                 .setUserMappingPattern("(.*)@something")
-                .setUserMappingFile(userMappingFile.toFile());
+                .setUserMappingFile(userMappingFile.toFile())
+                .setUserMappingFile(userMappingFile.toFile())
+                .setJwtIdpConfigFiles(ImmutableList.of(idpConfig1.toFile(), idpConfig2.toFile()));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Added support for multiple JWT issuers with specific implementation for Azure. JWT details are moved into individual property files based on the issuer and are read from config.properties
```
http-server.authentication.jwt.config-files=/etc/issuer1.properties,/etc/issuer2.properties
```

Solves issue #16949 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
JwtAuthenticator will get the configFiles in the constructor. In setTokenIssuers, if no config files are provided, then the legacy configurations will be used. Otherwise, it will create a TokenValidator for each of the config files provided. Each TokenValidator class includes the methods to validate that specific type of token, create the principal, and set the required and optional properties.

createIdentity in JwtAuthenticator will be called when a token comes in. It will try all the TokenValidators to validate the token until one is successful

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x ) Release notes are required, with the following suggested text:
 In docs/src/main/sphinx/security/jwt.rst

```markdown
JWT authentication configuration
--------------------------------

Enable JWT authentication by setting the :doc:`JWT authentication type
<authentication-types>` in :ref:`etc/config.properties <config_properties>`, and
specifying a single or multiple files with the remaining configurations for that issuer:

.. code-block:: properties

    http-server.authentication.type=JWT
    http-server.authentication.jwt.config-files=/etc/jwt.properties

JWT authentication is typically used in addition to other authentication
methods:

.. code-block:: properties

    http-server.authentication.type=PASSWORD,JWT
    http-server.authentication.jwt.config-files=/etc/jwt.properties

The following configuration properties are available:

.. list-table:: Configuration properties for JWT authentication
   :widths: 50 50
   :header-rows: 1

   * - Property
     - Description
   * - ``http-server.jwt.idp.name``
     - Required. Specifies a unique name for the JWT issuer.
   * - ``http-server.authentication.jwt.key-file``
     - Required. Specifies either the URL to a JWKS service or the path to a
       PEM or HMAC file, as described below this table.
   * - ``http-server.token.type``
     - Required. Specifies token type. (e.g. jwt, azure_ad)
   * - ``http-server.authentication.jwt.required-issuer``
     - Specifies a string that must match the value of the JWT's
       issuer (``iss``) field in order to consider this JWT valid.
       The ``iss`` field in the JWT identifies the principal that issued the
       JWT.
   * - ``http-server.authentication.jwt.required-audience``
     - Specifies a string that must match the value of the JWT's
       Audience (``aud``) field in order to consider this JWT valid.
       The ``aud`` field in the JWT identifies the recipients that the
       JWT is intended for.
   * - ``http-server.authentication.jwt.principal-field``
     - String to identify the field in the JWT that identifies the
       subject of the JWT. The default value is ``sub``. This field is used to
       create the Trino principal.
   * - ``http-server.authentication.jwt.user-mapping.pattern``
     - A regular expression pattern to :doc:`map all user names
       </security/user-mapping>` for this authentication system to the format
       expected by the Trino server.
   * - ``http-server.authentication.jwt.user-mapping.file``
     - The path to a JSON file that contains a set of
       :doc:`user mapping rules </security/user-mapping>` for this
       authentication system.
```