### PR TITLE
Disallow using @BeforeTest and @AfterTest testng annotations

### DIFF
--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportAfterMethodNotAlwaysRun.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportAfterMethodNotAlwaysRun.java
@@ -52,7 +52,7 @@ public class ReportAfterMethodNotAlwaysRun
     public void onBeforeClass(ITestClass testClass)
     {
         try {
-            checkHasAfterMethodsNotAlwaysRun(testClass.getRealClass());
+            checkHasAfterMethodsAlwaysRun(testClass.getRealClass());
         }
         catch (RuntimeException | Error e) {
             reportListenerFailure(
@@ -64,7 +64,7 @@ public class ReportAfterMethodNotAlwaysRun
     }
 
     @VisibleForTesting
-    static void checkHasAfterMethodsNotAlwaysRun(Class<?> testClass)
+    static void checkHasAfterMethodsAlwaysRun(Class<?> testClass)
     {
         List<Method> notAlwaysRunMethods = Arrays.stream(testClass.getMethods())
                 .filter(ReportAfterMethodNotAlwaysRun::isAfterMethodNotAlwaysRun)

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportBannedAnnotationUsage.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportBannedAnnotationUsage.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.testng.services.Listeners.reportListenerFailure;
+import static java.util.stream.Collectors.joining;
+
+public class ReportBannedAnnotationUsage
+        implements IClassListener
+{
+    private static final Set<Class<? extends Annotation>> BANNED_ANNOTATIONS = ImmutableSet.of(BeforeTest.class, AfterTest.class);
+
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        try {
+            checkNoBannedAnnotationsAreUsed(testClass.getRealClass());
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(
+                    ReportBannedAnnotationUsage.class,
+                    "Failed to process %s:%n%s",
+                    testClass.getName(),
+                    getStackTraceAsString(e));
+        }
+    }
+
+    @VisibleForTesting
+    static void checkNoBannedAnnotationsAreUsed(Class<?> testClass)
+    {
+        List<Method> notAlwaysRunMethods = Arrays.stream(testClass.getMethods())
+                .filter(ReportBannedAnnotationUsage::isUsingBannedAnnotation)
+                .collect(toImmutableList());
+
+        if (!notAlwaysRunMethods.isEmpty()) {
+            throw new RuntimeException(notAlwaysRunMethods.stream()
+                    .map(Method::toString)
+                    .sorted()
+                    .collect(joining("\n", "Annotations @BeforeTest and @AfterTests are banned. Use @BeforeClass and @AfterClass instead:\n", "")));
+        }
+    }
+
+    private static boolean isUsingBannedAnnotation(Method method)
+    {
+        return BANNED_ANNOTATIONS.stream().anyMatch(p -> method.getAnnotation(p) != null);
+    }
+
+    @Override
+    public void onAfterClass(ITestClass testClass) {}
+}

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -10,3 +10,4 @@ io.trino.testng.services.RetryAnnotationTransformer
 io.trino.testng.services.FlakyAnnotationVerifier
 io.trino.testng.services.ProgressLoggingListener
 io.trino.testng.services.ReportInnerTestClasses
+io.trino.testng.services.ReportBannedAnnotationUsage

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
@@ -29,7 +29,7 @@ public class TestReportAfterMethodNotAlwaysRun
     @Test(dataProvider = "correctCases")
     public void testCorrectCases(Class<?> testClass)
     {
-        assertThatNoException().isThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass));
+        assertThatNoException().isThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsAlwaysRun(testClass));
     }
 
     @DataProvider
@@ -48,7 +48,7 @@ public class TestReportAfterMethodNotAlwaysRun
     @Test(dataProvider = "incorrectCases")
     public void testIncorrectCases(Class<?> testClass, String... failMethods)
     {
-        assertThatThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass))
+        assertThatThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsAlwaysRun(testClass))
                 .hasMessage(
                         "The @AfterX methods should have the alwaysRun = true attribute to make sure that they'll run even if tests were skipped:%n%s",
                         String.join("\n", failMethods));

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportBannedAnnotationUsage.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportBannedAnnotationUsage.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testng.services;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestReportBannedAnnotationUsage
+{
+    @Test(dataProvider = "correctCases")
+    public void testCorrectCases(Class<?> testClass)
+    {
+        assertThatNoException().isThrownBy(() -> ReportBannedAnnotationUsage.checkNoBannedAnnotationsAreUsed(testClass));
+    }
+
+    @DataProvider
+    public static Object[][] correctCases()
+    {
+        return new Object[][] {
+                {NoMethods.class},
+                {NonBannedAnnotations.class},
+                {SubClassWithNonBannedAnnotations.class},
+        };
+    }
+
+    @Test(dataProvider = "incorrectCases")
+    public void testIncorrectCases(Class<?> testClass, String... failMethods)
+    {
+        assertThatThrownBy(() -> ReportBannedAnnotationUsage.checkNoBannedAnnotationsAreUsed(testClass))
+                .hasMessage(
+                        "Annotations @BeforeTest and @AfterTests are banned. Use @BeforeClass and @AfterClass instead:%n%s",
+                        String.join("\n", failMethods));
+    }
+
+    @DataProvider
+    public static Object[][] incorrectCases()
+            throws NoSuchMethodException
+    {
+        return new Object[][] {
+                {
+                        BannedBeforeTestAnnotation.class,
+                        BannedBeforeTestAnnotation.class.getMethod("beforeTest").toString(),
+                },
+                {
+                        BannedAfterTestAnnotation.class,
+                        BannedAfterTestAnnotation.class.getMethod("afterTest").toString(),
+                },
+                {
+                        SubClassWithBannedBeforeTestAnnotation.class,
+                        BannedBeforeTestAnnotation.class.getMethod("beforeTest").toString(),
+                },
+                {
+                        SubClassWithBannedAfterTestAnnotation.class,
+                        BannedAfterTestAnnotation.class.getMethod("afterTest").toString(),
+                },
+        };
+    }
+
+    private static class NoMethods
+    {
+    }
+
+    private static class NonBannedAnnotations
+    {
+        @AfterClass
+        public void afterClass() {}
+
+        @AfterGroups
+        public void afterGroup() {}
+
+        @AfterMethod
+        public void afterMethod() {}
+
+        @AfterSuite
+        public void afterSuite() {}
+    }
+
+    private static class BannedBeforeTestAnnotation
+    {
+        @BeforeTest
+        public void beforeTest() {}
+
+        @AfterSuite
+        public void afterSuite() {}
+    }
+
+    private static class BannedAfterTestAnnotation
+    {
+        @AfterTest
+        public void afterTest() {}
+
+        @AfterSuite
+        public void afterSuite() {}
+    }
+
+    private static class SubClassWithNonBannedAnnotations
+            extends NonBannedAnnotations {}
+
+    private static class SubClassWithBannedBeforeTestAnnotation
+            extends BannedBeforeTestAnnotation {}
+
+    private static class SubClassWithBannedAfterTestAnnotation
+            extends BannedAfterTestAnnotation {}
+}


### PR DESCRIPTION
Disallow using @BeforeTest and @AfterTest testng annotations

These annotation names are confusing and does not provide more value that one
can achieve using with @BeforeClass or @AfterClass
