### PR TITLE
Set default file format in Iceberg migrate procedure

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -64,6 +64,9 @@ public class TestIcebergMigrateProcedure
 
         assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableName + "')");
 
+        assertThat((String) computeScalar("SHOW CREATE TABLE " + icebergTableName))
+                .contains("format = '%s'".formatted(fileFormat));
+
         assertQuery("SELECT * FROM " + icebergTableName, "VALUES 1");
         assertQuery("SELECT count(*) FROM " + icebergTableName, "VALUES 1");
 


### PR DESCRIPTION
## Description

Set default file format in Iceberg migrate procedure.
Otherwise, the mgirated tables' table definition always shows `format = 'PARQUET'`

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
