### PR TITLE
Update airbase to 139

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/external/CompositeRedirectHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/CompositeRedirectHandler.java
@@ -34,7 +34,8 @@ public class CompositeRedirectHandler
     }
 
     @Override
-    public void redirectTo(URI uri) throws RedirectException
+    public void redirectTo(URI uri)
+            throws RedirectException
     {
         RedirectException redirectException = new RedirectException("Could not redirect to " + uri);
         for (RedirectHandler handler : handlers) {

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/SystemOutPrintRedirectHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/SystemOutPrintRedirectHandler.java
@@ -19,7 +19,8 @@ public class SystemOutPrintRedirectHandler
         implements RedirectHandler
 {
     @Override
-    public void redirectTo(URI uri) throws RedirectException
+    public void redirectTo(URI uri)
+            throws RedirectException
     {
         System.out.println("External authentication required. Please go to:");
         System.out.println(uri.toString());

--- a/core/trino-main/src/main/java/io/trino/server/security/HeaderAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/HeaderAuthenticator.java
@@ -46,7 +46,8 @@ public class HeaderAuthenticator
     }
 
     @Override
-    public Identity authenticate(ContainerRequestContext request) throws AuthenticationException
+    public Identity authenticate(ContainerRequestContext request)
+            throws AuthenticationException
     {
         AuthenticationException exception = null;
         Map<String, List<String>> lowerCasedHeaders = request.getHeaders().entrySet().stream()

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -704,6 +704,7 @@ public class TestBinPackingNodeAllocator
 
     interface ThrowingRunnable
     {
-        void run() throws Exception;
+        void run()
+                throws Exception;
     }
 }

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -23,12 +23,16 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <configuration>
-                        <excludes combine.children="append">
-                            <exclude>**/*.conf</exclude>
-                            <exclude>**/*.css</exclude>
-                            <exclude>**/*.js</exclude>
-                            <exclude>**/*.fragment</exclude>
-                        </excludes>
+                        <licenseSets>
+                            <licenseSet>
+                                <excludes combine.children="append">
+                                    <exclude>**/*.conf</exclude>
+                                    <exclude>**/*.css</exclude>
+                                    <exclude>**/*.js</exclude>
+                                    <exclude>**/*.fragment</exclude>
+                                </excludes>
+                            </licenseSet>
+                        </licenseSets>
                     </configuration>
                 </plugin>
             </plugins>

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestFileSystemCache.java
@@ -79,7 +79,8 @@ public class TestFileSystemCache
     }
 
     @Test
-    public void testFileSystemCacheException() throws IOException
+    public void testFileSystemCacheException()
+            throws IOException
     {
         HdfsEnvironment environment = new HdfsEnvironment(
                 new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(new HdfsConfig()), ImmutableSet.of()),
@@ -98,7 +99,8 @@ public class TestFileSystemCache
     }
 
     @Test
-    public void testFileSystemCacheConcurrency() throws InterruptedException, ExecutionException, IOException
+    public void testFileSystemCacheConcurrency()
+            throws InterruptedException, ExecutionException, IOException
     {
         int numThreads = 20;
         List<Callable<Void>> callableTasks = new ArrayList<>();
@@ -127,7 +129,8 @@ public class TestFileSystemCache
     @FunctionalInterface
     public interface FileSystemConsumer
     {
-        void consume(FileSystem fileSystem) throws IOException;
+        void consume(FileSystem fileSystem)
+                throws IOException;
     }
 
     private static class FileSystemCloser
@@ -135,7 +138,8 @@ public class TestFileSystemCache
     {
         @Override
         @SuppressModernizer
-        public void consume(FileSystem fileSystem) throws IOException
+        public void consume(FileSystem fileSystem)
+                throws IOException
         {
             fileSystem.close();  /* triggers fscache.remove() */
         }
@@ -163,7 +167,8 @@ public class TestFileSystemCache
         }
 
         @Override
-        public Void call() throws IOException
+        public Void call()
+                throws IOException
         {
             for (int i = 0; i < getCallsPerInvocation; i++) {
                 FileSystem fs = getFileSystem(environment, ConnectorIdentity.ofUser("user" + random.nextInt(userCount)));

--- a/lib/trino-phoenix5-patched/src/main/java/org/apache/phoenix/shaded/org/apache/zookeeper/client/StaticHostProvider.java
+++ b/lib/trino-phoenix5-patched/src/main/java/org/apache/phoenix/shaded/org/apache/zookeeper/client/StaticHostProvider.java
@@ -28,7 +28,8 @@ public final class StaticHostProvider
 {
     public interface Resolver
     {
-        InetAddress[] getAllByName(String name) throws UnknownHostException;
+        InetAddress[] getAllByName(String name)
+                throws UnknownHostException;
     }
 
     private final List<InetSocketAddress> serverAddresses = new ArrayList<InetSocketAddress>(5);

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeStorage.java
@@ -22,7 +22,8 @@ import java.util.List;
 public interface FileSystemExchangeStorage
         extends AutoCloseable
 {
-    void createDirectories(URI dir) throws IOException;
+    void createDirectories(URI dir)
+            throws IOException;
 
     ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize);
 
@@ -37,5 +38,6 @@ public interface FileSystemExchangeStorage
     int getWriteBufferSize();
 
     @Override
-    void close() throws IOException;
+    void close()
+            throws IOException;
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
@@ -48,7 +48,8 @@ public class TestIcebergMergeAppend
     private IcebergTableOperationsProvider tableOperationsProvider;
 
     @Override
-    protected QueryRunner createQueryRunner() throws Exception
+    protected QueryRunner createQueryRunner()
+            throws Exception
     {
         DistributedQueryRunner queryRunner = IcebergQueryRunner.createIcebergQueryRunner();
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveMetastoreTableOperationsReleaseLockFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestIcebergHiveMetastoreTableOperationsReleaseLockFailure.java
@@ -49,7 +49,8 @@ public class TestIcebergHiveMetastoreTableOperationsReleaseLockFailure
     private File baseDir;
 
     @Override
-    protected LocalQueryRunner createQueryRunner() throws Exception
+    protected LocalQueryRunner createQueryRunner()
+            throws Exception
     {
         Session session = testSessionBuilder()
                 .setCatalog(ICEBERG_CATALOG)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientWrapper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientWrapper.java
@@ -30,19 +30,26 @@ import java.io.IOException;
 public interface KuduClientWrapper
         extends AutoCloseable
 {
-    KuduTable createTable(String name, Schema schema, CreateTableOptions builder) throws KuduException;
+    KuduTable createTable(String name, Schema schema, CreateTableOptions builder)
+            throws KuduException;
 
-    DeleteTableResponse deleteTable(String name) throws KuduException;
+    DeleteTableResponse deleteTable(String name)
+            throws KuduException;
 
-    AlterTableResponse alterTable(String name, AlterTableOptions ato) throws KuduException;
+    AlterTableResponse alterTable(String name, AlterTableOptions ato)
+            throws KuduException;
 
-    ListTablesResponse getTablesList() throws KuduException;
+    ListTablesResponse getTablesList()
+            throws KuduException;
 
-    ListTablesResponse getTablesList(String nameFilter) throws KuduException;
+    ListTablesResponse getTablesList(String nameFilter)
+            throws KuduException;
 
-    boolean tableExists(String name) throws KuduException;
+    boolean tableExists(String name)
+            throws KuduException;
 
-    KuduTable openTable(String name) throws KuduException;
+    KuduTable openTable(String name)
+            throws KuduException;
 
     KuduScanner.KuduScannerBuilder newScannerBuilder(KuduTable table);
 
@@ -50,8 +57,10 @@ public interface KuduClientWrapper
 
     KuduSession newSession();
 
-    KuduScanner deserializeIntoScanner(byte[] serializedScanToken) throws IOException;
+    KuduScanner deserializeIntoScanner(byte[] serializedScanToken)
+            throws IOException;
 
     @Override
-    void close() throws KuduException;
+    void close()
+            throws KuduException;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>138</version>
+        <version>139</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -2211,7 +2211,7 @@
                             <DynamicDependency>
                                 <groupId>org.junit.platform</groupId>
                                 <artifactId>junit-platform-launcher</artifactId>
-                                <version>1.9.2</version> <!-- legacy version which Surefire seems to need for some reason -->
+                                <version>1.9.3</version> <!-- legacy version which Surefire seems to need for some reason -->
                                 <type>jar</type>
                                 <repositoryType>MAIN</repositoryType>
                             </DynamicDependency>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentDescribe.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentDescribe.java
@@ -128,7 +128,8 @@ public class EnvironmentDescribe
         }
 
         @Override
-        public Integer call() throws Exception
+        public Integer call()
+                throws Exception
         {
             Optional<Path> environmentLogPath = environmentUpOptions.logsDirBase.map(dir -> dir.resolve(environmentUpOptions.environment));
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kudu/TestKuduConnectoKerberosSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kudu/TestKuduConnectoKerberosSmokeTest.java
@@ -28,7 +28,8 @@ import static java.lang.String.format;
 public class TestKuduConnectoKerberosSmokeTest
 {
     @Test(groups = {KUDU, PROFILE_SPECIFIC_TESTS})
-    public void kerberosAuthTicketExpiryTest() throws InterruptedException
+    public void kerberosAuthTicketExpiryTest()
+            throws InterruptedException
     {
         String kuduTable = "kudu.default.nation_" + UUID.randomUUID().toString().replace("-", "");
         String table = "tpch.tiny.nation";


### PR DESCRIPTION
This brings following improvements:

* Replace checkstyle illegal imports with `RestrictImports` enforcer rules
* Checkstyle updates:
  - Require throws keyword to be on a new line.
* Dependency updates:
  - JUnit 5.9.3 (from 5.9.2)
  - Kotlin 1.8.21 (from 1.8.20)
  - Opentelemetry 1.26.0 (from 1.25.0)
  - Opentelemetry Instrumentation 1.25.1 (from 1.24.0)
  - Logback 1.4.7 (from 1.4.6)
  - Checkstyle 10.11.0 (from 10.9.3)
  - Guice 6.0.0 (from 5.1.0)
* Plugin updates:
  - Surefire 3.1.0 (from 3.0.0)
  - maven-clean-plugin 3.2.0 (from 3.0.0)
  - maven-install-plugin 3.1.1 (from 2.5.2)
  - maven-enforcer-plugin 3.3.0 (from 3.2.1)
  - maven-resources-plugin 3.3.1 (from 3.2.0)
  - maven-assembly-plugin 3.5.0 (from 3.3.0)
  - maven-javadoc-plugin 3.5.0 (from 3.2.0)
  - maven-jar-plugin 3.3.0 (from 3.2.0)
  - migrate to git-commit-id-maven-plugin 5.0.0 (from git-commit-id-plugin 4.0.5)
  - maven-source-plugin 3.2.1 (from 3.2.0)
  - license-maven-plugin 4.2 (from 3.0)
  - jacoco-maven-plugin 0.8.10 (from 0.8.9)
  - maven-checkstyle-plugin 3.2.2 (from 3.2.1)
  - maven-site-plugin 3.12.1 (from 3.2)
  - maven-scm-plugin 2.0.0 (from 1.8.1)

The first commit is a preparatory one to fix checkstyle violations due to a new rule.
