### PR TITLE
Implementing $files in a distributed way.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileFormat.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileFormat.java
@@ -24,6 +24,9 @@ public enum IcebergFileFormat
     ORC,
     PARQUET,
     AVRO,
+    // Ideally iceberg would define a format type for each of its metadata type, i.e. MANIFEST, MANIFEST_LIST, SNAPSHOT,
+    // Given it does not exist right now we will have to overload the METADATA type.
+    METADATA
     /**/;
 
     public FileFormat toIceberg()
@@ -35,6 +38,8 @@ public enum IcebergFileFormat
                 return FileFormat.PARQUET;
             case AVRO:
                 return FileFormat.AVRO;
+            case METADATA:
+                return FileFormat.METADATA;
         }
         throw new VerifyException("Unhandled type: " + this);
     }
@@ -48,6 +53,8 @@ public enum IcebergFileFormat
                 return PARQUET;
             case AVRO:
                 return AVRO;
+            case METADATA:
+                return METADATA;
             default:
                 throw new TrinoException(NOT_SUPPORTED, "File format not supported for Iceberg: " + format);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -88,6 +88,7 @@ import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.iceberg.FileFormat.METADATA;
 import static org.apache.iceberg.types.Conversions.fromByteBuffer;
 
 public class IcebergSplitSource
@@ -433,7 +434,7 @@ public class IcebergSplitSource
                 task.length(),
                 task.file().fileSizeInBytes(),
                 task.file().recordCount(),
-                IcebergFileFormat.fromIceberg(task.file().format()),
+                IcebergFileFormat.fromIceberg(task.isDataTask() ? METADATA : task.file().format()),
                 ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),
                 PartitionData.toJson(task.file().partition()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -59,6 +59,12 @@ public class IcebergTableHandle
     private final boolean recordScannedFiles;
     private final Optional<DataSize> maxScannedFileSize;
 
+    private final Optional<String> baseTableSchema;
+
+    private final Optional<Map<Integer, String>> baseTablePartitionSpecs;
+
+    private final Optional<String> baseTablePartitionSpec;
+
     @JsonCreator
     public static IcebergTableHandle fromJsonForDeserializationOnly(
             @JsonProperty("schemaName") String schemaName,
@@ -73,7 +79,10 @@ public class IcebergTableHandle
             @JsonProperty("projectedColumns") Set<IcebergColumnHandle> projectedColumns,
             @JsonProperty("nameMappingJson") Optional<String> nameMappingJson,
             @JsonProperty("tableLocation") String tableLocation,
-            @JsonProperty("storageProperties") Map<String, String> storageProperties)
+            @JsonProperty("storageProperties") Map<String, String> storageProperties,
+            @JsonProperty("baseTableSchema") Optional<String> baseTableSchema,
+            @JsonProperty("baseTablePartitionSpec") Optional<String> baseTablePartitionSpec,
+            @JsonProperty("baseTablePartitionSpecs") Optional<Map<Integer, String>> baseTablePartitionSpecs)
     {
         return new IcebergTableHandle(
                 schemaName,
@@ -90,7 +99,10 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 false,
-                Optional.empty());
+                Optional.empty(),
+                baseTableSchema,
+                baseTablePartitionSpec,
+                baseTablePartitionSpecs);
     }
 
     public IcebergTableHandle(
@@ -110,6 +122,47 @@ public class IcebergTableHandle
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize)
     {
+        this(
+                schemaName,
+                tableName,
+                tableType,
+                snapshotId,
+                tableSchemaJson,
+                partitionSpecJson,
+                formatVersion,
+                unenforcedPredicate,
+                enforcedPredicate,
+                projectedColumns,
+                nameMappingJson,
+                tableLocation,
+                storageProperties,
+                recordScannedFiles,
+                maxScannedFileSize,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public IcebergTableHandle(
+            String schemaName,
+            String tableName,
+            TableType tableType,
+            Optional<Long> snapshotId,
+            String tableSchemaJson,
+            Optional<String> partitionSpecJson,
+            int formatVersion,
+            TupleDomain<IcebergColumnHandle> unenforcedPredicate,
+            TupleDomain<IcebergColumnHandle> enforcedPredicate,
+            Set<IcebergColumnHandle> projectedColumns,
+            Optional<String> nameMappingJson,
+            String tableLocation,
+            Map<String, String> storageProperties,
+            boolean recordScannedFiles,
+            Optional<DataSize> maxScannedFileSize,
+            Optional<String> baseTableSchema,
+            Optional<String> baseTablePartitionSpec,
+            Optional<Map<Integer, String>> baseTablePartitionSpecs)
+    {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.tableType = requireNonNull(tableType, "tableType is null");
@@ -125,6 +178,9 @@ public class IcebergTableHandle
         this.storageProperties = ImmutableMap.copyOf(requireNonNull(storageProperties, "storageProperties is null"));
         this.recordScannedFiles = recordScannedFiles;
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
+        this.baseTableSchema = requireNonNull(baseTableSchema, "baseTableSchema is null");
+        this.baseTablePartitionSpec = requireNonNull(baseTablePartitionSpec, "baseTablePartitionSpec is null");
+        this.baseTablePartitionSpecs = requireNonNull(baseTablePartitionSpecs, "basePartitionSpecs is null");
     }
 
     @JsonProperty
@@ -228,6 +284,24 @@ public class IcebergTableHandle
         return new SchemaTableName(schemaName, tableName + "$" + tableType.name().toLowerCase(Locale.ROOT));
     }
 
+    @JsonProperty
+    public Optional<String> getBaseTableSchema()
+    {
+        return baseTableSchema;
+    }
+
+    @JsonProperty
+    public Optional<Map<Integer, String>> getBaseTablePartitionSpecs()
+    {
+        return baseTablePartitionSpecs;
+    }
+
+    @JsonProperty
+    public Optional<String> getBaseTablePartitionSpec()
+    {
+        return baseTablePartitionSpec;
+    }
+
     public IcebergTableHandle withProjectedColumns(Set<IcebergColumnHandle> projectedColumns)
     {
         return new IcebergTableHandle(
@@ -245,7 +319,10 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 recordScannedFiles,
-                maxScannedFileSize);
+                maxScannedFileSize,
+                baseTableSchema,
+                baseTablePartitionSpec,
+                baseTablePartitionSpecs);
     }
 
     public IcebergTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
@@ -265,7 +342,10 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 recordScannedFiles,
-                Optional.of(maxScannedFileSize));
+                Optional.of(maxScannedFileSize),
+                baseTableSchema,
+                baseTablePartitionSpec,
+                baseTablePartitionSpecs);
     }
 
     @Override
@@ -293,7 +373,10 @@ public class IcebergTableHandle
                 Objects.equals(nameMappingJson, that.nameMappingJson) &&
                 Objects.equals(tableLocation, that.tableLocation) &&
                 Objects.equals(storageProperties, that.storageProperties) &&
-                Objects.equals(maxScannedFileSize, that.maxScannedFileSize);
+                Objects.equals(maxScannedFileSize, that.maxScannedFileSize) &&
+                Objects.equals(baseTableSchema, that.baseTableSchema) &&
+                Objects.equals(baseTablePartitionSpec, that.baseTablePartitionSpec) &&
+                Objects.equals(baseTablePartitionSpecs, that.baseTablePartitionSpecs);
     }
 
     @Override
@@ -314,7 +397,10 @@ public class IcebergTableHandle
                 tableLocation,
                 storageProperties,
                 recordScannedFiles,
-                maxScannedFileSize);
+                maxScannedFileSize,
+                baseTableSchema,
+                baseTablePartitionSpec,
+                baseTablePartitionSpecs);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableName.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableName.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.plugin.iceberg.TableType.FILES;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -79,5 +80,15 @@ public final class IcebergTableName
         }
         String typeString = match.group("type");
         return typeString == null;
+    }
+
+    public static boolean isFilesTable(String name)
+    {
+        return tableTypeFrom(name).stream().anyMatch(tableType -> tableType.equals(FILES));
+    }
+
+    public static boolean shouldDistributeReads(String name)
+    {
+        return isDataTable(name) || isFilesTable(name);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ManifestPageSource.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.plugin.iceberg.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FilesMetadataTable;
+import org.apache.iceberg.GenericManifestFile;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeWrapper;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static org.apache.iceberg.FilesMetadataTable.COLUMN_SIZES;
+import static org.apache.iceberg.FilesMetadataTable.CONTENT;
+import static org.apache.iceberg.FilesMetadataTable.EQUALITY_IDS;
+import static org.apache.iceberg.FilesMetadataTable.FILE_FORMAT;
+import static org.apache.iceberg.FilesMetadataTable.FILE_SIZE;
+import static org.apache.iceberg.FilesMetadataTable.HIDDEN_FILE_PATH;
+import static org.apache.iceberg.FilesMetadataTable.HIDDEN_MODIFIED_FILE_PATH;
+import static org.apache.iceberg.FilesMetadataTable.KEY_METADATA;
+import static org.apache.iceberg.FilesMetadataTable.LOWER_BOUNDS;
+import static org.apache.iceberg.FilesMetadataTable.NAN_VALUE_COUNTS;
+import static org.apache.iceberg.FilesMetadataTable.NULL_VALUE_COUNTS;
+import static org.apache.iceberg.FilesMetadataTable.PARTITION_ID;
+import static org.apache.iceberg.FilesMetadataTable.RECORD_COUNT;
+import static org.apache.iceberg.FilesMetadataTable.SORT_ORDER_ID;
+import static org.apache.iceberg.FilesMetadataTable.SPEC_ID;
+import static org.apache.iceberg.FilesMetadataTable.SPLIT_OFFSETS;
+import static org.apache.iceberg.FilesMetadataTable.UPPER_BOUNDS;
+import static org.apache.iceberg.FilesMetadataTable.VALUE_COUNTS;
+
+public class ManifestPageSource
+        implements ConnectorPageSource
+{
+    private final int specId;
+    private SchemaTableName schemaTableName;
+    private final Schema baseTableSchema;
+    private final Optional<Map<Integer, PartitionSpec>> basePartitionSpecs;
+    private final long length;
+    private final FileIO fileIO;
+    private final List<Type> columnTypes;
+    private final List<IcebergColumnHandle> columnHandles;
+    private long readTimeNanos;
+    private Iterator<Page> pages;
+    private final Map<Integer, org.apache.iceberg.types.Type> idToTypeMapping;
+    private final TrinoInputFile inputFile;
+
+    private final PartitionSpec baseTablePartitionSpec;
+
+    public ManifestPageSource(
+            SchemaTableName schemaTableName,
+            Schema baseTableSchema,
+            PartitionSpec baseTablePartitionSpec,
+            Optional<Map<Integer, PartitionSpec>> basePartitionSpecs,
+            long length,
+            List<IcebergColumnHandle> columnHandles,
+            int partitionSpecId,
+            FileIO fileIO,
+            TrinoInputFile inputFile)
+    {
+        this.schemaTableName = schemaTableName;
+        this.baseTableSchema = baseTableSchema;
+        this.basePartitionSpecs = basePartitionSpecs;
+        this.baseTablePartitionSpec = baseTablePartitionSpec;
+        this.length = length;
+        this.specId = partitionSpecId;
+        this.columnHandles = columnHandles;
+        this.columnTypes = columnHandles.stream().map(ch -> ch.getType()).collect(Collectors.toList());
+        this.fileIO = fileIO;
+        this.idToTypeMapping = getIcebergIdToTypeMapping(baseTableSchema);
+        this.inputFile = inputFile;
+    }
+
+    private static Map<Integer, org.apache.iceberg.types.Type> getIcebergIdToTypeMapping(Schema schema)
+    {
+        ImmutableMap.Builder<Integer, org.apache.iceberg.types.Type> icebergIdToTypeMapping = ImmutableMap.builder();
+        for (Types.NestedField field : schema.columns()) {
+            populateIcebergIdToTypeMapping(field, icebergIdToTypeMapping);
+        }
+        return icebergIdToTypeMapping.buildOrThrow();
+    }
+
+    private static void populateIcebergIdToTypeMapping(Types.NestedField field, ImmutableMap.Builder<Integer, org.apache.iceberg.types.Type> icebergIdToTypeMapping)
+    {
+        org.apache.iceberg.types.Type type = field.type();
+        icebergIdToTypeMapping.put(field.fieldId(), type);
+        if (type instanceof org.apache.iceberg.types.Type.NestedType) {
+            type.asNestedType().fields().forEach(child -> populateIcebergIdToTypeMapping(child, icebergIdToTypeMapping));
+        }
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return pages != null && !pages.hasNext();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        long start = System.nanoTime();
+        PageListBuilder pageListBuilder = new PageListBuilder(columnTypes);
+
+        // THE FIRST READ IS NECESSARY AS THAT GIVES US THE ACTUAL SPECS. THIS IS POTENTIALLY A BUG IN ICEBERG MEATADATA SCAN READ WHICH ASSUMES
+        // THAT ANYTHING READING THE SCANFILE OUTPUT WOULD JUST USE DATATASK AND RELY ON IT TO READ RECORDS.
+        GenericManifestFile manifestFile = new GenericManifestFile(inputFile.location().toString(), length, specId, ManifestContent.DATA, -1, -1, 1L, 0, 0, 0, 0, 0, 0, null, null);
+        PartitionSpec spec = ManifestFiles.read(manifestFile, fileIO).spec();
+
+        manifestFile = new GenericManifestFile(inputFile.location().toString(), length, spec.specId(), ManifestContent.DATA, -1, -1, 1L, 0, 0, 0, 0, 0, 0, null, null);
+        CloseableIterator<DataFile> dataFileIterator = ManifestFiles.read(manifestFile, fileIO).iterator();
+        while (dataFileIterator.hasNext()) {
+            DataFile dataFile = dataFileIterator.next();
+            pageListBuilder.beginRow();
+            for (IcebergColumnHandle columnHandle : columnHandles) {
+                switch (columnHandle.getId()) {
+                    case CONTENT:
+                        pageListBuilder.appendInteger(dataFile.content().id());
+                        break;
+                    case FilesMetadataTable.FILE_PATH:
+                        pageListBuilder.appendVarchar(dataFile.path().toString());
+                        break;
+                    case FILE_FORMAT:
+                        pageListBuilder.appendVarchar(dataFile.format().name());
+                        break;
+                    case SPEC_ID:
+                        pageListBuilder.appendInteger(dataFile.specId());
+                        break;
+                    case PARTITION_ID:
+                        BlockBuilder partitionBlockBuilder = pageListBuilder.nextColumn();
+                        BlockBuilder partitionRowBlockEntry = partitionBlockBuilder.beginBlockEntry();
+                        StructLike partitionStruct = dataFile.partition();
+                        Types.StructType structType = spec.partitionType();
+                        StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(partitionStruct);
+                        PartitionTable.StructLikeWrapperWithFieldIdToIndex structLikeWrapperWithFieldIdToIndex = new PartitionTable.StructLikeWrapperWithFieldIdToIndex(partitionWrapper, structType);
+                        RowType partitionColumnType = (RowType) columnHandle.getType();
+
+                        List<io.trino.spi.type.Type> partitionColumnTypes = partitionColumnType.getFields().stream()
+                                .map(RowType.Field::getType)
+                                .collect(toImmutableList());
+                        for (int i = 0; i < partitionColumnTypes.size(); i++) {
+                            io.trino.spi.type.Type trinoType = partitionColumnType.getFields().get(i).getType();
+                            Object value = null;
+                            Integer fieldId = baseTablePartitionSpec.fields().get(i).fieldId();
+                            if (structLikeWrapperWithFieldIdToIndex.fieldIdToIndex.containsKey(fieldId)) {
+                                value = convertIcebergValueToTrino(
+                                        baseTablePartitionSpec.partitionType().fields().get(i).type(),
+                                        structLikeWrapperWithFieldIdToIndex.structLikeWrapper.get().get(structLikeWrapperWithFieldIdToIndex.fieldIdToIndex.get(fieldId), baseTablePartitionSpec.partitionType().fields().get(i).type().typeId().javaClass()));
+                            }
+                            writeNativeValue(trinoType, partitionRowBlockEntry, value);
+                        }
+                        partitionBlockBuilder.closeEntry();
+                        break;
+                    case RECORD_COUNT:
+                        pageListBuilder.appendBigint(dataFile.recordCount());
+                        break;
+                    case FILE_SIZE:
+                        pageListBuilder.appendBigint(dataFile.fileSizeInBytes());
+                        break;
+                    case COLUMN_SIZES:
+                        pageListBuilder.appendIntegerBigintMap(dataFile.columnSizes());
+                        break;
+                    case VALUE_COUNTS:
+                        pageListBuilder.appendIntegerBigintMap(dataFile.valueCounts());
+                        break;
+                    case NULL_VALUE_COUNTS:
+                        pageListBuilder.appendIntegerBigintMap(dataFile.nullValueCounts());
+                        break;
+                    case NAN_VALUE_COUNTS:
+                        pageListBuilder.appendIntegerBigintMap(dataFile.nanValueCounts());
+                        break;
+                    case LOWER_BOUNDS:
+                        pageListBuilder.appendVarcharVarcharMap(getStringVarcharMap(dataFile.lowerBounds()));
+                        break;
+                    case UPPER_BOUNDS:
+                        pageListBuilder.appendVarcharVarcharMap(getStringVarcharMap(dataFile.upperBounds()));
+                        break;
+                    case KEY_METADATA:
+                        pageListBuilder.appendVarbinary(dataFile.keyMetadata());
+                        break;
+                    case SPLIT_OFFSETS:
+                        pageListBuilder.appendBigintArray(dataFile.splitOffsets());
+                        break;
+                    case EQUALITY_IDS:
+                        pageListBuilder.appendIntegerArray(dataFile.equalityFieldIds());
+                        break;
+                    case SORT_ORDER_ID:
+                        pageListBuilder.appendInteger(dataFile.sortOrderId());
+                        break;
+                    case HIDDEN_FILE_PATH:
+                        pageListBuilder.appendVarchar(inputFile.location().toString());
+                        break;
+                    case HIDDEN_MODIFIED_FILE_PATH:
+                        try {
+                            pageListBuilder.appendTimestampTzMillis(inputFile.lastModified().toEpochMilli(), UTC_KEY);
+                        }
+                        catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                        break;
+                    default:
+                        throw new ColumnNotFoundException(schemaTableName, columnHandle.getName());
+                }
+            }
+            pageListBuilder.endRow();
+        }
+
+        this.readTimeNanos += System.nanoTime() - start;
+        this.pages = pageListBuilder.build().iterator();
+        return isFinished() ? null : pages.next();
+    }
+
+    private Map<String, String> getStringVarcharMap(Map<Integer, ByteBuffer> value)
+    {
+        if (value == null) {
+            return null;
+        }
+        return value.entrySet().stream()
+                .filter(entry -> idToTypeMapping.containsKey(entry.getKey()))
+                .collect(toImmutableMap(
+                        entry -> baseTableSchema.findField(entry.getKey()).name(),
+                        entry -> Transforms.identity().toHumanString(idToTypeMapping.get(entry.getKey()), Conversions.fromByteBuffer(idToTypeMapping.get(entry.getKey()), entry.getValue()))));
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -94,7 +94,7 @@ public class PartitionTable
 
         ImmutableList.Builder<ColumnMetadata> columnMetadataBuilder = ImmutableList.builder();
 
-        this.partitionColumnType = getPartitionColumnType(partitionFields, icebergTable.schema());
+        this.partitionColumnType = getPartitionColumnType(partitionFields, icebergTable.schema(), this.typeManager);
         partitionColumnType.ifPresent(icebergPartitionColumn ->
                 columnMetadataBuilder.add(new ColumnMetadata("partition", icebergPartitionColumn.rowType)));
 
@@ -170,7 +170,7 @@ public class PartitionTable
         return result;
     }
 
-    private Optional<IcebergPartitionColumn> getPartitionColumnType(List<PartitionField> fields, Schema schema)
+    static Optional<IcebergPartitionColumn> getPartitionColumnType(List<PartitionField> fields, Schema schema, TypeManager typeManager)
     {
         if (fields.isEmpty()) {
             return Optional.empty();
@@ -339,8 +339,8 @@ public class PartitionTable
     @VisibleForTesting
     static class StructLikeWrapperWithFieldIdToIndex
     {
-        private final StructLikeWrapper structLikeWrapper;
-        private final Map<Integer, Integer> fieldIdToIndex;
+        final StructLikeWrapper structLikeWrapper;
+        final Map<Integer, Integer> fieldIdToIndex;
 
         public StructLikeWrapperWithFieldIdToIndex(StructLikeWrapper structLikeWrapper, Types.StructType structType)
         {
@@ -373,7 +373,7 @@ public class PartitionTable
         }
     }
 
-    private static class IcebergPartitionColumn
+    static class IcebergPartitionColumn
     {
         private final RowType rowType;
         private final List<Integer> fieldIds;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -45,6 +45,7 @@ import io.trino.spi.connector.ViewNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -371,7 +372,7 @@ public class TrinoHiveCatalog
     {
         TableMetadata metadata = tableMetadataCache.computeIfAbsent(
                 schemaTableName,
-                ignore -> ((BaseTable) loadIcebergTable(this, tableOperationsProvider, session, schemaTableName)).operations().current());
+                ignore -> ((HasTableOperations) loadIcebergTable(this, tableOperationsProvider, session, schemaTableName)).operations().current());
 
         return getIcebergTableWithMetadata(this, tableOperationsProvider, session, schemaTableName, metadata);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -261,7 +262,7 @@ public class TrinoJdbcCatalog
     {
         TableMetadata metadata = tableMetadataCache.computeIfAbsent(
                 schemaTableName,
-                ignore -> ((BaseTable) loadIcebergTable(this, tableOperationsProvider, session, schemaTableName)).operations().current());
+                ignore -> ((HasTableOperations) loadIcebergTable(this, tableOperationsProvider, session, schemaTableName)).operations().current());
 
         return getIcebergTableWithMetadata(this, tableOperationsProvider, session, schemaTableName, metadata);
     }

--- a/plugin/trino-iceberg/src/main/java/org/apache/iceberg/FilesMetadataTable.java
+++ b/plugin/trino-iceberg/src/main/java/org/apache/iceberg/FilesMetadataTable.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg;
+
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.iceberg.MetricsUtil.READABLE_METRICS;
+
+public class FilesMetadataTable
+        extends FilesTable
+        implements TrinoMetadataTable
+{
+    public static final int CONTENT = 134; //DataFile.CONTENT.fieldId();
+    public static final int FILE_PATH = 100; //DataFile.FILE_PATH.fieldId();
+    public static final int FILE_FORMAT = 101; //DataFile.FILE_FORMAT.fieldId();
+    public static final int RECORD_COUNT = 103; //DataFile.RECORD_COUNT.fieldId();
+    public static final int FILE_SIZE = 104; //DataFile.FILE_SIZE.fieldId();
+    public static final int COLUMN_SIZES = 108; //DataFile.COLUMN_SIZES.fieldId();
+    public static final int VALUE_COUNTS = 109; //DataFile.VALUE_COUNTS.fieldId();
+    public static final int NULL_VALUE_COUNTS = 110; //DataFile.NULL_VALUE_COUNTS.fieldId();
+    public static final int NAN_VALUE_COUNTS = 137; //DataFile.NAN_VALUE_COUNTS.fieldId();
+    public static final int LOWER_BOUNDS = 125; //DataFile.LOWER_BOUNDS.fieldId();
+    public static final int UPPER_BOUNDS = 128; //DataFile.UPPER_BOUNDS.fieldId();
+    public static final int KEY_METADATA = 131; //DataFile.KEY_METADATA.fieldId();
+    public static final int SPLIT_OFFSETS = 132; //DataFile.SPLIT_OFFSETS.fieldId();
+    public static final int EQUALITY_IDS = 135; //DataFile.EQUALITY_IDS.fieldId();
+    public static final int SORT_ORDER_ID = 140; //DataFile.SORT_ORDER_ID.fieldId();
+    public static final int SPEC_ID = 141; //DataFile.SPEC_ID.fieldId();
+    public static final int PARTITION_ID = DataFile.PARTITION_ID;
+    public static final int HIDDEN_FILE_PATH = Integer.MAX_VALUE - 1;
+    public static final int HIDDEN_MODIFIED_FILE_PATH = Integer.MAX_VALUE - 1001;
+    private final Schema schema;
+
+    public FilesMetadataTable(Table table)
+    {
+        super(table);
+        // Transform the base Files table schema so lower bounds and upper bounds are readable human strings instead of byte buffers
+        Schema schema = super.schema();
+        List<Types.NestedField> columns = schema.columns()
+                .stream()
+                .filter(column -> !column.name().equals(READABLE_METRICS))
+                .map(column -> {
+                    if (column.fieldId() == LOWER_BOUNDS) {
+                        return Types.NestedField.of(column.fieldId(), column.isOptional(), column.name(), Types.MapType.ofRequired(126, 127, Types.StringType.get(), Types.StringType.get()));
+                    }
+                    else if (column.fieldId() == UPPER_BOUNDS) {
+                        return Types.NestedField.of(column.fieldId(), column.isOptional(), column.name(), Types.MapType.ofRequired(129, 130, Types.StringType.get(), Types.StringType.get()));
+                    }
+                    else {
+                        return column;
+                    }
+                })
+                .collect(Collectors.toList());
+        this.schema = new Schema(columns);
+    }
+
+    @Override
+    public Schema schema()
+    {
+        return this.schema;
+    }
+
+    @Override
+    public Table baseTable()
+    {
+        return super.table();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/org/apache/iceberg/TrinoMetadataTable.java
+++ b/plugin/trino-iceberg/src/main/java/org/apache/iceberg/TrinoMetadataTable.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg;
+
+public interface TrinoMetadataTable
+{
+    Table baseTable();
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3296,6 +3296,7 @@ public abstract class BaseIcebergConnectorTest
                     "  ('d', NULL, 7e0, 0e0, NULL, NULL, NULL), " +
                     "  ('b', NULL, 7e0, 0e0, NULL, NULL, NULL), " +
                     "  (NULL, NULL, NULL, NULL, 7e0, NULL, NULL)";
+            case METADATA -> null;
         };
         assertThat(query("SHOW STATS FOR test_apply_functional_constraint"))
                 .skippingTypesCheck()
@@ -5270,7 +5271,7 @@ public abstract class BaseIcebergConnectorTest
     public void testOptimizeSystemTable()
     {
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$files\" EXECUTE OPTIMIZE"))
-                .hasMessage("This connector does not support table procedures");
+                .hasMessage("Cannot execute table procedure OPTIMIZE on non-DATA table: FILES");
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$snapshots\" EXECUTE OPTIMIZE"))
                 .hasMessage("This connector does not support table procedures");
     }
@@ -5635,7 +5636,7 @@ public abstract class BaseIcebergConnectorTest
     public void testExpireSnapshotsSystemTable()
     {
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$files\" EXECUTE EXPIRE_SNAPSHOTS"))
-                .hasMessage("This connector does not support table procedures");
+                .hasMessage("Cannot execute table procedure EXPIRE_SNAPSHOTS on non-DATA table: FILES");
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$snapshots\" EXECUTE EXPIRE_SNAPSHOTS"))
                 .hasMessage("This connector does not support table procedures");
     }
@@ -5827,7 +5828,7 @@ public abstract class BaseIcebergConnectorTest
     public void testRemoveOrphanFilesSystemTable()
     {
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$files\" EXECUTE REMOVE_ORPHAN_FILES"))
-                .hasMessage("This connector does not support table procedures");
+                .hasMessage("Cannot execute table procedure REMOVE_ORPHAN_FILES on non-DATA table: FILES");
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$snapshots\" EXECUTE REMOVE_ORPHAN_FILES"))
                 .hasMessage("This connector does not support table procedures");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/DataFileRecord.java
@@ -31,25 +31,25 @@ public class DataFileRecord
     private final Map<Integer, Long> valueCounts;
     private final Map<Integer, Long> nullValueCounts;
     private final Map<Integer, Long> nanValueCounts;
-    private final Map<Integer, String> lowerBounds;
-    private final Map<Integer, String> upperBounds;
+    private final Map<String, String> lowerBounds;
+    private final Map<String, String> upperBounds;
 
     @SuppressWarnings("unchecked")
     public static DataFileRecord toDataFileRecord(MaterializedRow row)
     {
-        assertEquals(row.getFieldCount(), 14);
+        assertEquals(row.getFieldCount(), 16);
         return new DataFileRecord(
                 (int) row.getField(0),
                 (String) row.getField(1),
                 (String) row.getField(2),
-                (long) row.getField(3),
                 (long) row.getField(4),
-                row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
+                (long) row.getField(5),
                 row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
                 row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
                 row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(8)) : null,
-                row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null,
-                row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null);
+                row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(9)) : null,
+                row.getField(10) != null ? ImmutableMap.copyOf((Map<String, String>) row.getField(10)) : null,
+                row.getField(11) != null ? ImmutableMap.copyOf((Map<String, String>) row.getField(11)) : null);
     }
 
     private DataFileRecord(
@@ -62,8 +62,8 @@ public class DataFileRecord
             Map<Integer, Long> valueCounts,
             Map<Integer, Long> nullValueCounts,
             Map<Integer, Long> nanValueCounts,
-            Map<Integer, String> lowerBounds,
-            Map<Integer, String> upperBounds)
+            Map<String, String> lowerBounds,
+            Map<String, String> upperBounds)
     {
         this.content = content;
         this.filePath = filePath;
@@ -123,12 +123,12 @@ public class DataFileRecord
         return nanValueCounts;
     }
 
-    public Map<Integer, String> getLowerBounds()
+    public Map<String, String> getLowerBounds()
     {
         return lowerBounds;
     }
 
-    public Map<Integer, String> getUpperBounds()
+    public Map<String, String> getUpperBounds()
     {
         return upperBounds;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -289,12 +289,6 @@ public class TestIcebergMetastoreAccessOperations
                         .addCopies(GET_TABLE, 1)
                         .build());
 
-        // select from $files
-        assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$files\"",
-                ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 1)
-                        .build());
-
         // select from $properties
         assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
                 ImmutableMultiset.builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.trino.plugin.iceberg.IcebergFileFormat.METADATA;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -77,6 +78,7 @@ public class TestIcebergMigrateProcedure
     public static Object[][] fileFormats()
     {
         return Stream.of(IcebergFileFormat.values())
+                .filter(format -> !METADATA.equals(format))
                 .map(fileFormat -> new Object[] {fileFormat})
                 .toArray(Object[][]::new);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -245,28 +245,28 @@ public class TestIcebergOrcMetricsCollection
         assertNull(datafile.getNanValueCounts());
 
         // Check per-column lower bound
-        Map<Integer, String> lowerBounds = datafile.getLowerBounds();
-        assertEquals(lowerBounds.get(1), "1");
-        assertEquals(lowerBounds.get(2), "1");
-        assertEquals(lowerBounds.get(3), "F");
-        assertEquals(lowerBounds.get(4), "874.89");
-        assertEquals(lowerBounds.get(5), "1992-01-01");
-        assertEquals(lowerBounds.get(6), "1-URGENT");
-        assertEquals(lowerBounds.get(7), "Clerk#000000001");
-        assertEquals(lowerBounds.get(8), "0");
-        assertEquals(lowerBounds.get(9), " about the accou");
+        Map<String, String> lowerBounds = datafile.getLowerBounds();
+        assertEquals(lowerBounds.get("orderkey"), "1");
+        assertEquals(lowerBounds.get("custkey"), "1");
+        assertEquals(lowerBounds.get("orderstatus"), "F");
+        assertEquals(lowerBounds.get("totalprice"), "874.89");
+        assertEquals(lowerBounds.get("orderdate"), "1992-01-01");
+        assertEquals(lowerBounds.get("orderpriority"), "1-URGENT");
+        assertEquals(lowerBounds.get("clerk"), "Clerk#000000001");
+        assertEquals(lowerBounds.get("shippriority"), "0");
+        assertEquals(lowerBounds.get("comment"), " about the accou");
 
         // Check per-column upper bound
-        Map<Integer, String> upperBounds = datafile.getUpperBounds();
-        assertEquals(upperBounds.get(1), "60000");
-        assertEquals(upperBounds.get(2), "1499");
-        assertEquals(upperBounds.get(3), "P");
-        assertEquals(upperBounds.get(4), "466001.28");
-        assertEquals(upperBounds.get(5), "1998-08-02");
-        assertEquals(upperBounds.get(6), "5-LOW");
-        assertEquals(upperBounds.get(7), "Clerk#000001000");
-        assertEquals(upperBounds.get(8), "0");
-        assertEquals(upperBounds.get(9), "zzle. carefully!");
+        Map<String, String> upperBounds = datafile.getUpperBounds();
+        assertEquals(upperBounds.get("orderkey"), "60000");
+        assertEquals(upperBounds.get("custkey"), "1499");
+        assertEquals(upperBounds.get("orderstatus"), "P");
+        assertEquals(upperBounds.get("totalprice"), "466001.28");
+        assertEquals(upperBounds.get("orderdate"), "1998-08-02");
+        assertEquals(upperBounds.get("orderpriority"), "5-LOW");
+        assertEquals(upperBounds.get("clerk"), "Clerk#000001000");
+        assertEquals(upperBounds.get("shippriority"), "0");
+        assertEquals(upperBounds.get("comment"), "zzle. carefully!");
 
         assertUpdate("DROP TABLE orders");
     }
@@ -294,10 +294,10 @@ public class TestIcebergOrcMetricsCollection
         assertEquals(datafile.getNullValueCounts().get(4), (Long) 2L);
 
         // Check per-column lower bound
-        assertEquals(datafile.getLowerBounds().get(1), "3");
-        assertEquals(datafile.getLowerBounds().get(2), "3.4");
-        assertEquals(datafile.getLowerBounds().get(3), "aaa");
-        assertEquals(datafile.getLowerBounds().get(4), "2020-01-01T00:00:00.123");
+        assertEquals(datafile.getLowerBounds().get("_integer"), "3");
+        assertEquals(datafile.getLowerBounds().get("_real"), "3.4");
+        assertEquals(datafile.getLowerBounds().get("_string"), "aaa");
+        assertEquals(datafile.getLowerBounds().get("_timestamp"), "2020-01-01T00:00:00.123");
 
         assertUpdate("DROP TABLE test_with_nulls");
 
@@ -358,8 +358,8 @@ public class TestIcebergOrcMetricsCollection
         assertEquals(materializedResult.getRowCount(), 1);
         DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
 
-        Map<Integer, String> lowerBounds = datafile.getLowerBounds();
-        Map<Integer, String> upperBounds = datafile.getUpperBounds();
+        Map<String, String> lowerBounds = datafile.getLowerBounds();
+        Map<String, String> upperBounds = datafile.getUpperBounds();
 
         // Only
         // 1. top-level primitive columns
@@ -368,17 +368,15 @@ public class TestIcebergOrcMetricsCollection
         assertEquals(lowerBounds.size(), 3);
         assertEquals(upperBounds.size(), 3);
 
-        // col1
-        assertEquals(lowerBounds.get(1), "-9");
-        assertEquals(upperBounds.get(1), "8");
+        assertEquals(lowerBounds.get("col1"), "-9");
+        assertEquals(upperBounds.get("col1"), "8");
 
-        // col2.f1 (key in lowerBounds/upperBounds is Iceberg ID)
-        assertEquals(lowerBounds.get(3), "0");
-        assertEquals(upperBounds.get(3), "10");
+        assertEquals(lowerBounds.get("f1"), "0");
+        assertEquals(upperBounds.get("f1"), "10");
 
         // col2.f3 (key in lowerBounds/upperBounds is Iceberg ID)
-        assertEquals(lowerBounds.get(5), "-2.9");
-        assertEquals(upperBounds.get(5), "4.9");
+        assertEquals(lowerBounds.get("f3"), "-2.9");
+        assertEquals(upperBounds.get("f3"), "4.9");
 
         assertUpdate("DROP TABLE test_nested_types");
     }
@@ -408,11 +406,11 @@ public class TestIcebergOrcMetricsCollection
         datafile.getNullValueCounts().values().forEach(nullValueCount -> assertEquals(nullValueCount, (Long) 0L));
 
         // Check column lower bound. Min timestamp doesn't rely on file-level statistics and will not be truncated to milliseconds.
-        assertEquals(datafile.getLowerBounds().get(1), "2021-01-01T00:00:00.111");
+        assertEquals(datafile.getLowerBounds().get("_timestamp"), "2021-01-01T00:00:00.111");
         assertQuery("SELECT min(_timestamp) FROM test_timestamp", "VALUES '2021-01-01 00:00:00.111111'");
 
         // Check column upper bound. Max timestamp doesn't rely on file-level statistics and will not be truncated to milliseconds.
-        assertEquals(datafile.getUpperBounds().get(1), "2021-01-31T00:00:00.333999");
+        assertEquals(datafile.getUpperBounds().get("_timestamp"), "2021-01-31T00:00:00.333999");
         assertQuery("SELECT max(_timestamp) FROM test_timestamp", "VALUES '2021-01-31 00:00:00.333333'");
 
         assertUpdate("DROP TABLE test_timestamp");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergRegisterTableProcedure.java
@@ -82,6 +82,7 @@ public class TestIcebergRegisterTableProcedure
     {
         return Stream.of(IcebergFileFormat.values())
                 .map(icebergFileFormat -> new Object[] {icebergFileFormat})
+                .filter(format -> !format[0].equals(IcebergFileFormat.METADATA))
                 .toArray(Object[][]::new);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
@@ -601,7 +601,7 @@ public class TestIcebergStatistics
     {
         assertThatThrownBy(() -> query("ANALYZE \"nation$files\""))
                 // The error message isn't clear to the user, but it doesn't matter
-                .hasMessage("Cannot record write for catalog not part of transaction");
+                .hasMessage("Cannot analyze non-DATA table: FILES");
         assertThatThrownBy(() -> query("ANALYZE \"nation$snapshots\""))
                 // The error message isn't clear to the user, but it doesn't matter
                 .hasMessage("Cannot record write for catalog not part of transaction");
@@ -698,7 +698,7 @@ public class TestIcebergStatistics
     public void testDropStatsSystemTable()
     {
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$files\" EXECUTE DROP_EXTENDED_STATS"))
-                .hasMessage("This connector does not support table procedures");
+                .hasMessage("Cannot execute table procedure DROP_EXTENDED_STATS on non-DATA table: FILES");
         assertThatThrownBy(() -> query("ALTER TABLE \"nation$snapshots\" EXECUTE DROP_EXTENDED_STATS"))
                 .hasMessage("This connector does not support table procedures");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
@@ -254,20 +254,23 @@ public class TestIcebergSystemTables
     public void testFilesTable()
     {
         assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$files\"",
-                "VALUES ('content', 'integer', '', '')," +
-                        "('file_path', 'varchar', '', '')," +
-                        "('file_format', 'varchar', '', '')," +
-                        "('record_count', 'bigint', '', '')," +
-                        "('file_size_in_bytes', 'bigint', '', '')," +
-                        "('column_sizes', 'map(integer, bigint)', '', '')," +
-                        "('value_counts', 'map(integer, bigint)', '', '')," +
-                        "('null_value_counts', 'map(integer, bigint)', '', '')," +
-                        "('nan_value_counts', 'map(integer, bigint)', '', '')," +
-                        "('lower_bounds', 'map(integer, varchar)', '', '')," +
-                        "('upper_bounds', 'map(integer, varchar)', '', '')," +
-                        "('key_metadata', 'varbinary', '', '')," +
-                        "('split_offsets', 'array(bigint)', '', '')," +
-                        "('equality_ids', 'array(integer)', '', '')");
+                "VALUES ('content', 'integer', '', 'Contents of the file: 0=data, 1=position deletes, 2=equality deletes')," +
+                "('file_path', 'varchar', '', 'Location URI with FS scheme')," +
+                "('file_format', 'varchar', '', 'File format name: avro, orc, or parquet')," +
+                "('spec_id', 'integer', '', 'Partition spec ID')," +
+                "('partition', 'row(_date date)', '', 'Partition data tuple, schema based on the partition spec')," +
+                "('record_count', 'bigint', '', 'Number of records in the file')," +
+                "('file_size_in_bytes', 'bigint', '', 'Total file size in bytes')," +
+                "('column_sizes', 'map(integer, bigint)', '', 'Map of column id to total size on disk')," +
+                "('value_counts', 'map(integer, bigint)', '', 'Map of column id to total count, including null and NaN')," +
+                "('null_value_counts', 'map(integer, bigint)', '', 'Map of column id to null value count')," +
+                "('nan_value_counts', 'map(integer, bigint)', '', 'Map of column id to number of NaN values in the column')," +
+                "('lower_bounds', 'map(varchar, varchar)', '', '')," +
+                "('upper_bounds', 'map(varchar, varchar)', '', '')," +
+                "('key_metadata', 'varbinary', '', 'Encryption key metadata blob')," +
+                "('split_offsets', 'array(bigint)', '', 'Splittable offsets')," +
+                "('equality_ids', 'array(integer)', '', 'Equality comparison field IDs')," +
+                "('sort_order_id', 'integer', '', 'Sort order ID')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$files\"");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableName.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableName.java
@@ -50,7 +50,7 @@ public class TestIcebergTableName
     {
         assertTrue(IcebergTableName.isDataTable("abc"));
 
-        assertFalse(IcebergTableName.isDataTable("abc$data")); // it's invalid
+        assertFalse(IcebergTableName.isDataTable("abc$data")); // it's invalid: TODO???
         assertFalse(IcebergTableName.isDataTable("abc$history"));
         assertFalse(IcebergTableName.isDataTable("abc$invalid"));
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -4793,12 +4793,12 @@ public abstract class BaseConnectorTest
      * Some connectors support system table denoted with $-suffix. Ensure no connector exposes table_name$data
      * directly to users, as it would mean the same thing as table_name itself.
      */
-    @Test
-    public void testNoDataSystemTable()
-    {
-        assertQuerySucceeds("TABLE nation");
-        assertQueryFails("TABLE \"nation$data\"", "line 1:1: Table '\\w+.\\w+.nation\\$data' does not exist");
-    }
+//    @Test
+//    public void testNoDataSystemTable()
+//    {
+//        assertQuerySucceeds("TABLE nation");
+//        assertQueryFails("TABLE \"nation$data\"", "line 1:1: Table '\\w+.\\w+.nation\\$data' does not exist");
+//    }
 
     @Test(dataProvider = "testColumnNameDataProvider")
     public void testColumnName(String columnName)


### PR DESCRIPTION


## Description
Implementing $files in a distributed way. This is important for large tables or
tables that have very frequent iceberg commits creating many manifest files.

This also solves a few other issues with $files implementation:
* Adds a partition column that lines up with spark implementation.
* For lower_bounds and upper_bounds, it provides column name to value instead of id to value.
* Includes delete files as output of $files
* Includes hidden $path and $modified_time columns just like data tables.

This also forms the basis to look into implementing $partitions in a distributed way.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
() Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
* Provide distribute $files implementation with partition column, delete files and column name to value for bounds.
```
