### PR TITLE
Fix improper maven plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2073,8 +2073,8 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
                     <configuration>
                         <runOnlyOnce>true</runOnlyOnce>
                         <injectAllReactorProjects>true</injectAllReactorProjects>


### PR DESCRIPTION
https://github.com/trinodb/trino/pull/17484 switched git-commit-id plugin to new coordinates but the configuration in the parent pom wasn't updated properly.