### PR TITLE
Prioritize scheduling build-side of joins

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.google.common.graph.Traverser;
 import com.google.common.io.Closer;
 import com.google.common.primitives.ImmutableLongArray;
 import com.google.common.util.concurrent.FutureCallback;
@@ -147,6 +146,7 @@ import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.REMOTE_HOST_GONE;
 import static io.trino.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.TopologicalOrderSubPlanVisitor.sortPlanInTopologicalOrder;
 import static io.trino.util.Failures.toFailure;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -1173,13 +1173,6 @@ public class EventDrivenFaultTolerantQueryScheduler
             StageExecution execution = stageExecutions.get(stageId);
             checkState(execution != null, "stage execution does not exist for stage: %s", stageId);
             return execution;
-        }
-
-        private static List<SubPlan> sortPlanInTopologicalOrder(SubPlan subPlan)
-        {
-            ImmutableList.Builder<SubPlan> result = ImmutableList.builder();
-            Traverser.forTree(SubPlan::getChildren).depthFirstPostOrder(subPlan).forEach(result::add);
-            return result.build();
         }
 
         private boolean shouldDelayScheduling(@Nullable ErrorCode errorCode)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/BuildSideJoinPlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/BuildSideJoinPlanVisitor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.sql.planner.plan.IndexJoinNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.SemiJoinNode;
+import io.trino.sql.planner.plan.SpatialJoinNode;
+
+public class BuildSideJoinPlanVisitor<C>
+        extends SimplePlanVisitor<C>
+{
+    @Override
+    public Void visitJoin(JoinNode node, C context)
+    {
+        node.getRight().accept(this, context);
+        node.getLeft().accept(this, context);
+        return null;
+    }
+
+    @Override
+    public Void visitSemiJoin(SemiJoinNode node, C context)
+    {
+        node.getFilteringSource().accept(this, context);
+        node.getSource().accept(this, context);
+        return null;
+    }
+
+    @Override
+    public Void visitSpatialJoin(SpatialJoinNode node, C context)
+    {
+        node.getRight().accept(this, context);
+        node.getLeft().accept(this, context);
+        return null;
+    }
+
+    @Override
+    public Void visitIndexJoin(IndexJoinNode node, C context)
+    {
+        node.getIndexSource().accept(this, context);
+        node.getProbeSource().accept(this, context);
+        return null;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SchedulingOrderVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SchedulingOrderVisitor.java
@@ -15,12 +15,8 @@
 package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
-import io.trino.sql.planner.plan.IndexJoinNode;
-import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
-import io.trino.sql.planner.plan.SemiJoinNode;
-import io.trino.sql.planner.plan.SpatialJoinNode;
 import io.trino.sql.planner.plan.TableFunctionProcessorNode;
 import io.trino.sql.planner.plan.TableScanNode;
 
@@ -41,45 +37,13 @@ public final class SchedulingOrderVisitor
     private SchedulingOrderVisitor() {}
 
     private static class Visitor
-            extends SimplePlanVisitor<Void>
+            extends BuildSideJoinPlanVisitor<Void>
     {
         private final Consumer<PlanNodeId> schedulingOrder;
 
         public Visitor(Consumer<PlanNodeId> schedulingOrder)
         {
             this.schedulingOrder = requireNonNull(schedulingOrder, "schedulingOrder is null");
-        }
-
-        @Override
-        public Void visitJoin(JoinNode node, Void context)
-        {
-            node.getRight().accept(this, context);
-            node.getLeft().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitSemiJoin(SemiJoinNode node, Void context)
-        {
-            node.getFilteringSource().accept(this, context);
-            node.getSource().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitSpatialJoin(SpatialJoinNode node, Void context)
-        {
-            node.getRight().accept(this, context);
-            node.getLeft().accept(this, context);
-            return null;
-        }
-
-        @Override
-        public Void visitIndexJoin(IndexJoinNode node, Void context)
-        {
-            node.getIndexSource().accept(this, context);
-            node.getProbeSource().accept(this, context);
-            return null;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TopologicalOrderSubPlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TopologicalOrderSubPlanVisitor.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.graph.SuccessorsFunction;
+import com.google.common.graph.Traverser;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
+
+public class TopologicalOrderSubPlanVisitor
+{
+    private TopologicalOrderSubPlanVisitor() {}
+
+    public static List<SubPlan> sortPlanInTopologicalOrder(SubPlan subPlan)
+    {
+        return ImmutableList.copyOf(Traverser.forTree(getChildren).depthFirstPostOrder(subPlan));
+    }
+
+    private static final SuccessorsFunction<SubPlan> getChildren = subPlan -> {
+        Visitor visitor = new Visitor(subPlan);
+        subPlan.getFragment().getRoot().accept(visitor, null);
+        checkState(visitor.getSourceSubPlans().isEmpty(),
+                "Some SubNode sources have not been visited: %s",
+                visitor.getSourceSubPlans());
+        return visitor.getChildren();
+    };
+
+    private static class Visitor
+            extends BuildSideJoinPlanVisitor<Void>
+    {
+        private final SubPlan subPlan;
+        private final Map<PlanFragmentId, SubPlan> sourceSubPlans;
+        private final ImmutableList.Builder<SubPlan> children = ImmutableList.builder();
+
+        public Visitor(SubPlan subPlan)
+        {
+            this.subPlan = subPlan;
+            this.sourceSubPlans = subPlan.getChildren().stream()
+                    .collect(toMap(plan -> plan.getFragment().getId(), plan -> plan));
+        }
+
+        public Map<PlanFragmentId, SubPlan> getSourceSubPlans()
+        {
+            return sourceSubPlans;
+        }
+
+        public List<SubPlan> getChildren()
+        {
+            return children.build();
+        }
+
+        @Override
+        public Void visitRemoteSource(RemoteSourceNode node, Void context)
+        {
+            for (PlanFragmentId fragmentId : node.getSourceFragmentIds()) {
+                SubPlan child = sourceSubPlans.remove(fragmentId);
+                requireNonNull(child, "PlanFragmentId %s does not appear in sources of %s".formatted(fragmentId, subPlan));
+                children.add(child);
+            }
+            return null;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTopologicalOrderSubPlanVisitor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTopologicalOrderSubPlanVisitor.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.cost.StatsAndCosts;
+import io.trino.operator.RetryPolicy;
+import io.trino.sql.planner.plan.IndexJoinNode;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.SemiJoinNode;
+import io.trino.sql.planner.plan.SpatialJoinNode;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.Row;
+import io.trino.sql.tree.StringLiteral;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static io.trino.sql.planner.TopologicalOrderSubPlanVisitor.sortPlanInTopologicalOrder;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTopologicalOrderSubPlanVisitor
+{
+    private interface JoinFunction
+    {
+        PlanNode apply(String id, PlanNode left, PlanNode right);
+    }
+
+    private void test(JoinFunction f)
+    {
+        //   * root
+        //  / \
+        // A   * middle
+        //    / \
+        //   B   C
+        SubPlan a = valuesSubPlan("a");
+        SubPlan b = valuesSubPlan("b");
+        SubPlan c = valuesSubPlan("c");
+
+        SubPlan middle = createSubPlan("middle",
+                f.apply("middle_join", remoteSource("b"), remoteSource("c")),
+                ImmutableList.of(b, c));
+
+        SubPlan root = createSubPlan("root",
+                f.apply("root_join", remoteSource("a"), remoteSource("middle")),
+                ImmutableList.of(a, middle));
+
+        assertThat(sortPlanInTopologicalOrder(root))
+                .isEqualTo(ImmutableList.of(c, b, middle, a, root));
+    }
+
+    @Test
+    public void testJoinOrder()
+    {
+        test(TestTopologicalOrderSubPlanVisitor::join);
+    }
+
+    @Test
+    public void testSemiJoinOrder()
+    {
+        test(TestTopologicalOrderSubPlanVisitor::semiJoin);
+    }
+
+    @Test
+    public void testIndexJoin()
+    {
+        test(TestTopologicalOrderSubPlanVisitor::indexJoin);
+    }
+
+    @Test
+    public void testSpatialJoin()
+    {
+        test(TestTopologicalOrderSubPlanVisitor::spatialJoin);
+    }
+
+    private static RemoteSourceNode remoteSource(String fragmentId)
+    {
+        return remoteSource(ImmutableList.of(fragmentId));
+    }
+
+    private static RemoteSourceNode remoteSource(List<String> fragmentIds)
+    {
+        return new RemoteSourceNode(
+                new PlanNodeId(fragmentIds.get(0)),
+                fragmentIds.stream().map(PlanFragmentId::new).collect(toImmutableList()),
+                ImmutableList.of(new Symbol("blah")),
+                Optional.empty(),
+                REPARTITION,
+                RetryPolicy.TASK);
+    }
+
+    private static JoinNode join(String id, PlanNode left, PlanNode right)
+    {
+        return new JoinNode(
+                new PlanNodeId(id),
+                INNER,
+                left,
+                right,
+                ImmutableList.of(),
+                left.getOutputSymbols(),
+                right.getOutputSymbols(),
+                false,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableMap.of(),
+                Optional.empty());
+    }
+
+    private static SemiJoinNode semiJoin(String id, PlanNode left, PlanNode right)
+    {
+        return new SemiJoinNode(
+                new PlanNodeId(id),
+                left,
+                right,
+                left.getOutputSymbols().get(0),
+                right.getOutputSymbols().get(0),
+                new Symbol(id),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static IndexJoinNode indexJoin(String id, PlanNode left, PlanNode right)
+    {
+        return new IndexJoinNode(
+                new PlanNodeId(id),
+                IndexJoinNode.Type.INNER,
+                left,
+                right,
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static SpatialJoinNode spatialJoin(String id, PlanNode left, PlanNode right)
+    {
+        return new SpatialJoinNode(
+                new PlanNodeId(id),
+                SpatialJoinNode.Type.INNER,
+                left,
+                right,
+                left.getOutputSymbols(),
+                BooleanLiteral.TRUE_LITERAL,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private static SubPlan valuesSubPlan(String fragmentId)
+    {
+        Symbol symbol = new Symbol("column");
+        return createSubPlan(fragmentId, new ValuesNode(new PlanNodeId(fragmentId + "Values"),
+                        ImmutableList.of(symbol),
+                        ImmutableList.of(new Row(ImmutableList.of(new StringLiteral("foo"))))),
+                ImmutableList.of());
+    }
+
+    private static SubPlan createSubPlan(String fragmentId, PlanNode plan, List<SubPlan> children)
+    {
+        Symbol symbol = plan.getOutputSymbols().get(0);
+        PlanNodeId valuesNodeId = new PlanNodeId("plan");
+        PlanFragment planFragment = new PlanFragment(
+                new PlanFragmentId(fragmentId),
+                plan,
+                ImmutableMap.of(symbol, VARCHAR),
+                SOURCE_DISTRIBUTION,
+                Optional.empty(),
+                ImmutableList.of(valuesNodeId),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), ImmutableList.of(symbol)),
+                StatsAndCosts.empty(),
+                ImmutableList.of(),
+                Optional.empty());
+        return new SubPlan(planFragment, children);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This modifies the topological scheduling order of SubPlans so that the build side is prioritized for all join types.

The intent here is to optimize query performance to ensure the "build" (i.e. right) side (which must be complete before the join can progress _at all_) is scheduled ahead of the "probe" (i.e. left) side.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
