### PR TITLE
Put testing with with JDK 20 on hold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         java-version:
           - 17
-          - 20
+          - 19
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
@@ -542,7 +542,7 @@ jobs:
           include:
             - { modules: [ client/trino-jdbc, plugin/trino-base-jdbc, plugin/trino-thrift, plugin/trino-memory ] }
             - { modules: core/trino-main }
-            - { modules: core/trino-main, jdk: 20 }
+            - { modules: core/trino-main, jdk: 19 }
             - { modules: plugin/trino-accumulo }
             - { modules: plugin/trino-bigquery }
             - { modules: plugin/trino-bigquery, profile: cloud-tests-arrow }


### PR DESCRIPTION
We observed CI instability with 20. We should reintroduce testing with 20 in a way that doesn't break the CI builds.

Motivation / context: https://github.com/trinodb/trino/issues/16933#issuecomment-1546718406
stress test on the CI with further evidence: https://github.com/trinodb/trino/pull/17490

Hopefully fixes https://github.com/trinodb/trino/issues/16987
Hopefully fixes https://github.com/trinodb/trino/issues/16933