### PR TITLE
Disable creation of reduced pom during shading

### DIFF
--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -191,6 +191,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>executable</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <!-- filter out signature files from signed dependencies -->


### PR DESCRIPTION
Disable creation of reduced pom during shading

Maven-shade-plugin after
https://issues.apache.org/jira/browse/MSHADE-321 by default creates
reduced pom. So all dependencies are removed. This works well when you
want when you only provide shaded binary as the target artifact.
Here we use shading to generate executable jar, and still we would like to
provide regular jar artifact so it can be used as a library. In library
case reduced pom is undesired.
