### PR TITLE
Remove warning about experimental ARM support

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -74,9 +74,6 @@ final class TrinoSystemRequirements
             if (!ImmutableSet.of("amd64", "aarch64", "ppc64le").contains(osArch)) {
                 failRequirement("Trino requires amd64, aarch64, or ppc64le on Linux (found %s)", osArch);
             }
-            if ("aarch64".equals(osArch)) {
-                warnRequirement("Support for the ARM architecture is experimental");
-            }
             else if ("ppc64le".equals(osArch)) {
                 warnRequirement("Support for the POWER architecture is experimental");
             }


### PR DESCRIPTION
## Description
Trino deployments on ARM are common enough that it shouldn't be considered experimental anymore


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: