### PR TITLE
Improve migrate procedure docs for Iceberg

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -544,19 +544,35 @@ existing Iceberg table from the metastores without deleting the data::
 Migrate table
 """""""""""""
 
-The connector can read from or write to Hive tables that have been migrated to Iceberg.
-The procedure ``system.migrate`` allows the caller to replace
-a Hive table with an Iceberg table, loaded with the source’s data files.
-Table schema, partitioning, properties, and location will be copied from the source table.
-Migrate will fail if any table partition uses an unsupported format::
+The connector can read from or write to Hive tables that have been migrated to
+Iceberg.
 
-    CALL iceberg.system.migrate(schema_name => 'testdb', table_name => 'customer_orders')
+Use the procedure ``system.migrate`` to move a table from the Hive format to the
+Iceberg format, loaded with the source’s data files. Table schema, partitioning,
+properties, and location are copied from the source table. The data files in the
+Hive table must use the Parquet, ORC, or Avro file format.
 
-In addition, you can provide a ``recursive_directory`` argument to migrate a Hive table that contains subdirectories.
-The possible values are ``true``, ``false`` and ``fail``. The default value is ``fail`` that throws an exception
-if nested directory exists::
+The procedure must be called for a specific catalog ``example`` with the
+relevant schema and table names supplied with the required parameters
+``schema_name`` and ``table_name``::
 
-    CALL iceberg.system.migrate(schema_name => 'testdb', table_name => 'customer_orders', recursive_directory => 'true')
+    CALL example.system.migrate(
+        schema_name => 'testdb',
+        table_name => 'customer_orders')
+
+Migrate fails if any table partition uses an unsupported file format.
+
+In addition, you can provide a ``recursive_directory`` argument to migrate a
+Hive table that contains subdirectories::
+
+    CALL example.system.migrate(
+        schema_name => 'testdb',
+        table_name => 'customer_orders',
+        recursive_directory => 'true')
+
+The default value is ``fail``, and cause the migrate procedure to throw an
+exception if subdirectories are found. Set the value to ``true`` to migrate
+nested directories, or ``false`` to ignore them.
 
 .. _iceberg-data-management:
 


### PR DESCRIPTION
## Description

Fix confusion about connector name vs catalog name and generally improve the section for clarity.

## Additional context and related issues

Need clarification a bit more.. also do we need to warn the user that this might take a while .. or very long depending on table size? Or is this essentially just rejigging metadata and therefore actually fast .. well actually. Even if that the case .. thats potentially a lot of metadata to get from the HMS and pump into the Iceberg metadata files... do we have any experience how long this can take .. for example for a 1GB, 100GB, or 1TB table? 

Any idea here @ebyhr @findinpath @alexjo2144 @findepi 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.

