### PR TITLE
Use shared cache for per transaction file listing cache

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -254,7 +254,8 @@ Hive connector documentation.
       - How long a cached directory listing is considered valid.
       - ``1m``
     * - ``hive.per-transaction-file-status-cache.max-retained-size``
-      - Maximum retained size of cached file status entries per transaction
+      - Maximum retained size of all entries in per transaction file status cache.
+        Retained size limit is shared across all running queries.
       - ``100MB``
     * - ``hive.rcfile.time-zone``
       - Adjusts binary encoded timestamp values to a specific time zone. For

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
@@ -49,6 +49,7 @@ import io.trino.plugin.hive.PartitionsSystemTableProvider;
 import io.trino.plugin.hive.PropertiesSystemTableProvider;
 import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
 import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
@@ -162,6 +163,7 @@ public class S3SelectTestHelper
                 new DefaultHiveMaterializedViewMetadataFactory(),
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
+                new TransactionScopeCachingDirectoryListerFactory(hiveConfig),
                 new PartitionProjectionService(this.hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
                 true);
         transactionManager = new HiveTransactionManager(metadataFactory);

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/S3SelectTestHelper.java
@@ -100,13 +100,13 @@ public class S3SelectTestHelper
     private ScheduledExecutorService heartbeatService;
 
     public S3SelectTestHelper(String host,
-                              int port,
-                              String databaseName,
-                              String awsAccessKey,
-                              String awsSecretKey,
-                              String writableBucket,
-                              String testDirectory,
-                              HiveConfig hiveConfig)
+            int port,
+            String databaseName,
+            String awsAccessKey,
+            String awsSecretKey,
+            String writableBucket,
+            String testDirectory,
+            HiveConfig hiveConfig)
     {
         checkArgument(!isNullOrEmpty(host), "Expected non empty host");
         checkArgument(!isNullOrEmpty(databaseName), "Expected non empty databaseName");
@@ -195,12 +195,12 @@ public class S3SelectTestHelper
     }
 
     public S3SelectTestHelper(String host,
-                              int port,
-                              String databaseName,
-                              String awsAccessKey,
-                              String awsSecretKey,
-                              String writableBucket,
-                              String testDirectory)
+            int port,
+            String databaseName,
+            String awsAccessKey,
+            String awsSecretKey,
+            String writableBucket,
+            String testDirectory)
     {
         this(host, port, databaseName, awsAccessKey, awsSecretKey, writableBucket, testDirectory, new HiveConfig().setS3SelectPushdownEnabled(true));
     }
@@ -279,8 +279,8 @@ public class S3SelectTestHelper
     }
 
     static boolean isSplitCountInOpenInterval(int splitCount,
-                                       int lowerBound,
-                                       int upperBound)
+            int lowerBound,
+            int upperBound)
     {
         // Split number may vary, the minimum number of splits being obtained with
         // the first split of maxInitialSplitSize and the rest of maxSplitSize

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -25,6 +25,7 @@ import io.trino.hdfs.TrinoFileSystemCache;
 import io.trino.hdfs.TrinoFileSystemCacheStats;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
 import io.trino.plugin.hive.line.JsonFileWriterFactory;
@@ -106,6 +107,7 @@ public class HiveModule
                 .setDefault().to(DefaultHiveMaterializedViewMetadataFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, TransactionalMetadataFactory.class)
                 .setDefault().to(HiveMetadataFactory.class).in(Scopes.SINGLETON);
+        binder.bind(TransactionScopeCachingDirectoryListerFactory.class).in(Scopes.SINGLETON);
         binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorSplitManager.class).to(HiveSplitManager.class).in(Scopes.SINGLETON);
         newExporter(binder).export(ConnectorSplitManager.class).as(generator -> generator.generatedNameOf(HiveSplitManager.class));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionDirectoryListingCacheKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionDirectoryListingCacheKey.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public class TransactionDirectoryListingCacheKey
+{
+    private static final long INSTANCE_SIZE = instanceSize(TransactionDirectoryListingCacheKey.class);
+
+    private final long transactionId;
+    private final DirectoryListingCacheKey key;
+
+    public TransactionDirectoryListingCacheKey(long transactionId, DirectoryListingCacheKey key)
+    {
+        this.transactionId = transactionId;
+        this.key = requireNonNull(key, "key is null");
+    }
+
+    public DirectoryListingCacheKey getKey()
+    {
+        return key;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + key.getRetainedSizeInBytes();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TransactionDirectoryListingCacheKey that = (TransactionDirectoryListingCacheKey) o;
+        return transactionId == that.transactionId && key.equals(that.key);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(transactionId, key);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("transactionId", transactionId)
+                .add("key", key)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
@@ -16,8 +16,6 @@ package io.trino.plugin.hive.fs;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.airlift.units.DataSize;
-import io.trino.collect.cache.EvictableCacheBuilder;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Storage;
 import io.trino.plugin.hive.metastore.Table;
@@ -40,9 +38,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.SizeOf.sizeOfObjectArray;
-import static java.lang.Math.toIntExact;
+import static io.trino.plugin.hive.fs.DirectoryListingCacheKey.allKeysWithPath;
 import static java.util.Collections.synchronizedList;
 import static java.util.Objects.requireNonNull;
 
@@ -55,42 +54,34 @@ import static java.util.Objects.requireNonNull;
 public class TransactionScopeCachingDirectoryLister
         implements DirectoryLister
 {
+    private final long transactionId;
     //TODO use a cache key based on Path & SchemaTableName and iterate over the cache keys
     // to deal more efficiently with cache invalidation scenarios for partitioned tables.
-    private final Cache<DirectoryListingCacheKey, FetchingValueHolder> cache;
+    private final Cache<TransactionDirectoryListingCacheKey, FetchingValueHolder> cache;
     private final DirectoryLister delegate;
 
-    public TransactionScopeCachingDirectoryLister(DirectoryLister delegate, DataSize maxSize)
+    public TransactionScopeCachingDirectoryLister(DirectoryLister delegate, long transactionId, Cache<TransactionDirectoryListingCacheKey, FetchingValueHolder> cache)
     {
-        this(delegate, maxSize, Optional.empty());
-    }
-
-    @VisibleForTesting
-    TransactionScopeCachingDirectoryLister(DirectoryLister delegate, DataSize maxSize, Optional<Integer> concurrencyLevel)
-    {
-        EvictableCacheBuilder<DirectoryListingCacheKey, FetchingValueHolder> cacheBuilder = EvictableCacheBuilder.newBuilder()
-                .maximumWeight(maxSize.toBytes())
-                .weigher((key, value) -> toIntExact(key.getRetainedSizeInBytes() + value.getRetainedSizeInBytes()));
-        concurrencyLevel.ifPresent(cacheBuilder::concurrencyLevel);
-        this.cache = cacheBuilder.build();
         this.delegate = requireNonNull(delegate, "delegate is null");
+        this.transactionId = transactionId;
+        this.cache = requireNonNull(cache, "cache is null");
     }
 
     @Override
     public RemoteIterator<TrinoFileStatus> list(FileSystem fs, Table table, Path path)
             throws IOException
     {
-        return listInternal(fs, table, new DirectoryListingCacheKey(path.toString(), false));
+        return listInternal(fs, table, new TransactionDirectoryListingCacheKey(transactionId, new DirectoryListingCacheKey(path.toString(), false)));
     }
 
     @Override
     public RemoteIterator<TrinoFileStatus> listFilesRecursively(FileSystem fs, Table table, Path path)
             throws IOException
     {
-        return listInternal(fs, table, new DirectoryListingCacheKey(path.toString(), true));
+        return listInternal(fs, table, new TransactionDirectoryListingCacheKey(transactionId, new DirectoryListingCacheKey(path.toString(), true)));
     }
 
-    private RemoteIterator<TrinoFileStatus> listInternal(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> listInternal(FileSystem fs, Table table, TransactionDirectoryListingCacheKey cacheKey)
             throws IOException
     {
         FetchingValueHolder cachedValueHolder;
@@ -101,7 +92,7 @@ public class TransactionScopeCachingDirectoryLister
             Throwable throwable = e.getCause();
             throwIfInstanceOf(throwable, IOException.class);
             throwIfUnchecked(throwable);
-            throw new RuntimeException("Failed to list directory: " + cacheKey.getPath(), throwable);
+            throw new RuntimeException("Failed to list directory: " + cacheKey.getKey().getPath(), throwable);
         }
 
         if (cachedValueHolder.isFullyCached()) {
@@ -111,13 +102,13 @@ public class TransactionScopeCachingDirectoryLister
         return cachingRemoteIterator(cachedValueHolder, cacheKey);
     }
 
-    private RemoteIterator<TrinoFileStatus> createListingRemoteIterator(FileSystem fs, Table table, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> createListingRemoteIterator(FileSystem fs, Table table, TransactionDirectoryListingCacheKey cacheKey)
             throws IOException
     {
-        if (cacheKey.isRecursiveFilesOnly()) {
-            return delegate.listFilesRecursively(fs, table, new Path(cacheKey.getPath()));
+        if (cacheKey.getKey().isRecursiveFilesOnly()) {
+            return delegate.listFilesRecursively(fs, table, new Path(cacheKey.getKey().getPath()));
         }
-        return delegate.list(fs, table, new Path(cacheKey.getPath()));
+        return delegate.list(fs, table, new Path(cacheKey.getKey().getPath()));
     }
 
     @Override
@@ -125,7 +116,9 @@ public class TransactionScopeCachingDirectoryLister
     {
         if (isLocationPresent(table.getStorage())) {
             if (table.getPartitionColumns().isEmpty()) {
-                cache.invalidateAll(DirectoryListingCacheKey.allKeysWithPath(new Path(table.getStorage().getLocation())));
+                cache.invalidateAll(allKeysWithPath(new Path(table.getStorage().getLocation())).stream()
+                        .map(key -> new TransactionDirectoryListingCacheKey(transactionId, key))
+                        .collect(toImmutableList()));
             }
             else {
                 // a partitioned table can have multiple paths in cache
@@ -139,12 +132,14 @@ public class TransactionScopeCachingDirectoryLister
     public void invalidate(Partition partition)
     {
         if (isLocationPresent(partition.getStorage())) {
-            cache.invalidateAll(DirectoryListingCacheKey.allKeysWithPath(new Path(partition.getStorage().getLocation())));
+            cache.invalidateAll(allKeysWithPath(new Path(partition.getStorage().getLocation())).stream()
+                    .map(key -> new TransactionDirectoryListingCacheKey(transactionId, key))
+                    .collect(toImmutableList()));
         }
         delegate.invalidate(partition);
     }
 
-    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(FetchingValueHolder cachedValueHolder, DirectoryListingCacheKey cacheKey)
+    private RemoteIterator<TrinoFileStatus> cachingRemoteIterator(FetchingValueHolder cachedValueHolder, TransactionDirectoryListingCacheKey cacheKey)
     {
         return new RemoteIterator<>()
         {
@@ -183,11 +178,11 @@ public class TransactionScopeCachingDirectoryLister
     @VisibleForTesting
     boolean isCached(Path path)
     {
-        return isCached(new DirectoryListingCacheKey(path.toString(), false));
+        return isCached(new TransactionDirectoryListingCacheKey(transactionId, new DirectoryListingCacheKey(path.toString(), false)));
     }
 
     @VisibleForTesting
-    boolean isCached(DirectoryListingCacheKey cacheKey)
+    boolean isCached(TransactionDirectoryListingCacheKey cacheKey)
     {
         FetchingValueHolder cached = cache.getIfPresent(cacheKey);
         return cached != null && cached.isFullyCached();
@@ -199,7 +194,7 @@ public class TransactionScopeCachingDirectoryLister
         return storage.getOptionalLocation().isPresent() && !storage.getLocation().isEmpty();
     }
 
-    private static class FetchingValueHolder
+    static class FetchingValueHolder
     {
         private static final long ATOMIC_LONG_SIZE = instanceSize(AtomicLong.class);
         private static final long INSTANCE_SIZE = instanceSize(FetchingValueHolder.class);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryListerFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryListerFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.fs;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import io.airlift.units.DataSize;
+import io.trino.collect.cache.EvictableCacheBuilder;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryLister.FetchingValueHolder;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class TransactionScopeCachingDirectoryListerFactory
+{
+    //TODO use a cache key based on Path & SchemaTableName and iterate over the cache keys
+    // to deal more efficiently with cache invalidation scenarios for partitioned tables.
+    private final Optional<Cache<TransactionDirectoryListingCacheKey, FetchingValueHolder>> cache;
+    private final AtomicLong nextTransactionId = new AtomicLong();
+
+    @Inject
+    public TransactionScopeCachingDirectoryListerFactory(HiveConfig hiveConfig)
+    {
+        this(requireNonNull(hiveConfig, "hiveConfig is null").getPerTransactionFileStatusCacheMaxRetainedSize(), Optional.empty());
+    }
+
+    @VisibleForTesting
+    TransactionScopeCachingDirectoryListerFactory(DataSize maxSize, Optional<Integer> concurrencyLevel)
+    {
+        if (maxSize.toBytes() > 0) {
+            EvictableCacheBuilder<TransactionDirectoryListingCacheKey, FetchingValueHolder> cacheBuilder = EvictableCacheBuilder.newBuilder()
+                    .maximumWeight(maxSize.toBytes())
+                    .weigher((key, value) -> toIntExact(key.getRetainedSizeInBytes() + value.getRetainedSizeInBytes()));
+            concurrencyLevel.ifPresent(cacheBuilder::concurrencyLevel);
+            this.cache = Optional.of(cacheBuilder.build());
+        }
+        else {
+            cache = Optional.empty();
+        }
+    }
+
+    public DirectoryLister get(DirectoryLister delegate)
+    {
+        return cache
+                .map(cache -> (DirectoryLister) new TransactionScopeCachingDirectoryLister(delegate, nextTransactionId.getAndIncrement(), cache))
+                .orElse(delegate);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -37,6 +37,7 @@ import io.trino.plugin.base.metrics.LongCount;
 import io.trino.plugin.hive.LocationService.WriteInfo;
 import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.DirectoryLister;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
 import io.trino.plugin.hive.fs.TrinoFileStatus;
 import io.trino.plugin.hive.fs.TrinoFileStatusRemoteIterator;
 import io.trino.plugin.hive.line.LinePageSource;
@@ -200,7 +201,6 @@ import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
-import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.parquet.reader.ParquetReader.PARQUET_CODEC_METRIC_PREFIX;
 import static io.trino.plugin.hive.AbstractTestHive.TransactionDeleteInsertTestTag.COMMIT;
 import static io.trino.plugin.hive.AbstractTestHive.TransactionDeleteInsertTestTag.ROLLBACK_AFTER_APPEND_PAGE;
@@ -888,7 +888,7 @@ public abstract class AbstractTestHive
                 },
                 SqlStandardAccessControlMetadata::new,
                 countingDirectoryLister,
-                DataSize.of(1, MEGABYTE),
+                new TransactionScopeCachingDirectoryListerFactory(hiveConfig),
                 new PartitionProjectionService(hiveConfig, ImmutableMap.of(), new TestingTypeManager()),
                 true,
                 HiveTimestampPrecision.DEFAULT_PRECISION);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -36,6 +36,7 @@ import io.trino.plugin.hive.AbstractTestHive.Transaction;
 import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
 import io.trino.plugin.hive.fs.HiveFileIterator;
+import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
 import io.trino.plugin.hive.fs.TrinoFileStatus;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
@@ -224,6 +225,7 @@ public abstract class AbstractTestHiveFileSystem
                 new DefaultHiveMaterializedViewMetadataFactory(),
                 SqlStandardAccessControlMetadata::new,
                 new FileSystemDirectoryLister(),
+                new TransactionScopeCachingDirectoryListerFactory(config),
                 new PartitionProjectionService(config, ImmutableMap.of(), new TestingTypeManager()),
                 true);
         transactionManager = new HiveTransactionManager(metadataFactory);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestTransactionScopeCachingDirectoryLister.java
@@ -73,7 +73,7 @@ public class TestTransactionScopeCachingDirectoryLister
     @Override
     protected TransactionScopeCachingDirectoryLister createDirectoryLister()
     {
-        return new TransactionScopeCachingDirectoryLister(new FileSystemDirectoryLister(), DataSize.of(1, MEGABYTE));
+        return (TransactionScopeCachingDirectoryLister) new TransactionScopeCachingDirectoryListerFactory(DataSize.of(1, MEGABYTE), Optional.empty()).get(new FileSystemDirectoryLister());
     }
 
     @Override
@@ -100,7 +100,7 @@ public class TestTransactionScopeCachingDirectoryLister
 
         // Set concurrencyLevel to 1 as EvictableCache with higher concurrencyLimit is not deterministic
         // due to Token being a key in segmented cache.
-        TransactionScopeCachingDirectoryLister cachingLister = new TransactionScopeCachingDirectoryLister(countingLister, DataSize.ofBytes(500), Optional.of(1));
+        TransactionScopeCachingDirectoryLister cachingLister = (TransactionScopeCachingDirectoryLister) new TransactionScopeCachingDirectoryListerFactory(DataSize.ofBytes(500), Optional.of(1)).get(countingLister);
 
         assertFiles(cachingLister.list(null, TABLE, path2), ImmutableList.of(thirdFile));
         assertThat(countingLister.getListCount()).isEqualTo(1);
@@ -138,7 +138,7 @@ public class TestTransactionScopeCachingDirectoryLister
         Path path = new Path("x");
 
         CountingDirectoryLister countingLister = new CountingDirectoryLister(ImmutableMap.of(path, ImmutableList.of(file)));
-        DirectoryLister cachingLister = new TransactionScopeCachingDirectoryLister(countingLister, DataSize.ofBytes(500));
+        DirectoryLister cachingLister = new TransactionScopeCachingDirectoryListerFactory(DataSize.ofBytes(600), Optional.empty()).get(countingLister);
 
         // start listing path concurrently
         countingLister.setThrowException(true);


### PR DESCRIPTION
This allows to cap cache size independently of query concurrency.

This will be added to exiting RN (if it lands in this Trino version) or new RN will be created