### PR TITLE
Add predicate push down test for dereference column in Delta connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeWriter.java
@@ -57,10 +57,11 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.convertNestedMapKeys;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.hasInvalidStatistics;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMax;
 import static io.trino.plugin.deltalake.transactionlog.DeltaLakeParquetStatisticsUtils.jsonEncodeMin;
@@ -200,10 +201,14 @@ public class DeltaLakeWriter
     private static DeltaLakeJsonFileStatistics readStatistics(TrinoInputFile inputFile, List<String> dataColumnNames, List<Type> dataColumnTypes, long rowCount)
             throws IOException
     {
-        ImmutableMap.Builder<String, Type> typeForColumn = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Type> typeForProjectedColumnBuilder = ImmutableMap.builder();
         for (int i = 0; i < dataColumnNames.size(); i++) {
-            typeForColumn.put(dataColumnNames.get(i), dataColumnTypes.get(i));
+            String columnName = dataColumnNames.get(i);
+            Type columnType = dataColumnTypes.get(i);
+            populateType(columnName, columnType, typeForProjectedColumnBuilder);
         }
+
+        Map<String, Type> typeForProjectedColumn = typeForProjectedColumnBuilder.buildOrThrow();
 
         try (TrinoParquetDataSource trinoParquetDataSource = new TrinoParquetDataSource(
                 inputFile,
@@ -214,15 +219,15 @@ public class DeltaLakeWriter
             ImmutableMultimap.Builder<String, ColumnChunkMetaData> metadataForColumn = ImmutableMultimap.builder();
             for (BlockMetaData blockMetaData : parquetMetadata.getBlocks()) {
                 for (ColumnChunkMetaData columnChunkMetaData : blockMetaData.getColumns()) {
-                    if (columnChunkMetaData.getPath().size() != 1) {
-                        continue; // Only base column stats are supported
+                    checkArgument(columnChunkMetaData.getPath().size() > 0, "columnChunkMetaData path must not be empty");
+                    String columnName = columnChunkMetaData.getPath().toDotString();
+                    if (typeForProjectedColumn.containsKey(columnName)) {
+                        metadataForColumn.put(columnName, columnChunkMetaData);
                     }
-                    String columnName = getOnlyElement(columnChunkMetaData.getPath());
-                    metadataForColumn.put(columnName, columnChunkMetaData);
                 }
             }
 
-            return mergeStats(metadataForColumn.build(), typeForColumn.buildOrThrow(), rowCount);
+            return mergeStats(metadataForColumn.build(), typeForProjectedColumn, rowCount);
         }
     }
 
@@ -232,15 +237,18 @@ public class DeltaLakeWriter
         Map<String, Optional<Statistics<?>>> statsForColumn = metadataForColumn.keySet().stream()
                 .collect(toImmutableMap(identity(), key -> mergeMetadataList(metadataForColumn.get(key))));
 
-        Map<String, Object> nullCount = statsForColumn.entrySet().stream()
+        Map<String, Optional<Object>> nullCount = statsForColumn.entrySet().stream()
                 .filter(entry -> entry.getValue().isPresent())
-                .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().get().getNumNulls()));
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> Optional.of(entry.getValue().get().getNumNulls())));
+
+        // TODO Databricks collect nullCount stats for Map and Array type as well, whereas trino does not collect
+        Map<String, Object> convertedNullCount = convertNestedMapKeys(nullCount);
 
         return new DeltaLakeJsonFileStatistics(
                 Optional.of(rowCount),
                 Optional.of(jsonEncodeMin(statsForColumn, typeForColumn)),
                 Optional.of(jsonEncodeMax(statsForColumn, typeForColumn)),
-                Optional.of(nullCount));
+                Optional.of(convertedNullCount));
     }
 
     private static Optional<Statistics<?>> mergeMetadataList(Collection<ColumnChunkMetaData> metadataList)
@@ -255,6 +263,20 @@ public class DeltaLakeWriter
                     statsA.mergeStatistics(statsB);
                     return statsA;
                 });
+    }
+
+    private static void populateType(String name, Type type, ImmutableMap.Builder<String, Type> typeForProjectedColumn)
+    {
+        if (type instanceof RowType rowType) {
+            List<RowType.Field> fields = rowType.getFields();
+            for (RowType.Field field : fields) {
+                String projectedName = name + "." + field.getName().orElseThrow();
+                populateType(projectedName, field.getType(), typeForProjectedColumn);
+            }
+        }
+        else {
+            typeForProjectedColumn.put(name, type);
+        }
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
@@ -45,6 +45,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.REGULAR;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.createStatisticsPredicate;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.toColumnHandle;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.isExtendedStatisticsEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeSplitManager.partitionMatchesPredicate;
 import static io.trino.spi.statistics.StatsUtil.toStatsRepresentation;
@@ -105,8 +106,9 @@ public class FileBasedTableStatisticsProvider
         Set<String> predicatedColumnNames = tableHandle.getNonPartitionConstraint().getDomains().orElseThrow().keySet().stream()
                 .map(DeltaLakeColumnHandle::getBaseColumnName)
                 .collect(toImmutableSet());
-        List<DeltaLakeColumnMetadata> predicatedColumns = columnMetadata.stream()
+        List<DeltaLakeColumnHandle> predicatedColumns = columnMetadata.stream()
                 .filter(column -> predicatedColumnNames.contains(column.getName()))
+                .map(column -> toColumnHandle(column.getColumnMetadata(), column.getFieldId(), column.getPhysicalName(), column.getPhysicalColumnType(), tableHandle.getMetadataEntry().getCanonicalPartitionColumns()))
                 .collect(toImmutableList());
 
         for (AddFileEntry addEntry : transactionLogAccess.getActiveFiles(tableSnapshot, session)) {
@@ -122,8 +124,7 @@ public class FileBasedTableStatisticsProvider
 
             TupleDomain<DeltaLakeColumnHandle> statisticsPredicate = createStatisticsPredicate(
                     addEntry,
-                    predicatedColumns,
-                    tableHandle.getMetadataEntry().getCanonicalPartitionColumns());
+                    predicatedColumns);
             if (!tableHandle.getNonPartitionConstraint().overlaps(statisticsPredicate)) {
                 continue;
             }
@@ -147,7 +148,7 @@ public class FileBasedTableStatisticsProvider
                     }
                 }
                 else {
-                    Optional<Long> maybeNullCount = column.isBaseColumn() ? stats.getNullCount(column.getBasePhysicalColumnName()) : Optional.empty();
+                    Optional<Long> maybeNullCount = column.isBaseColumn() ? stats.getNullCount(column) : Optional.empty();
                     if (maybeNullCount.isPresent()) {
                         nullCounts.put(column, nullCounts.get(column) + maybeNullCount.get());
                     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -26,6 +26,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.plugin.base.util.JsonUtils;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.transactionlog.checkpoint.LastCheckpoint;
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.DecimalType;
@@ -53,7 +54,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogJsonEntryPath;
@@ -164,8 +164,7 @@ public final class TransactionLogParser
 
     public static Object deserializeColumnValue(DeltaLakeColumnHandle column, String valueString, Function<String, Long> timestampReader)
     {
-        verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
-        Type type = column.getBaseType();
+        Type type = column.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getType).orElse(column.getBaseType());
         try {
             if (type.equals(BOOLEAN)) {
                 if (valueString.equalsIgnoreCase("true")) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeFileStatistics.java
@@ -33,7 +33,7 @@ public interface DeltaLakeFileStatistics
 
     Optional<Map<String, Object>> getNullCount();
 
-    Optional<Long> getNullCount(String columnName);
+    Optional<Long> getNullCount(DeltaLakeColumnHandle columnHandle);
 
     Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -17,10 +17,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.log.Logger;
 import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.transactionlog.CanonicalColumnName;
 import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
 import io.trino.spi.type.TimestampWithTimeZoneType;
@@ -112,28 +114,19 @@ public class DeltaLakeJsonFileStatistics
     @Override
     public Optional<Object> getMaxColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
-        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), maxValues);
+        Optional<Object> value = getStat(columnHandle, maxValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     @Override
     public Optional<Object> getMinColumnValue(DeltaLakeColumnHandle columnHandle)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
-        Optional<Object> value = getStat(columnHandle.getBasePhysicalColumnName(), minValues);
+        Optional<Object> value = getStat(columnHandle, minValues);
         return value.flatMap(o -> deserializeStatisticsValue(columnHandle, String.valueOf(o)));
     }
 
     private Optional<Object> deserializeStatisticsValue(DeltaLakeColumnHandle columnHandle, String statValue)
     {
-        if (!columnHandle.isBaseColumn()) {
-            return Optional.empty();
-        }
         Object columnValue = deserializeColumnValue(columnHandle, statValue, DeltaLakeJsonFileStatistics::readStatisticsTimestamp);
 
         Type columnType = columnHandle.getBaseType();
@@ -161,23 +154,30 @@ public class DeltaLakeJsonFileStatistics
     }
 
     @Override
-    public Optional<Long> getNullCount(String columnName)
+    public Optional<Long> getNullCount(DeltaLakeColumnHandle columnHandle)
     {
-        return getStat(columnName, nullCount).map(o -> Long.valueOf(o.toString()));
+        return getStat(columnHandle, nullCount).map(o -> Long.valueOf(o.toString()));
     }
 
-    private Optional<Object> getStat(String columnName, Optional<Map<CanonicalColumnName, Object>> stats)
+    private Optional<Object> getStat(DeltaLakeColumnHandle columnHandle, Optional<Map<CanonicalColumnName, Object>> stats)
     {
         if (stats.isEmpty()) {
             return Optional.empty();
         }
-        CanonicalColumnName canonicalColumnName = new CanonicalColumnName(columnName);
+        CanonicalColumnName canonicalColumnName = new CanonicalColumnName(columnHandle.getBasePhysicalColumnName());
+        List<String> dereferenceNames = columnHandle.getProjectionInfo().map(DeltaLakeColumnProjectionInfo::getDereferencePhysicalNames)
+                .orElse(ImmutableList.of());
         Object contents = stats.get().get(canonicalColumnName);
+        for (String dereferenceName : dereferenceNames) {
+            if (contents instanceof Map map) {
+                contents = map.get(dereferenceName);
+            }
+        }
         if (contents == null) {
             return Optional.empty();
         }
         if (contents instanceof List || contents instanceof Map) {
-            log.debug("Skipping statistics value for column with complex value type: %s", columnName);
+            log.debug("Skipping statistics value for column with complex value type: %s", columnHandle);
             return Optional.empty();
         }
         return Optional.of(contents);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeComplexTypePredicatePushDown.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeComplexTypePredicatePushDown.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.BaseTestFileFormatComplexTypesPredicatePushDown;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
+import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDeltaLakeQueryRunner;
+
+public class TestDeltaLakeComplexTypePredicatePushDown
+        extends BaseTestFileFormatComplexTypesPredicatePushDown
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createDeltaLakeQueryRunner(
+                DELTA_CATALOG,
+                ImmutableMap.of(),
+                ImmutableMap.of("delta.enable-non-concurrent-writes", "true"));
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeCreateTableStatistics.java
@@ -93,13 +93,13 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(2L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("foo")));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("moo")));
-            assertEquals(fileStatistics.getNullCount("d"), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
 
             for (String complexColumn : ImmutableList.of("a", "b", "c")) {
                 columnHandle = new DeltaLakeColumnHandle(complexColumn, createUnboundedVarcharType(), OptionalInt.empty(), complexColumn, createUnboundedVarcharType(), REGULAR, Optional.empty());
                 assertThat(fileStatistics.getMaxColumnValue(columnHandle)).isEmpty();
                 assertThat(fileStatistics.getMinColumnValue(columnHandle)).isEmpty();
-                assertThat(fileStatistics.getNullCount(complexColumn)).isEmpty();
+                assertThat(fileStatistics.getNullCount(columnHandle)).isEmpty();
             }
         }
     }
@@ -125,7 +125,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(2L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.empty());
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.empty());
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.empty());
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.empty());
         }
     }
 
@@ -147,7 +147,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(3L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(NEGATIVE_INFINITY));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(POSITIVE_INFINITY));
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
         }
     }
 
@@ -169,7 +169,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.empty());
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.empty());
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.empty());
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.empty());
         }
     }
 
@@ -191,7 +191,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.empty());
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.empty());
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.empty());
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.empty());
         }
     }
 
@@ -213,7 +213,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.empty());
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.empty());
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.empty());
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.empty());
         }
     }
 
@@ -269,7 +269,7 @@ public class TestDeltaLakeCreateTableStatistics
             }
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), expectedMin);
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), expectedMax);
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
         }
     }
 
@@ -288,7 +288,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(0.0));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(1.0));
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(2L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(2L));
         }
     }
 
@@ -310,7 +310,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.empty());
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.empty());
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(4L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(4L));
         }
     }
 
@@ -332,7 +332,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(LocalDate.parse("2011-08-08").toEpochDay()));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(LocalDate.parse("2013-08-09").toEpochDay()));
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
         }
     }
 
@@ -358,7 +358,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(
                     fileStatistics.getMaxColumnValue(columnHandle),
                     Optional.of(packDateTimeWithZone(ZonedDateTime.parse("2012-10-31T08:00:00.123Z").toInstant().toEpochMilli(), UTC_KEY)));
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
         }
     }
 
@@ -377,7 +377,7 @@ public class TestDeltaLakeCreateTableStatistics
             assertEquals(fileStatistics.getNumRecords(), Optional.of(2L));
             assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("ab\uFAD8")));
             assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("ab\uD83D\uDD74")));
-            assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+            assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
         }
     }
 
@@ -404,13 +404,13 @@ public class TestDeltaLakeCreateTableStatistics
                     assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("a")));
                     assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("c")));
                     assertEquals(fileStatistics.getNumRecords(), Optional.of(4L));
-                    assertEquals(fileStatistics.getNullCount(columnName), Optional.of(1L));
+                    assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(1L));
                 }
                 else if (addFileEntry.getPartitionValues().get(partitionColumn).equals("2")) {
                     assertEquals(fileStatistics.getMinColumnValue(columnHandle), Optional.of(utf8Slice("c")));
                     assertEquals(fileStatistics.getMaxColumnValue(columnHandle), Optional.of(utf8Slice("e")));
                     assertEquals(fileStatistics.getNumRecords(), Optional.of(3L));
-                    assertEquals(fileStatistics.getNullCount(columnName), Optional.of(0L));
+                    assertEquals(fileStatistics.getNullCount(columnHandle), Optional.of(0L));
                 }
             }
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableStatistics.java
@@ -41,6 +41,9 @@ public class TestDeltaLakeTableStatistics
         String dataPath = Resources.getResource("databricks/person").toExternalForm();
         getQueryRunner().execute(
                 format("CALL system.register_table('%s', 'person', '%s')", getSession().getSchema().orElseThrow(), dataPath));
+        dataPath = Resources.getResource("databricks/pruning/nested_fields").toExternalForm();
+        getQueryRunner().execute(
+                format("CALL system.register_table('%s', 'nested_fields', '%s')", getSession().getSchema().orElseThrow(), dataPath));
     }
 
     @Test
@@ -175,5 +178,18 @@ public class TestDeltaLakeTableStatistics
                         //  column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
                         "('col', 0.0, 0.0, 1.0, null, null, null)," +
                         "(null, null, null, null, 1.0, null, null)");
+    }
+
+    @Test
+    public void testShowStatsNestedFields()
+    {
+        assertQuery(
+                "SHOW STATS FOR nested_fields",
+                "VALUES " +
+                        //  column_name | data_size | distinct_values_count | nulls_fraction | row_count | low_value | high_value
+                        "('id', null, null, 0.0, null, 1, 10)," +
+                        "('parent', null, null, null, null, null, null)," +
+                        "('grandparent', null, null, null, null, null, null)," +
+                        "(null, null, null, null, 10.0, null, null)");
     }
 }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeWriter.java
@@ -64,7 +64,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(intColumn), Optional.of(-200L));
         assertEquals(fileStats.getMaxColumnValue(intColumn), Optional.of(250L));
-        assertEquals(fileStats.getNullCount(columnName), Optional.of(13L));
+        assertEquals(fileStats.getNullCount(intColumn), Optional.of(13L));
     }
 
     @Test
@@ -83,7 +83,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(floatColumn), Optional.of((long) floatToRawIntBits(-2.001f)));
         assertEquals(fileStats.getMaxColumnValue(floatColumn), Optional.of((long) floatToRawIntBits(1.0f)));
-        assertEquals(fileStats.getNullCount(columnName), Optional.of(13L));
+        assertEquals(fileStats.getNullCount(floatColumn), Optional.of(13L));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(floatColumn), Optional.empty());
         assertEquals(fileStats.getMaxColumnValue(floatColumn), Optional.empty());
-        assertEquals(fileStats.getNullCount(columnName), Optional.empty());
+        assertEquals(fileStats.getNullCount(floatColumn), Optional.empty());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(doubleColumn), Optional.empty());
         assertEquals(fileStats.getMaxColumnValue(doubleColumn), Optional.empty());
-        assertEquals(fileStats.getNullCount(columnName), Optional.empty());
+        assertEquals(fileStats.getNullCount(doubleColumn), Optional.empty());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(varcharColumn), Optional.of(utf8Slice("aba")));
         assertEquals(fileStats.getMaxColumnValue(varcharColumn), Optional.of(utf8Slice("ab⌘")));
-        assertEquals(fileStats.getNullCount(columnName), Optional.of(12L));
+        assertEquals(fileStats.getNullCount(varcharColumn), Optional.of(12L));
     }
 
     @Test
@@ -163,7 +163,7 @@ public class TestDeltaLakeWriter
         assertEquals(fileStats.getNumRecords(), Optional.of(20L));
         assertEquals(fileStats.getMinColumnValue(varcharColumn), Optional.of(utf8Slice("aba")));
         assertEquals(fileStats.getMaxColumnValue(varcharColumn), Optional.of(utf8Slice("ab\uD83D\uDD74")));
-        assertEquals(fileStats.getNullCount(columnName), Optional.of(12L));
+        assertEquals(fileStats.getNullCount(varcharColumn), Optional.of(12L));
     }
 
     private ColumnChunkMetaData createMetaData(String columnName, PrimitiveType columnType, long valueCount, Statistics<?> statistics)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestSplitPruning.java
@@ -372,17 +372,40 @@ public class TestSplitPruning
                 Set.of(),
                 0);
 
-        // TODO pruning does not work on primitive fields inside a struct, expected splits should be 1 after file pruning (https://github.com/trinodb/trino/issues/17164)
+        assertResultAndSplitCount(
+                "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 400",
+                Set.of(50.99, 60.99, 70.99, 80.99, 90.99, 100.99),
+                2);
+
         assertResultAndSplitCount(
                 "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 600",
                 Set.of(70.99, 80.99, 90.99, 100.99),
-                2);
+                1);
 
-        // TODO pruning does not work on primitive fields inside a struct, expected splits should be 0 after file pruning (https://github.com/trinodb/trino/issues/17164)
+        assertResultAndSplitCount(
+                "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 600 AND parent.child1 < 1000",
+                Set.of(70.99, 80.99, 90.99),
+                1);
+
+        assertResultAndSplitCount(
+                "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 600 AND grandparent.parent1.child1 < 100",
+                Set.of(70.99, 80.99, 90.99),
+                1);
+
         assertResultAndSplitCount(
                 "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 1000",
                 Set.of(),
-                2);
+                0);
+
+        assertResultAndSplitCount(
+                "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 1000 AND parent.child2 = 'INDIA'",
+                Set.of(),
+                0);
+
+        assertResultAndSplitCount(
+                "SELECT grandparent.parent1.child1 FROM nested_fields WHERE parent.child1 > 1000 AND grandparent.parent1.child1 < 20",
+                Set.of(),
+                0);
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -624,7 +624,7 @@ public class TestTransactionLogAccess
                 DeltaLakeColumnHandle columnHandle = new DeltaLakeColumnHandle(column.getName(), column.getType(), OptionalInt.empty(), column.getName(), column.getType(), REGULAR, Optional.empty());
                 assertEquals(expected.getStats().get().getMinColumnValue(columnHandle), actual.getStats().get().getMinColumnValue(columnHandle));
                 assertEquals(expected.getStats().get().getMaxColumnValue(columnHandle), actual.getStats().get().getMaxColumnValue(columnHandle));
-                assertEquals(expected.getStats().get().getNullCount(columnHandle.getBaseColumnName()), actual.getStats().get().getNullCount(columnHandle.getBaseColumnName()));
+                assertEquals(expected.getStats().get().getNullCount(columnHandle), actual.getStats().get().getNullCount(columnHandle));
                 assertEquals(expected.getStats().get().getNumRecords(), actual.getStats().get().getNumRecords());
             }
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/BenchmarkExtendedStatistics.java
@@ -127,7 +127,7 @@ public class BenchmarkExtendedStatistics
                 DeltaLakeColumnHandle column = benchmarkData.columns.get(benchmarkData.random.nextInt(benchmarkData.columnsCount));
                 result += (long) statistics.getMaxColumnValue(column).get();
                 result += (long) statistics.getMinColumnValue(column).get();
-                result += statistics.getNullCount(column.getBaseColumnName()).get();
+                result += statistics.getNullCount(column).get();
             }
         }
         return result;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/statistics/TestDeltaLakeFileStatistics.java
@@ -14,11 +14,13 @@
 package io.trino.plugin.deltalake.transactionlog.statistics;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.local.LocalInputFile;
 import io.trino.plugin.deltalake.DeltaLakeColumnHandle;
+import io.trino.plugin.deltalake.DeltaLakeColumnProjectionInfo;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeTransactionLogEntry;
 import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
@@ -163,6 +165,9 @@ public class TestDeltaLakeFileStatistics
         assertEquals(
                 fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR, Optional.empty())),
                 Optional.empty());
+        assertEquals(
+                fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("row", rowType, OptionalInt.empty(), "row", rowType, REGULAR, Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0), ImmutableList.of("s1"))))),
+                Optional.of(1L));
         assertEquals(
                 fileStatistics.getMinColumnValue(new DeltaLakeColumnHandle("arr", new ArrayType(INTEGER), OptionalInt.empty(), "arr", new ArrayType(INTEGER), REGULAR, Optional.empty())),
                 Optional.empty());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Predicate pushdown for parquet dereference column is implemented in https://github.com/trinodb/trino/pull/15163. Delta connector gets direct benefits from this implementation.

1st cherry-pick -> https://github.com/trinodb/trino/pull/17464
2nd cherry-pick -> https://github.com/trinodb/trino/pull/17486

Fixes https://github.com/trinodb/trino/issues/17463

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
