### PR TITLE
Avoid using trace span links

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -335,8 +335,6 @@ public class QueuedStatementResource
             this.queryInfoUrl = queryInfoUrlFactory.getQueryInfoUrl(queryId);
             requireNonNull(tracer, "tracer is null");
             this.querySpan = tracer.spanBuilder("query")
-                    .addLink(Span.current().getSpanContext())
-                    .setNoParent()
                     .setAttribute(TrinoAttributes.QUERY_ID, queryId.toString())
                     .startSpan();
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Make the query span child of the current span and avoid using links, because there's always a single query that exists only in the context of a series of client requests. If the client propagates a root span, the query should be a child of that span.

This is also needed, because some tools, like DataDog, don't support OTEL span links at all.

Thanks to this, the whole query is visible along with the client span:
![image](https://github.com/trinodb/trino/assets/795177/135fcd7c-77b9-4a91-b105-491081088c31)

Without this, only the server requests are visible:
![image](https://github.com/trinodb/trino/assets/795177/14693276-7bb2-4a50-a195-3bf12b5a8f7b)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: