### PR TITLE
Document fault tolerant execution for Oracle connector

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.rst
@@ -50,6 +50,7 @@ depending on the desired :ref:`retry policy <fte-retry-policy>`.
   * :ref:`Iceberg connector <iceberg-fte-support>`
   * :ref:`MongoDB connector <mongodb-fte-support>`
   * :ref:`MySQL connector <mysql-fte-support>`
+  * :ref:`Oracle connector <oracle-fte-support>`
   * :ref:`PostgreSQL connector <postgresql-fte-support>`
   * :ref:`Redshift connector <redshift-fte-support>`
   * :ref:`SQL Server connector <sqlserver-fte-support>`

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -411,6 +411,14 @@ supports the following statements:
 
 .. include:: alter-table-limitation.fragment
 
+.. _oracle-fte-support:
+
+Fault-tolerant execution support
+--------------------------------
+
+The connector supports :doc:`/admin/fault-tolerant-execution` of query
+processing. Read and write operations are both supported with any retry policy.
+
 Table functions
 ---------------
 


### PR DESCRIPTION
## Description

Follow-up of #17200

<img width="787" alt="Screenshot 2023-05-11 at 18 20 28" src="https://github.com/trinodb/trino/assets/6237050/376aebea-b600-4649-9aed-b93647e53da4">
<img width="771" alt="Screenshot 2023-05-11 at 18 20 43" src="https://github.com/trinodb/trino/assets/6237050/76abf5e2-0ee8-4bfe-9f7a-f0935637cdf8">


## Release notes

(x) This is not user-visible or docs only and no release notes are required.
