### PR TITLE
Add dependency-reduced-pom.xml files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ product-test-reports
 .github/test-matrix.yaml
 .github/test-pt-matrix.yaml
 .github/bin/redshift/.cluster-identifier
+**/dependency-reduced-pom.xml


### PR DESCRIPTION
It is generated by maven-shade-plugin and it shouldn't be checked into the repository