### PR TITLE
Collect stats for primitive fields inside ROW column in Delta connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3258,22 +3258,20 @@ public class DeltaLakeMetadata
 
     public static TupleDomain<DeltaLakeColumnHandle> createStatisticsPredicate(
             AddFileEntry addFileEntry,
-            List<DeltaLakeColumnMetadata> schema,
-            List<String> canonicalPartitionColumns)
+            List<DeltaLakeColumnHandle> schema)
     {
         return addFileEntry.getStats()
                 .map(deltaLakeFileStatistics -> withColumnDomains(
                         schema.stream()
-                                .filter(column -> canUseInPredicate(column.getColumnMetadata()))
+                                .filter(column -> canUseInPredicate(column.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getType).orElse(column.getBaseType())))
                                 .collect(toImmutableMap(
-                                        column -> DeltaLakeMetadata.toColumnHandle(column.getName(), column.getType(), column.getFieldId(), column.getPhysicalName(), column.getPhysicalColumnType(), canonicalPartitionColumns),
-                                        column -> buildColumnDomain(column, deltaLakeFileStatistics, canonicalPartitionColumns)))))
+                                        Function.identity(),
+                                        column -> buildColumnDomain(column, deltaLakeFileStatistics)))))
                 .orElseGet(TupleDomain::all);
     }
 
-    private static boolean canUseInPredicate(ColumnMetadata column)
+    private static boolean canUseInPredicate(Type type)
     {
-        Type type = column.getType();
         return type.equals(TINYINT)
                 || type.equals(SMALLINT)
                 || type.equals(INTEGER)
@@ -3287,49 +3285,49 @@ public class DeltaLakeMetadata
                 || type.equals(VARCHAR);
     }
 
-    private static Domain buildColumnDomain(DeltaLakeColumnMetadata column, DeltaLakeFileStatistics stats, List<String> canonicalPartitionColumns)
+    private static Domain buildColumnDomain(DeltaLakeColumnHandle column, DeltaLakeFileStatistics stats)
     {
-        Optional<Long> nullCount = stats.getNullCount(column.getPhysicalName());
+        Type type = column.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getType).orElse(column.getBaseType());
+        Optional<Long> nullCount = stats.getNullCount(column);
         if (nullCount.isEmpty()) {
             // No stats were collected for this column; this can happen in 2 scenarios:
             // 1. The column didn't exist in the schema when the data file was created
             // 2. The column does exist in the file, but Spark property 'delta.dataSkippingNumIndexedCols'
             //    was used to limit the number of columns for which stats are collected
             // Since we don't know which scenario we're dealing with, we can't make a decision to prune.
-            return Domain.all(column.getType());
+            return Domain.all(type);
         }
         if (stats.getNumRecords().equals(nullCount)) {
-            return Domain.onlyNull(column.getType());
+            return Domain.onlyNull(type);
         }
 
         boolean hasNulls = nullCount.get() > 0;
-        DeltaLakeColumnHandle deltaLakeColumnHandle = toColumnHandle(column.getName(), column.getType(), column.getFieldId(), column.getPhysicalName(), column.getPhysicalColumnType(), canonicalPartitionColumns);
-        Optional<Object> minValue = stats.getMinColumnValue(deltaLakeColumnHandle);
-        if (minValue.isPresent() && isFloatingPointNaN(column.getType(), minValue.get())) {
-            return allValues(column.getType(), hasNulls);
+        Optional<Object> minValue = stats.getMinColumnValue(column);
+        if (minValue.isPresent() && isFloatingPointNaN(type, minValue.get())) {
+            return allValues(type, hasNulls);
         }
-        if (isNotFinite(minValue, column.getType())) {
+        if (isNotFinite(minValue, type)) {
             minValue = Optional.empty();
         }
-        Optional<Object> maxValue = stats.getMaxColumnValue(deltaLakeColumnHandle);
-        if (maxValue.isPresent() && isFloatingPointNaN(column.getType(), maxValue.get())) {
-            return allValues(column.getType(), hasNulls);
+        Optional<Object> maxValue = stats.getMaxColumnValue(column);
+        if (maxValue.isPresent() && isFloatingPointNaN(type, maxValue.get())) {
+            return allValues(type, hasNulls);
         }
-        if (isNotFinite(maxValue, column.getType())) {
+        if (isNotFinite(maxValue, type)) {
             maxValue = Optional.empty();
         }
         if (minValue.isPresent() && maxValue.isPresent()) {
             return Domain.create(
-                    ofRanges(range(column.getType(), minValue.get(), true, maxValue.get(), true)),
+                    ofRanges(range(type, minValue.get(), true, maxValue.get(), true)),
                     hasNulls);
         }
         if (minValue.isPresent()) {
-            return Domain.create(ofRanges(greaterThanOrEqual(column.getType(), minValue.get())), hasNulls);
+            return Domain.create(ofRanges(greaterThanOrEqual(type, minValue.get())), hasNulls);
         }
 
         return maxValue
-                .map(value -> Domain.create(ofRanges(lessThanOrEqual(column.getType(), value)), hasNulls))
-                .orElseGet(() -> Domain.all(column.getType()));
+                .map(value -> Domain.create(ofRanges(lessThanOrEqual(type, value)), hasNulls))
+                .orElseGet(() -> Domain.all(type));
     }
 
     private static boolean isNotFinite(Optional<Object> value, Type type)
@@ -3359,7 +3357,7 @@ public class DeltaLakeMetadata
         return Domain.notNull(type);
     }
 
-    private static DeltaLakeColumnHandle toColumnHandle(String originalName, Type type, OptionalInt fieldId, String physicalName, Type physicalType, Collection<String> partitionColumns)
+    public static DeltaLakeColumnHandle toColumnHandle(String originalName, Type type, OptionalInt fieldId, String physicalName, Type physicalType, Collection<String> partitionColumns)
     {
         boolean isPartitionKey = partitionColumns.stream().anyMatch(partition -> partition.equalsIgnoreCase(originalName));
         return new DeltaLakeColumnHandle(

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -25,6 +25,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.plugin.base.util.JsonUtils;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.DecimalType;
@@ -51,7 +52,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.google.common.base.Verify.verify;
 import static com.google.common.math.LongMath.divide;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
@@ -174,8 +174,7 @@ public final class TransactionLogParser
 
     public static Object deserializeColumnValue(DeltaLakeColumnHandle column, String valueString, Function<String, Long> timestampReader, Function<String, Long> timestampWithZoneReader)
     {
-        verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
-        Type type = column.getBaseType();
+        Type type = column.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getType).orElse(column.getBaseType());
         try {
             if (type.equals(BOOLEAN)) {
                 if (valueString.equalsIgnoreCase("true")) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
@@ -33,7 +33,7 @@ public interface DeltaLakeFileStatistics
 
     Optional<Map<String, Object>> getNullCount();
 
-    Optional<Long> getNullCount(String columnName);
+    Optional<Long> getNullCount(DeltaLakeColumnHandle columnHandle);
 
     Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -17,10 +17,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.log.Logger;
 import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.transactionlog.CanonicalColumnName;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.spi.type.TimestampType;
@@ -119,28 +121,19 @@ public class DeltaLakeJsonFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
-        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), maxValues);
+        Optional<Object> value = getStat(columnHandle, maxValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
-        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), minValues);
+        Optional<Object> value = getStat(columnHandle, minValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     private Optional<Object> deserializeStatisticsValue(DeltaLakeColumnHandle columnHandle, String statValue)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
         Object columnValue = deserializeColumnValue(columnHandle, statValue, DeltaLakeJsonFileStatistics::readStatisticsTimestamp, DeltaLakeJsonFileStatistics::readStatisticsTimestampWithZone);
 
         Type columnType = columnHandle.getBaseType();
@@ -180,23 +173,30 @@ public class DeltaLakeJsonFileStatistics
     }
 
     @Override
-    public Optional<Long> getNullCount(String columnName)
+    public Optional<Long> getNullCount(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnName, nullCount).map(o -> Long.valueOf(o.toString()));
+        return getStat(columnHandle, nullCount).map(o -> Long.valueOf(o.toString()));
     }
 
-    private Optional<Object> getStat(String columnName, Optional<Map<CanonicalColumnName, Object>> stats)
+    private Optional<Object> getStat(DeltaLakeColumnHandle columnHandle, Optional<Map<CanonicalColumnName, Object>> stats)
     {
         if (stats.isEmpty()) {
             return Optional.empty();
         }
-        CanonicalColumnName canonicalColumnName = new CanonicalColumnName(columnName);
+        CanonicalColumnName canonicalColumnName = new CanonicalColumnName(columnHandle.getBasePhysicalColumnName());
+        List<String> dereferenceNames = columnHandle.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getDereferencePhysicalNames)
+                .orElse(ImmutableList.of());
         Object contents = stats.get().get(canonicalColumnName);
+        for (String dereferenceName : dereferenceNames) {
+            if (contents instanceof Map map) {
+                contents = map.get(dereferenceName);
+            }
+        }
         if (contents == null) {
             return Optional.empty();
         }
         if (contents instanceof List || contents instanceof Map) {
-            log.debug("Skipping statistics value for column with complex value type: %s", columnName);
+            log.debug("Skipping statistics value for column with complex value type: %s", columnHandle);
             return Optional.empty();
         }
         return Optional.of(contents);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -273,7 +273,7 @@ public class TestDeltaLakeBasic
         DeltaLakeFileStatistics stats = addFileEntry.getStats().orElseThrow();
         assertThat(stats.getMinValues().orElseThrow().get(physicalName)).isEqualTo(10);
         assertThat(stats.getMaxValues().orElseThrow().get(physicalName)).isEqualTo(20);
-        assertThat(stats.getNullCount(physicalName).orElseThrow()).isEqualTo(1);
+        assertThat(stats.getNullCount().orElseThrow().get(physicalName)).isEqualTo(1);
 
         // Verify optimized parquet file contains the expected physical id and name
         TrinoInputFile inputFile = new LocalInputFile(tableLocation.resolve(addFileEntry.getPath()).toFile());
@@ -444,7 +444,7 @@ public class TestDeltaLakeBasic
         DeltaLakeFileStatistics stats = addFileEntry.getStats().orElseThrow();
         assertThat(stats.getMinValues().orElseThrow().get("UPPER_CASE")).isEqualTo(10);
         assertThat(stats.getMaxValues().orElseThrow().get("UPPER_CASE")).isEqualTo(20);
-        assertThat(stats.getNullCount("UPPER_CASE").orElseThrow()).isEqualTo(1);
+        assertThat(stats.getNullCount().orElseThrow().get("UPPER_CASE")).isEqualTo(1);
 
         assertUpdate("UPDATE " + tableName + " SET upper_case = upper_case + 10", 3);
 
@@ -454,7 +454,7 @@ public class TestDeltaLakeBasic
         DeltaLakeFileStatistics updateStats = updateAddFileEntry.getStats().orElseThrow();
         assertThat(updateStats.getMinValues().orElseThrow().get("UPPER_CASE")).isEqualTo(20);
         assertThat(updateStats.getMaxValues().orElseThrow().get("UPPER_CASE")).isEqualTo(30);
-        assertThat(updateStats.getNullCount("UPPER_CASE").orElseThrow()).isEqualTo(1);
+        assertThat(updateStats.getNullCount().orElseThrow().get("UPPER_CASE")).isEqualTo(1);
 
         assertQuery(
                 "SHOW STATS FOR " + tableName,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
@@ -41,6 +41,9 @@ public class TestDeltaLakeTableStatistics
         String dataPath = Resources.getResource("databricks/person").toExternalForm();
         getQueryRunner().execute(
                 format("CALL system.register_table('%s', 'person', '%s')", getSession().getSchema().orElseThrow(), dataPath));
+        dataPath = Resources.getResource("databricks/pruning/nested_fields").toExternalForm();
+        getQueryRunner().execute(
+                format("CALL system.register_table('%s', 'nested_fields', '%s')", getSession().getSchema().orElseThrow(), dataPath));
     }
 
     @Test
@@ -175,5 +178,18 @@ public class TestDeltaLakeTableStatistics
                         //  column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
                         "('col', 0.0, 0.0, 1.0, null, null, null)," +
                         "(null, null, null, null, 1.0, null, null)");
+    }
+
+    @Test
+    public void testShowStatsNestedFields()
+    {
+        assertQuery(
+                "SHOW STATS FOR nested_fields",
+                "VALUES " +
+                        //  column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
+                        "('id', null, null, 0.0, null, 1, 10)," +
+                        "('parent', null, null, null, null, null, null)," +
+                        "('grandparent', null, null, null, null, null, null)," +
+                        "(null, null, null, null, 10.0, null, null)");
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeParquetStatisticsUtils.java
@@ -26,9 +26,13 @@ import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
@@ -171,6 +175,120 @@ public class TestDeltaLakeParquetStatisticsUtils
                 ImmutableMap.of(columnName, "2020-08-26T01:02:03.123Z"));
     }
 
+    @Test
+    public void testNestedFieldStatistics()
+    {
+        String stringColumn = "t_grandparent.t_parent.t_string";
+        PrimitiveType stringType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BINARY, stringColumn);
+        Statistics<?> stringColumnStats = Statistics.getBuilderForReading(stringType)
+                .withMin("abc".getBytes(UTF_8))
+                .withMax("bac".getBytes(UTF_8))
+                .withNumNulls(1)
+                .build();
+
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMin(ImmutableMap.of(stringColumn, Optional.of(stringColumnStats)), ImmutableMap.of(stringColumn, createUnboundedVarcharType())),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of("t_string", "abc"))));
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMax(ImmutableMap.of(stringColumn, Optional.of(stringColumnStats)), ImmutableMap.of(stringColumn, createUnboundedVarcharType())),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of("t_string", "bac"))));
+
+        String booleanColumn = "t_grandparent.t_parent.t_boolean";
+        PrimitiveType booleanType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BOOLEAN, booleanColumn);
+        Statistics<?> booleanColumnStats = Statistics.getBuilderForReading(booleanType)
+                .withMin(getBooleanByteArray(false))
+                .withMax(getBooleanByteArray(true))
+                .withNumNulls(1)
+                .build();
+
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMin(ImmutableMap.of(booleanColumn, Optional.of(booleanColumnStats)), ImmutableMap.of(booleanColumn, BOOLEAN)),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of())));
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMax(ImmutableMap.of(booleanColumn, Optional.of(booleanColumnStats)), ImmutableMap.of(booleanColumn, BOOLEAN)),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of())));
+
+        String nullColumn = "t_parent.t_null";
+        PrimitiveType nullColumnType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.INT32, nullColumn);
+        Statistics<?> nullColumnStats = Statistics.getBuilderForReading(nullColumnType)
+                .withMin(null)
+                .withMax(null)
+                .withNumNulls(1)
+                .build();
+
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMin(ImmutableMap.of(nullColumn, Optional.of(nullColumnStats)), ImmutableMap.of(nullColumn, INTEGER)),
+                ImmutableMap.of("t_parent", ImmutableMap.of()));
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMax(ImmutableMap.of(nullColumn, Optional.of(nullColumnStats)), ImmutableMap.of(nullColumn, INTEGER)),
+                ImmutableMap.of("t_parent", ImmutableMap.of()));
+    }
+
+    @Test
+    public void testMultipleNestedFieldStatistics()
+    {
+        String stringColumn = "t_grandparent.t_parent.t_string";
+        PrimitiveType stringType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BINARY, stringColumn);
+        Statistics<?> stringColumnStats = Statistics.getBuilderForReading(stringType)
+                .withMin("abc".getBytes(UTF_8))
+                .withMax("bac".getBytes(UTF_8))
+                .withNumNulls(1)
+                .build();
+
+        String booleanColumn = "t_grandparent.t_parent.t_boolean";
+        PrimitiveType booleanType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.BOOLEAN, booleanColumn);
+        Statistics<?> booleanColumnStats = Statistics.getBuilderForReading(booleanType)
+                .withMin(getBooleanByteArray(false))
+                .withMax(getBooleanByteArray(true))
+                .withNumNulls(1)
+                .build();
+
+        String timestampColumn = "t_grandparent.t_timestamp";
+        PrimitiveType timestampType = new PrimitiveType(Type.Repetition.REQUIRED, PrimitiveType.PrimitiveTypeName.INT96, timestampColumn);
+        Statistics<?> timestampColumnStats = Statistics.getBuilderForReading(timestampType)
+                .withMin(toParquetEncoding(LocalDateTime.parse("2020-08-26T01:02:03.123456789")))
+                .withMax(toParquetEncoding(LocalDateTime.parse("2020-08-26T01:02:03.123987654")))
+                .withNumNulls(2)
+                .build();
+
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMin(
+                        ImmutableMap.of(stringColumn, Optional.of(stringColumnStats), booleanColumn, Optional.of(booleanColumnStats), timestampColumn, Optional.of(timestampColumnStats)),
+                        ImmutableMap.of(stringColumn, createUnboundedVarcharType(), booleanColumn, BOOLEAN, timestampColumn, TIMESTAMP_TZ_MILLIS)),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of("t_string", "abc"), "t_timestamp", "2020-08-26T01:02:03.123Z")));
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.jsonEncodeMax(
+                        ImmutableMap.of(stringColumn, Optional.of(stringColumnStats), booleanColumn, Optional.of(booleanColumnStats), timestampColumn, Optional.of(timestampColumnStats)),
+                        ImmutableMap.of(stringColumn, createUnboundedVarcharType(), booleanColumn, BOOLEAN, timestampColumn, TIMESTAMP_TZ_MILLIS)),
+                ImmutableMap.of("t_grandparent", ImmutableMap.of("t_parent", ImmutableMap.of("t_string", "bac"), "t_timestamp", "2020-08-26T01:02:03.124Z")));
+    }
+
+    @Test
+    public void testPopulateNestedStats()
+    {
+        Map<String, Optional<Object>> allStats = new HashMap<>();
+        allStats.put("base1", Optional.of(2));
+        allStats.put("base2", Optional.of("base2Value"));
+        allStats.put("base3", Optional.of(100L));
+        allStats.put("base4", Optional.empty()); // should get discarded
+        allStats.put("base5", null); // should get discarded
+        allStats.put("base6.f1", Optional.empty()); // should get discarded
+        allStats.put("base6.f2", Optional.of(99.99));
+        allStats.put("base6.f3", Optional.of("2020-08-26T01:02:03.123Z"));
+        allStats.put("base7.level1.f4", null); // should get discarded
+        allStats.put("base7.level1.f5", Optional.empty()); // should get discarded
+        allStats.put("base7.level1.f6", Optional.of("base5Level1F6Value"));
+
+        assertEquals(
+                DeltaLakeParquetStatisticsUtils.flattenNestedKeyMap(allStats),
+                ImmutableMap.of(
+                        "base1", 2,
+                        "base2", "base2Value",
+                        "base3", 100L,
+                        "base6", ImmutableMap.of("f2", 99.99, "f3", "2020-08-26T01:02:03.123Z"),
+                        "base7", ImmutableMap.of("level1", ImmutableMap.of("f6", "base5Level1F6Value"))));
+    }
+
     private static byte[] toParquetEncoding(LocalDateTime time)
     {
         long timeOfDayNanos = (long) time.getNano() + (time.toEpochSecond(UTC) - time.toLocalDate().atStartOfDay().toEpochSecond(UTC)) * 1_000_000_000;
@@ -201,5 +319,10 @@ public class TestDeltaLakeParquetStatisticsUtils
     static byte[] getDoubleByteArray(double d)
     {
         return ByteBuffer.allocate(8).order(LITTLE_ENDIAN).putDouble(d).array();
+    }
+
+    static byte[] getBooleanByteArray(boolean b)
+    {
+        return ByteBuffer.allocate(1).put((byte) (b ? 1 : 0)).array();
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
@@ -127,7 +127,7 @@ public class BenchmarkExtendedStatistics
                 DeltaLakeColumnHandle column = benchmarkData.columns.get(benchmarkData.random.nextInt(benchmarkData.columnsCount));
                 result += (long) statistics.getMaxColumnValue(column).get();
                 result += (long) statistics.getMinColumnValue(column).get();
-                result += statistics.getNullCount(column.getBaseColumnName()).get();
+                result += statistics.getNullCount(column).get();
             }
         }
         return result;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -14,11 +14,13 @@
 package io.trino.plugin.deltalake.transactionlog.statistics;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.local.LocalInputFile;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -163,6 +165,9 @@ public class TestDeltaLakeFileStatistics
         assertEquals(
                 fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR, Optional.empty())),
                 Optional.empty());
+        assertEquals(
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR, Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0), ImmutableList.of("s1"))))),
+                Optional.of(1L));
         assertEquals(
                 fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), OptionalInt.empty(), "arr", new ArrayType(INTEGER), REGULAR, Optional.empty())),
                 Optional.empty());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes: https://github.com/trinodb/trino/issues/17164

1. x ROW(a INT, b VARCHAR) -> Stats collected for { x.a, x.b } 
2. x ROW(a INT, y ROW(b INT, c STRING)) -> Stats collected for { x.a, x.y.b, x.y.c } 
3. x ROW(a INT, b ARRAY[INT], c MAP(INT, INT)) -> Stats collected for { x.a } 
4. x ROW(a INT,  y ROW(b INT, c ARRAY[INT], MAP(INT, INT))) -> Stats collected for { x.a, x.y.b } 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Delta
* Collect stats for primitive fields inside `row` ({issue}`17486`)
```
