### PR TITLE
Revert "Retry docker build"

### DIFF
--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -71,7 +71,7 @@ TAG_PREFIX="trino:${TRINO_VERSION}"
 
 for arch in "${ARCHITECTURES[@]}"; do
     echo "🫙  Building the image for $arch"
-    "${SOURCE_DIR}/.github/bin/retry" docker build \
+    docker build \
         "${WORK_DIR}" \
         --pull \
         --platform "linux/$arch" \


### PR DESCRIPTION
This reverts commit c68b03011300b33d97e7ed0c3c71f0e4993d751e.

The Docker build script in `core/docker` should be standalone and not depend on `.github/bin` which is intended for CI usage.