### PR TITLE
Migrate trino-base-jdbc to AssertJ

### DIFF
--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -262,6 +262,20 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules combine.children="append">
+                        <RestrictImports>
+                            <reason>Use AssertJ assertions instead of TestNG</reason>
+                            <bannedImport>org.testng.Assert.*</bannedImport>
+                            <bannedImport>org.testng.AssertJUnit.*</bannedImport>
+                            <bannedImport>org.testng.asserts.**</bannedImport>
+                        </RestrictImports>
+                    </rules>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logging;
 import io.trino.plugin.jdbc.mapping.IdentifierMappingModule;
 import io.trino.plugin.jdbc.mapping.SchemaMappingRule;
@@ -36,7 +35,6 @@ import static io.trino.plugin.jdbc.mapping.RuleBasedIdentifierMappingUtils.updat
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 // Tests are using JSON based identifier mapping which is one for all tests
 @Test(singleThreaded = true)
@@ -90,11 +88,10 @@ public abstract class BaseCaseInsensitiveMappingTest
             assertQuery(
                     "SELECT column_name FROM information_schema.columns WHERE table_name = 'nonlowercasetable'",
                     "VALUES 'lower_case_name', 'mixed_case_name', 'upper_case_name'");
-            assertEquals(
-                    computeActual("SHOW COLUMNS FROM someschema.nonlowercasetable").getMaterializedRows().stream()
+            assertThat(computeActual("SHOW COLUMNS FROM someschema.nonlowercasetable").getMaterializedRows().stream()
                             .map(row -> row.getField(0))
-                            .collect(toImmutableSet()),
-                    ImmutableSet.of("lower_case_name", "mixed_case_name", "upper_case_name"));
+                            .collect(toImmutableSet()))
+                    .containsOnly("lower_case_name", "mixed_case_name", "upper_case_name");
 
             // Note: until https://github.com/prestodb/presto/issues/2863 is resolved, this is *the* way to access the tables.
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -111,7 +111,6 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertFalse;
 
 public abstract class BaseJdbcConnectorTest
         extends BaseConnectorTest
@@ -1796,17 +1795,17 @@ public abstract class BaseJdbcConnectorTest
     public void testNativeQueryCreateStatement()
     {
         skipTestUnless(hasBehavior(SUPPORTS_NATIVE_QUERY));
-        assertFalse(getQueryRunner().tableExists(getSession(), "numbers"));
+        assertThat(getQueryRunner().tableExists(getSession(), "numbers")).isFalse();
         assertThatThrownBy(() -> query("SELECT * FROM TABLE(system.query(query => 'CREATE TABLE numbers(n INTEGER)'))"))
                 .hasMessageContaining("Query not supported: ResultSetMetaData not available for query: CREATE TABLE numbers(n INTEGER)");
-        assertFalse(getQueryRunner().tableExists(getSession(), "numbers"));
+        assertThat(getQueryRunner().tableExists(getSession(), "numbers")).isFalse();
     }
 
     @Test
     public void testNativeQueryInsertStatementTableDoesNotExist()
     {
         skipTestUnless(hasBehavior(SUPPORTS_NATIVE_QUERY));
-        assertFalse(getQueryRunner().tableExists(getSession(), "non_existent_table"));
+        assertThat(getQueryRunner().tableExists(getSession(), "non_existent_table")).isFalse();
         assertThatThrownBy(() -> query("SELECT * FROM TABLE(system.query(query => 'INSERT INTO non_existent_table VALUES (1)'))"))
                 .hasMessageContaining("Failed to get table handle for prepared query");
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/MetadataUtil.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/MetadataUtil.java
@@ -28,7 +28,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Locale.ENGLISH;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 final class MetadataUtil
 {
@@ -72,6 +72,6 @@ final class MetadataUtil
     {
         String json = codec.toJson(object);
         T copy = codec.fromJson(json);
-        assertEquals(copy, object);
+        assertThat(copy).isEqualTo(object);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
@@ -30,8 +29,8 @@ import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
 
 public class TestBaseJdbcConfig
 {
@@ -74,7 +73,7 @@ public class TestBaseJdbcConfig
 
         assertFullMapping(properties, expected);
 
-        assertEquals(expected.getJdbcTypesMappedToVarchar(), ImmutableSet.of("mytype", "struct_type1"));
+        assertThat(expected.getJdbcTypesMappedToVarchar()).containsOnly("mytype", "struct_type1");
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -52,9 +52,6 @@ import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestDefaultJdbcMetadata
@@ -118,24 +115,24 @@ public class TestDefaultJdbcMetadata
     @Test
     public void testListSchemaNames()
     {
-        assertTrue(metadata.listSchemaNames(SESSION).containsAll(ImmutableSet.of("example", "tpch")));
+        assertThat(metadata.listSchemaNames(SESSION)).containsAll(ImmutableSet.of("example", "tpch"));
     }
 
     @Test
     public void testGetTableHandle()
     {
         JdbcTableHandle tableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"));
-        assertEquals(metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers")), tableHandle);
-        assertNull(metadata.getTableHandle(SESSION, new SchemaTableName("example", "unknown")));
-        assertNull(metadata.getTableHandle(SESSION, new SchemaTableName("unknown", "numbers")));
-        assertNull(metadata.getTableHandle(SESSION, new SchemaTableName("unknown", "unknown")));
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("example", "numbers"))).isEqualTo(tableHandle);
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("example", "unknown"))).isNull();
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("unknown", "numbers"))).isNull();
+        assertThat(metadata.getTableHandle(SESSION, new SchemaTableName("unknown", "unknown"))).isNull();
     }
 
     @Test
     public void testGetColumnHandles()
     {
         // known table
-        assertEquals(metadata.getColumnHandles(SESSION, tableHandle), ImmutableMap.of(
+        assertThat(metadata.getColumnHandles(SESSION, tableHandle)).isEqualTo(ImmutableMap.of(
                 "text", new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
                 "text_short", new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
                 "value", new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
@@ -157,8 +154,8 @@ public class TestDefaultJdbcMetadata
     {
         // known table
         ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(SESSION, tableHandle);
-        assertEquals(tableMetadata.getTable(), new SchemaTableName("example", "numbers"));
-        assertEquals(tableMetadata.getColumns(), ImmutableList.of(
+        assertThat(tableMetadata.getTable()).isEqualTo(new SchemaTableName("example", "numbers"));
+        assertThat(tableMetadata.getColumns()).isEqualTo(ImmutableList.of(
                 ColumnMetadata.builder().setName("text").setType(VARCHAR).setNullable(false).build(), // primary key is not null in H2
                 new ColumnMetadata("text_short", createVarcharType(32)),
                 new ColumnMetadata("value", BIGINT)));
@@ -166,8 +163,8 @@ public class TestDefaultJdbcMetadata
         // escaping name patterns
         JdbcTableHandle specialTableHandle = metadata.getTableHandle(SESSION, new SchemaTableName("exa_ple", "num_ers"));
         ConnectorTableMetadata specialTableMetadata = metadata.getTableMetadata(SESSION, specialTableHandle);
-        assertEquals(specialTableMetadata.getTable(), new SchemaTableName("exa_ple", "num_ers"));
-        assertEquals(specialTableMetadata.getColumns(), ImmutableList.of(
+        assertThat(specialTableMetadata.getTable()).isEqualTo(new SchemaTableName("exa_ple", "num_ers"));
+        assertThat(specialTableMetadata.getColumns()).isEqualTo(ImmutableList.of(
                 ColumnMetadata.builder().setName("te_t").setType(VARCHAR).setNullable(false).build(), // primary key is not null in H2
                 new ColumnMetadata("va%ue", BIGINT)));
 
@@ -188,7 +185,7 @@ public class TestDefaultJdbcMetadata
     public void testListTables()
     {
         // all schemas
-        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.empty())), ImmutableSet.of(
+        assertThat(metadata.listTables(SESSION, Optional.empty())).containsOnly(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "timestamps"),
                 new SchemaTableName("example", "view_source"),
@@ -196,31 +193,34 @@ public class TestDefaultJdbcMetadata
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem"),
                 new SchemaTableName("exa_ple", "table_with_float_col"),
-                new SchemaTableName("exa_ple", "num_ers")));
+                new SchemaTableName("exa_ple", "num_ers"));
 
         // specific schema
-        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("example"))), ImmutableSet.of(
-                new SchemaTableName("example", "numbers"),
-                new SchemaTableName("example", "timestamps"),
-                new SchemaTableName("example", "view_source"),
-                new SchemaTableName("example", "view")));
-        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("tpch"))), ImmutableSet.of(
-                new SchemaTableName("tpch", "orders"),
-                new SchemaTableName("tpch", "lineitem")));
-        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("exa_ple"))), ImmutableSet.of(
-                new SchemaTableName("exa_ple", "num_ers"),
-                new SchemaTableName("exa_ple", "table_with_float_col")));
+        assertThat(metadata.listTables(SESSION, Optional.of("example")))
+                .containsOnly(
+                        new SchemaTableName("example", "numbers"),
+                        new SchemaTableName("example", "timestamps"),
+                        new SchemaTableName("example", "view_source"),
+                        new SchemaTableName("example", "view"));
+
+        assertThat(metadata.listTables(SESSION, Optional.of("tpch")))
+                .containsOnly(
+                        new SchemaTableName("tpch", "orders"),
+                        new SchemaTableName("tpch", "lineitem"));
+
+        assertThat(metadata.listTables(SESSION, Optional.of("exa_ple")))
+                .containsOnly(
+                        new SchemaTableName("exa_ple", "num_ers"),
+                        new SchemaTableName("exa_ple", "table_with_float_col"));
 
         // unknown schema
-        assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("unknown"))), ImmutableSet.of());
+        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("unknown")))).isEmpty();
     }
 
     @Test
     public void getColumnMetadata()
     {
-        assertEquals(
-                metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)),
-                new ColumnMetadata("text", VARCHAR));
+        assertThat(metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR))).isEqualTo(new ColumnMetadata("text", VARCHAR));
     }
 
     @Test
@@ -232,29 +232,29 @@ public class TestDefaultJdbcMetadata
         JdbcTableHandle handle = metadata.getTableHandle(SESSION, table);
 
         ConnectorTableMetadata layout = metadata.getTableMetadata(SESSION, handle);
-        assertEquals(layout.getTable(), table);
-        assertEquals(layout.getColumns().size(), 1);
-        assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
+        assertThat(layout.getTable()).isEqualTo(table);
+        assertThat(layout.getColumns()).hasSize(1);
+        assertThat(layout.getColumns().get(0)).isEqualTo(new ColumnMetadata("text", VARCHAR));
 
         metadata.addColumn(SESSION, handle, new ColumnMetadata("x", VARCHAR));
         layout = metadata.getTableMetadata(SESSION, handle);
-        assertEquals(layout.getColumns().size(), 2);
-        assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
-        assertEquals(layout.getColumns().get(1), new ColumnMetadata("x", VARCHAR));
+        assertThat(layout.getColumns()).hasSize(2);
+        assertThat(layout.getColumns().get(0)).isEqualTo(new ColumnMetadata("text", VARCHAR));
+        assertThat(layout.getColumns().get(1)).isEqualTo(new ColumnMetadata("x", VARCHAR));
 
         JdbcColumnHandle columnHandle = new JdbcColumnHandle("x", JDBC_VARCHAR, VARCHAR);
         metadata.dropColumn(SESSION, handle, columnHandle);
         layout = metadata.getTableMetadata(SESSION, handle);
-        assertEquals(layout.getColumns().size(), 1);
-        assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
+        assertThat(layout.getColumns()).hasSize(1);
+        assertThat(layout.getColumns().get(0)).isEqualTo(new ColumnMetadata("text", VARCHAR));
 
         SchemaTableName newTableName = new SchemaTableName("example", "bar");
         metadata.renameTable(SESSION, handle, newTableName);
         handle = metadata.getTableHandle(SESSION, newTableName);
         layout = metadata.getTableMetadata(SESSION, handle);
-        assertEquals(layout.getTable(), newTableName);
-        assertEquals(layout.getColumns().size(), 1);
-        assertEquals(layout.getColumns().get(0), new ColumnMetadata("text", VARCHAR));
+        assertThat(layout.getTable()).isEqualTo(newTableName);
+        assertThat(layout.getColumns()).hasSize(1);
+        assertThat(layout.getColumns().get(0)).isEqualTo(new ColumnMetadata("text", VARCHAR));
     }
 
     @Test
@@ -304,7 +304,7 @@ public class TestDefaultJdbcMetadata
         Domain domain = Domain.singleValue(VARCHAR, utf8Slice("one"));
         JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, domain))));
 
-        assertEquals(tableHandleWithFilter.getConstraint().getDomains(), Optional.of(ImmutableMap.of(groupByColumn, domain)));
+        assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(groupByColumn, domain)));
     }
 
     @Test
@@ -323,14 +323,13 @@ public class TestDefaultJdbcMetadata
 
         Domain secondDomain = Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("one"), utf8Slice("three")));
         JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, secondDomain))));
-        assertEquals(
-                tableHandleWithFilter.getConstraint().getDomains(),
-                // The query effectively intersects firstDomain and secondDomain, but this is not visible in JdbcTableHandle.constraint,
-                // as firstDomain has been converted into a PreparedQuery
-                Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
-        assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
+        assertThat(tableHandleWithFilter.getConstraint().getDomains())
+                .isEqualTo(
+                    // The query effectively intersects firstDomain and secondDomain, but this is not visible in JdbcTableHandle.constraint,
+                    // as firstDomain has been converted into a PreparedQuery
+                    Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
+        assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
+                .isEqualTo("SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "WHERE \"TEXT\" IN (?,?) " +
                         "GROUP BY \"TEXT\"");
@@ -354,12 +353,9 @@ public class TestDefaultJdbcMetadata
                 session,
                 aggregatedTable,
                 new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(nonGroupByColumn, domain))));
-        assertEquals(
-                tableHandleWithFilter.getConstraint().getDomains(),
-                Optional.of(ImmutableMap.of(nonGroupByColumn, domain)));
-        assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
+        assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(nonGroupByColumn, domain)));
+        assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
+                .isEqualTo("SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY \"TEXT\"");
     }
@@ -383,12 +379,9 @@ public class TestDefaultJdbcMetadata
                 session,
                 aggregatedTable,
                 new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(valueColumn, domain))));
-        assertEquals(
-                tableHandleWithFilter.getConstraint().getDomains(),
-                Optional.of(ImmutableMap.of(valueColumn, domain)));
-        assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_0\" " +
+        assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(valueColumn, domain)));
+        assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
+                .isEqualTo("SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY GROUPING SETS ((\"TEXT\", \"VALUE\"), (\"TEXT\"))");
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -89,7 +89,6 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
 public class TestDefaultJdbcQueryBuilder
@@ -251,7 +250,7 @@ public class TestDefaultJdbcQueryBuilder
                     builder.add((Long) resultSet.getObject("col_0"));
                 }
             }
-            assertEquals(builder.build(), ImmutableSet.of(68L, 180L, 196L));
+            assertThat(builder.build()).containsOnly(68L, 180L, 196L);
         }
     }
 
@@ -298,7 +297,7 @@ public class TestDefaultJdbcQueryBuilder
                     builder.add((Long) resultSet.getObject("col_0"));
                 }
             }
-            assertEquals(builder.build(), LongStream.range(980, 1000).boxed().collect(toImmutableList()));
+            assertThat(builder.build()).containsExactlyElementsOf(LongStream.range(980, 1000).boxed().collect(toImmutableList()));
         }
     }
 
@@ -331,8 +330,8 @@ public class TestDefaultJdbcQueryBuilder
                     floatBuilder.add((Float) resultSet.getObject("col_10"));
                 }
             }
-            assertEquals(longBuilder.build(), ImmutableSet.of(0L, 14L));
-            assertEquals(floatBuilder.build(), ImmutableSet.of(100.0f, 114.0f));
+            assertThat(longBuilder.build()).containsOnly(0L, 14L);
+            assertThat(floatBuilder.build()).containsOnly(100.0f, 114.0f);
         }
     }
 
@@ -363,7 +362,7 @@ public class TestDefaultJdbcQueryBuilder
                     builder.add((String) resultSet.getObject("col_3"));
                 }
             }
-            assertEquals(builder.build(), ImmutableSet.of("test_str_700", "test_str_701", "test_str_180", "test_str_196"));
+            assertThat(builder.build()).containsOnly("test_str_700", "test_str_701", "test_str_180", "test_str_196");
 
             assertContains(preparedStatement.toString(), "\"col_3\" >= ?");
             assertContains(preparedStatement.toString(), "\"col_3\" < ?");
@@ -447,8 +446,14 @@ public class TestDefaultJdbcQueryBuilder
                     timeBuilder.add((Time) resultSet.getObject("col_5"));
                 }
             }
-            assertEquals(dateBuilder.build(), ImmutableSet.of(toDate(2016, 6, 7), toDate(2016, 6, 13), toDate(2016, 10, 21)));
-            assertEquals(timeBuilder.build(), ImmutableSet.of(toTime(8, 23, 37), toTime(20, 23, 37)));
+            assertThat(dateBuilder.build()).containsOnly(
+                    toDate(2016, 6, 7),
+                    toDate(2016, 6, 13),
+                    toDate(2016, 10, 21));
+
+            assertThat(timeBuilder.build()).containsOnly(
+                    toTime(8, 23, 37),
+                    toTime(20, 23, 37));
 
             assertContains(preparedStatement.toString(), "\"col_4\" >= ?");
             assertContains(preparedStatement.toString(), "\"col_4\" < ?");
@@ -486,11 +491,11 @@ public class TestDefaultJdbcQueryBuilder
                     builder.add((Timestamp) resultSet.getObject("col_6"));
                 }
             }
-            assertEquals(builder.build(), ImmutableSet.of(
+            assertThat(builder.build()).containsOnly(
                     toTimestamp(2016, 6, 3, 0, 23, 37),
                     toTimestamp(2016, 6, 8, 10, 23, 37),
                     toTimestamp(2016, 6, 9, 12, 23, 37),
-                    toTimestamp(2016, 10, 19, 16, 23, 37)));
+                    toTimestamp(2016, 10, 19, 16, 23, 37));
 
             assertContains(preparedStatement.toString(), "\"col_6\" > ?");
             assertContains(preparedStatement.toString(), "\"col_6\" <= ?");
@@ -527,7 +532,7 @@ public class TestDefaultJdbcQueryBuilder
                     count++;
                 }
             }
-            assertEquals(count, 8);
+            assertThat(count).isEqualTo(8);
         }
     }
 
@@ -552,7 +557,7 @@ public class TestDefaultJdbcQueryBuilder
                     count++;
                 }
             }
-            assertEquals(count, 10);
+            assertThat(count).isEqualTo(10);
         }
     }
 
@@ -574,7 +579,7 @@ public class TestDefaultJdbcQueryBuilder
                     "FROM \"test_table\" " +
                     "WHERE \"col_1\" IS NULL");
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                assertEquals(resultSet.next(), false);
+                assertThat(resultSet.next()).isFalse();
             }
         }
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -41,8 +41,6 @@ import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 public class TestJdbcClient
 {
@@ -72,27 +70,28 @@ public class TestJdbcClient
     @Test
     public void testMetadata()
     {
-        assertTrue(jdbcClient.getSchemaNames(session).containsAll(ImmutableSet.of("example", "tpch")));
-        assertEquals(jdbcClient.getTableNames(session, Optional.of("example")), ImmutableList.of(
+        assertThat(jdbcClient.getSchemaNames(session).containsAll(ImmutableSet.of("example", "tpch"))).isTrue();
+        assertThat(jdbcClient.getTableNames(session, Optional.of("example"))).containsExactly(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("example", "timestamps"),
                 new SchemaTableName("example", "view_source"),
-                new SchemaTableName("example", "view")));
-        assertEquals(jdbcClient.getTableNames(session, Optional.of("tpch")), ImmutableList.of(
+                new SchemaTableName("example", "view"));
+
+        assertThat(jdbcClient.getTableNames(session, Optional.of("tpch"))).containsExactly(
                 new SchemaTableName("tpch", "lineitem"),
-                new SchemaTableName("tpch", "orders")));
+                new SchemaTableName("tpch", "orders"));
 
         SchemaTableName schemaTableName = new SchemaTableName("example", "numbers");
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
-        assertTrue(table.isPresent(), "table is missing");
-        assertEquals(table.get().getRequiredNamedRelation().getRemoteTableName().getCatalogName().orElse(null), catalogName.toUpperCase(ENGLISH));
-        assertEquals(table.get().getRequiredNamedRelation().getRemoteTableName().getSchemaName().orElse(null), "EXAMPLE");
-        assertEquals(table.get().getRequiredNamedRelation().getRemoteTableName().getTableName(), "NUMBERS");
-        assertEquals(table.get().getRequiredNamedRelation().getSchemaTableName(), schemaTableName);
-        assertEquals(jdbcClient.getColumns(session, table.orElse(null)), ImmutableList.of(
+        assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
+        assertThat(table.get().getRequiredNamedRelation().getRemoteTableName().getCatalogName().orElse(null)).isEqualTo(catalogName.toUpperCase(ENGLISH));
+        assertThat(table.get().getRequiredNamedRelation().getRemoteTableName().getSchemaName().orElse(null)).isEqualTo("EXAMPLE");
+        assertThat(table.get().getRequiredNamedRelation().getRemoteTableName().getTableName()).isEqualTo("NUMBERS");
+        assertThat(table.get().getRequiredNamedRelation().getSchemaTableName()).isEqualTo(schemaTableName);
+        assertThat(jdbcClient.getColumns(session, table.orElse(null))).containsExactly(
                 new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
                 new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
+                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -100,10 +99,10 @@ public class TestJdbcClient
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "num_ers");
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
-        assertTrue(table.isPresent(), "table is missing");
-        assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
+        assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
+        assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
                 new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT)));
+                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -111,12 +110,12 @@ public class TestJdbcClient
     {
         SchemaTableName schemaTableName = new SchemaTableName("exa_ple", "table_with_float_col");
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
-        assertTrue(table.isPresent(), "table is missing");
-        assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
+        assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
+        assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
                 new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
                 new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("COL4", JDBC_REAL, REAL)));
+                new JdbcColumnHandle("COL4", JDBC_REAL, REAL));
     }
 
     @Test
@@ -124,11 +123,11 @@ public class TestJdbcClient
     {
         SchemaTableName schemaTableName = new SchemaTableName("example", "timestamps");
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
-        assertTrue(table.isPresent(), "table is missing");
-        assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
+        assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
+        assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
                 new JdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
                 new JdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
-                new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS)));
+                new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS));
     }
 
     @Test
@@ -156,7 +155,9 @@ public class TestJdbcClient
         jdbcClient.renameTable(session, jdbcClient.getTableHandle(session, oldTable).get(), newTable);
         jdbcClient.dropTable(session, jdbcClient.getTableHandle(session, newTable).get());
         jdbcClient.dropSchema(session, schemaName);
-        assertThat(jdbcClient.getTableNames(session, Optional.empty())).doesNotContain(oldTable).doesNotContain(newTable);
+        assertThat(jdbcClient.getTableNames(session, Optional.empty()))
+                .doesNotContain(oldTable)
+                .doesNotContain(newTable);
         assertThat(jdbcClient.getSchemaNames(session)).doesNotContain(schemaName);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcDynamicFilteringSplitManager.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcDynamicFilteringSplitManager.java
@@ -37,8 +37,7 @@ import static io.trino.plugin.jdbc.JdbcDynamicFilteringSessionProperties.DYNAMIC
 import static io.trino.plugin.jdbc.JdbcDynamicFilteringSessionProperties.DYNAMIC_FILTERING_WAIT_TIMEOUT;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJdbcDynamicFilteringSplitManager
 {
@@ -102,9 +101,9 @@ public class TestJdbcDynamicFilteringSplitManager
 
         // verify that getNextBatch() future completes after a timeout
         CompletableFuture<?> future = splitSource.getNextBatch(100);
-        assertFalse(future.isDone());
+        assertThat(future.isDone()).isFalse();
         future.get(10, SECONDS);
-        assertTrue(splitSource.isFinished());
+        assertThat(splitSource.isFinished()).isTrue();
         splitSource.close();
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
@@ -35,9 +35,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJdbcRecordSet
 {
@@ -78,21 +76,21 @@ public class TestJdbcRecordSet
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR),
                 new JdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32)),
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT)));
-        assertEquals(recordSet.getColumnTypes(), ImmutableList.of(VARCHAR, createVarcharType(32), BIGINT));
+        assertThat(recordSet.getColumnTypes()).containsExactly(VARCHAR, createVarcharType(32), BIGINT);
 
         recordSet = createRecordSet(ImmutableList.of(
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
-        assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, VARCHAR));
+        assertThat(recordSet.getColumnTypes()).containsExactly(BIGINT, VARCHAR);
 
         recordSet = createRecordSet(ImmutableList.of(
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
                 new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
-        assertEquals(recordSet.getColumnTypes(), ImmutableList.of(BIGINT, BIGINT, VARCHAR));
+        assertThat(recordSet.getColumnTypes()).containsExactly(BIGINT, BIGINT, VARCHAR);
 
         recordSet = createRecordSet(ImmutableList.of());
-        assertEquals(recordSet.getColumnTypes(), ImmutableList.of());
+        assertThat(recordSet.getColumnTypes()).isEmpty();
     }
 
     @Test
@@ -104,20 +102,20 @@ public class TestJdbcRecordSet
                 columnHandles.get("value")));
 
         try (RecordCursor cursor = recordSet.cursor()) {
-            assertEquals(cursor.getType(0), VARCHAR);
-            assertEquals(cursor.getType(1), createVarcharType(32));
-            assertEquals(cursor.getType(2), BIGINT);
+            assertThat(cursor.getType(0)).isEqualTo(VARCHAR);
+            assertThat(cursor.getType(1)).isEqualTo(createVarcharType(32));
+            assertThat(cursor.getType(2)).isEqualTo(BIGINT);
 
             Map<String, Long> data = new LinkedHashMap<>();
             while (cursor.advanceNextPosition()) {
                 data.put(cursor.getSlice(0).toStringUtf8(), cursor.getLong(2));
-                assertEquals(cursor.getSlice(0), cursor.getSlice(1));
-                assertFalse(cursor.isNull(0));
-                assertFalse(cursor.isNull(1));
-                assertFalse(cursor.isNull(2));
+                assertThat(cursor.getSlice(0)).isEqualTo(cursor.getSlice(1));
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                assertThat(cursor.isNull(2)).isFalse();
             }
 
-            assertEquals(data, ImmutableMap.<String, Long>builder()
+            assertThat(data).isEqualTo(ImmutableMap.<String, Long>builder()
                     .put("one", 1L)
                     .put("two", 2L)
                     .put("three", 3L)
@@ -126,7 +124,7 @@ public class TestJdbcRecordSet
                     .put("twelve", 12L)
                     .buildOrThrow());
 
-            assertThat(cursor.getReadTimeNanos()).isGreaterThan(0);
+            assertThat(cursor.getReadTimeNanos()).isPositive();
         }
     }
 
@@ -139,17 +137,17 @@ public class TestJdbcRecordSet
                 columnHandles.get("text")));
 
         try (RecordCursor cursor = recordSet.cursor()) {
-            assertEquals(cursor.getType(0), BIGINT);
-            assertEquals(cursor.getType(1), BIGINT);
-            assertEquals(cursor.getType(2), VARCHAR);
+            assertThat(cursor.getType(0)).isEqualTo(BIGINT);
+            assertThat(cursor.getType(1)).isEqualTo(BIGINT);
+            assertThat(cursor.getType(2)).isEqualTo(VARCHAR);
 
             Map<String, Long> data = new LinkedHashMap<>();
             while (cursor.advanceNextPosition()) {
-                assertEquals(cursor.getLong(0), cursor.getLong(1));
+                assertThat(cursor.getLong(0)).isEqualTo(cursor.getLong(1));
                 data.put(cursor.getSlice(2).toStringUtf8(), cursor.getLong(0));
             }
 
-            assertEquals(data, ImmutableMap.<String, Long>builder()
+            assertThat(data).isEqualTo(ImmutableMap.<String, Long>builder()
                     .put("one", 1L)
                     .put("two", 2L)
                     .put("three", 3L)
@@ -158,7 +156,7 @@ public class TestJdbcRecordSet
                     .put("twelve", 12L)
                     .buildOrThrow());
 
-            assertThat(cursor.getReadTimeNanos()).isGreaterThan(0);
+            assertThat(cursor.getReadTimeNanos()).isPositive();
         }
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -46,8 +46,7 @@ import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJdbcRecordSetProvider
 {
@@ -100,17 +99,17 @@ public class TestJdbcRecordSetProvider
         ConnectorTransactionHandle transaction = new JdbcTransactionHandle();
         JdbcRecordSetProvider recordSetProvider = new JdbcRecordSetProvider(jdbcClient, executor);
         RecordSet recordSet = recordSetProvider.getRecordSet(transaction, SESSION, split, table, ImmutableList.of(textColumn, textShortColumn, valueColumn));
-        assertNotNull(recordSet, "recordSet is null");
+        assertThat(recordSet).withFailMessage("recordSet is null").isNotNull();
 
         RecordCursor cursor = recordSet.cursor();
-        assertNotNull(cursor, "cursor is null");
+        assertThat(cursor).withFailMessage("cursor is null").isNotNull();
 
         Map<String, Long> data = new LinkedHashMap<>();
         while (cursor.advanceNextPosition()) {
             data.put(cursor.getSlice(0).toStringUtf8(), cursor.getLong(2));
-            assertEquals(cursor.getSlice(0), cursor.getSlice(1));
+            assertThat(cursor.getSlice(0)).isEqualTo(cursor.getSlice(1));
         }
-        assertEquals(data, ImmutableMap.<String, Long>builder()
+        assertThat(data).isEqualTo(ImmutableMap.<String, Long>builder()
                 .put("one", 1L)
                 .put("two", 2L)
                 .put("three", 3L)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcSplit.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcSplit.java
@@ -13,14 +13,13 @@
  */
 package io.trino.plugin.jdbc;
 
-import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJdbcSplit
 {
@@ -30,11 +29,11 @@ public class TestJdbcSplit
     public void testAddresses()
     {
         // split uses "example" scheme so no addresses are available and is not remotely accessible
-        assertEquals(split.getAddresses(), ImmutableList.of());
-        assertEquals(split.isRemotelyAccessible(), true);
+        assertThat(split.getAddresses()).isEmpty();
+        assertThat(split.isRemotelyAccessible()).isTrue();
 
         JdbcSplit jdbcSplit = new JdbcSplit(Optional.empty());
-        assertEquals(jdbcSplit.getAddresses(), ImmutableList.of());
+        assertThat(jdbcSplit.getAddresses()).isEmpty();
     }
 
     @Test
@@ -43,9 +42,9 @@ public class TestJdbcSplit
         JsonCodec<JdbcSplit> codec = jsonCodec(JdbcSplit.class);
         String json = codec.toJson(split);
         JdbcSplit copy = codec.fromJson(json);
-        assertEquals(copy.getAdditionalPredicate(), split.getAdditionalPredicate());
+        assertThat(copy.getAdditionalPredicate()).isEqualTo(split.getAdditionalPredicate());
 
-        assertEquals(copy.getAddresses(), ImmutableList.of());
-        assertEquals(copy.isRemotelyAccessible(), true);
+        assertThat(copy.getAddresses()).isEmpty();
+        assertThat(copy.isRemotelyAccessible()).isTrue();
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 // Single-threaded because of shared mutable state, e.g. onGetTableProperties
 @Test(singleThreaded = true)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJmxStats.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJmxStats.java
@@ -29,8 +29,7 @@ import java.util.Set;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJmxStats
 {
@@ -44,14 +43,14 @@ public class TestJmxStats
         MBeanServer mbeanServer = getPlatformMBeanServer();
         Set<ObjectName> objectNames = mbeanServer.queryNames(new ObjectName("io.trino.plugin.jdbc:*"), null);
 
-        assertTrue(objectNames.containsAll(
+        assertThat(objectNames.containsAll(
                 ImmutableSet.of(
                         new ObjectName("io.trino.plugin.jdbc:type=ConnectionFactory,name=test"),
-                        new ObjectName("io.trino.plugin.jdbc:type=JdbcClient,name=test"))));
+                        new ObjectName("io.trino.plugin.jdbc:type=JdbcClient,name=test")))).isTrue();
 
         for (ObjectName objectName : objectNames) {
             MBeanInfo mbeanInfo = mbeanServer.getMBeanInfo(objectName);
-            assertNotEquals(mbeanInfo.getAttributes().length, 0, format("Object %s doesn't expose JMX stats", objectName.getCanonicalName()));
+            assertThat(mbeanInfo.getAttributes().length).withFailMessage(format("Object %s doesn't expose JMX stats", objectName.getCanonicalName())).isNotEqualTo(0);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRemoteTableName.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRemoteTableName.java
@@ -19,7 +19,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRemoteTableName
 {
@@ -29,8 +29,8 @@ public class TestRemoteTableName
         JsonCodec<RemoteTableName> codec = JsonCodec.jsonCodec(RemoteTableName.class);
         RemoteTableName table = new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table");
         RemoteTableName roundTrip = codec.fromJson(codec.toJson(table));
-        assertEquals(table.getCatalogName(), roundTrip.getCatalogName());
-        assertEquals(table.getSchemaName(), roundTrip.getSchemaName());
-        assertEquals(table.getTableName(), roundTrip.getTableName());
+        assertThat(table.getCatalogName()).isEqualTo(roundTrip.getCatalogName());
+        assertThat(table.getSchemaName()).isEqualTo(roundTrip.getSchemaName());
+        assertThat(table.getTableName()).isEqualTo(roundTrip.getTableName());
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRetryingConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestRetryingConnectionFactory.java
@@ -35,9 +35,8 @@ import static io.trino.plugin.jdbc.TestRetryingConnectionFactory.MockConnectorFa
 import static io.trino.spi.block.TestingSession.SESSION;
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 public class TestRetryingConnectionFactory
 {
@@ -53,8 +52,8 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(SESSION));
-        assertEquals(mock.getCallCount(), 1);
+        assertThat(factory.openConnection(SESSION)).isNotNull();
+        assertThat(mock.getCallCount()).isEqualTo(1);
     }
 
     @Test
@@ -65,7 +64,7 @@ public class TestRetryingConnectionFactory
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Testing Trino exception");
-        assertEquals(mock.getCallCount(), 2);
+        assertThat(mock.getCallCount()).isEqualTo(2);
     }
 
     @Test
@@ -76,7 +75,7 @@ public class TestRetryingConnectionFactory
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(SQLException.class)
                 .hasMessage("Testing sql exception");
-        assertEquals(mock.getCallCount(), 2);
+        assertThat(mock.getCallCount()).isEqualTo(2);
     }
 
     @Test
@@ -87,7 +86,7 @@ public class TestRetryingConnectionFactory
         assertThatThrownBy(() -> factory.openConnection(SESSION))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Testing NPE");
-        assertEquals(mock.getCallCount(), 1);
+        assertThat(mock.getCallCount()).isEqualTo(1);
     }
 
     @Test
@@ -96,8 +95,8 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_SQL_RECOVERABLE_EXCEPTION, RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(SESSION));
-        assertEquals(mock.getCallCount(), 2);
+        assertThat(factory.openConnection(SESSION)).isNotNull();
+        assertThat(mock.getCallCount()).isEqualTo(2);
     }
 
     @Test
@@ -106,8 +105,8 @@ public class TestRetryingConnectionFactory
     {
         MockConnectorFactory mock = new MockConnectorFactory(THROW_WRAPPED_SQL_RECOVERABLE_EXCEPTION, RETURN);
         ConnectionFactory factory = new RetryingConnectionFactory(mock);
-        assertNotNull(factory.openConnection(SESSION));
-        assertEquals(mock.getCallCount(), 2);
+        assertThat(factory.openConnection(SESSION)).isNotNull();
+        assertThat(mock.getCallCount()).isEqualTo(2);
     }
 
     public static class MockConnectorFactory

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/credential/TestCredentialProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/credential/TestCredentialProvider.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.io.Resources.getResource;
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCredentialProvider
 {
@@ -37,8 +37,8 @@ public class TestCredentialProvider
                 "connection-password", "password_for_user_from_inline");
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
-        assertEquals(credentialProvider.getConnectionUser(Optional.empty()).get(), "user_from_inline");
-        assertEquals(credentialProvider.getConnectionPassword(Optional.empty()).get(), "password_for_user_from_inline");
+        assertThat(credentialProvider.getConnectionUser(Optional.empty()).get()).isEqualTo("user_from_inline");
+        assertThat(credentialProvider.getConnectionPassword(Optional.empty()).get()).isEqualTo("password_for_user_from_inline");
     }
 
     @Test
@@ -50,8 +50,8 @@ public class TestCredentialProvider
                 "connection-credential-file", getResourceFilePath("credentials.properties"));
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
-        assertEquals(credentialProvider.getConnectionUser(Optional.empty()).get(), "user_from_file");
-        assertEquals(credentialProvider.getConnectionPassword(Optional.empty()).get(), "password_for_user_from_file");
+        assertThat(credentialProvider.getConnectionUser(Optional.empty()).get()).isEqualTo("user_from_file");
+        assertThat(credentialProvider.getConnectionPassword(Optional.empty()).get()).isEqualTo("password_for_user_from_file");
     }
 
     @Test
@@ -70,8 +70,8 @@ public class TestCredentialProvider
                 .buildOrThrow();
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
-        assertEquals(credentialProvider.getConnectionUser(Optional.empty()).get(), "user_from_keystore");
-        assertEquals(credentialProvider.getConnectionPassword(Optional.empty()).get(), "password_from_keystore");
+        assertThat(credentialProvider.getConnectionUser(Optional.empty()).get()).isEqualTo("user_from_keystore");
+        assertThat(credentialProvider.getConnectionPassword(Optional.empty()).get()).isEqualTo("password_from_keystore");
     }
 
     private CredentialProvider getCredentialProvider(Map<String, String> properties)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/credential/TestExtraCredentialProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/credential/TestExtraCredentialProvider.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExtraCredentialProvider
 {
@@ -35,8 +35,8 @@ public class TestExtraCredentialProvider
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
         Optional<ConnectorIdentity> identity = Optional.of(ConnectorIdentity.forUser("user").withExtraCredentials(ImmutableMap.of("user", "overwritten_user")).build());
-        assertEquals(credentialProvider.getConnectionUser(identity).get(), "overwritten_user");
-        assertEquals(credentialProvider.getConnectionPassword(identity).get(), "default_password");
+        assertThat(credentialProvider.getConnectionUser(identity).get()).isEqualTo("overwritten_user");
+        assertThat(credentialProvider.getConnectionPassword(identity).get()).isEqualTo("default_password");
     }
 
     @Test
@@ -49,8 +49,8 @@ public class TestExtraCredentialProvider
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
         Optional<ConnectorIdentity> identity = Optional.of(ConnectorIdentity.forUser("user").withExtraCredentials(ImmutableMap.of("password", "overwritten_password")).build());
-        assertEquals(credentialProvider.getConnectionUser(identity).get(), "default_user");
-        assertEquals(credentialProvider.getConnectionPassword(identity).get(), "overwritten_password");
+        assertThat(credentialProvider.getConnectionUser(identity).get()).isEqualTo("default_user");
+        assertThat(credentialProvider.getConnectionPassword(identity).get()).isEqualTo("overwritten_password");
     }
 
     @Test
@@ -66,8 +66,8 @@ public class TestExtraCredentialProvider
         Optional<ConnectorIdentity> identity = Optional.of(ConnectorIdentity.forUser("user")
                 .withExtraCredentials(ImmutableMap.of("user", "overwritten_user", "password", "overwritten_password"))
                 .build());
-        assertEquals(credentialProvider.getConnectionUser(identity).get(), "overwritten_user");
-        assertEquals(credentialProvider.getConnectionPassword(identity).get(), "overwritten_password");
+        assertThat(credentialProvider.getConnectionUser(identity).get()).isEqualTo("overwritten_user");
+        assertThat(credentialProvider.getConnectionPassword(identity).get()).isEqualTo("overwritten_password");
     }
 
     @Test
@@ -81,14 +81,14 @@ public class TestExtraCredentialProvider
 
         CredentialProvider credentialProvider = getCredentialProvider(properties);
         Optional<ConnectorIdentity> identity = Optional.of(ConnectorIdentity.ofUser("user"));
-        assertEquals(credentialProvider.getConnectionUser(identity).get(), "default_user");
-        assertEquals(credentialProvider.getConnectionPassword(identity).get(), "default_password");
+        assertThat(credentialProvider.getConnectionUser(identity).get()).isEqualTo("default_user");
+        assertThat(credentialProvider.getConnectionPassword(identity).get()).isEqualTo("default_password");
 
         identity = Optional.of(ConnectorIdentity.forUser("user")
                 .withExtraCredentials(ImmutableMap.of("connection_user", "overwritten_user", "connection_password", "overwritten_password"))
                 .build());
-        assertEquals(credentialProvider.getConnectionUser(identity).get(), "default_user");
-        assertEquals(credentialProvider.getConnectionPassword(identity).get(), "default_password");
+        assertThat(credentialProvider.getConnectionUser(identity).get()).isEqualTo("default_user");
+        assertThat(credentialProvider.getConnectionPassword(identity).get()).isEqualTo("default_password");
     }
 
     private static CredentialProvider getCredentialProvider(Map<String, String> properties)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/TestExpressionMappingParser.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/TestExpressionMappingParser.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExpressionMappingParser
 {
@@ -105,8 +105,8 @@ public class TestExpressionMappingParser
 
     private static void assertExpressionPattern(String expressionPattern, String canonical, ExpressionPattern expected)
     {
-        assertEquals(expressionPattern(expressionPattern), expected);
-        assertEquals(expected.toString(), canonical);
+        assertThat(expressionPattern(expressionPattern)).isEqualTo(expected);
+        assertThat(expected.toString()).isEqualTo(canonical);
     }
 
     private static ExpressionPattern expressionPattern(String expressionPattern)


### PR DESCRIPTION
This was achieved with the https://github.com/PicnicSupermarket/error-prone-support TestNGToAssertJRules rules and IntelliJ's optimize imports (refaster leaves behind unused imports).

The only manual change was the fix `assertEquals` in one of the files that weren't refactored automatically.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
