### PR TITLE
Add support for `DATE` type and run BaseConnectorTest in Pinot Connector

### DIFF
--- a/docs/src/main/sphinx/connector/pinot.md
+++ b/docs/src/main/sphinx/connector/pinot.md
@@ -185,9 +185,20 @@ according to the following table:
   - `VARCHAR`
 :::
 
-Pinot does not allow null values in any data type.
-
 No other types are supported.
+
+#### Date Type
+
+For Pinot `DateTimeFields`, if the `FormatSpec` is in days,
+then it is converted to a Trino `DATE` type.
+Pinot allows for `LONG` fields to have a `FormatSpec` of days as well, if the 
+value is larger than `Integer.MAX_VALUE` then the conversion to Trino `DATE` fails.  
+
+#### Null Handling
+
+If a Pinot TableSpec has `nullHandlingEnabled` set to true, then for numeric 
+types the null value is encoded as `MIN_VALUE` for that type. 
+For Pinot `STRING` type, the value `null` is interpreted as a `NULL` value.
 
 (pinot-sql-support)=
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/decoders/DecoderFactory.java
@@ -17,6 +17,7 @@ import io.trino.plugin.pinot.PinotException;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.FixedWidthType;
 import io.trino.spi.type.IntegerType;
@@ -50,7 +51,7 @@ public class DecoderFactory
             if (type instanceof BigintType) {
                 return new BigintDecoder();
             }
-            if (type instanceof IntegerType) {
+            if (type instanceof IntegerType || type instanceof DateType) {
                 return new IntegerDecoder();
             }
             if (type instanceof BooleanType) {

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
@@ -732,7 +732,7 @@ public abstract class BasePinotConnectorSmokeTest
         }
     }
 
-    private static Map<String, String> schemaRegistryAwareProducer(TestingKafka testingKafka)
+    public static Map<String, String> schemaRegistryAwareProducer(TestingKafka testingKafka)
     {
         return ImmutableMap.<String, String>builder()
                 .put(SCHEMA_REGISTRY_URL_CONFIG, testingKafka.getSchemaRegistryConnectString())

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/PinotQueryRunner.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.pinot;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -22,16 +23,31 @@ import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.metadata.SessionPropertyManager;
+import io.trino.plugin.pinot.client.PinotHostMapper;
+import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.MaterializedRow;
 import io.trino.testing.kafka.TestingKafka;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.trino.plugin.pinot.BasePinotConnectorSmokeTest.schemaRegistryAwareProducer;
 import static io.trino.plugin.pinot.TestingPinotCluster.PINOT_LATEST_IMAGE_NAME;
 import static io.trino.testing.TestingHandles.createTestCatalogHandle;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.time.temporal.ChronoUnit.DAYS;
 
 public class PinotQueryRunner
 {
@@ -67,6 +83,123 @@ public class PinotQueryRunner
                 .build();
     }
 
+    public static void createTpchTables(TestingKafka kafka, TestingPinotCluster pinot, DistributedQueryRunner queryRunner, Instant initialUpdatedAt)
+            throws Exception
+    {
+        // Create and populate table and topic data
+        String regionTableName = "region";
+        kafka.createTopicWithConfig(2, 1, regionTableName, false);
+        Schema regionSchema = SchemaBuilder.record(regionTableName).fields()
+                .name("regionkey").type().longType().noDefault()
+                .name("name").type().stringType().noDefault()
+                .name("comment").type().stringType().noDefault()
+                .name("updated_at_seconds").type().longType().noDefault()
+                .endRecord();
+        ImmutableList.Builder<ProducerRecord<String, GenericRecord>> regionRowsBuilder = ImmutableList.builder();
+        MaterializedResult regionRows = queryRunner.execute("SELECT * FROM tpch.tiny.region");
+        for (MaterializedRow row : regionRows.getMaterializedRows()) {
+            regionRowsBuilder.add(new ProducerRecord<>(regionTableName, "key" + row.getField(0), new GenericRecordBuilder(regionSchema)
+                    .set("regionkey", row.getField(0))
+                    .set("name", row.getField(1))
+                    .set("comment", row.getField(2))
+                    .set("updated_at_seconds", initialUpdatedAt.plusMillis(1000).toEpochMilli())
+                    .build()));
+        }
+        kafka.sendMessages(regionRowsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
+        pinot.createSchema(PinotQueryRunner.class.getClassLoader().getResourceAsStream("region_schema.json"), regionTableName);
+        pinot.addRealTimeTable(PinotQueryRunner.class.getClassLoader().getResourceAsStream("region_realtimeSpec.json"), regionTableName);
+
+        String nationTableName = "nation";
+        kafka.createTopicWithConfig(2, 1, nationTableName, false);
+        Schema nationSchema = SchemaBuilder.record(nationTableName).fields()
+                .name("nationkey").type().longType().noDefault()
+                .name("name").type().stringType().noDefault()
+                .name("comment").type().stringType().noDefault()
+                .name("regionkey").type().longType().noDefault()
+                .name("updated_at_seconds").type().longType().noDefault()
+                .endRecord();
+        ImmutableList.Builder<ProducerRecord<String, GenericRecord>> nationRowsBuilder = ImmutableList.builder();
+        MaterializedResult nationRows = queryRunner.execute("SELECT * FROM tpch.tiny.nation");
+        for (MaterializedRow row : nationRows.getMaterializedRows()) {
+            nationRowsBuilder.add(new ProducerRecord<>(nationTableName, "key" + row.getField(0), new GenericRecordBuilder(nationSchema)
+                    .set("nationkey", row.getField(0))
+                    .set("name", row.getField(1))
+                    .set("comment", row.getField(3))
+                    .set("regionkey", row.getField(2))
+                    .set("updated_at_seconds", initialUpdatedAt.plusMillis(1000).toEpochMilli())
+                    .build()));
+        }
+        kafka.sendMessages(nationRowsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
+        pinot.createSchema(PinotQueryRunner.class.getClassLoader().getResourceAsStream("nation_schema.json"), nationTableName);
+        pinot.addRealTimeTable(PinotQueryRunner.class.getClassLoader().getResourceAsStream("nation_realtimeSpec.json"), nationTableName);
+
+        String ordersTableName = "orders";
+        kafka.createTopicWithConfig(2, 1, ordersTableName, false);
+        Schema ordersSchema = SchemaBuilder.record(ordersTableName).fields()
+                .name("orderkey").type().longType().noDefault()
+                .name("custkey").type().longType().noDefault()
+                .name("orderstatus").type().stringType().noDefault()
+                .name("totalprice").type().doubleType().noDefault()
+                .name("orderdate").type().longType().noDefault()
+                .name("orderpriority").type().stringType().noDefault()
+                .name("clerk").type().stringType().noDefault()
+                .name("shippriority").type().intType().noDefault()
+                .name("comment").type().stringType().noDefault()
+                .name("updated_at").type().longType().noDefault()
+                .endRecord();
+        ImmutableList.Builder<ProducerRecord<String, GenericRecord>> ordersRowsBuilder = ImmutableList.builder();
+        MaterializedResult ordersRows = queryRunner.execute("SELECT * FROM tpch.tiny.orders");
+        for (MaterializedRow row : ordersRows.getMaterializedRows()) {
+            ordersRowsBuilder.add(new ProducerRecord<>(ordersTableName, "key" + row.getField(0), new GenericRecordBuilder(ordersSchema)
+                    .set("orderkey", row.getField(0))
+                    .set("custkey", row.getField(1))
+                    .set("orderstatus", row.getField(2))
+                    .set("totalprice", row.getField(3))
+                    .set("orderdate", LocalDate.parse(row.getField(4).toString()).toEpochDay())
+                    .set("orderpriority", row.getField(5))
+                    .set("clerk", row.getField(6))
+                    .set("shippriority", row.getField(7))
+                    .set("comment", row.getField(8))
+                    .set("updated_at", initialUpdatedAt.plusMillis(1000).toEpochMilli())
+                    .build()));
+        }
+        kafka.sendMessages(ordersRowsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
+        pinot.createSchema(PinotQueryRunner.class.getClassLoader().getResourceAsStream("orders_schema.json"), ordersTableName);
+        pinot.addRealTimeTable(PinotQueryRunner.class.getClassLoader().getResourceAsStream("orders_realtimeSpec.json"), ordersTableName);
+
+        String customerTableName = "customer";
+        kafka.createTopicWithConfig(2, 1, customerTableName, false);
+        Schema customerSchema = SchemaBuilder.record(customerTableName).fields()
+                .name("custkey").type().longType().noDefault()
+                .name("name").type().stringType().noDefault()
+                .name("address").type().stringType().noDefault()
+                .name("nationkey").type().longType().noDefault()
+                .name("phone").type().stringType().noDefault()
+                .name("acctbal").type().doubleType().noDefault()
+                .name("mktsegment").type().stringType().noDefault()
+                .name("comment").type().stringType().noDefault()
+                .name("updated_at").type().longType().noDefault()
+                .endRecord();
+        ImmutableList.Builder<ProducerRecord<String, GenericRecord>> customerRowsBuilder = ImmutableList.builder();
+        MaterializedResult customerRows = queryRunner.execute("SELECT * FROM tpch.tiny.customer");
+        for (MaterializedRow row : customerRows.getMaterializedRows()) {
+            customerRowsBuilder.add(new ProducerRecord<>(customerTableName, "key" + row.getField(0), new GenericRecordBuilder(customerSchema)
+                    .set("custkey", row.getField(0))
+                    .set("name", row.getField(1))
+                    .set("address", row.getField(2))
+                    .set("nationkey", row.getField(3))
+                    .set("phone", row.getField(4))
+                    .set("acctbal", row.getField(5))
+                    .set("mktsegment", row.getField(6))
+                    .set("comment", row.getField(7))
+                    .set("updated_at", initialUpdatedAt.plusMillis(1000).toEpochMilli())
+                    .build()));
+        }
+        kafka.sendMessages(customerRowsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
+        pinot.createSchema(PinotQueryRunner.class.getClassLoader().getResourceAsStream("customer_schema.json"), customerTableName);
+        pinot.addRealTimeTable(PinotQueryRunner.class.getClassLoader().getResourceAsStream("customer_realtimeSpec.json"), customerTableName);
+    }
+
     public static void main(String[] args)
             throws Exception
     {
@@ -79,7 +212,14 @@ public class PinotQueryRunner
                 .put("pinot.controller-urls", pinot.getControllerConnectString())
                 .put("pinot.segments-per-split", "10")
                 .buildOrThrow();
-        DistributedQueryRunner queryRunner = createPinotQueryRunner(properties, pinotProperties, Optional.empty());
+        DistributedQueryRunner queryRunner = createPinotQueryRunner(
+                properties,
+                pinotProperties,
+                Optional.of(binder -> newOptionalBinder(binder, PinotHostMapper.class).setBinding()
+                        .toInstance(new TestingPinotHostMapper(pinot.getBrokerHostAndPort(), pinot.getServerHostAndPort(), pinot.getServerGrpcHostAndPort()))));
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+        createTpchTables(kafka, pinot, queryRunner, Instant.now().minus(Duration.ofDays(1)).truncatedTo(DAYS));
         Thread.sleep(10);
         Logger log = Logger.get(PinotQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotConnectorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.pinot;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.pinot.client.PinotHostMapper;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.kafka.TestingKafka;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.trino.plugin.pinot.PinotQueryRunner.createPinotQueryRunner;
+import static io.trino.plugin.pinot.PinotQueryRunner.createTpchTables;
+import static io.trino.plugin.pinot.TestingPinotCluster.PINOT_LATEST_IMAGE_NAME;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestPinotConnectorTest
+        extends BaseConnectorTest
+{
+    // Use a recent value for updated_at to ensure Pinot doesn't clean up records older than retentionTimeValue as defined in the table specs
+    private static final Instant INITIAL_UPDATED_AT = Instant.now().minus(Duration.ofDays(1)).truncatedTo(SECONDS);
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingKafka kafka = closeAfterClass(TestingKafka.createWithSchemaRegistry());
+        kafka.start();
+        TestingPinotCluster pinot = closeAfterClass(new TestingPinotCluster(kafka.getNetwork(), false, PINOT_LATEST_IMAGE_NAME));
+        pinot.start();
+
+        DistributedQueryRunner queryRunner = createPinotQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.<String, String>builder()
+                        .put("pinot.controller-urls", pinot.getControllerConnectString())
+                        .put("pinot.grpc.enabled", "true")
+                        .buildOrThrow(),
+                Optional.of(binder -> newOptionalBinder(binder, PinotHostMapper.class).setBinding()
+                        .toInstance(new TestingPinotHostMapper(pinot.getBrokerHostAndPort(), pinot.getServerHostAndPort(), pinot.getServerGrpcHostAndPort()))));
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        createTpchTables(kafka, pinot, queryRunner, INITIAL_UPDATED_AT);
+
+        return queryRunner;
+    }
+
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_ADD_COLUMN,
+                    SUPPORTS_ARRAY,
+                    SUPPORTS_COMMENT_ON_COLUMN,
+                    SUPPORTS_COMMENT_ON_TABLE,
+                    SUPPORTS_CREATE_MATERIALIZED_VIEW,
+                    SUPPORTS_CREATE_SCHEMA,
+                    SUPPORTS_CREATE_TABLE,
+                    SUPPORTS_CREATE_VIEW,
+                    SUPPORTS_DELETE,
+                    SUPPORTS_INSERT,
+                    SUPPORTS_MERGE,
+                    SUPPORTS_RENAME_COLUMN,
+                    SUPPORTS_RENAME_TABLE,
+                    SUPPORTS_ROW_TYPE,
+                    SUPPORTS_SET_COLUMN_TYPE,
+                    SUPPORTS_TOPN_PUSHDOWN,
+                    SUPPORTS_UPDATE -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
+    @Override // Override because updated_at_seconds column exists
+    protected MaterializedResult getDescribeOrdersResult()
+    {
+        return resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("updated_at_seconds", "bigint", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "date", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("totalprice", "double", "", "")
+                .build();
+    }
+
+    @Test
+    @Override // Override because updated_at_seconds column exists
+    public void testShowColumns()
+    {
+        assertThat(query("SHOW COLUMNS FROM orders")).matches(getDescribeOrdersResult());
+    }
+
+    @Test
+    @Override // Override because updated_at_seconds column exists
+    public void testSelectAll()
+    {
+        assertQuery("SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment FROM orders");
+    }
+
+    @Test
+    @Override // Override because updated_at_seconds column exists
+    public void testSelectInformationSchemaColumns()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll(".$", "_");
+
+        @Language("SQL") String ordersTableWithColumns = """
+                VALUES
+                    ('orders', 'orderkey'),
+                    ('orders', 'custkey'),
+                    ('orders', 'orderstatus'),
+                    ('orders', 'totalprice'),
+                    ('orders', 'orderdate'),
+                    ('orders', 'updated_at_seconds'),
+                    ('orders', 'orderpriority'),
+                    ('orders', 'clerk'),
+                    ('orders', 'shippriority'),
+                    ('orders', 'comment')
+                """;
+
+        assertQuery("SELECT table_schema FROM information_schema.columns WHERE table_schema = '" + schema + "' GROUP BY table_schema", "VALUES '" + schema + "'");
+        assertQuery("SELECT table_name FROM information_schema.columns WHERE table_name = 'orders' GROUP BY table_name", "VALUES 'orders'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'orders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name LIKE '%rders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '_rder_'", ordersTableWithColumns);
+        assertQuery(
+                "SELECT table_name, column_name FROM information_schema.columns " +
+                        "WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '%orders%'",
+                ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+    }
+
+    @Test
+    @Override // Override because updated_at_seconds column exists
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo("""
+                        CREATE TABLE pinot.default.orders (
+                           clerk varchar,
+                           orderkey bigint,
+                           orderstatus varchar,
+                           updated_at_seconds bigint,
+                           custkey bigint,
+                           totalprice double,
+                           comment varchar,
+                           orderdate date,
+                           orderpriority varchar,
+                           shippriority integer
+                        )""");
+    }
+
+    @Test
+    @Override // Override because the regexp is different from the base test
+    public void testPredicateReflectedInExplain()
+    {
+        assertExplain(
+                "EXPLAIN SELECT name FROM nation WHERE nationkey = 42",
+                "columnName=nationkey", "dataType=bigint", "\\s\\{\\[42\\]\\}");
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/alltypes_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/alltypes_realtimeSpec.json
@@ -60,7 +60,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/customer_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/customer_realtimeSpec.json
@@ -1,0 +1,44 @@
+{
+    "tableName": "customer",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+        "timeColumnName": "updated_at_seconds",
+        "timeType": "SECONDS",
+        "retentionTimeUnit": "DAYS",
+        "retentionTimeValue": "365000",
+        "segmentPushType": "APPEND",
+        "segmentPushFrequency": "daily",
+        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+        "schemaName": "customer",
+        "replicasPerPartition": "1"
+    },
+    "tenants": {
+        "broker": "DefaultTenant",
+        "server": "DefaultTenant"
+    },
+    "tableIndexConfig": {
+        "loadMode": "MMAP",
+        "noDictionaryColumns": [],
+        "aggregateMetrics": "false",
+        "nullHandlingEnabled": "true",
+        "streamConfigs": {
+            "streamType": "kafka",
+            "stream.kafka.consumer.type": "lowLevel",
+            "stream.kafka.topic.name": "customer",
+            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+            "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+            "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
+            "stream.kafka.zk.broker.url": "zookeeper:2181/",
+            "stream.kafka.broker.list": "kafka:9092",
+            "realtime.segment.flush.threshold.time": "24h",
+            "realtime.segment.flush.threshold.size": "0",
+            "realtime.segment.flush.desired.size": "1M",
+            "isolation.level": "read_committed",
+            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+            "stream.kafka.consumer.prop.group.id": "pinot-customer"
+        }
+    },
+    "metadata": {
+        "customConfigs": {}
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/customer_schema.json
+++ b/plugin/trino-pinot/src/test/resources/customer_schema.json
@@ -1,0 +1,47 @@
+{
+    "schemaName": "customer",
+    "dimensionFieldSpecs": [
+        {
+            "name": "custkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "name",
+            "dataType": "STRING"
+        },
+        {
+            "name": "address",
+            "dataType": "STRING"
+        },
+        {
+            "name": "nationkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "phone",
+            "dataType": "STRING"
+        },
+        {
+            "name": "acctbal",
+            "dataType": "DOUBLE"
+        },
+        {
+            "name": "mktsegment",
+            "dataType": "STRING"
+        },
+        {
+            "name": "comment",
+            "dataType": "STRING"
+        }
+    ],
+    "dateTimeFieldSpecs": [
+        {
+            "name": "updated_at_seconds",
+            "dataType": "LONG",
+            "defaultNullValue": 0,
+            "format": "1:SECONDS:EPOCH",
+            "transformFunction": "toEpochSeconds(updated_at)",
+            "granularity": "1:SECONDS"
+        }
+    ]
+}

--- a/plugin/trino-pinot/src/test/resources/date_time_fields_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/date_time_fields_realtimeSpec.json
@@ -31,7 +31,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/dup_table_lower_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/dup_table_lower_case_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/dup_table_mixed_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/dup_table_mixed_case_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/duplicate_values_in_columns_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/duplicate_values_in_columns_realtimeSpec.json
@@ -31,7 +31,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/hybrid_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/hybrid_realtimeSpec.json
@@ -41,7 +41,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/json_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/json_realtimeSpec.json
@@ -30,7 +30,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_distinct_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_distinct_realtimeSpec.json
@@ -32,7 +32,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_realtimeSpec.json
@@ -44,7 +44,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/mixed_case_table_name_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/mixed_case_table_name_realtimeSpec.json
@@ -44,7 +44,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/nation_realtimeSpec.json
@@ -32,7 +32,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/orders_realtimeSpec.json
@@ -1,0 +1,44 @@
+{
+    "tableName": "orders",
+    "tableType": "REALTIME",
+    "segmentsConfig": {
+        "timeColumnName": "updated_at_seconds",
+        "timeType": "SECONDS",
+        "retentionTimeUnit": "DAYS",
+        "retentionTimeValue": "365000",
+        "segmentPushType": "APPEND",
+        "segmentPushFrequency": "daily",
+        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+        "schemaName": "orders",
+        "replicasPerPartition": "1"
+    },
+    "tenants": {
+        "broker": "DefaultTenant",
+        "server": "DefaultTenant"
+    },
+    "tableIndexConfig": {
+        "loadMode": "MMAP",
+        "noDictionaryColumns": [],
+        "aggregateMetrics": "false",
+        "nullHandlingEnabled": "true",
+        "streamConfigs": {
+            "streamType": "kafka",
+            "stream.kafka.consumer.type": "lowLevel",
+            "stream.kafka.topic.name": "orders",
+            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder",
+            "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
+            "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
+            "stream.kafka.zk.broker.url": "zookeeper:2181/",
+            "stream.kafka.broker.list": "kafka:9092",
+            "realtime.segment.flush.threshold.time": "24h",
+            "realtime.segment.flush.threshold.size": "0",
+            "realtime.segment.flush.desired.size": "1M",
+            "isolation.level": "read_committed",
+            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+            "stream.kafka.consumer.prop.group.id": "pinot-orders"
+        }
+    },
+    "metadata": {
+        "customConfigs": {}
+    }
+}

--- a/plugin/trino-pinot/src/test/resources/orders_schema.json
+++ b/plugin/trino-pinot/src/test/resources/orders_schema.json
@@ -1,0 +1,54 @@
+{
+    "schemaName": "orders",
+    "dimensionFieldSpecs": [
+        {
+            "name": "orderkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "custkey",
+            "dataType": "LONG"
+        },
+        {
+            "name": "orderstatus",
+            "dataType": "STRING"
+        },
+        {
+            "name": "totalprice",
+            "dataType": "DOUBLE"
+        },
+        {
+            "name": "orderpriority",
+            "dataType": "STRING"
+        },
+        {
+            "name": "clerk",
+            "dataType": "STRING"
+        },
+        {
+            "name": "shippriority",
+            "dataType": "INT"
+        },
+        {
+            "name": "comment",
+            "dataType": "STRING"
+        }
+    ],
+    "dateTimeFieldSpecs": [
+        {
+            "name": "orderdate",
+            "dataType": "LONG",
+            "defaultNullValue": 0,
+            "format": "1:DAYS:EPOCH",
+            "granularity": "1:DAYS"
+        },
+        {
+            "name": "updated_at_seconds",
+            "dataType": "LONG",
+            "defaultNullValue" : 0,
+            "transformFunction": "toEpochSeconds(updated_at)",
+            "format": "1:SECONDS:EPOCH",
+            "granularity" : "1:SECONDS"
+        }
+    ]
+}

--- a/plugin/trino-pinot/src/test/resources/quotes_in_column_name_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/quotes_in_column_name_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/realtimeSpec.json
@@ -28,7 +28,7 @@
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
       "stream.kafka.zk.broker.url": "zookeeper:2181/",
       "stream.kafka.broker.list": "kafka:9092",
-      "realtime.segment.flush.threshold.time": "1h",
+      "realtime.segment.flush.threshold.time": "24h",
       "realtime.segment.flush.threshold.size": "0",
       "realtime.segment.flush.desired.size": "1M",
       "stream.kafka.consumer.prop.auto.isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/region_realtimeSpec.json
@@ -32,7 +32,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/reserved_keyword_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/reserved_keyword_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/too_many_broker_rows_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/too_many_broker_rows_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",

--- a/plugin/trino-pinot/src/test/resources/too_many_rows_realtimeSpec.json
+++ b/plugin/trino-pinot/src/test/resources/too_many_rows_realtimeSpec.json
@@ -29,7 +29,7 @@
             "stream.kafka.decoder.prop.schema.registry.rest.url": "http://schema-registry:8081",
             "stream.kafka.zk.broker.url": "zookeeper:2181/",
             "stream.kafka.broker.list": "kafka:9092",
-            "realtime.segment.flush.threshold.time": "1m",
+            "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.size": "0",
             "realtime.segment.flush.desired.size": "1M",
             "isolation.level": "read_committed",


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #13059

In order to pass the connector test we need to support the date type.
This is similar to what is done for the datetime fields and timestamp types for other resolutions (1 ms, 1 sec, etc.)

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Pinot
* Add support for `DATE` type. ({issue}`17582`)
```
