### PR TITLE
Fix incorrect @BeforeTest usages

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
@@ -19,7 +19,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -53,7 +53,7 @@ public class TestJdbcTableProperties
         return createH2QueryRunner(ImmutableList.copyOf(TpchTable.getTables()), properties, module);
     }
 
-    @BeforeTest
+    @BeforeMethod
     public void reset()
     {
         onGetTableProperties = () -> {};

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
@@ -22,8 +22,8 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -51,14 +51,14 @@ public class TestBlackHoleSmoke
 {
     private QueryRunner queryRunner;
 
-    @BeforeTest
+    @BeforeClass
     public void setUp()
             throws Exception
     {
         queryRunner = createQueryRunner();
     }
 
-    @AfterTest(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void tearDown()
     {
         assertThatNoBlackHoleTableIsCreated();

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
@@ -24,7 +24,7 @@ import io.trino.plugin.cassandra.CassandraTypes;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.plugin.cassandra.CassandraTestingUtils.CASSANDRA_TYPE_MANAGER;
@@ -40,7 +40,7 @@ public class TestCassandraClusteringPredicatesExtractor
     private static CassandraTable cassandraTable;
     private static Version cassandraVersion;
 
-    @BeforeTest
+    @BeforeClass
     public void setUp()
     {
         col1 = new CassandraColumnHandle("partitionKey1", 1, CassandraTypes.BIGINT, true, false, false, false);

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportPrivateMethods.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportPrivateMethods.java
@@ -13,7 +13,7 @@
  */
 package io.trino.testng.services;
 
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -65,7 +65,7 @@ public class TestReportPrivateMethods
     private static class PackagePrivateTest
     {
         // using @Test would make the class a test, and fail the build
-        @BeforeTest
+        @BeforeMethod
         void testPackagePrivate() {}
     }
 
@@ -84,7 +84,7 @@ public class TestReportPrivateMethods
     private static class BasePackagePrivateTest
     {
         // using @Test would make the class a test, and fail the build
-        @BeforeTest
+        @BeforeMethod
         void testPackagePrivateInBase() {}
     }
 
@@ -92,14 +92,14 @@ public class TestReportPrivateMethods
             extends BasePackagePrivateTest
     {
         // using @Test would make the class a test, and fail the build
-        @BeforeTest
+        @BeforeMethod
         public void testPublic() {}
     }
 
     private static class PackagePrivateSuppressedTest
     {
         // using @Test would make the class a test, and fail the build
-        @BeforeTest
+        @BeforeMethod
         @ReportPrivateMethods.Suppress
         void testPackagePrivate() {}
     }


### PR DESCRIPTION
In some places before-test-method and in some before-class was apparently meant.

`TestReportPrivateMethods`is changed too to limit proliferation of this annotation.

TestNG method invocation order example

```
Test class 1: @BeforeTest
Test class 2: @BeforeTest
Test class 1: @BeforeCass
Test class 1: @BeforeMethod
Test class 1: a test 1
Test class 1: @AfterMethod
Test class 1: @BeforeMethod
Test class 1: a test 2
Test class 1: @AfterMethod
Test class 1: @afterclass
Test class 2: @BeforeCass
Test class 2: @BeforeMethod
Test class 2: a test 1
Test class 2: @AfterMethod
Test class 2: @BeforeMethod
Test class 2: a test 2
Test class 2: @AfterMethod
Test class 2: @afterclass
Test class 1: @AfterTest
Test class 2: @AfterTest
```

