### PR TITLE
Improve Delta lake caching of metadata

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConcurrentWrites.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConcurrentWrites.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.Session;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeConcurrentWrites
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("delta_lake")
+                .setSchema("default")
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .build();
+        try {
+            String metastoreDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_metastore").toFile().getAbsoluteFile().toURI().toString();
+            String writeMetastoreDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_write_metastore").toFile().getAbsoluteFile().toURI().toString();
+
+            queryRunner.installPlugin(new TestingDeltaLakePlugin(Optional.empty(), Optional.of(new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS)), EMPTY_MODULE));
+            queryRunner.createCatalog(
+                    "delta_lake",
+                    "delta_lake",
+                    Map.of(
+                            "hive.metastore", "file",
+                            "hive.metastore.catalog.dir", metastoreDirectory,
+                            "delta.enable-non-concurrent-writes", "true"));
+            queryRunner.createCatalog(
+                    "delta_lake_writer",
+                    "delta_lake",
+                    Map.of(
+                            "hive.metastore", "file",
+                            "hive.metastore.catalog.dir", writeMetastoreDirectory,
+                            "delta.register-table-procedure.enabled", "true",
+                            "delta.default-checkpoint-writing-interval", "2",
+                            "delta.enable-non-concurrent-writes", "true"));
+
+            queryRunner.execute("CREATE SCHEMA " + session.getSchema().orElseThrow());
+            queryRunner.execute("CREATE SCHEMA delta_lake_writer." + session.getSchema().orElseThrow());
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    @Test
+    public void testMetadataEntryIsFresh()
+    {
+        String tableName = "test_checkpoint_metadata_file_operations";
+        String schema = getSession().getSchema().orElseThrow();
+        String writeTable = "delta_lake_writer." + schema + "." + tableName;
+
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate("CREATE TABLE " + tableName + "(c varchar) COMMENT 'commit-0' WITH (checkpoint_interval = 2)");
+        assertUpdate("CALL delta_lake_writer.system.register_table(schema_name => '" + schema + "', table_name => '" + tableName + "', table_location => '" + getTableLocation(tableName) + "')");
+
+        assertUpdate("COMMENT ON TABLE " + writeTable + " IS 'commit-1'");
+        assertUpdate("INSERT INTO " + writeTable + " VALUES 'commit-2'", 1); // metadata commits do not trigger checkpoint writes
+        assertThat(getTableComment(tableName)).isEqualTo("commit-1");
+
+        assertUpdate("COMMENT ON TABLE " + writeTable + " IS 'commit-3'");
+        assertUpdate("INSERT INTO " + writeTable + " VALUES 'commit-4'", 1);
+        assertThat(getTableComment(tableName)).isEqualTo("commit-3");
+    }
+
+    private String getTableLocation(String tableName)
+    {
+        Pattern locationPattern = Pattern.compile(".*location = '(.*?)'.*", Pattern.DOTALL);
+        Matcher m = locationPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        if (m.find()) {
+            String location = m.group(1);
+            verify(!m.find(), "Unexpected second match");
+            return location;
+        }
+        throw new IllegalStateException("Location not found in SHOW CREATE TABLE result");
+    }
+
+    private String getTableComment(String tableName)
+    {
+        Pattern commentPattern = Pattern.compile(".*COMMENT\\s+'([^']*)'.*", Pattern.DOTALL);
+        Matcher m = commentPattern.matcher((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue());
+        if (m.find()) {
+            String location = m.group(1);
+            verify(!m.find(), "Unexpected second match");
+            return location;
+        }
+        throw new IllegalStateException("COMMENT not found in SHOW CREATE TABLE result");
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -115,7 +115,7 @@ public class TestDeltaLakeFileOperations
                         .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_NEW_STREAM), 1)
                         .build());
         trackingFileSystemFactory.reset();
-        // reads of checkpoint, commits and metadata are partially cached
+        // reads of checkpoint and commits are cached
         assertFileSystemAccesses(
                 "SELECT * FROM test_checkpoint_file_operations",
                 ImmutableMultiset.<FileOperation>builder()
@@ -136,8 +136,8 @@ public class TestDeltaLakeFileOperations
                         .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 2)
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", INPUT_FILE_NEW_STREAM), 2)
-                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 2) // read metadata and protocol entries
-                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 1) // read protocol entries
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 2)
                         .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_GET_LENGTH), 1)
                         .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_NEW_STREAM), 1)
                         .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_GET_LENGTH), 1)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, when a new commit is made to a Delta table, the cached metadata entry of the most up to date `TableSnapshot` is invalidated. This means that a metadata entry must be re-read from the checkpoint and the commits made after the checkpoint (please see https://github.com/trinodb/trino/commit/c0d09377b05000145852fff6e7e649c9f6ba76de). This is unnecessary work, as we always read the new commits, and could be reconciling the cached metadata entry with the possible metadata entries loaded from the new commits.

This PR modifies the `TransactionLogTail` to keep track of any metadata entries it may contain. In the `TableSnapshot` the cached metadata entry is reconciled with any metadata entry of the `TransactionLogTail`.

This fixes the seconds part of https://github.com/trinodb/trino/issues/17406 .

Similar code can be added to cache the protocol entry, to avoid any reads from the checkpoint files except when new checkpoints are made. I'd be happy to contribute this as well.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Please see https://github.com/trinodb/trino/issues/17406 .

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Improve caching of metadata entries from Delta logs. ({issue}`17406`)
```
