### PR TITLE
Downgrade the shade plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1948,6 +1948,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.4</version>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Downgrade the shade plugin version

3.4.1 is generating different artifacts. The generated pom is missing
all dependencies.
