### PR TITLE
Retry docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64,ppc64le
-      - name: Test Docker Image
+      - name: Build and Test Docker Image
         run: core/docker/build.sh
       - name: Remove Trino from local Maven repo to avoid caching it
         # Avoid caching artifacts built in this job, cache should only include dependencies

--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -71,7 +71,7 @@ TAG_PREFIX="trino:${TRINO_VERSION}"
 
 for arch in "${ARCHITECTURES[@]}"; do
     echo "🫙  Building the image for $arch"
-    docker build \
+    "${SOURCE_DIR}/.github/bin/retry" docker build \
         "${WORK_DIR}" \
         --pull \
         --platform "linux/$arch" \


### PR DESCRIPTION
Docker build involves network operations and some of them do not have implicit retries. For example, the command

    git clone https://github.com/airlift/jvmkill /tmp/jvmkill

currently does not retry.

fixes https://github.com/trinodb/trino/issues/17472 