### PR TITLE
Deny array, map and row types in Iceberg migrate procedure

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -44,6 +44,10 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.procedure.Procedure;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -291,13 +295,22 @@ public class MigrateProcedure
         List<Types.NestedField> icebergColumns = new ArrayList<>();
         for (Column column : columns) {
             int index = icebergColumns.size();
-            org.apache.iceberg.types.Type type = toIcebergTypeForNewColumn(typeManager.getType(column.getType().getTypeSignature()), nextFieldId);
+            org.apache.iceberg.types.Type type = toIcebergType(typeManager.getType(column.getType().getTypeSignature()), nextFieldId);
             Types.NestedField field = Types.NestedField.of(index, false, column.getName(), type, column.getComment().orElse(null));
             icebergColumns.add(field);
         }
         org.apache.iceberg.types.Type icebergSchema = Types.StructType.of(icebergColumns);
         icebergSchema = TypeUtil.assignFreshIds(icebergSchema, nextFieldId::getAndIncrement);
         return new Schema(icebergSchema.asStructType().fields());
+    }
+
+    private static org.apache.iceberg.types.Type toIcebergType(Type type, AtomicInteger nextFieldId)
+    {
+        if (type instanceof ArrayType || type instanceof MapType || type instanceof RowType) {
+            // TODO https://github.com/trinodb/trino/issues/17583 Add support for these complex types
+            throw new TrinoException(NOT_SUPPORTED, "Migrating %s type is not supported".formatted(type));
+        }
+        return toIcebergTypeForNewColumn(type, nextFieldId);
     }
 
     public Map<String, Optional<Partition>> listAllPartitions(HiveMetastore metastore, io.trino.plugin.hive.metastore.Table table)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -236,6 +236,26 @@ public class TestIcebergMigrateProcedure
     }
 
     @Test
+    public void testMigrateUnsupportedComplexColumnType()
+    {
+        // TODO https://github.com/trinodb/trino/issues/17583 Add support for these complex types
+        String tableName = "test_migrate_unsupported_complex_column_type_" + randomNameSuffix();
+        String hiveTableName = "hive.tpch." + tableName;
+
+        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT array[1] x", 1);
+        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating array(integer) type is not supported");
+        assertUpdate("DROP TABLE " + hiveTableName);
+
+        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT map(array['key'], array[2]) x", 1);
+        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating map(varchar(3), integer) type is not supported");
+        assertUpdate("DROP TABLE " + hiveTableName);
+
+        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT CAST(row(1) AS row(y integer)) x", 1);
+        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating row(y integer) type is not supported");
+        assertUpdate("DROP TABLE " + hiveTableName);
+    }
+
+    @Test
     public void testMigrateUnsupportedTableFormat()
     {
         String tableName = "test_migrate_unsupported_table_format_" + randomNameSuffix();


### PR DESCRIPTION
## Description

Deny array, map and row types in Iceberg migrate procedure to avoid correctness issue #17583.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Disallow migrating Hive tables with `array`, `map` and `row` types. 
  Previously, it returned incorrect results after the migration. ({issue}`17587`)
```
