### PR TITLE
Fix testIdentityColumn in Delta Lake product tests

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlterTableCompatibility.java
@@ -15,7 +15,6 @@ package io.trino.tests.product.deltalake;
 
 import io.trino.tempto.assertions.QueryAssert;
 import io.trino.testng.services.Flaky;
-import io.trino.tests.product.deltalake.util.DatabricksVersion;
 import org.assertj.core.api.Assertions;
 import org.testng.annotations.Test;
 
@@ -32,7 +31,6 @@ import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_73;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_91;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
-import static io.trino.tests.product.deltalake.util.DatabricksVersion.DATABRICKS_122_RUNTIME_VERSION;
 import static io.trino.tests.product.deltalake.util.DatabricksVersion.DATABRICKS_91_RUNTIME_VERSION;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
@@ -443,9 +441,7 @@ public class TestDeltaLakeAlterTableCompatibility
                     .contains("b BIGINT GENERATED ALWAYS AS IDENTITY");
             onDelta().executeQuery("INSERT INTO default." + tableName + " (a) VALUES (0)");
 
-            DatabricksVersion databricksRuntimeVersion = getDatabricksRuntimeVersion().orElseThrow();
-            // Actual value for IDENTITY column varies between Databricks versions
-            QueryAssert.Row expected = databricksRuntimeVersion.isOlderThan(DATABRICKS_122_RUNTIME_VERSION) ? row(0, 1) : row(0, 2);
+            QueryAssert.Row expected = row(0, 1);
             assertThat(onTrino().executeQuery("SELECT * FROM delta.default." + tableName)).containsOnly(expected);
             assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName)).containsOnly(expected);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It seems Databricks 12.2 changed the behavior recently. 
https://github.com/trinodb/trino/actions/runs/5028373638/jobs/9019175717
```
tests               | 2023-05-20 03:45:33 INFO: FAILURE     /    io.trino.tests.product.deltalake.TestDeltaLakeAlterTableCompatibility.testIdentityColumn (Groups: profile_specific_tests, delta-lake-exclude-91, delta-lake-databricks, delta-lake-exclude-73) took 15.8 seconds
tests               | 2023-05-20 03:45:33 SEVERE: Failure cause:
tests               | java.lang.AssertionError: Could not find rows:
tests               | [0, 2]
tests               | 
tests               | actual rows:
tests               | [0, 1]
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
