### PR TITLE
Make worker not fail on getOptionalCatalogMetadata during coercion resolution

### DIFF
--- a/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
@@ -93,7 +93,11 @@ public class NoOpTransactionManager
     @Override
     public Optional<CatalogMetadata> getOptionalCatalogMetadata(TransactionId transactionId, String catalogName)
     {
-        throw new UnsupportedOperationException();
+        /*
+         * When SQL path is present in the session, it is possible for a worker node to invoke this method in the
+         * process of resolving a coercion. Return Optional.empty() here to avoid failing the query in that scenario.
+         */
+        return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
* To address #17598 
* As discussed on [slack](https://trinodb.slack.com/archives/CP1MUNEUX/p1684469852421559), fix this from `NoOpTransactionManager`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
