### PR TITLE
Use predicates which are pushed down to Parquet reader in CheckpointEntryIterator

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake.transactionlog.checkpoint;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.parquet.writer.ParquetSchemaConverter;
@@ -84,12 +85,20 @@ public class CheckpointWriter
     private final TypeManager typeManager;
     private final CheckpointSchemaManager checkpointSchemaManager;
     private final String trinoVersion;
+    private final ParquetWriterOptions parquetWriterOptions;
 
     public CheckpointWriter(TypeManager typeManager, CheckpointSchemaManager checkpointSchemaManager, String trinoVersion)
+    {
+        this(typeManager, checkpointSchemaManager, trinoVersion, ParquetWriterOptions.builder().build());
+    }
+
+    @VisibleForTesting
+    public CheckpointWriter(TypeManager typeManager, CheckpointSchemaManager checkpointSchemaManager, String trinoVersion, ParquetWriterOptions parquetWriterOptions)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.checkpointSchemaManager = requireNonNull(checkpointSchemaManager, "checkpointSchemaManager is null");
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
+        this.parquetWriterOptions = requireNonNull(parquetWriterOptions, "parquetWriterOptions is null");
     }
 
     public void write(CheckpointEntries entries, TrinoOutputFile outputFile)
@@ -127,7 +136,7 @@ public class CheckpointWriter
                 outputFile.create(),
                 schemaConverter.getMessageType(),
                 schemaConverter.getPrimitiveTypes(),
-                ParquetWriterOptions.builder().build(),
+                parquetWriterOptions,
                 CompressionCodec.SNAPPY,
                 trinoVersion,
                 false,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -14,12 +14,16 @@
 package io.trino.plugin.deltalake.transactionlog.checkpoint;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
+import io.airlift.units.DataSize;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
@@ -32,6 +36,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -39,7 +44,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.IntStream;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.io.Resources.getResource;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.deltalake.transactionlog.checkpoint.CheckpointEntryIterator.EntryType.ADD;
@@ -103,6 +111,24 @@ public class TestCheckpointEntryIterator
                                 List.of("age"),
                                 Map.of(),
                                 1579190100722L));
+    }
+
+    @Test
+    public void testReadProtocolEntries()
+            throws Exception
+    {
+        URI checkpointUri = getResource(TEST_CHECKPOINT).toURI();
+        CheckpointEntryIterator checkpointEntryIterator = createCheckpointEntryIterator(checkpointUri, ImmutableSet.of(PROTOCOL), Optional.empty());
+        List<DeltaLakeTransactionLogEntry> entries = ImmutableList.copyOf(checkpointEntryIterator);
+
+        assertThat(entries).hasSize(1);
+
+        assertThat(entries).element(0).extracting(DeltaLakeTransactionLogEntry::getProtocol).isEqualTo(
+                new ProtocolEntry(
+                        1,
+                        2,
+                        Optional.empty(),
+                        Optional.empty()));
     }
 
     @Test
@@ -207,6 +233,92 @@ public class TestCheckpointEntryIterator
                 .isEmpty();
     }
 
+    @Test
+    public void testSkipRemoveEntries()
+            throws IOException
+    {
+        MetadataEntry metadataEntry = new MetadataEntry(
+                "metadataId",
+                "metadataName",
+                "metadataDescription",
+                new MetadataEntry.Format(
+                        "metadataFormatProvider",
+                        ImmutableMap.of()),
+                "{\"type\":\"struct\",\"fields\":" +
+                        "[{\"name\":\"ts\",\"type\":\"timestamp\",\"nullable\":true,\"metadata\":{}}]}",
+                ImmutableList.of("part_key"),
+                ImmutableMap.of(),
+                1000);
+        ProtocolEntry protocolEntry = new ProtocolEntry(10, 20, Optional.empty(), Optional.empty());
+        AddFileEntry addFileEntryJsonStats = new AddFileEntry(
+                "addFilePathJson",
+                ImmutableMap.of(),
+                1000,
+                1001,
+                true,
+                Optional.of("{" +
+                        "\"numRecords\":20," +
+                        "\"minValues\":{" +
+                        "\"ts\":\"2960-10-31T01:00:00.000Z\"" +
+                        "}," +
+                        "\"maxValues\":{" +
+                        "\"ts\":\"2960-10-31T02:00:00.000Z\"" +
+                        "}," +
+                        "\"nullCount\":{" +
+                        "\"ts\":1" +
+                        "}}"),
+                Optional.empty(),
+                ImmutableMap.of());
+
+        int numRemoveEntries = 100;
+        Set<RemoveFileEntry> removeEntries = IntStream.range(0, numRemoveEntries).mapToObj(x ->
+                        new RemoveFileEntry(
+                                UUID.randomUUID().toString(),
+                                1000,
+                                true))
+                .collect(toImmutableSet());
+
+        CheckpointEntries entries = new CheckpointEntries(
+                metadataEntry,
+                protocolEntry,
+                ImmutableSet.of(),
+                ImmutableSet.of(addFileEntryJsonStats),
+                removeEntries);
+
+        CheckpointWriter writer = new CheckpointWriter(
+                TESTING_TYPE_MANAGER,
+                checkpointSchemaManager,
+                "test",
+                ParquetWriterOptions.builder() // approximately 2 rows per row group
+                        .setMaxBlockSize(DataSize.ofBytes(64L))
+                        .setMaxPageSize(DataSize.ofBytes(64L))
+                        .build());
+
+        File targetFile = File.createTempFile("testSkipRemoveEntries-", ".checkpoint.parquet");
+        targetFile.deleteOnExit();
+
+        String targetPath = "file://" + targetFile.getAbsolutePath();
+        targetFile.delete(); // file must not exist when writer is called
+        writer.write(entries, createOutputFile(targetPath));
+
+        CheckpointEntryIterator addEntryIterator = createCheckpointEntryIterator(
+                URI.create(targetPath),
+                ImmutableSet.of(ADD),
+                Optional.of(metadataEntry));
+        CheckpointEntryIterator removeEntryIterator =
+                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(REMOVE), Optional.empty());
+        CheckpointEntryIterator txnEntryIterator =
+                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(TRANSACTION), Optional.empty());
+
+        assertThat(Iterators.size(addEntryIterator)).isEqualTo(1);
+        assertThat(Iterators.size(removeEntryIterator)).isEqualTo(numRemoveEntries);
+        assertThat(Iterators.size(txnEntryIterator)).isEqualTo(0);
+
+        assertThat(addEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(2L);
+        assertThat(removeEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(100L);
+        assertThat(txnEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(0L);
+    }
+
     private MetadataEntry readMetadataEntry(URI checkpointUri)
             throws IOException
     {
@@ -232,5 +344,10 @@ public class TestCheckpointEntryIterator
                 new ParquetReaderConfig().toParquetReaderOptions(),
                 true,
                 new DeltaLakeConfig().getDomainCompactionThreshold());
+    }
+
+    private static TrinoOutputFile createOutputFile(String path)
+    {
+        return new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS).create(SESSION).newOutputFile(Location.of(path));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/17405

Instead of a not null filter on the entry type column, which is a complex type for which null filters are NOOPs, we use a not null filter on a primitive required field of the entry type. This enables data skipping in the Parquet reader.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Please see https://github.com/trinodb/trino/issues/17405

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta
* Improve performance of reading from tables with a large number of checkpoint entries. ({issue}`17405`)
```
