### PR TITLE
Apply Limit to the payload when sending split completed events

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/SplitMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/SplitMonitor.java
@@ -14,7 +14,6 @@
 package io.trino.event;
 
 import io.airlift.json.JsonCodec;
-import io.airlift.log.Logger;
 import io.trino.eventlistener.EventListenerManager;
 import io.trino.execution.TaskId;
 import io.trino.operator.DriverStats;
@@ -36,20 +35,19 @@ import static java.util.Objects.requireNonNull;
 
 public class SplitMonitor
 {
-    private static final Logger log = Logger.get(SplitMonitor.class);
-
     private final JsonCodec<DriverStats> driverStatsJsonCodec;
     private final EventListenerManager eventListenerManager;
     private final int maxJsonLimit;
 
     @Inject
     public SplitMonitor(EventListenerManager eventListenerManager, JsonCodec<DriverStats> driverStatsJsonCodec,
-            QueryMonitorConfig queryMonitorConfig)
+            SplitMonitorConfig splitMonitorConfig)
     {
         this.eventListenerManager = requireNonNull(eventListenerManager, "eventListenerManager is null");
-        this.driverStatsJsonCodec = requireNonNull(driverStatsJsonCodec, "objectMapper is null");
+        this.driverStatsJsonCodec = requireNonNull(driverStatsJsonCodec, "driverStatsJsonCodec is null");
         this.maxJsonLimit = toIntExact(
-                requireNonNull(queryMonitorConfig, "queryMonitorConfig is null").getMaxOutputStageJsonSize().toBytes());
+                requireNonNull(splitMonitorConfig, "splitMonitorConfig is null").getMaxSplitOutputStageJsonSize()
+                        .toBytes());
     }
 
     public void splitCompletedEvent(TaskId taskId, DriverStats driverStats)

--- a/core/trino-main/src/main/java/io/trino/event/SplitMonitorConfig.java
+++ b/core/trino-main/src/main/java/io/trino/event/SplitMonitorConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.event;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.DataSize;
+import io.airlift.units.DataSize.Unit;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MinDataSize;
+
+import javax.validation.constraints.NotNull;
+
+public class SplitMonitorConfig
+{
+    private DataSize maxSplitOutputStageJsonSize = DataSize.of(16, Unit.MEGABYTE);
+
+    @MinDataSize("1kB")
+    @MaxDataSize("1GB")
+    @NotNull
+    public DataSize getMaxSplitOutputStageJsonSize()
+    {
+        return maxSplitOutputStageJsonSize;
+    }
+
+    @Config("event.max-split-output-stage-size")
+    public SplitMonitorConfig setMaxSplitOutputStageJsonSize(DataSize maxSplitOutputStageJsonSize)
+    {
+        this.maxSplitOutputStageJsonSize = maxSplitOutputStageJsonSize;
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -85,6 +85,7 @@ import io.trino.memory.NoneLowMemoryKiller;
 import io.trino.memory.TotalReservationLowMemoryKiller;
 import io.trino.memory.TotalReservationOnBlockedNodesQueryLowMemoryKiller;
 import io.trino.memory.TotalReservationOnBlockedNodesTaskLowMemoryKiller;
+import io.trino.operator.DriverStats;
 import io.trino.operator.ForScheduler;
 import io.trino.operator.OperatorStats;
 import io.trino.server.protocol.ExecutingStatementResource;
@@ -172,6 +173,7 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(OperatorStats.class);
         jsonCodecBinder(binder).bindJsonCodec(StageInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(StatsAndCosts.class);
+        jsonCodecBinder(binder).bindJsonCodec(DriverStats.class);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
 

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -85,7 +85,6 @@ import io.trino.memory.NoneLowMemoryKiller;
 import io.trino.memory.TotalReservationLowMemoryKiller;
 import io.trino.memory.TotalReservationOnBlockedNodesQueryLowMemoryKiller;
 import io.trino.memory.TotalReservationOnBlockedNodesTaskLowMemoryKiller;
-import io.trino.operator.DriverStats;
 import io.trino.operator.ForScheduler;
 import io.trino.operator.OperatorStats;
 import io.trino.server.protocol.ExecutingStatementResource;
@@ -173,7 +172,6 @@ public class CoordinatorModule
         jsonCodecBinder(binder).bindJsonCodec(OperatorStats.class);
         jsonCodecBinder(binder).bindJsonCodec(StageInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(StatsAndCosts.class);
-        jsonCodecBinder(binder).bindJsonCodec(DriverStats.class);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
 

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -35,6 +35,7 @@ import io.trino.client.NodeVersion;
 import io.trino.connector.system.SystemConnectorModule;
 import io.trino.dispatcher.DispatchManager;
 import io.trino.event.SplitMonitor;
+import io.trino.event.SplitMonitorConfig;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.ExplainAnalyzeContext;
 import io.trino.execution.FailureInjectionConfig;
@@ -83,6 +84,7 @@ import io.trino.metadata.TypeRegistry;
 import io.trino.operator.DirectExchangeClientConfig;
 import io.trino.operator.DirectExchangeClientFactory;
 import io.trino.operator.DirectExchangeClientSupplier;
+import io.trino.operator.DriverStats;
 import io.trino.operator.ForExchange;
 import io.trino.operator.GroupByHashPageIndexerFactory;
 import io.trino.operator.OperatorFactories;
@@ -425,6 +427,8 @@ public class ServerMainModule
         jsonBinder(binder).addDeserializerBinding(Expression.class).to(ExpressionDeserializer.class);
 
         // split monitor
+        jsonCodecBinder(binder).bindJsonCodec(DriverStats.class);
+        configBinder(binder).bindConfig(SplitMonitorConfig.class);
         binder.bind(SplitMonitor.class).in(Scopes.SINGLETON);
 
         // version and announcement

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -15,11 +15,13 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.cost.StatsAndCosts;
+import io.trino.event.QueryMonitorConfig;
 import io.trino.event.SplitMonitor;
 import io.trino.eventlistener.EventListenerConfig;
 import io.trino.eventlistener.EventListenerManager;
@@ -32,6 +34,7 @@ import io.trino.execution.scheduler.UniformNodeSelectorFactory;
 import io.trino.index.IndexManager;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.Split;
+import io.trino.operator.DriverStats;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.TrinoOperatorFactories;
 import io.trino.operator.index.IndexJoinLookupStats;
@@ -188,8 +191,8 @@ public final class TaskTestUtils
 
     public static SplitMonitor createTestSplitMonitor()
     {
-        return new SplitMonitor(
-                new EventListenerManager(new EventListenerConfig()),
-                new ObjectMapperProvider().get());
+        return new SplitMonitor(new EventListenerManager(new EventListenerConfig()),
+                new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(DriverStats.class),
+                new QueryMonitorConfig());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -21,8 +21,8 @@ import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.cost.StatsAndCosts;
-import io.trino.event.QueryMonitorConfig;
 import io.trino.event.SplitMonitor;
+import io.trino.event.SplitMonitorConfig;
 import io.trino.eventlistener.EventListenerConfig;
 import io.trino.eventlistener.EventListenerManager;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -193,6 +193,6 @@ public final class TaskTestUtils
     {
         return new SplitMonitor(new EventListenerManager(new EventListenerConfig()),
                 new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(DriverStats.class),
-                new QueryMonitorConfig());
+                new SplitMonitorConfig());
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -222,6 +222,22 @@
                                         <match>@io.trino.spi.Unstable *;</match>
                                     </old>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>
+                                        <matcher>java</matcher>
+                                        <match>@io.trino.spi.Unstable *;</match>
+                                    </old>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method java.lang.String io.trino.spi.eventlistener.SplitCompletedEvent::getPayload()</old>
+                                    <new>method java.util.Optional&lt;java.lang.String&gt; io.trino.spi.eventlistener.SplitCompletedEvent::getPayload()</new>
+                                    <justification>The class is marked @Unstable</justification>
+                                </item>
+
                                 <!-- Allow removing things that were previously deprecated -->
                                 <item>
                                     <regex>true</regex>

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
@@ -40,7 +40,7 @@ public class SplitCompletedEvent
     private final SplitStatistics statistics;
     private final Optional<SplitFailureInfo> failureInfo;
 
-    private final String payload;
+    private final Optional<String> payload;
 
     @JsonCreator
     @Unstable
@@ -54,7 +54,7 @@ public class SplitCompletedEvent
             Optional<Instant> endTime,
             SplitStatistics statistics,
             Optional<SplitFailureInfo> failureInfo,
-            String payload)
+            Optional<String> payload)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.stageId = requireNonNull(stageId, "stageId is null");
@@ -117,7 +117,7 @@ public class SplitCompletedEvent
     }
 
     @JsonProperty
-    public String getPayload()
+    public Optional<String> getPayload()
     {
         return payload;
     }

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpEventListener.java
@@ -201,7 +201,7 @@ public class TestHttpEventListener
                 Optional.of(Instant.now()),
                 splitStatistics,
                 Optional.empty(),
-                "payload");
+                Optional.of("payload"));
 
         queryCreatedEvent = new QueryCreatedEvent(
                 Instant.now(),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The current pull request integrates the capability to enforce a JSON payload size limit when dispatching split-completed events, aligning its truncation behavior with that observed in query-completed events.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
In certain instances, Driver statistics may reach significant volumes, necessitating their exclusion similar to the procedure employed for query-completed events
Changing the return type of payload to optional, To keep it consistent with the QueryCompleted event leads to a change in the SPI. Another option is to keep it as is and return a `null` String.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

() This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X ) Release notes are required, with the following suggested text:
```
Discard output stage JSON from split completion event when it is very long.
  This limit can be configured with `event.max-split-output-stage-size`
```
