### PR TITLE
Fix decode of URI path

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -32,6 +32,7 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.FAIL;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.RECURSE;
+import static java.net.URLDecoder.decode;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.Path.SEPARATOR_CHAR;
 
@@ -122,7 +123,7 @@ public class HiveFileIterator
     @VisibleForTesting
     static boolean isHiddenOrWithinHiddenParentDirectory(Path path, String prefix)
     {
-        String pathString = path.toUri().toString();
+        String pathString = decode(path.toUri().toString());
         checkArgument(pathString.startsWith(prefix), "path %s does not start with prefix %s", pathString, prefix);
         return containsHiddenPathPartAfterIndex(pathString, prefix.endsWith("/") ? prefix.length() : prefix.length() + 1);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -94,4 +94,15 @@ public class TestCachingDirectoryListerRecursiveFilesOnly
 
         assertFalse(isCached(tableLocation));
     }
+
+    @Test
+    public void testRecursiveDirectoriesWithSpecialCharacters()
+    {
+        // Create partitioned table with special characters
+        assertUpdate("CREATE TABLE recursive_directories_with_special_chars (payload varchar, event_name varchar) WITH (format = 'ORC', partitioned_by = ARRAY['event_name'])");
+        assertUpdate("INSERT INTO recursive_directories_with_special_chars VALUES ('data', 'level1|level2'), ('data', 'level1 | level2')", 2);
+        // Check that all files can be read
+        assertQuery("SELECT count(*) FROM recursive_directories_with_special_chars", "VALUES (2)");
+        assertUpdate("DROP TABLE recursive_directories_with_special_chars");
+    }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestHiveFileIterator.java
@@ -37,6 +37,8 @@ public class TestHiveFileIterator
         assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(rootWithinHidden, "file.txt"), rootWithinHidden));
         String rootHiddenEnding = new Path("file:///root/hidden-ending_").toUri().getPath();
         assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(rootHiddenEnding, "file.txt"), rootHiddenEnding));
+        String insideNonAlphanumericPrefix = new Path("file:///root/With spaces and | pipes/.hidden").toUri().getPath();
+        assertFalse(isHiddenOrWithinHiddenParentDirectory(new Path(insideNonAlphanumericPrefix, "file.txt"), insideNonAlphanumericPrefix));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/BaseTestTrinoS3FileSystemObjectStorage.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/BaseTestTrinoS3FileSystemObjectStorage.java
@@ -315,6 +315,34 @@ public abstract class BaseTestTrinoS3FileSystemObjectStorage
     }
 
     @Test
+    public void testDeleteRecursivelyPrefixWithSpecialCharacters()
+            throws Exception
+    {
+        String prefix = "test-delete-recursively-path-with-special characters |" + randomNameSuffix();
+        String prefixPath = "s3://%s/%s".formatted(getBucketName(), prefix);
+
+        try (TrinoS3FileSystem fs = createFileSystem()) {
+            try {
+                String filename1 = "file1.txt";
+                String filename2 = "file2.txt";
+                fs.createNewFile(new Path(prefixPath, filename1));
+                fs.createNewFile(new Path(prefixPath, filename2));
+                List<String> paths = listPaths(fs.getS3Client(), getBucketName(), prefix, true);
+                assertThat(paths).containsOnly(
+                        "%s/%s".formatted(prefix, filename1),
+                        "%s/%s".formatted(prefix, filename2));
+
+                assertTrue(fs.delete(new Path(prefixPath), true));
+
+                assertThat(listPaths(fs.getS3Client(), getBucketName(), prefix, true)).isEmpty();
+            }
+            finally {
+                fs.delete(new Path(prefixPath), true);
+            }
+        }
+    }
+
+    @Test
     public void testDeleteRecursivelyDirectoryWithDeepHierarchy()
             throws Exception
     {


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/17621

## Release notes

( x) Release notes are required, with the following suggested text:

```markdown
# Hive connector
* Fix query failure for paths containing special characters. ({issue}`17621`)
```
