### PR TITLE
Keep Trino's behavior when writing null values consistent with Clickhouse

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -1395,7 +1395,7 @@ public abstract class BaseJdbcClient
         return name;
     }
 
-    private static RemoteTableName getRemoteTable(ResultSet resultSet)
+    public static RemoteTableName getRemoteTable(ResultSet resultSet)
             throws SQLException
     {
         return new RemoteTableName(

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseConfig.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseConfig.java
@@ -22,10 +22,16 @@ public class ClickHouseConfig
 {
     // TODO (https://github.com/trinodb/trino/issues/7102) reconsider default behavior
     private boolean mapStringAsVarchar;
+    private boolean replaceNullToDefault;
 
     public boolean isMapStringAsVarchar()
     {
         return mapStringAsVarchar;
+    }
+
+    public boolean isReplaceNullToDefault()
+    {
+        return replaceNullToDefault;
     }
 
     @Config("clickhouse.map-string-as-varchar")
@@ -33,6 +39,14 @@ public class ClickHouseConfig
     public ClickHouseConfig setMapStringAsVarchar(boolean mapStringAsVarchar)
     {
         this.mapStringAsVarchar = mapStringAsVarchar;
+        return this;
+    }
+
+    @Config("clickhouse.replace-null-to-default")
+    @ConfigDescription("Replace null to the default value of corresponding data type")
+    public ClickHouseConfig setReplaceNullToDefault(boolean replaceNullToDefault)
+    {
+        this.replaceNullToDefault = replaceNullToDefault;
         return this;
     }
 }

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseSessionProperties.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseSessionProperties.java
@@ -28,6 +28,7 @@ public class ClickHouseSessionProperties
         implements SessionPropertiesProvider
 {
     public static final String MAP_STRING_AS_VARCHAR = "map_string_as_varchar";
+    public static final String REPLACE_NULL_TO_DEFAULT = "replace_null_to_default";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -39,6 +40,11 @@ public class ClickHouseSessionProperties
                         MAP_STRING_AS_VARCHAR,
                         "Map ClickHouse String and FixedString as varchar instead of varbinary",
                         clickHouseConfig.isMapStringAsVarchar(),
+                        false),
+                booleanProperty(
+                        REPLACE_NULL_TO_DEFAULT,
+                        "Replace null to the default value of corresponding data type",
+                        clickHouseConfig.isReplaceNullToDefault(),
                         false));
     }
 
@@ -51,5 +57,10 @@ public class ClickHouseSessionProperties
     public static boolean isMapStringAsVarchar(ConnectorSession session)
     {
         return session.getProperty(MAP_STRING_AS_VARCHAR, Boolean.class);
+    }
+
+    public static boolean isReplaceNullToDefault(ConnectorSession session)
+    {
+        return session.getProperty(REPLACE_NULL_TO_DEFAULT, Boolean.class);
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConfig.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConfig.java
@@ -42,7 +42,8 @@ public class TestClickHouseConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ClickHouseConfig.class)
-                .setMapStringAsVarchar(false));
+                .setMapStringAsVarchar(false)
+                .setReplaceNullToDefault(false));
     }
 
     @Test
@@ -50,10 +51,12 @@ public class TestClickHouseConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("clickhouse.map-string-as-varchar", "true")
+                .put("clickhouse.replace-null-to-default", "true")
                 .buildOrThrow();
 
         ClickHouseConfig expected = new ClickHouseConfig()
-                .setMapStringAsVarchar(true);
+                .setMapStringAsVarchar(true)
+                .setReplaceNullToDefault(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Clickhouse allows null values to be inserted into non null declared columns, which by default converts null to the default value of the corresponding data type. This PR maintains the same behavior as Clickhouse when Trino writes null values.There is a parameter 'clickhouse.replace-null-to-default' control that defaults to not being enabled.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(*) Release notes are required, with the following suggested text:

```markdown
# Clickhouse
* Keep Trino's behavior when writing null values consistent with Clickhouse
```
