### PR TITLE
Remove defunct write partitioning property

### DIFF
--- a/docs/src/main/sphinx/admin/properties-write-partitioning.rst
+++ b/docs/src/main/sphinx/admin/properties-write-partitioning.rst
@@ -9,25 +9,9 @@ Write partitioning properties
 * **Type:** :ref:`prop-type-boolean`
 * **Default value:** ``true``
 
-Enable preferred write partitioning. When set to ``true`` and more than the
-minimum number of partitions, set in ``preferred-write-partitioning-min-number-of-partitions``,
-are written, each partition is written by a separate writer. As a result, for some connectors such as the
-Hive connector, only a single new file is written per partition, instead of
-multiple files. Partition writer assignments are distributed across worker
-nodes for parallel processing. ``use-preferred-write-partitioning`` can be
-specified on a per-query basis using the ``use_preferred_write_partitioning``
-session property.
-
-``preferred-write-partitioning-min-number-of-partitions``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* **Type:** :ref:`prop-type-integer`
-* **Default value:** ``50``
-
-Use the connector's preferred write partitioning when the optimizer's estimate
-of the number of partitions that will be written by the query is greater than
-the configured value. If the number of partitions cannot be estimated from the
-statistics, then preferred write partitioning is not used.
-If the threshold value is ``1`` then preferred write partitioning is always used.
-``preferred-write-partitioning-min-number-of-partitions`` can be specified on a
-per-query basis using the ``preferred_write_partitioning_min_number_of_partitions``
-session property.
+Enable preferred write partitioning. When set to ``true``, each partition is
+written by a separate writer. For some connectors such as the Hive connector,
+only a single new file is written per partition, instead of multiple files.
+Partition writer assignments are distributed across worker nodes for parallel
+processing. ``use-preferred-write-partitioning`` can be specified on a per-query
+basis using the ``use_preferred_write_partitioning`` session property.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Removes `preferred-write-partitioning-min-number-of-partitions` from properties reference.
* Removes reference to defunct property in description of `use-preferred-write-partitioning`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* This commit removed the property in Trino 416 release: https://github.com/trinodb/trino/pull/16802/commits/f6a8eb2ded4155d3457bea1a78844099860656de

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
