### PR TITLE
Cache AccumulatorFactory instances basing on last access time

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -437,10 +437,10 @@ public class LocalExecutionPlanner
 
     private final NonEvictableCache<FunctionKey, AccumulatorFactory> accumulatorFactoryCache = buildNonEvictableCache(CacheBuilder.newBuilder()
             .maximumSize(1000)
-            .expireAfterWrite(1, HOURS));
+            .expireAfterAccess(1, HOURS));
     private final NonEvictableCache<FunctionKey, AggregationWindowFunctionSupplier> aggregationWindowFunctionSupplierCache = buildNonEvictableCache(CacheBuilder.newBuilder()
             .maximumSize(1000)
-            .expireAfterWrite(1, HOURS));
+            .expireAfterAccess(1, HOURS));
 
     @Inject
     public LocalExecutionPlanner(


### PR DESCRIPTION
Currently, `AccumulatorFactory` instances are flushed after one hour has elapsed. It can cause a lot of deoptimzation as an side effect. We observie it in benchmarks (that takes more one hour). Anyway, user's queries (repeated, dashboard queries) can experiance same issue.  

## Release notes

(*) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

