### PR TITLE
Add since_timestamp parameter to table_changes ptf

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesTableFunctionHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesTableFunctionHandle.java
@@ -19,18 +19,22 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
 public record TableChangesTableFunctionHandle(
         SchemaTableName schemaTableName,
-        long firstReadVersion,
+        Optional<Long> firstReadVersion,
+        Optional<Long> firstReadTimestamp,
         long tableReadVersion,
         String tableLocation,
         List<DeltaLakeColumnHandle> columns) implements ConnectorTableFunctionHandle
 {
     public TableChangesTableFunctionHandle {
         requireNonNull(schemaTableName, "schemaTableName is null");
+        requireNonNull(firstReadVersion, "firstReadVersion is null");
+        requireNonNull(firstReadTimestamp, "firstReadTimestamp is null");
         requireNonNull(tableLocation, "tableLocation is null");
         columns = ImmutableList.copyOf(columns);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add since_timestamp field to table_changes function in delta _lake connector.
Unfortunately there is no ptf overloading so to use it user has to use named parameters.
To make future changes in table_fuction not break backward compatibility I decided to block calls like:
`table_changes('schema', 'table', null, TIMESTAMP '2122-32-23 12:12').  
If these were allowed and users start use it, it could be broken when we add `to_version` and put it before `since_timestamps` 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Add timestamp_table_changes to delta lake. ({issue}`issuenumber`)
```
