### PR TITLE
Catch Throwable when Coral failed to convert views

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -243,7 +243,7 @@ public final class ViewReaderUtil
                         Optional.empty(), // will be filled in later by HiveMetadata
                         hiveViewsRunAsInvoker);
             }
-            catch (RuntimeException e) {
+            catch (Throwable e) {
                 throw new TrinoException(HIVE_VIEW_TRANSLATION_ERROR,
                         format("Failed to translate Hive view '%s': %s",
                                 table.getSchemaTableName(),


### PR DESCRIPTION
## Description

Coral may throw AssertionError internally
Fixes #17568

## Release notes

(x) This is not user-visible or docs only and no release notes are required.