### PR TITLE
Refer ${project.version} instead of hardcoded version in trino-test-jdbc-compatibility-old-driver pom.xml

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.presto-jdbc-under-test>420-SNAPSHOT</dep.presto-jdbc-under-test>
+        <dep.presto-jdbc-under-test>${project.version}</dep.presto-jdbc-under-test>
     </properties>
 
     <dependencies>


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The default value of `dep.presto-jdbc-under-test` is hardcoded to the current version. Instead `${project.version}` can be used.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

