### PR TITLE
Fix Iceberg $history table when using REST Catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HistoryTable.java
@@ -25,7 +25,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TimeZoneKey;
-import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -77,14 +76,13 @@ public class HistoryTable
 
         Set<Long> ancestorIds = ImmutableSet.copyOf(SnapshotUtil.currentAncestorIds(icebergTable));
         TimeZoneKey timeZoneKey = session.getTimeZoneKey();
-        for (HistoryEntry historyEntry : icebergTable.history()) {
-            long snapshotId = historyEntry.snapshotId();
-            Snapshot snapshot = icebergTable.snapshot(snapshotId);
+        for (Snapshot snapshot : icebergTable.snapshots()) {
+            long snapshotId = snapshot.snapshotId();
 
             table.addRow(
-                    packDateTimeWithZone(historyEntry.timestampMillis(), timeZoneKey),
+                    packDateTimeWithZone(snapshot.timestampMillis(), timeZoneKey),
                     snapshotId,
-                    snapshot != null ? snapshot.parentId() : null,
+                    snapshot.parentId(),
                     ancestorIds.contains(snapshotId));
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -595,6 +595,33 @@ public abstract class BaseIcebergConnectorSmokeTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
+    // Verify the accuracy of Trino metadata tables while retrieving Iceberg table metadata from the underlying `TrinoCatalog` implementation
+    @Test
+    public void testMetadataTables()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_metadata_tables",
+                "(id int, part varchar) WITH (partitioning = ARRAY['part'])",
+                ImmutableList.of("1, 'p1'", "2, 'p1'", "3, 'p2'"))) {
+            List<Long> snapshotIds = computeActual("SELECT snapshot_id FROM \"" + table.getName() + "$snapshots\" ORDER BY committed_at DESC")
+                    .getOnlyColumn()
+                    .map(Long.class::cast)
+                    .collect(toImmutableList());
+            List<Long> historySnapshotIds = computeActual("SELECT snapshot_id FROM \"" + table.getName() + "$history\" ORDER BY made_current_at DESC")
+                    .getOnlyColumn()
+                    .map(Long.class::cast)
+                    .collect(toImmutableList());
+            long filesCount = (long) computeScalar("SELECT count(*) FROM \"" + table.getName() + "$files\"");
+            long partitionsCount = (long) computeScalar("SELECT count(*) FROM \"" + table.getName() + "$partitions\"");
+
+            assertThat(snapshotIds).hasSize(4);
+            assertThat(snapshotIds).hasSameElementsAs(historySnapshotIds);
+            assertThat(filesCount).isEqualTo(3L);
+            assertThat(partitionsCount).isEqualTo(2L);
+        }
+    }
+
     protected abstract boolean isFileSorted(Location path, String sortColumnName);
 
     private String getTableLocation(String tableName)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In the current version of Iceberg library, when not all the snapshots are initially loaded (for the REST session catalog), the `snapshotsLog` does not get reinitialized, causing to expose only the current snapshots in the `history()` method of the Iceberg table.

Related Iceberg code

https://github.com/apache/iceberg/blob/8865be48bcb20ce07972bf5176955d03a1347d27/core/src/main/java/org/apache/iceberg/TableMetadata.java#L497-L516

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
