### PR TITLE
Use uppercase for web ui authentication types in docs

### DIFF
--- a/docs/src/main/sphinx/admin/properties-web-interface.rst
+++ b/docs/src/main/sphinx/admin/properties-web-interface.rst
@@ -7,8 +7,8 @@ The following properties can be used to configure the :doc:`web-interface`.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** :ref:`prop-type-string`
-* **Allowed values:** ``form``, ``fixed``, ``certificate``, ``kerberos``, ``jwt``, ``oauth2``
-* **Default value:** ``form``
+* **Allowed values:** ``FORM``, ``FIXED``, ``CERTIFICATE``, ``KERBEROS``, ``JWT``, ``OAUTH2``
+* **Default value:** ``FORM``
 
 The authentication mechanism to allow user access to the Web UI. See
 :ref:`Web UI Authentication <web-ui-authentication>`.

--- a/docs/src/main/sphinx/admin/web-interface.rst
+++ b/docs/src/main/sphinx/admin/web-interface.rst
@@ -31,7 +31,7 @@ Typically, a password-based authentication method
 such as :doc:`LDAP </security/ldap>` or :doc:`password file </security/password-file>`
 is used to secure both the Trino server and the Web UI. When the Trino server
 is configured to use a password authenticator, the Web UI authentication type
-is automatically set to ``form``. In this case, the Web UI displays a login form
+is automatically set to ``FORM``. In this case, the Web UI displays a login form
 that accepts a username and password.
 
 Fixed user authentication
@@ -39,7 +39,7 @@ Fixed user authentication
 
 If you require the Web UI to be accessible without authentication, you can set a fixed
 username that will be used for all Web UI access by setting the authentication type to
-``fixed`` and setting the username with the ``web-ui.user`` configuration property.
+``FIXED`` and setting the username with the ``web-ui.user`` configuration property.
 If there is a system access control installed, this user must have permission to view
 (and possibly to kill) queries.
 
@@ -48,10 +48,10 @@ Other authentication types
 
 The following Web UI authentication types are also supported:
 
-* ``certificate``, see details in :doc:`/security/certificate`
-* ``kerberos``, see details in :doc:`/security/kerberos`
-* ``jwt``, see details in :doc:`/security/jwt`
-* ``oauth2``, see details in :doc:`/security/oauth2`
+* ``CERTIFICATE``, see details in :doc:`/security/certificate`
+* ``KERBEROS``, see details in :doc:`/security/kerberos`
+* ``JWT``, see details in :doc:`/security/jwt`
+* ``OAUTH2``, see details in :doc:`/security/oauth2`
 
 For these authentication types, the username is defined by :doc:`/security/user-mapping`.
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Update documentation to use uppercase for authentication types for web ui to be consistent with other authentication types. This was implemented to work in the linked ticket and should only be merged after a release was cut as agreed with @electrum and @Praveen2112 .

Not sure if we should update any of the tests. Wdyt?

## Additional context and related issues

Follow up to #17360 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
