### PR TITLE
Add extra_properties to Delta Lake table properties

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -643,6 +643,10 @@ The following table properties are available for use:
       * ``NONE``
 
       Defaults to ``NONE``.
+  * - ``extra_properties``
+    - Additional properties added to a Delta table. The properties are not used by Trino,
+      and are available in the ``$properties`` metadata table.
+      The properties are not included in the output of ``SHOW CREATE TABLE`` statements.
 ```
 
 The following example uses all available table properties:
@@ -654,7 +658,8 @@ WITH (
   partitioned_by = ARRAY['regionkey'],
   checkpoint_interval = 5,
   change_data_feed_enabled = false,
-  column_mapping_mode = 'name'
+  column_mapping_mode = 'name',
+  extra_properties = map_from_entries(ARRAY[('key1', 'value1'), ('key2', 'value2')])
 )
 AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
 ```

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -206,6 +206,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableProperties.LOCATION_PROPER
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.PARTITIONED_BY_PROPERTY;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getChangeDataFeedEnabled;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getCheckpointInterval;
+import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getExtraProperties;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getLocation;
 import static io.trino.plugin.deltalake.DeltaLakeTableProperties.getPartitionedBy;
 import static io.trino.plugin.deltalake.metastore.HiveMetastoreBackedDeltaLakeMetastore.TABLE_PROVIDER_PROPERTY;
@@ -885,7 +886,12 @@ public class DeltaLakeMetadata
                         columnComments,
                         columnsNullability,
                         columnsMetadata.buildOrThrow(),
-                        configurationForNewTable(checkpointInterval, changeDataFeedEnabled, columnMappingMode, maxFieldId),
+                        configurationForNewTable(
+                                checkpointInterval,
+                                changeDataFeedEnabled,
+                                columnMappingMode,
+                                maxFieldId,
+                                getExtraProperties(tableMetadata.getProperties())),
                         CREATE_TABLE_OPERATION,
                         session,
                         tableMetadata.getComment(),
@@ -1047,7 +1053,8 @@ public class DeltaLakeMetadata
                 schemaString,
                 columnMappingMode,
                 maxFieldId,
-                protocolEntryForNewTable(tableMetadata.getProperties()));
+                protocolEntryForNewTable(tableMetadata.getProperties()),
+                getExtraProperties(tableMetadata.getProperties()));
     }
 
     private Optional<String> getSchemaLocation(Database database)
@@ -1181,7 +1188,12 @@ public class DeltaLakeMetadata
                     randomUUID().toString(),
                     schemaString,
                     handle.getPartitionedBy(),
-                    configurationForNewTable(handle.getCheckpointInterval(), handle.getChangeDataFeedEnabled(), columnMappingMode, handle.getMaxColumnId()),
+                    configurationForNewTable(
+                            handle.getCheckpointInterval(),
+                            handle.getChangeDataFeedEnabled(),
+                            columnMappingMode,
+                            handle.getMaxColumnId(),
+                            handle.getExtraTableProperties()),
                     CREATE_TABLE_AS_OPERATION,
                     session,
                     handle.getComment(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -17,11 +17,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode;
 import io.trino.plugin.deltalake.transactionlog.ProtocolEntry;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -44,6 +46,7 @@ public class DeltaLakeOutputTableHandle
     private final OptionalInt maxColumnId;
     private final String schemaString;
     private final ProtocolEntry protocolEntry;
+    private final Map<String, String> extraTableProperties;
 
     @JsonCreator
     public DeltaLakeOutputTableHandle(
@@ -58,7 +61,8 @@ public class DeltaLakeOutputTableHandle
             @JsonProperty("schemaString") String schemaString,
             @JsonProperty("columnMappingMode") ColumnMappingMode columnMappingMode,
             @JsonProperty("maxColumnId") OptionalInt maxColumnId,
-            @JsonProperty("protocolEntry") ProtocolEntry protocolEntry)
+            @JsonProperty("protocolEntry") ProtocolEntry protocolEntry,
+            @JsonProperty("extraTableProperties") Map<String, String> extraTableProperties)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -72,6 +76,7 @@ public class DeltaLakeOutputTableHandle
         this.columnMappingMode = requireNonNull(columnMappingMode, "columnMappingMode is null");
         this.maxColumnId = requireNonNull(maxColumnId, "maxColumnId is null");
         this.protocolEntry = requireNonNull(protocolEntry, "protocolEntry is null");
+        this.extraTableProperties = ImmutableMap.copyOf(requireNonNull(extraTableProperties, "extraTableProperties is null"));
     }
 
     @JsonProperty
@@ -153,5 +158,11 @@ public class DeltaLakeOutputTableHandle
     public ProtocolEntry getProtocolEntry()
     {
         return protocolEntry;
+    }
+
+    @JsonProperty
+    public Map<String, String> getExtraTableProperties()
+    {
+        return extraTableProperties;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -500,7 +500,7 @@ public final class DeltaLakeSchemaSupport
 
     public static boolean changeDataFeedEnabled(MetadataEntry metadataEntry)
     {
-        String enableChangeDataFeed = metadataEntry.getConfiguration().getOrDefault("delta.enableChangeDataFeed", "false");
+        String enableChangeDataFeed = metadataEntry.getConfiguration().getOrDefault(MetadataEntry.DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY, "false");
         return parseBoolean(enableChangeDataFeed);
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/MetadataEntry.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.ColumnMappingMode;
 import io.trino.spi.TrinoException;
 
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
@@ -41,6 +43,12 @@ public class MetadataEntry
     public static final String DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY = "delta.enableChangeDataFeed";
 
     private static final String DELTA_CHECKPOINT_INTERVAL_PROPERTY = "delta.checkpointInterval";
+
+    public static final Set<String> RESERVED_TRINO_PROPERTY_NAMES = ImmutableSet.of(
+            DELTA_CHECKPOINT_WRITE_STATS_AS_JSON_PROPERTY,
+            DELTA_CHECKPOINT_WRITE_STATS_AS_STRUCT_PROPERTY,
+            DELTA_CHANGE_DATA_FEED_ENABLED_PROPERTY,
+            DELTA_CHECKPOINT_INTERVAL_PROPERTY);
 
     private final String id;
     private final String name;
@@ -181,7 +189,8 @@ public class MetadataEntry
             Optional<Long> checkpointInterval,
             Optional<Boolean> changeDataFeedEnabled,
             ColumnMappingMode columnMappingMode,
-            OptionalInt maxFieldId)
+            OptionalInt maxFieldId,
+            Map<String, String> extraProperties)
     {
         ImmutableMap.Builder<String, String> configurationMapBuilder = ImmutableMap.builder();
         checkpointInterval.ifPresent(interval -> configurationMapBuilder.put(DELTA_CHECKPOINT_INTERVAL_PROPERTY, String.valueOf(interval)));
@@ -194,6 +203,7 @@ public class MetadataEntry
             }
             case UNKNOWN -> throw new UnsupportedOperationException();
         }
+        configurationMapBuilder.putAll(extraProperties);
         return configurationMapBuilder.buildOrThrow();
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -180,7 +181,8 @@ public class TestDeltaLakePageSink
                 schemaString,
                 NONE,
                 OptionalInt.empty(),
-                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()));
+                new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()),
+                Collections.emptyMap());
 
         TypeOperators typeOperators = new TypeOperators();
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableProperties.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.TestingTypeManager;
+import org.testng.annotations.Test;
+
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDeltaLakeTableProperties
+{
+    @Test
+    public void testPropertyNamesCompleteness()
+    {
+        assertEquals(new DeltaLakeTableProperties(new TestingTypeManager())
+                        .getTableProperties()
+                        .stream()
+                        .map(PropertyMetadata::getName)
+                        .collect(Collectors.toSet()),
+                DeltaLakeTableProperties.PROPERTY_NAMES);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Similar to https://github.com/trinodb/trino/pull/17172 this adds support for the `extra_properties` table property to Delta tables, such that additional table properties can be set on Delta tables.

The additional properties will not be exposed in SHOW CREATE.

It's a bit unclear how we should handle table properties which can be set by other features, and through extra_properties. Currently we take the simplest approach and allow setting properties both through Trino specific table properties, and through `extra_properties`. For instance, it's possible to set `delta.enableChangeDataFeed` both implicitly by setting `change_data_feed_enabled`, and explicitly by setting `extra_properties = MAP(ARRAY['delta.enableChangeDataFeed'], ARRAY['true'])`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/17428

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Introduce `extra_properties` for adding arbitrary properties to Delta tables. ({issue}`17428`)
```
