### PR TITLE
Fix typo in Hive docs

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -397,7 +397,7 @@ Specific properties can be used to further configure the
 Thrift metastore configuration properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In order to use a Hive Thrisft metastore, you must configure the metastore with
+In order to use a Hive Thrift metastore, you must configure the metastore with
 ``hive.metastore=thrift`` and provide further details with the following
 properties:
 


### PR DESCRIPTION

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
