### PR TITLE
Add BaseBigQueryConnectorSmokeTest

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorSmokeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.TestingConnectorBehavior;
+
+public abstract class BaseBigQueryConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    @SuppressWarnings("DuplicateBranchesInSwitch")
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        switch (connectorBehavior) {
+            case SUPPORTS_DELETE:
+            case SUPPORTS_UPDATE:
+            case SUPPORTS_MERGE:
+                return false;
+            case SUPPORTS_TRUNCATE:
+                return true;
+
+            case SUPPORTS_RENAME_TABLE:
+            case SUPPORTS_RENAME_SCHEMA:
+                return false;
+
+            case SUPPORTS_CREATE_VIEW:
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW:
+                return false;
+
+            default:
+                return super.hasBehavior(connectorBehavior);
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryArrowConnectorSmokeTest.java
@@ -14,12 +14,10 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.TestingConnectorBehavior;
 
 public class TestBigQueryArrowConnectorSmokeTest
-        extends BaseConnectorSmokeTest
+        extends BaseBigQueryConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
@@ -29,30 +27,5 @@ public class TestBigQueryArrowConnectorSmokeTest
                 ImmutableMap.of(),
                 ImmutableMap.of("bigquery.experimental.arrow-serialization.enabled", "true"),
                 REQUIRED_TPCH_TABLES);
-    }
-
-    @SuppressWarnings("DuplicateBranchesInSwitch")
-    @Override
-    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
-    {
-        switch (connectorBehavior) {
-            case SUPPORTS_DELETE:
-            case SUPPORTS_UPDATE:
-            case SUPPORTS_MERGE:
-                return false;
-
-            case SUPPORTS_RENAME_SCHEMA:
-                return false;
-
-            case SUPPORTS_RENAME_TABLE:
-                return false;
-
-            case SUPPORTS_CREATE_VIEW:
-            case SUPPORTS_CREATE_MATERIALIZED_VIEW:
-                return false;
-
-            default:
-                return super.hasBehavior(connectorBehavior);
-        }
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
@@ -14,9 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.TestingConnectorBehavior;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -26,7 +24,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
-        extends BaseConnectorSmokeTest
+        extends BaseBigQueryConnectorSmokeTest
 {
     private static final String ALTERNATE_PROJECT_CATALOG = "bigquery";
     private static final String SERVICE_ACCOUNT_CATALOG = "service_account_bigquery";
@@ -45,31 +43,6 @@ public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
                 REQUIRED_TPCH_TABLES);
         queryRunner.createCatalog(SERVICE_ACCOUNT_CATALOG, "bigquery", Map.of());
         return queryRunner;
-    }
-
-    @SuppressWarnings("DuplicateBranchesInSwitch")
-    @Override
-    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
-    {
-        switch (connectorBehavior) {
-            case SUPPORTS_DELETE:
-            case SUPPORTS_UPDATE:
-            case SUPPORTS_MERGE:
-                return false;
-            case SUPPORTS_TRUNCATE:
-                return true;
-
-            case SUPPORTS_RENAME_TABLE:
-            case SUPPORTS_RENAME_SCHEMA:
-                return false;
-
-            case SUPPORTS_CREATE_VIEW:
-            case SUPPORTS_CREATE_MATERIALIZED_VIEW:
-                return false;
-
-            default:
-                return super.hasBehavior(connectorBehavior);
-        }
     }
 
     @Test


### PR DESCRIPTION
## Description

`TestBigQueryArrowConnectorSmokeTest` didn't have false `SUPPORTS_TRUNCATE`. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.