### PR TITLE
Ensure FileSystem not GCed while RemoteIterator in use

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/TrinoFileSystemCache.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/TrinoFileSystemCache.java
@@ -387,7 +387,7 @@ public class TrinoFileSystemCache
         public RemoteIterator<LocatedFileStatus> listFiles(Path path, boolean recursive)
                 throws IOException
         {
-            return fs.listFiles(path, recursive);
+            return new RemoteIteratorWrapper(fs.listFiles(path, recursive), this);
         }
     }
 
@@ -426,6 +426,34 @@ public class TrinoFileSystemCache
         public InputStream getWrappedStream()
         {
             return ((FSDataInputStream) super.getWrappedStream()).getWrappedStream();
+        }
+    }
+
+    private static class RemoteIteratorWrapper
+            implements RemoteIterator<LocatedFileStatus>
+    {
+        private final RemoteIterator<LocatedFileStatus> delegate;
+        @SuppressWarnings({"FieldCanBeLocal", "unused"})
+        private final FileSystem fileSystem;
+
+        public RemoteIteratorWrapper(RemoteIterator<LocatedFileStatus> delegate, FileSystem fileSystem)
+        {
+            this.delegate = delegate;
+            this.fileSystem = fileSystem;
+        }
+
+        @Override
+        public boolean hasNext()
+                throws IOException
+        {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public LocatedFileStatus next()
+                throws IOException
+        {
+            return delegate.next();
         }
     }
 


### PR DESCRIPTION
Add wrapper around RemoteIterarator obtained from
FileSystemWrapper.listFiles. Using wrapper ensures that there is strong referenct to FileSystemWrapper object while RemoteIterarator is in use. Otherwise it was possible that FileSystemWrapper and underlying FileSystem were garbage collected in the meantime which rendered RemoteIterarator unusable.

In case of TrinoS3FileSystem it manifested itself in closed http pool deep down the stack.

Thanks to @findepi for helping understanding what is the root cause of the problem.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix bug where spurious query failures could occur when using Hive, Delta, Iceberg and Hudi tables.
```
