### PR TITLE
Correct code example for CLI auth with env variable

### DIFF
--- a/docs/src/main/sphinx/client/cli.rst
+++ b/docs/src/main/sphinx/client/cli.rst
@@ -288,18 +288,19 @@ and prompts the CLI for your password:
   ./trino --server https://trino.example.com --user=exampleusername --password
 
 Alternatively, set the password as the value of the ``TRINO_PASSWORD``
-environment variables. Typically use single quotes to avoid problems with
+environment variable. Typically use single quotes to avoid problems with
 special characters such as ``$``:
 
 .. code-block:: text
 
   export TRINO_PASSWORD='LongSecurePassword123!@#'
 
-The password is automatically used in any following start of the CLI:
+If the ``TRINO_PASSWORD`` environment variable is set, you are not prompted
+to provide a password to connect with the CLI.
 
 .. code-block:: text
 
-  ./trino --server https://trino.example.com --user=exampleusername
+  ./trino --server https://trino.example.com --user=exampleusername --password
 
 .. _cli-external-sso-auth:
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Updates code example and text for CLI password authentication after setting `TRINO_PASSWORD` environment variable
* Current behavior requires `--password` in CLI code snippet even after setting the `TRINO_PASSWORD` environment variable. If `--password` is not provided, trino CLI will appear to start without CLI prompt for password, but running SQL results in "Error running command: Authentication failed: Authentication required"

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* https://github.com/trinodb/trino/issues/17402

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
