### PR TITLE
Fix current_timestamp failure due to improper rounding

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -648,10 +648,13 @@ public final class DateTimes
     {
         checkArgument(precision <= TimestampWithTimeZoneType.MAX_PRECISION, "Precision is out of range");
 
-        return LongTimestampWithTimeZone.fromEpochMillisAndFraction(
-                start.toEpochMilli(),
-                (int) round((start.getNano() % NANOSECONDS_PER_MILLISECOND) * PICOSECONDS_PER_NANOSECOND, (int) (TimestampWithTimeZoneType.MAX_PRECISION - precision)),
-                timeZoneKey);
+        long epochMilli = start.toEpochMilli();
+        int picosOfMilli = (int) round((start.getNano() % NANOSECONDS_PER_MILLISECOND) * PICOSECONDS_PER_NANOSECOND, (int) (TimestampWithTimeZoneType.MAX_PRECISION - precision));
+        if (picosOfMilli == PICOSECONDS_PER_MILLISECOND) {
+            epochMilli++;
+            picosOfMilli = 0;
+        }
+        return LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMilli, picosOfMilli, timeZoneKey);
     }
 
     public static LongTimestampWithTimeZone longTimestampWithTimeZone(long epochSecond, long fractionInPicos, ZoneId zoneId)


### PR DESCRIPTION
When the number of nanoseconds in the current instant is such that it needs to round up to the nearest millisecond, the calculation doesn't properly compute the carryover.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix failure when invoking `current_timestamp`. ({issue}`17455`)
```
