### PR TITLE
Cache symbols and subexpressions for expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -576,7 +576,7 @@ public class EffectivePredicateExtractor
 
         private Expression pullExpressionThroughSymbols(Expression expression, Collection<Symbol> symbols)
         {
-            EqualityInference equalityInference = EqualityInference.newInstance(metadata, expression);
+            EqualityInference equalityInference = new EqualityInference(metadata, expression);
 
             ImmutableList.Builder<Expression> effectiveConjuncts = ImmutableList.builder();
             Set<Symbol> scope = ImmutableSet.copyOf(symbols);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -41,6 +41,7 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.ExpressionNodeInliner.replaceExpression;
@@ -53,25 +54,85 @@ import static java.util.Objects.requireNonNull;
 public class EqualityInference
 {
     // Comparator used to determine Expression preference when determining canonicals
-    private static final Comparator<Expression> CANONICAL_COMPARATOR = Comparator
-            // Current cost heuristic:
-            // 1) Prefer fewer input symbols
-            // 2) Prefer smaller expression trees
-            // 3) Sort the expressions alphabetically - creates a stable consistent ordering (extremely useful for unit testing)
-            // TODO: be more precise in determining the cost of an expression
-            .comparingInt((ToIntFunction<Expression>) (expression -> SymbolsExtractor.extractAll(expression).size()))
-            .thenComparingLong(expression -> SubExpressionExtractor.extract(expression).count())
-            .thenComparing(Expression::toString);
-
+    private final Comparator<Expression> canonicalComparator;
     private final Multimap<Expression, Expression> equalitySets; // Indexed by canonical expression
     private final Map<Expression, Expression> canonicalMap; // Map each known expression to canonical expression
     private final Set<Expression> derivedExpressions;
+    private final Map<Expression, List<Expression>> expressionCache = new HashMap<>();
+    private final Map<Expression, List<Symbol>> symbolsCache = new HashMap<>();
+    private final Map<Expression, Set<Symbol>> uniqueSymbolsCache = new HashMap<>();
 
-    private EqualityInference(Multimap<Expression, Expression> equalitySets, Map<Expression, Expression> canonicalMap, Set<Expression> derivedExpressions)
+    public EqualityInference(Metadata metadata, Expression... expressions)
     {
+        this(metadata, Arrays.asList(expressions));
+    }
+
+    public EqualityInference(Metadata metadata, Collection<Expression> expressions)
+    {
+        DisjointSet<Expression> equalities = new DisjointSet<>();
+        expressions.stream()
+                .flatMap(expression -> extractConjuncts(expression).stream())
+                .filter(expression -> isInferenceCandidate(metadata, expression))
+                .forEach(expression -> {
+                    ComparisonExpression comparison = (ComparisonExpression) expression;
+                    Expression expression1 = comparison.getLeft();
+                    Expression expression2 = comparison.getRight();
+
+                    equalities.findAndUnion(expression1, expression2);
+                });
+
+        Collection<Set<Expression>> equivalentClasses = equalities.getEquivalentClasses();
+
+        // Map every expression to the set of equivalent expressions
+        Map<Expression, Set<Expression>> byExpression = new LinkedHashMap<>();
+        for (Set<Expression> equivalence : equivalentClasses) {
+            equivalence.forEach(expression -> byExpression.put(expression, equivalence));
+        }
+
+        // For every non-derived expression, extract the sub-expressions and see if they can be rewritten as other expressions. If so,
+        // use this new information to update the known equalities.
+        Set<Expression> derivedExpressions = new LinkedHashSet<>();
+        for (Expression expression : byExpression.keySet()) {
+            if (derivedExpressions.contains(expression)) {
+                continue;
+            }
+
+            extractSubExpressions(expression)
+                    .stream()
+                    .filter(e -> !e.equals(expression))
+                    .forEach(subExpression -> byExpression.getOrDefault(subExpression, ImmutableSet.of())
+                            .stream()
+                            .filter(e -> !e.equals(subExpression))
+                            .forEach(equivalentSubExpression -> {
+                                Expression rewritten = replaceExpression(expression, ImmutableMap.of(subExpression, equivalentSubExpression));
+                                equalities.findAndUnion(expression, rewritten);
+                                derivedExpressions.add(rewritten);
+                            }));
+        }
+
+        Comparator<Expression> canonicalComparator = Comparator
+                // Current cost heuristic:
+                // 1) Prefer fewer input symbols
+                // 2) Prefer smaller expression trees
+                // 3) Sort the expressions alphabetically - creates a stable consistent ordering (extremely useful for unit testing)
+                // TODO: be more precise in determining the cost of an expression
+                .comparingInt((ToIntFunction<Expression>) (expression -> extractAllSymbols(expression).size()))
+                .thenComparingLong(expression -> extractSubExpressions(expression).size())
+                .thenComparing(Expression::toString);
+
+        Multimap<Expression, Expression> equalitySets = makeEqualitySets(equalities, canonicalComparator);
+
+        ImmutableMap.Builder<Expression, Expression> canonicalMappings = ImmutableMap.builder();
+        for (Map.Entry<Expression, Expression> entry : equalitySets.entries()) {
+            Expression canonical = entry.getKey();
+            Expression expression = entry.getValue();
+            canonicalMappings.put(expression, canonical);
+        }
+
         this.equalitySets = equalitySets;
-        this.canonicalMap = canonicalMap;
+        this.canonicalMap = canonicalMappings.buildOrThrow();
         this.derivedExpressions = derivedExpressions;
+        this.canonicalComparator = canonicalComparator;
     }
 
     /**
@@ -190,65 +251,6 @@ public class EqualityInference
         return false;
     }
 
-    public static EqualityInference newInstance(Metadata metadata, Expression... expressions)
-    {
-        return newInstance(metadata, Arrays.asList(expressions));
-    }
-
-    public static EqualityInference newInstance(Metadata metadata, Collection<Expression> expressions)
-    {
-        DisjointSet<Expression> equalities = new DisjointSet<>();
-        expressions.stream()
-                .flatMap(expression -> extractConjuncts(expression).stream())
-                .filter(expression -> isInferenceCandidate(metadata, expression))
-                .forEach(expression -> {
-                    ComparisonExpression comparison = (ComparisonExpression) expression;
-                    Expression expression1 = comparison.getLeft();
-                    Expression expression2 = comparison.getRight();
-
-                    equalities.findAndUnion(expression1, expression2);
-                });
-
-        Collection<Set<Expression>> equivalentClasses = equalities.getEquivalentClasses();
-
-        // Map every expression to the set of equivalent expressions
-        Map<Expression, Set<Expression>> byExpression = new LinkedHashMap<>();
-        for (Set<Expression> equivalence : equivalentClasses) {
-            equivalence.forEach(expression -> byExpression.put(expression, equivalence));
-        }
-
-        // For every non-derived expression, extract the sub-expressions and see if they can be rewritten as other expressions. If so,
-        // use this new information to update the known equalities.
-        Set<Expression> derivedExpressions = new LinkedHashSet<>();
-        for (Expression expression : byExpression.keySet()) {
-            if (derivedExpressions.contains(expression)) {
-                continue;
-            }
-
-            SubExpressionExtractor.extract(expression)
-                    .filter(e -> !e.equals(expression))
-                    .forEach(subExpression -> byExpression.getOrDefault(subExpression, ImmutableSet.of())
-                            .stream()
-                            .filter(e -> !e.equals(subExpression))
-                            .forEach(equivalentSubExpression -> {
-                                Expression rewritten = replaceExpression(expression, ImmutableMap.of(subExpression, equivalentSubExpression));
-                                equalities.findAndUnion(expression, rewritten);
-                                derivedExpressions.add(rewritten);
-                            }));
-        }
-
-        Multimap<Expression, Expression> equalitySets = makeEqualitySets(equalities);
-
-        ImmutableMap.Builder<Expression, Expression> canonicalMappings = ImmutableMap.builder();
-        for (Map.Entry<Expression, Expression> entry : equalitySets.entries()) {
-            Expression canonical = entry.getKey();
-            Expression expression = entry.getValue();
-            canonicalMappings.put(expression, canonical);
-        }
-
-        return new EqualityInference(equalitySets, canonicalMappings.buildOrThrow(), derivedExpressions);
-    }
-
     /**
      * Provides a convenience Stream of Expression conjuncts which have not been added to the inference
      */
@@ -261,7 +263,8 @@ public class EqualityInference
     private Expression rewrite(Expression expression, Predicate<Symbol> symbolScope, boolean allowFullReplacement)
     {
         Map<Expression, Expression> expressionRemap = new HashMap<>();
-        SubExpressionExtractor.extract(expression)
+        extractSubExpressions(expression)
+                .stream()
                 .filter(allowFullReplacement
                         ? subExpression -> true
                         : subExpression -> !subExpression.equals(expression))
@@ -286,9 +289,9 @@ public class EqualityInference
     /**
      * Returns the most preferrable expression to be used as the canonical expression
      */
-    private static Expression getCanonical(Stream<Expression> expressions)
+    private Expression getCanonical(Stream<Expression> expressions)
     {
-        return expressions.min(CANONICAL_COMPARATOR).orElse(null);
+        return expressions.min(canonicalComparator).orElse(null);
     }
 
     /**
@@ -320,20 +323,35 @@ public class EqualityInference
                         .filter(e -> isScoped(e, symbolScope)));
     }
 
-    private static boolean isScoped(Expression expression, Predicate<Symbol> symbolScope)
+    private boolean isScoped(Expression expression, Predicate<Symbol> symbolScope)
     {
-        return SymbolsExtractor.extractUnique(expression).stream().allMatch(symbolScope);
+        return extractUniqueSymbols(expression).stream().allMatch(symbolScope);
     }
 
-    private static Multimap<Expression, Expression> makeEqualitySets(DisjointSet<Expression> equalities)
+    private static Multimap<Expression, Expression> makeEqualitySets(DisjointSet<Expression> equalities, Comparator<Expression> canonicalComparator)
     {
         ImmutableSetMultimap.Builder<Expression, Expression> builder = ImmutableSetMultimap.builder();
         for (Set<Expression> equalityGroup : equalities.getEquivalentClasses()) {
             if (!equalityGroup.isEmpty()) {
-                builder.putAll(equalityGroup.stream().min(CANONICAL_COMPARATOR).get(), equalityGroup);
+                builder.putAll(equalityGroup.stream().min(canonicalComparator).get(), equalityGroup);
             }
         }
         return builder.build();
+    }
+
+    private List<Expression> extractSubExpressions(Expression expression)
+    {
+        return expressionCache.computeIfAbsent(expression, e -> SubExpressionExtractor.extract(e).collect(toImmutableList()));
+    }
+
+    private Set<Symbol> extractUniqueSymbols(Expression expression)
+    {
+        return uniqueSymbolsCache.computeIfAbsent(expression, e -> ImmutableSet.copyOf(extractAllSymbols(expression)));
+    }
+
+    private List<Symbol> extractAllSymbols(Expression expression)
+    {
+        return symbolsCache.computeIfAbsent(expression, SymbolsExtractor::extractAll);
     }
 
     public static class EqualityPartition

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
@@ -193,7 +193,7 @@ public class ReorderJoins
             this.resultComparator = costComparator.forSession(session).onResultOf(result -> result.cost);
             this.idAllocator = requireNonNull(context.getIdAllocator(), "idAllocator is null");
             this.allFilter = requireNonNull(filter, "filter is null");
-            this.allFilterInference = EqualityInference.newInstance(metadata, filter);
+            this.allFilterInference = new EqualityInference(metadata, filter);
             this.lookup = requireNonNull(context.getLookup(), "lookup is null");
         }
 
@@ -364,7 +364,7 @@ public class ReorderJoins
             // create equality inference on available symbols
             // TODO: make generateEqualitiesPartitionedBy take left and right scope
             List<Expression> joinEqualities = allFilterInference.generateEqualitiesPartitionedBy(Sets.union(leftSymbols, rightSymbols)).getScopeEqualities();
-            EqualityInference joinInference = EqualityInference.newInstance(metadata, joinEqualities);
+            EqualityInference joinInference = new EqualityInference(metadata, joinEqualities);
             joinPredicatesBuilder.addAll(joinInference.generateEqualitiesPartitionedBy(leftSymbols).getScopeStraddlingEqualities());
 
             return joinPredicatesBuilder.build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -872,24 +872,24 @@ public class PredicatePushDown
             joinPredicate = filterDeterministicConjuncts(metadata, joinPredicate);
 
             // Generate equality inferences
-            EqualityInference inheritedInference = EqualityInference.newInstance(metadata, inheritedPredicate);
-            EqualityInference outerInference = EqualityInference.newInstance(metadata, inheritedPredicate, outerEffectivePredicate);
+            EqualityInference inheritedInference = new EqualityInference(metadata, inheritedPredicate);
+            EqualityInference outerInference = new EqualityInference(metadata, inheritedPredicate, outerEffectivePredicate);
 
             Set<Symbol> innerScope = ImmutableSet.copyOf(innerSymbols);
             Set<Symbol> outerScope = ImmutableSet.copyOf(outerSymbols);
 
             EqualityInference.EqualityPartition equalityPartition = inheritedInference.generateEqualitiesPartitionedBy(outerScope);
             Expression outerOnlyInheritedEqualities = combineConjuncts(metadata, equalityPartition.getScopeEqualities());
-            EqualityInference potentialNullSymbolInference = EqualityInference.newInstance(metadata, outerOnlyInheritedEqualities, outerEffectivePredicate, innerEffectivePredicate, joinPredicate);
+            EqualityInference potentialNullSymbolInference = new EqualityInference(metadata, outerOnlyInheritedEqualities, outerEffectivePredicate, innerEffectivePredicate, joinPredicate);
 
             // Push outer and join equalities into the inner side. For example:
             // SELECT * FROM nation LEFT OUTER JOIN region ON nation.regionkey = region.regionkey and nation.name = region.name WHERE nation.name = 'blah'
 
-            EqualityInference potentialNullSymbolInferenceWithoutInnerInferred = EqualityInference.newInstance(metadata, outerOnlyInheritedEqualities, outerEffectivePredicate, joinPredicate);
+            EqualityInference potentialNullSymbolInferenceWithoutInnerInferred = new EqualityInference(metadata, outerOnlyInheritedEqualities, outerEffectivePredicate, joinPredicate);
             innerPushdownConjuncts.addAll(potentialNullSymbolInferenceWithoutInnerInferred.generateEqualitiesPartitionedBy(innerScope).getScopeEqualities());
 
             // TODO: we can further improve simplifying the equalities by considering other relationships from the outer side
-            EqualityInference.EqualityPartition joinEqualityPartition = EqualityInference.newInstance(metadata, joinPredicate).generateEqualitiesPartitionedBy(innerScope);
+            EqualityInference.EqualityPartition joinEqualityPartition = new EqualityInference(metadata, joinPredicate).generateEqualitiesPartitionedBy(innerScope);
             innerPushdownConjuncts.addAll(joinEqualityPartition.getScopeEqualities());
             joinConjuncts.addAll(joinEqualityPartition.getScopeComplementEqualities())
                     .addAll(joinEqualityPartition.getScopeStraddlingEqualities());
@@ -1009,14 +1009,14 @@ public class PredicatePushDown
 
             // Attempt to simplify the effective left/right predicates with the predicate we're pushing down
             // This, effectively, inlines any constants derived from such predicate
-            EqualityInference predicateInference = EqualityInference.newInstance(metadata, inheritedPredicate);
+            EqualityInference predicateInference = new EqualityInference(metadata, inheritedPredicate);
             Expression simplifiedLeftEffectivePredicate = predicateInference.rewrite(leftEffectivePredicate, leftScope);
             Expression simplifiedRightEffectivePredicate = predicateInference.rewrite(rightEffectivePredicate, rightScope);
 
             // Generate equality inferences
-            EqualityInference allInference = EqualityInference.newInstance(metadata, inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate, simplifiedRightEffectivePredicate);
-            EqualityInference allInferenceWithoutLeftInferred = EqualityInference.newInstance(metadata, inheritedPredicate, rightEffectivePredicate, joinPredicate, simplifiedRightEffectivePredicate);
-            EqualityInference allInferenceWithoutRightInferred = EqualityInference.newInstance(metadata, inheritedPredicate, leftEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate);
+            EqualityInference allInference = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, rightEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate, simplifiedRightEffectivePredicate);
+            EqualityInference allInferenceWithoutLeftInferred = new EqualityInference(metadata, inheritedPredicate, rightEffectivePredicate, joinPredicate, simplifiedRightEffectivePredicate);
+            EqualityInference allInferenceWithoutRightInferred = new EqualityInference(metadata, inheritedPredicate, leftEffectivePredicate, joinPredicate, simplifiedLeftEffectivePredicate);
 
             // Add equalities from the inference back in
             leftPushDownConjuncts.addAll(allInferenceWithoutLeftInferred.generateEqualitiesPartitionedBy(leftScope).getScopeEqualities());
@@ -1309,7 +1309,7 @@ public class PredicatePushDown
 
             // Push inheritedPredicates down to the source if they don't involve the semi join output
             ImmutableSet<Symbol> sourceScope = ImmutableSet.copyOf(node.getSource().getOutputSymbols());
-            EqualityInference inheritedInference = EqualityInference.newInstance(metadata, inheritedPredicate);
+            EqualityInference inheritedInference = new EqualityInference(metadata, inheritedPredicate);
             EqualityInference.nonInferrableConjuncts(metadata, inheritedPredicate).forEach(conjunct -> {
                 Expression rewrittenConjunct = inheritedInference.rewrite(conjunct, sourceScope);
                 // Since each source row is reflected exactly once in the output, ok to push non-deterministic predicates down
@@ -1368,9 +1368,9 @@ public class PredicatePushDown
             List<Expression> postJoinConjuncts = new ArrayList<>();
 
             // Generate equality inferences
-            EqualityInference allInference = EqualityInference.newInstance(metadata, deterministicInheritedPredicate, sourceEffectivePredicate, filteringSourceEffectivePredicate, joinExpression);
-            EqualityInference allInferenceWithoutSourceInferred = EqualityInference.newInstance(metadata, deterministicInheritedPredicate, filteringSourceEffectivePredicate, joinExpression);
-            EqualityInference allInferenceWithoutFilteringSourceInferred = EqualityInference.newInstance(metadata, deterministicInheritedPredicate, sourceEffectivePredicate, joinExpression);
+            EqualityInference allInference = new EqualityInference(metadata, deterministicInheritedPredicate, sourceEffectivePredicate, filteringSourceEffectivePredicate, joinExpression);
+            EqualityInference allInferenceWithoutSourceInferred = new EqualityInference(metadata, deterministicInheritedPredicate, filteringSourceEffectivePredicate, joinExpression);
+            EqualityInference allInferenceWithoutFilteringSourceInferred = new EqualityInference(metadata, deterministicInheritedPredicate, sourceEffectivePredicate, joinExpression);
 
             // Push inheritedPredicates down to the source if they don't involve the semi join output
             Set<Symbol> sourceScope = ImmutableSet.copyOf(sourceSymbols);
@@ -1461,7 +1461,7 @@ public class PredicatePushDown
 
             Expression inheritedPredicate = context.get();
 
-            EqualityInference equalityInference = EqualityInference.newInstance(metadata, inheritedPredicate);
+            EqualityInference equalityInference = new EqualityInference(metadata, inheritedPredicate);
 
             List<Expression> pushdownConjuncts = new ArrayList<>();
             List<Expression> postAggregationConjuncts = new ArrayList<>();
@@ -1523,7 +1523,7 @@ public class PredicatePushDown
             }
 
             //TODO for LEFT or INNER join type, push down UnnestNode's filter on replicate symbols
-            EqualityInference equalityInference = EqualityInference.newInstance(metadata, inheritedPredicate);
+            EqualityInference equalityInference = new EqualityInference(metadata, inheritedPredicate);
 
             List<Expression> pushdownConjuncts = new ArrayList<>();
             List<Expression> postUnnestConjuncts = new ArrayList<>();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -1236,7 +1236,7 @@ public class TestEffectivePredicateExtractor
         predicate = expressionNormalizer.normalize(predicate);
 
         // Equality inference rewrites and equality generation will always be stable across multiple runs in the same JVM
-        EqualityInference inference = EqualityInference.newInstance(metadata, predicate);
+        EqualityInference inference = new EqualityInference(metadata, predicate);
 
         Set<Symbol> scope = SymbolsExtractor.extractUnique(predicate);
         Set<Expression> rewrittenSet = EqualityInference.nonInferrableConjuncts(metadata, predicate)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
@@ -72,7 +72,7 @@ public class TestEqualityInference
     @Test
     public void testTransitivity()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals("a1", "b1"),
                 equals("b1", "c1"),
@@ -110,7 +110,7 @@ public class TestEqualityInference
     @Test
     public void testTriviallyRewritable()
     {
-        Expression expression = EqualityInference.newInstance(metadata)
+        Expression expression = new EqualityInference(metadata)
                 .rewrite(someExpression("a1", "a2"), symbols("a1", "a2"));
 
         assertEquals(expression, someExpression("a1", "a2"));
@@ -119,7 +119,7 @@ public class TestEqualityInference
     @Test
     public void testUnrewritable()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals("a1", "b1"),
                 equals("a2", "b2"));
@@ -131,7 +131,7 @@ public class TestEqualityInference
     @Test
     public void testParseEqualityExpression()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals("a1", "b1"),
                 equals("a1", "c1"),
@@ -144,7 +144,7 @@ public class TestEqualityInference
     @Test
     public void testExtractInferrableEqualities()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 ExpressionUtils.and(equals("a1", "b1"), equals("b1", "c1"), someExpression("c1", "d1")));
 
@@ -158,7 +158,7 @@ public class TestEqualityInference
     @Test
     public void testEqualityPartitionGeneration()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals(nameReference("a1"), nameReference("b1")),
                 equals(add("a1", "a1"), multiply(nameReference("a1"), number(2))),
@@ -193,7 +193,7 @@ public class TestEqualityInference
 
         // There should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around
-        EqualityInference newInference = EqualityInference.newInstance(
+        EqualityInference newInference = new EqualityInference(
                 metadata,
                 ImmutableList.<Expression>builder()
                         .addAll(equalityPartition.getScopeEqualities())
@@ -211,7 +211,7 @@ public class TestEqualityInference
     @Test
     public void testMultipleEqualitySetsPredicateGeneration()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals("a1", "b1"),
                 equals("b1", "c1"),
@@ -240,7 +240,7 @@ public class TestEqualityInference
 
         // Again, there should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around
-        EqualityInference newInference = EqualityInference.newInstance(
+        EqualityInference newInference = new EqualityInference(
                 metadata,
                 ImmutableList.<Expression>builder()
                         .addAll(equalityPartition.getScopeEqualities())
@@ -258,7 +258,7 @@ public class TestEqualityInference
     @Test
     public void testSubExpressionRewrites()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals(nameReference("a1"), add("b", "c")), // a1 = b + c
                 equals(nameReference("a2"), multiply(nameReference("b"), add("b", "c"))), // a2 = b * (b + c)
@@ -277,7 +277,7 @@ public class TestEqualityInference
     @Test
     public void testConstantEqualities()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals("a1", "b1"),
                 equals("b1", "c1"),
@@ -300,7 +300,7 @@ public class TestEqualityInference
     @Test
     public void testEqualityGeneration()
     {
-        EqualityInference inference = EqualityInference.newInstance(
+        EqualityInference inference = new EqualityInference(
                 metadata,
                 equals(nameReference("a1"), add("b", "c")), // a1 = b + c
                 equals(nameReference("e1"), add("b", "d")), // e1 = b + d
@@ -327,7 +327,7 @@ public class TestEqualityInference
                 new SubscriptExpression(new Array(ImmutableList.of(new NullLiteral())), nameReference("b")));
 
         for (Expression candidate : candidates) {
-            EqualityInference inference = EqualityInference.newInstance(
+            EqualityInference inference = new EqualityInference(
                     metadata,
                     equals(nameReference("b"), nameReference("x")),
                     equals(nameReference("a"), candidate));


### PR DESCRIPTION
## Description

Extracting symbols and subexpressions from expression is a relatively expensive operation. `CachingSymbolExtractor` and `CachingSubExpressionExtractor` were added to memoize result for this operations.
This is `Method Profile` for master
![image](https://github.com/trinodb/trino/assets/94364205/ea73bf44-733f-4220-ba4a-e2abeb51d6de)
There is a lot of top methods related to extracting symbols and sub-expressions. 

Results for microbenchmark: `BenchmarkReorderChainedJoins`
```
BenchmarkReorderChainedJoins.benchmarkReorderJoins                 AUTOMATIC  avgt   40  362.936 ? 0.832  ms/op (before)
BenchmarkReorderChainedJoins.benchmarkReorderJoins                 AUTOMATIC  avgt   40  288.576 ? 0.741  ms/op (after)
```


Macrobenchmark results:
5% difference in total tpcds planning time is more or less stable. 
![image](https://github.com/trinodb/trino/assets/94364205/135a2c8a-c195-4dae-8026-61546c5f06ff)


## Release notes
(*) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
