### PR TITLE
Create tasks all at once on first assignment of HashDistributionSplitAssigner

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestHashDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestHashDistributionSplitAssigner.java
@@ -73,7 +73,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(10)
                 .withTargetPartitionSizeInBytes(1024)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(10)
                 .run();
         testAssigner()
                 .withReplicatedSources(REPLICATED_1)
@@ -93,7 +93,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(10)
                 .withTargetPartitionSizeInBytes(1024)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(10)
                 .run();
         testAssigner()
                 .withPartitionedSources(PARTITIONED_1, PARTITIONED_2)
@@ -106,7 +106,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(10)
                 .withTargetPartitionSizeInBytes(1024)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(10)
                 .run();
     }
 
@@ -135,7 +135,7 @@ public class TestHashDistributionSplitAssigner
                 .withTargetPartitionSizeInBytes(1000)
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
         // no splits
         testAssigner()
@@ -147,7 +147,7 @@ public class TestHashDistributionSplitAssigner
                 .withTargetPartitionSizeInBytes(1000)
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
     }
 
@@ -174,7 +174,7 @@ public class TestHashDistributionSplitAssigner
                 .withTargetPartitionSizeInBytes(1000)
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(false)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
         // no splits
         testAssigner()
@@ -185,7 +185,7 @@ public class TestHashDistributionSplitAssigner
                 .withTargetPartitionSizeInBytes(1000)
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(false)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
     }
 
@@ -212,7 +212,7 @@ public class TestHashDistributionSplitAssigner
                 .withPartitionToNodeMap(Optional.of(ImmutableList.of(NODE_1, NODE_2, NODE_3)))
                 .withTargetPartitionSizeInBytes(1000)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
         // no splits
         testAssigner()
@@ -223,7 +223,7 @@ public class TestHashDistributionSplitAssigner
                 .withPartitionToNodeMap(Optional.of(ImmutableList.of(NODE_1, NODE_2, NODE_3)))
                 .withTargetPartitionSizeInBytes(1000)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(3)
                 .run();
     }
 
@@ -332,7 +332,7 @@ public class TestHashDistributionSplitAssigner
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
                 .withSplittableSources(PARTITIONED_1)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(2)
+                .withExpectedTaskCount(3)
                 .run();
 
         // largest source is not splittable
@@ -345,7 +345,7 @@ public class TestHashDistributionSplitAssigner
                 .withTargetPartitionSizeInBytes(3)
                 .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(2)
                 .run();
 
         // multiple sources
@@ -392,7 +392,7 @@ public class TestHashDistributionSplitAssigner
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(2, 1, 1))))
                 .withSplittableSources(PARTITIONED_2)
                 .withMergeAllowed(true)
-                .withExpectedTaskCount(1)
+                .withExpectedTaskCount(2)
                 .run();
 
         // targetPartitionSizeInBytes re-adjustment based on taskTargetMaxCount

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestHashDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestHashDistributionSplitAssigner.java
@@ -46,7 +46,7 @@ import static com.google.common.collect.ImmutableListMultimap.toImmutableListMul
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
-import static io.trino.execution.scheduler.HashDistributionSplitAssigner.createOutputPartitionToTaskPartition;
+import static io.trino.execution.scheduler.HashDistributionSplitAssigner.createSourcePartitionToTaskPartition;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -80,7 +80,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplits(new SplitBatch(REPLICATED_1, ImmutableListMultimap.of(), true))
                 .withSplitPartitionCount(1)
                 .withTargetPartitionSizeInBytes(1024)
-                .withOutputDataSizeEstimates(ImmutableMap.of(REPLICATED_1, new OutputDataSizeEstimate(ImmutableLongArray.builder().add(0).build())))
+                .withSourceDataSizeEstimates(ImmutableMap.of(REPLICATED_1, new OutputDataSizeEstimate(ImmutableLongArray.builder().add(0).build())))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -121,7 +121,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(3)
                 .withPartitionToNodeMap(Optional.of(ImmutableList.of(NODE_1, NODE_2, NODE_3)))
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(3)
                 .run();
@@ -133,7 +133,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(3)
                 .withPartitionToNodeMap(Optional.of(ImmutableList.of(NODE_1, NODE_2, NODE_3)))
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -145,7 +145,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(3)
                 .withPartitionToNodeMap(Optional.of(ImmutableList.of(NODE_1, NODE_2, NODE_3)))
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -161,7 +161,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(2, 1), createSplit(3, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(false)
                 .withExpectedTaskCount(3)
                 .run();
@@ -172,7 +172,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(0, 0), createSplit(1, 0)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(false)
                 .withExpectedTaskCount(1)
                 .run();
@@ -183,7 +183,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, ImmutableListMultimap.of(), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1000)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(false)
                 .withExpectedTaskCount(1)
                 .run();
@@ -237,7 +237,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(2, 1), createSplit(3, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(3)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -251,7 +251,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(6, 1), createSplit(7, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(3)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -265,7 +265,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(6, 1), createSplit(7, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(3)
                 .run();
@@ -279,7 +279,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(6, 1), createSplit(7, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(3)
                 .run();
@@ -294,7 +294,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(6, 1), createSplit(7, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(3)
                 .run();
@@ -310,7 +310,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(6, 1), createSplit(7, 2)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1)),
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(1, 1, 1))))
                 .withMergeAllowed(true)
@@ -329,7 +329,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(2, 0), createSplit(3, 0)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(3)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
                 .withSplittableSources(PARTITIONED_1)
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(2)
@@ -343,7 +343,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_1, createSplitMap(createSplit(2, 0), createSplit(3, 0)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(3)
-                .withOutputDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
+                .withSourceDataSizeEstimates(ImmutableMap.of(PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(5, 1, 1))))
                 .withMergeAllowed(true)
                 .withExpectedTaskCount(1)
                 .run();
@@ -357,7 +357,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_2, createSplitMap(createSplit(4, 0), createSplit(5, 1)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(30)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1)),
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(2, 1, 1))))
                 .withSplittableSources(PARTITIONED_1)
@@ -372,7 +372,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_2, createSplitMap(createSplit(4, 0), createSplit(5, 1)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(30)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1)),
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(2, 1, 1))))
                 .withSplittableSources(PARTITIONED_1, PARTITIONED_2)
@@ -387,7 +387,7 @@ public class TestHashDistributionSplitAssigner
                         new SplitBatch(PARTITIONED_2, createSplitMap(createSplit(4, 0), createSplit(5, 0)), true))
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(30)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1)),
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(2, 1, 1))))
                 .withSplittableSources(PARTITIONED_2)
@@ -405,7 +405,7 @@ public class TestHashDistributionSplitAssigner
                 .withSplitPartitionCount(3)
                 .withTargetPartitionSizeInBytes(30)
                 .withTaskTargetMaxCount(10)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(1000, 1, 1)),
                         PARTITIONED_2, new OutputDataSizeEstimate(ImmutableLongArray.of(2, 1, 1))))
                 .withSplittableSources(PARTITIONED_1, PARTITIONED_2)
@@ -420,7 +420,7 @@ public class TestHashDistributionSplitAssigner
         testPartitionMapping()
                 .withSplitPartitionCount(3)
                 .withPartitionedSources(PARTITIONED_1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1))))
                 .withTargetPartitionSizeInBytes(25)
                 .withSplittableSources(PARTITIONED_1)
@@ -432,7 +432,7 @@ public class TestHashDistributionSplitAssigner
         testPartitionMapping()
                 .withSplitPartitionCount(3)
                 .withPartitionedSources(PARTITIONED_1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1))))
                 .withTargetPartitionSizeInBytes(25)
                 .withMergeAllowed(true)
@@ -443,7 +443,7 @@ public class TestHashDistributionSplitAssigner
         testPartitionMapping()
                 .withSplitPartitionCount(3)
                 .withPartitionedSources(PARTITIONED_1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1))))
                 .withTargetPartitionSizeInBytes(25)
                 .withMergeAllowed(false)
@@ -455,7 +455,7 @@ public class TestHashDistributionSplitAssigner
         testPartitionMapping()
                 .withSplitPartitionCount(3)
                 .withPartitionedSources(PARTITIONED_1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(50, 1, 1))))
                 .withTargetPartitionSizeInBytes(25)
                 .withMergeAllowed(false)
@@ -468,7 +468,7 @@ public class TestHashDistributionSplitAssigner
         testPartitionMapping()
                 .withSplitPartitionCount(4)
                 .withPartitionedSources(PARTITIONED_1)
-                .withOutputDataSizeEstimates(ImmutableMap.of(
+                .withSourceDataSizeEstimates(ImmutableMap.of(
                         PARTITIONED_1, new OutputDataSizeEstimate(ImmutableLongArray.of(0, 0, 0, 60))))
                 .withTargetPartitionSizeInBytes(25)
                 .withMergeAllowed(false)
@@ -544,7 +544,7 @@ public class TestHashDistributionSplitAssigner
         private Optional<List<InternalNode>> partitionToNodeMap = Optional.empty();
         private long targetPartitionSizeInBytes;
         private int taskTargetMaxCount = Integer.MAX_VALUE;
-        private Map<PlanNodeId, OutputDataSizeEstimate> outputDataSizeEstimates = ImmutableMap.of();
+        private Map<PlanNodeId, OutputDataSizeEstimate> sourceDataSizeEstimates = ImmutableMap.of();
         private Set<PlanNodeId> splittableSources = ImmutableSet.of();
         private boolean mergeAllowed;
         private int expectedTaskCount;
@@ -591,9 +591,9 @@ public class TestHashDistributionSplitAssigner
             return this;
         }
 
-        public AssignerTester withOutputDataSizeEstimates(Map<PlanNodeId, OutputDataSizeEstimate> outputDataSizeEstimates)
+        public AssignerTester withSourceDataSizeEstimates(Map<PlanNodeId, OutputDataSizeEstimate> sourceDataSizeEstimates)
         {
-            this.outputDataSizeEstimates = outputDataSizeEstimates;
+            this.sourceDataSizeEstimates = sourceDataSizeEstimates;
             return this;
         }
 
@@ -618,10 +618,10 @@ public class TestHashDistributionSplitAssigner
         public void run()
         {
             FaultTolerantPartitioningScheme partitioningScheme = createPartitioningScheme(splitPartitionCount, partitionToNodeMap);
-            Map<Integer, TaskPartition> outputPartitionToTaskPartition = createOutputPartitionToTaskPartition(
+            Map<Integer, TaskPartition> sourcePartitionToTaskPartition = createSourcePartitionToTaskPartition(
                     partitioningScheme,
                     partitionedSources,
-                    outputDataSizeEstimates,
+                    sourceDataSizeEstimates,
                     targetPartitionSizeInBytes,
                     taskTargetMaxCount,
                     splittableSources::contains,
@@ -631,7 +631,7 @@ public class TestHashDistributionSplitAssigner
                     partitionedSources,
                     replicatedSources,
                     partitioningScheme,
-                    outputPartitionToTaskPartition);
+                    sourcePartitionToTaskPartition);
             SplitAssignerTester tester = new SplitAssignerTester();
             Map<Integer, ListMultimap<PlanNodeId, Integer>> partitionedSplitIds = new HashMap<>();
             Set<Integer> replicatedSplitIds = new HashSet<>();
@@ -675,7 +675,7 @@ public class TestHashDistributionSplitAssigner
             // validate partitioned splits
             partitionedSplitIds.forEach((partitionId, sourceSplits) -> {
                 sourceSplits.forEach((source, splitId) -> {
-                    List<TaskDescriptor> descriptors = outputPartitionToTaskPartition.get(partitionId).getSubPartitions().stream()
+                    List<TaskDescriptor> descriptors = sourcePartitionToTaskPartition.get(partitionId).getSubPartitions().stream()
                             .filter(HashDistributionSplitAssigner.SubPartition::isIdAssigned)
                             .map(HashDistributionSplitAssigner.SubPartition::getId)
                             .map(taskDescriptors::get)
@@ -710,7 +710,7 @@ public class TestHashDistributionSplitAssigner
         private int splitPartitionCount;
         private Optional<List<InternalNode>> partitionToNodeMap = Optional.empty();
         private long targetPartitionSizeInBytes;
-        private Map<PlanNodeId, OutputDataSizeEstimate> outputDataSizeEstimates = ImmutableMap.of();
+        private Map<PlanNodeId, OutputDataSizeEstimate> sourceDataSizeEstimates = ImmutableMap.of();
         private Set<PlanNodeId> splittableSources = ImmutableSet.of();
         private boolean mergeAllowed;
         private Set<PartitionMapping> expectedMappings = ImmutableSet.of();
@@ -739,9 +739,9 @@ public class TestHashDistributionSplitAssigner
             return this;
         }
 
-        public PartitionMappingTester withOutputDataSizeEstimates(Map<PlanNodeId, OutputDataSizeEstimate> outputDataSizeEstimates)
+        public PartitionMappingTester withSourceDataSizeEstimates(Map<PlanNodeId, OutputDataSizeEstimate> sourceDataSizeEstimates)
         {
-            this.outputDataSizeEstimates = outputDataSizeEstimates;
+            this.sourceDataSizeEstimates = sourceDataSizeEstimates;
             return this;
         }
 
@@ -766,10 +766,10 @@ public class TestHashDistributionSplitAssigner
         public void run()
         {
             FaultTolerantPartitioningScheme partitioningScheme = createPartitioningScheme(splitPartitionCount, partitionToNodeMap);
-            Map<Integer, TaskPartition> actual = createOutputPartitionToTaskPartition(
+            Map<Integer, TaskPartition> actual = createSourcePartitionToTaskPartition(
                     partitioningScheme,
                     partitionedSources,
-                    outputDataSizeEstimates,
+                    sourceDataSizeEstimates,
                     targetPartitionSizeInBytes,
                     Integer.MAX_VALUE,
                     splittableSources::contains,
@@ -778,9 +778,9 @@ public class TestHashDistributionSplitAssigner
             assertEquals(actualGroups, expectedMappings);
         }
 
-        private static Set<PartitionMapping> extractMappings(Map<Integer, TaskPartition> outputPartitionToTaskPartition)
+        private static Set<PartitionMapping> extractMappings(Map<Integer, TaskPartition> sourcePartitionToTaskPartition)
         {
-            SetMultimap<TaskPartition, Integer> grouped = outputPartitionToTaskPartition.entrySet().stream()
+            SetMultimap<TaskPartition, Integer> grouped = sourcePartitionToTaskPartition.entrySet().stream()
                     .collect(toImmutableSetMultimap(Map.Entry::getValue, Map.Entry::getKey));
             return Multimaps.asMap(grouped).entrySet().stream()
                     .map(entry -> new PartitionMapping(entry.getValue(), entry.getKey().getSubPartitions().size()))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Instead of lazily creating tasks, we create tasks all at once on first assignment of HashDistributionSplitAssigner, and also trigger `setNoMorePartitions` early

Benchmark on tpcds-sf1000: wall time -5.98%, cpu time +2.6%

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
