### PR TITLE
Use by default `ZSTD` Parquet compression codec for Delta Lake

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -108,7 +108,7 @@ values. Typical usage does not require you to configure them.
     * `GZIP`
 
     The equivalent catalog session property is `compression_codec`.
-  - `SNAPPY`
+  - `ZSTD`
 * - `delta.max-partitions-per-writer`
   - Maximum number of partitions per writer.
   - `100`

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConfig.java
@@ -78,7 +78,7 @@ public class DeltaLakeConfig
     private boolean tableStatisticsEnabled = true;
     private boolean extendedStatisticsEnabled = true;
     private boolean collectExtendedStatisticsOnWrite = true;
-    private HiveCompressionCodec compressionCodec = HiveCompressionCodec.SNAPPY;
+    private HiveCompressionCodec compressionCodec = HiveCompressionCodec.ZSTD;
     private long perTransactionMetastoreCacheMaximumSize = 1000;
     private boolean storeTableMetadataEnabled;
     private int storeTableMetadataThreads = 5;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -95,12 +95,12 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("Alluxio.writeCache", "00000000000000000002.json", 0, 658))
                         .add(new CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 220))
-                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 220))
-                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 220))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 220))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 220))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 227))
+                        .add(new CacheOperation("Input.readFully", "key=p1/", 0, 227))
+                        .add(new CacheOperation("Input.readFully", "key=p2/", 0, 227))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p1/", 0, 227))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p2/", 0, 227))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
@@ -113,8 +113,8 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000002.json"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000003.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 220))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 227))
                         .build());
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p3', '3-xyz')", 1);
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p4', '4-xyz')", 1);
@@ -139,17 +139,17 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000005.json"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000006.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 220))
-                        .add(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 220))
-                        .add(new CacheOperation("Input.readFully", "key=p3/", 0, 220))
-                        .add(new CacheOperation("Input.readFully", "key=p4/", 0, 220))
-                        .add(new CacheOperation("Input.readFully", "key=p5/", 0, 220))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p3/", 0, 220))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p4/", 0, 220))
-                        .add(new CacheOperation("Alluxio.writeCache", "key=p5/", 0, 220))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 227))
+                        .add(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 227))
+                        .add(new CacheOperation("Input.readFully", "key=p3/", 0, 227))
+                        .add(new CacheOperation("Input.readFully", "key=p4/", 0, 227))
+                        .add(new CacheOperation("Input.readFully", "key=p5/", 0, 227))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p3/", 0, 227))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p4/", 0, 227))
+                        .add(new CacheOperation("Alluxio.writeCache", "key=p5/", 0, 227))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
@@ -168,11 +168,11 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .add(new CacheOperation("InputFile.length", "00000000000000000005.json"))
                         .add(new CacheOperation("InputFile.length", "00000000000000000006.json"))
                         .add(new CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 220), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 220), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 220), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 220), 1)
-                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 220), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p1/", 0, 227), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p2/", 0, 227), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p3/", 0, 227), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p4/", 0, 227), 1)
+                        .addCopies(new CacheOperation("Alluxio.readCached", "key=p5/", 0, 227), 1)
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMutableTransactionLog.java
@@ -79,12 +79,12 @@ public class TestDeltaLakeAlluxioCacheMutableTransactionLog
                         .addCopies(new CacheFileSystemTraceUtils.CacheOperation("Input.readTail", "00000000000000000002.checkpoint.parquet"), 2)
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "00000000000000000003.json"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p1/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p2/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p1/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p2/", 0, 220))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p1/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Input.readFully", "key=p2/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p1/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.writeCache", "key=p2/", 0, 227))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_transaction_log_not_cached",
@@ -93,8 +93,8 @@ public class TestDeltaLakeAlluxioCacheMutableTransactionLog
                         .addCopies(new CacheFileSystemTraceUtils.CacheOperation("Input.readTail", "00000000000000000002.checkpoint.parquet"), 2)
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "00000000000000000003.json"))
                         .add(new CacheFileSystemTraceUtils.CacheOperation("InputFile.newStream", "_last_checkpoint"))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 220))
-                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 220))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p1/", 0, 227))
+                        .add(new CacheFileSystemTraceUtils.CacheOperation("Alluxio.readCached", "key=p2/", 0, 227))
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConfig.java
@@ -60,7 +60,7 @@ public class TestDeltaLakeConfig
                 .setTableStatisticsEnabled(true)
                 .setExtendedStatisticsEnabled(true)
                 .setCollectExtendedStatisticsOnWrite(true)
-                .setCompressionCodec(HiveCompressionCodec.SNAPPY)
+                .setCompressionCodec(HiveCompressionCodec.ZSTD)
                 .setDeleteSchemaLocationsFallback(false)
                 .setParquetTimeZone(TimeZone.getDefault().getID())
                 .setPerTransactionMetastoreCacheMaximumSize(1000)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractSinglenodeDeltaLakeDatabricks.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/AbstractSinglenodeDeltaLakeDatabricks.java
@@ -40,13 +40,13 @@ public abstract class AbstractSinglenodeDeltaLakeDatabricks
 
     private final DockerFiles dockerFiles;
 
-    abstract String databricksTestJdbcUrl();
-
     public AbstractSinglenodeDeltaLakeDatabricks(Standard standard, DockerFiles dockerFiles)
     {
         super(standard);
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
     }
+
+    abstract String databricksTestJdbcUrl();
 
     @Override
     public void extendEnvironment(Environment.Builder builder)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeInsertCompatibility.java
@@ -435,8 +435,8 @@ public class TestDeltaLakeInsertCompatibility
         assertThat(onTrino().executeQuery("SHOW SESSION LIKE 'delta.compression_codec'"))
                 .containsOnly(row(
                         "delta.compression_codec",
-                        "SNAPPY",
-                        "SNAPPY",
+                        "ZSTD",
+                        "ZSTD",
                         "varchar",
                         "Compression codec to use when writing new data files. Possible values: " +
                                 Stream.of(compressionCodecs())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Improve performance of reading from delta lake tables by compressing files with `ZSTD` by default ({issue}`17426`)
```
