### PR TITLE
Increase artifact-checks timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
   artifact-checks:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description

Fixes #17512 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.