### PR TITLE
Add `catalogVersion` into `QueryInputMetadata` & `QueryOutputMetadata`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -431,6 +431,7 @@ public class QueryMonitor
 
             inputs.add(new QueryInputMetadata(
                     input.getCatalogName(),
+                    input.getCatalogVersion(),
                     input.getSchema(),
                     input.getTable(),
                     input.getColumns().stream()
@@ -462,6 +463,7 @@ public class QueryMonitor
             output = Optional.of(
                     new QueryOutputMetadata(
                             queryInfo.getOutput().get().getCatalogName(),
+                            queryInfo.getOutput().get().getCatalogVersion(),
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             outputColumnsMetadata,

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -291,6 +291,7 @@ public class CreateTableTask
         }
         outputConsumer.accept(new Output(
                 catalogName,
+                catalogHandle.getVersion(),
                 tableName.getSchemaName(),
                 tableName.getObjectName(),
                 Optional.of(tableMetadata.getColumns().stream()

--- a/core/trino-main/src/main/java/io/trino/execution/Input.java
+++ b/core/trino-main/src/main/java/io/trino/execution/Input.java
@@ -49,21 +49,13 @@ public final class Input
             @JsonProperty("fragmentId") PlanFragmentId fragmentId,
             @JsonProperty("planNodeId") PlanNodeId planNodeId)
     {
-        requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(schema, "schema is null");
-        requireNonNull(table, "table is null");
-        requireNonNull(connectorInfo, "connectorInfo is null");
-        requireNonNull(columns, "columns is null");
-        requireNonNull(fragmentId, "fragmentId is null");
-        requireNonNull(planNodeId, "planNodeId is null");
-
-        this.catalogName = catalogName;
-        this.schema = schema;
-        this.table = table;
-        this.connectorInfo = connectorInfo;
-        this.columns = ImmutableList.copyOf(columns);
-        this.fragmentId = fragmentId;
-        this.planNodeId = planNodeId;
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.table = requireNonNull(table, "table is null");
+        this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.fragmentId = requireNonNull(fragmentId, "fragmentId is null");
+        this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/execution/Input.java
+++ b/core/trino-main/src/main/java/io/trino/execution/Input.java
@@ -16,6 +16,7 @@ package io.trino.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 
@@ -32,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 public final class Input
 {
     private final String catalogName;
+    private final CatalogVersion catalogVersion;
     private final String schema;
     private final String table;
     private final List<Column> columns;
@@ -42,6 +44,7 @@ public final class Input
     @JsonCreator
     public Input(
             @JsonProperty("catalogName") String catalogName,
+            @JsonProperty("catalogVersion") CatalogVersion catalogVersion,
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
             @JsonProperty("connectorInfo") Optional<Object> connectorInfo,
@@ -50,6 +53,7 @@ public final class Input
             @JsonProperty("planNodeId") PlanNodeId planNodeId)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.catalogVersion = requireNonNull(catalogVersion, "catalogVersion is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.connectorInfo = requireNonNull(connectorInfo, "connectorInfo is null");
@@ -62,6 +66,12 @@ public final class Input
     public String getCatalogName()
     {
         return catalogName;
+    }
+
+    @JsonProperty
+    public CatalogVersion getCatalogVersion()
+    {
+        return catalogVersion;
     }
 
     @JsonProperty
@@ -111,6 +121,7 @@ public final class Input
         }
         Input input = (Input) o;
         return Objects.equals(catalogName, input.catalogName) &&
+                Objects.equals(catalogVersion, input.catalogVersion) &&
                 Objects.equals(schema, input.schema) &&
                 Objects.equals(table, input.table) &&
                 Objects.equals(columns, input.columns) &&
@@ -122,7 +133,7 @@ public final class Input
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalogName, schema, table, columns, connectorInfo, fragmentId, planNodeId);
+        return Objects.hash(catalogName, catalogVersion, schema, table, columns, connectorInfo, fragmentId, planNodeId);
     }
 
     @Override
@@ -130,6 +141,7 @@ public final class Input
     {
         return toStringHelper(this)
                 .addValue(catalogName)
+                .addValue(catalogVersion)
                 .addValue(schema)
                 .addValue(table)
                 .addValue(columns)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
@@ -16,6 +16,7 @@ package io.trino.sql.analyzer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -29,6 +30,7 @@ import static java.util.Objects.requireNonNull;
 public final class Output
 {
     private final String catalogName;
+    private final CatalogVersion catalogVersion;
     private final String schema;
     private final String table;
     private final Optional<List<OutputColumn>> columns;
@@ -36,11 +38,13 @@ public final class Output
     @JsonCreator
     public Output(
             @JsonProperty("catalogName") String catalogName,
+            @JsonProperty("catalogVersion") CatalogVersion catalogVersion,
             @JsonProperty("schema") String schema,
             @JsonProperty("table") String table,
             @JsonProperty("columns") Optional<List<OutputColumn>> columns)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.catalogVersion = requireNonNull(catalogVersion, "catalogVersion is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = columns.map(ImmutableList::copyOf);
@@ -50,6 +54,12 @@ public final class Output
     public String getCatalogName()
     {
         return catalogName;
+    }
+
+    @JsonProperty
+    public CatalogVersion getCatalogVersion()
+    {
+        return catalogVersion;
     }
 
     @JsonProperty
@@ -81,6 +91,7 @@ public final class Output
         }
         Output output = (Output) o;
         return Objects.equals(catalogName, output.catalogName) &&
+                Objects.equals(catalogVersion, output.catalogVersion) &&
                 Objects.equals(schema, output.schema) &&
                 Objects.equals(table, output.table) &&
                 Objects.equals(columns, output.columns);
@@ -89,6 +100,6 @@ public final class Output
     @Override
     public int hashCode()
     {
-        return Objects.hash(catalogName, schema, table, columns);
+        return Objects.hash(catalogName, catalogVersion, schema, table, columns);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
@@ -67,7 +67,15 @@ public class InputExtractor
         CatalogSchemaTableName tableName = metadata.getTableName(session, table);
         SchemaTableName schemaTable = tableName.getSchemaTableName();
         Optional<Object> inputMetadata = metadata.getInfo(session, table);
-        return new Input(tableName.getCatalogName(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), fragmentId, planNodeId);
+        return new Input(
+                tableName.getCatalogName(),
+                table.getCatalogHandle().getVersion(),
+                schemaTable.getSchemaName(),
+                schemaTable.getTableName(),
+                inputMetadata,
+                ImmutableList.copyOf(columns),
+                fragmentId,
+                planNodeId);
     }
 
     private class Visitor

--- a/core/trino-main/src/test/java/io/trino/execution/TestInput.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestInput.java
@@ -15,6 +15,7 @@ package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.testng.annotations.Test;
@@ -32,6 +33,7 @@ public class TestInput
     {
         Input expected = new Input(
                 "connectorId",
+                new CatalogVersion("default"),
                 "schema",
                 "table",
                 Optional.empty(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryInfo.java
@@ -22,6 +22,7 @@ import io.trino.operator.RetryPolicy;
 import io.trino.spi.QueryId;
 import io.trino.spi.TrinoWarning;
 import io.trino.spi.WarningCode;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.security.SelectedRole;
@@ -119,7 +120,7 @@ public class TestQueryInfo
                 null,
                 null,
                 ImmutableList.of(new TrinoWarning(new WarningCode(1, "name"), "message")),
-                ImmutableSet.of(new Input("catalog", "schema", "talble", Optional.empty(), ImmutableList.of(new Column("name", "type")), new PlanFragmentId("id"), new PlanNodeId("1"))),
+                ImmutableSet.of(new Input("catalog", new CatalogVersion("default"), "schema", "talble", Optional.empty(), ImmutableList.of(new Column("name", "type")), new PlanFragmentId("id"), new PlanNodeId("1"))),
                 Optional.empty(),
                 ImmutableList.of(),
                 ImmutableList.of(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStateMachine.java
@@ -28,6 +28,7 @@ import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.type.Type;
@@ -82,6 +83,7 @@ public class TestQueryStateMachine
     private static final URI LOCATION = URI.create("fake://fake-query");
     private static final List<Input> INPUTS = ImmutableList.of(new Input(
             "connector",
+            new CatalogVersion("default"),
             "schema",
             "table",
             Optional.empty(),

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.trino.execution.Column;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.sql.analyzer.Analysis.SourceColumn;
 import org.testng.annotations.Test;
 
@@ -34,6 +35,7 @@ public class TestOutput
     {
         Output expected = new Output(
                 "connectorId",
+                new CatalogVersion("default"),
                 "schema",
                 "table",
                 Optional.of(

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
@@ -16,6 +16,7 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.spi.metrics.Metrics;
 
 import java.util.List;
@@ -30,6 +31,7 @@ import static java.util.Objects.requireNonNull;
 public class QueryInputMetadata
 {
     private final String catalogName;
+    private final CatalogVersion catalogVersion;
     private final String schema;
     private final String table;
     private final List<String> columns;
@@ -40,7 +42,9 @@ public class QueryInputMetadata
 
     @JsonCreator
     @Unstable
-    public QueryInputMetadata(String catalogName,
+    public QueryInputMetadata(
+            String catalogName,
+            CatalogVersion catalogVersion,
             String schema,
             String table,
             List<String> columns,
@@ -50,6 +54,7 @@ public class QueryInputMetadata
             OptionalLong physicalInputRows)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.catalogVersion = requireNonNull(catalogVersion, "catalogVersion is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = requireNonNull(columns, "columns is null");
@@ -63,6 +68,12 @@ public class QueryInputMetadata
     public String getCatalogName()
     {
         return catalogName;
+    }
+
+    @JsonProperty
+    public CatalogVersion getCatalogVersion()
+    {
+        return catalogVersion;
     }
 
     @JsonProperty

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
@@ -16,6 +16,7 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +29,7 @@ import static java.util.Objects.requireNonNull;
 public class QueryOutputMetadata
 {
     private final String catalogName;
+    private final CatalogVersion catalogVersion;
     private final String schema;
     private final String table;
     private final Optional<List<OutputColumnMetadata>> columns;
@@ -37,8 +39,9 @@ public class QueryOutputMetadata
 
     @JsonCreator
     @Unstable
-    public QueryOutputMetadata(String catalogName, String schema, String table, Optional<List<OutputColumnMetadata>> columns, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
+    public QueryOutputMetadata(String catalogName, CatalogVersion catalogVersion, String schema, String table, Optional<List<OutputColumnMetadata>> columns, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
     {
+        this.catalogVersion = requireNonNull(catalogVersion, "catalogVersion is null");
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
@@ -51,6 +54,12 @@ public class QueryOutputMetadata
     public String getCatalogName()
     {
         return catalogName;
+    }
+
+    @JsonProperty
+    public CatalogVersion getCatalogVersion()
+    {
+        return catalogVersion;
     }
 
     @JsonProperty

--- a/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
+++ b/plugin/trino-mysql-event-listener/src/test/java/io/trino/plugin/eventlistener/mysql/TestMysqlEventListener.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 import io.airlift.json.JsonCodecFactory;
 import io.trino.spi.TrinoWarning;
+import io.trino.spi.connector.CatalogHandle.CatalogVersion;
 import io.trino.spi.connector.StandardWarningCode;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.EventListener;
@@ -157,6 +158,7 @@ public class TestMysqlEventListener
             List.of(
                     new QueryInputMetadata(
                             "catalog1",
+                            new CatalogVersion("default"),
                             "schema1",
                             "table1",
                             List.of("column1", "column2"),
@@ -166,6 +168,7 @@ public class TestMysqlEventListener
                             OptionalLong.of(202)),
                     new QueryInputMetadata(
                             "catalog2",
+                            new CatalogVersion("default"),
                             "schema2",
                             "table2",
                             List.of("column3", "column4"),
@@ -175,6 +178,7 @@ public class TestMysqlEventListener
                             OptionalLong.of(204))),
             Optional.of(new QueryOutputMetadata(
                     "catalog3",
+                    new CatalogVersion("default"),
                     "schema3",
                     "table3",
                     Optional.of(List.of(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

As a follow-up on @dain 's work for adding `version` to the `CatalogHandle`, this PR adds `catalogVersion` to the `inputs` and `output` fields from `QueryIOMetadata` to eventually distinguish the catalog version from the output sent to the event listener for the tables involved in Trino queries.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
