### PR TITLE
Isolate TestFileSystemCache to fix its flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,10 @@ jobs:
             !:trino-sqlserver,
             !:trino-test-jdbc-compatibility-old-server,
             !:trino-tests'
+      - name: trino-hdfs isolated JVM tests
+        # Isolate HDFS file system cache concurrency test to avoid flakiness
+        run: |
+          $MAVEN test ${MAVEN_TEST} -pl :trino-hdfs -P test-isolated-jvm-suites
       - name: Upload test results
         uses: actions/upload-artifact@v3
         # Upload all test reports only on failure, because the artifacts are large

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -14,8 +14,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <!-- e.g. TestFileSystemCache asserts on static global state -->
-        <air.test.thread-count>1</air.test.thread-count>
         <!-- Move TestFileSystemCache to separate profile to isolate it from interactions coming
              from other threads against the global file system cache, resulting in flaky CI -->
         <isolatedJvmTests>**/TestFileSystemCache.java</isolatedJvmTests>

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -16,6 +16,9 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- e.g. TestFileSystemCache asserts on static global state -->
         <air.test.thread-count>1</air.test.thread-count>
+        <!-- Move TestFileSystemCache to separate profile to isolate it from interactions coming
+             from other threads against the global file system cache, resulting in flaky CI -->
+        <isolatedJvmTests>**/TestFileSystemCache.java</isolatedJvmTests>
     </properties>
 
     <dependencies>
@@ -225,4 +228,44 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>${isolatedJvmTests}</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-isolated-jvm-suites</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>${isolatedJvmTests}</include>
+                            </includes>
+                            <reuseForks>false</reuseForks>
+                            <forkCount>1</forkCount>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFSDataInputStreamTail.java
@@ -38,6 +38,7 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+@Test(singleThreaded = true) // e.g. test methods operate on shared, mutated tempFile
 public class TestFSDataInputStreamTail
 {
     private File tempRoot;

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
@@ -42,6 +42,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertSame;
 
+@Test(singleThreaded = true)
 public class TestFileSystemCache
 {
     @BeforeMethod(alwaysRun = true)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`TrinoFileSystemCache` holds the global cache of filesystem objects within a running server. `TestFileSystemCache` expects that this singleton instance is available to itself and validates the number of entries in the cache accordingly. This is not a valid assumption as other threads running concurrently in the same JVM can add and delete filesystem objects in `TrinoFileSystemCache`. To avoid this interference between `TestFileSystemCache` and other threads running in the same JVM, we move the former to run in a separate runner instance in CI. This should avoid the flakiness reported in https://github.com/trinodb/trino/issues/17158

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/17158


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
