### PR TITLE
Avoid getFunctionMetadata for connector provided functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2304,12 +2304,15 @@ public final class MetadataManager
                 .filter(Objects::nonNull)
                 .forEach(functions::add);
 
+        boolean deprecated = functionMetadata.isDeprecated();
         return new ResolvedFunction(
                 functionBinding.getBoundSignature(),
                 catalogHandle,
                 functionBinding.getFunctionId(),
                 functionMetadata.getKind(),
                 functionMetadata.isDeterministic(),
+                deprecated,
+                deprecated ? Optional.of(functionMetadata.getDescription()) : Optional.empty(),
                 functionMetadata.getFunctionNullability(),
                 dependentTypes,
                 functions.build());

--- a/core/trino-main/src/main/java/io/trino/metadata/ResolvedFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ResolvedFunction.java
@@ -65,6 +65,8 @@ public class ResolvedFunction
     private final FunctionId functionId;
     private final FunctionKind functionKind;
     private final boolean deterministic;
+    private final boolean deprecated;
+    private final Optional<String> description;
     private final FunctionNullability functionNullability;
     private final Map<TypeSignature, Type> typeDependencies;
     private final Set<ResolvedFunction> functionDependencies;
@@ -76,6 +78,8 @@ public class ResolvedFunction
             @JsonProperty("id") FunctionId functionId,
             @JsonProperty("functionKind") FunctionKind functionKind,
             @JsonProperty("deterministic") boolean deterministic,
+            @JsonProperty("deprecated") boolean deprecated,
+            @JsonProperty("description") Optional<String> description,
             @JsonProperty("functionNullability") FunctionNullability functionNullability,
             @JsonProperty("typeDependencies") Map<TypeSignature, Type> typeDependencies,
             @JsonProperty("functionDependencies") Set<ResolvedFunction> functionDependencies)
@@ -85,6 +89,8 @@ public class ResolvedFunction
         this.functionId = requireNonNull(functionId, "functionId is null");
         this.functionKind = requireNonNull(functionKind, "functionKind is null");
         this.deterministic = deterministic;
+        this.deprecated = deprecated;
+        this.description = requireNonNull(description, "description is null");
         this.functionNullability = requireNonNull(functionNullability, "functionNullability is null");
         this.typeDependencies = ImmutableMap.copyOf(requireNonNull(typeDependencies, "typeDependencies is null"));
         this.functionDependencies = ImmutableSet.copyOf(requireNonNull(functionDependencies, "functionDependencies is null"));
@@ -119,6 +125,18 @@ public class ResolvedFunction
     public boolean isDeterministic()
     {
         return deterministic;
+    }
+
+    @JsonProperty
+    public boolean isDeprecated()
+    {
+        return deprecated;
+    }
+
+    @JsonProperty
+    public Optional<String> getDescription()
+    {
+        return description;
     }
 
     @JsonProperty
@@ -175,6 +193,8 @@ public class ResolvedFunction
                 Objects.equals(functionId, that.functionId) &&
                 functionKind == that.functionKind &&
                 deterministic == that.deterministic &&
+                deprecated == that.deprecated &&
+                Objects.equals(description, that.description) &&
                 Objects.equals(functionNullability, that.functionNullability) &&
                 Objects.equals(typeDependencies, that.typeDependencies) &&
                 Objects.equals(functionDependencies, that.functionDependencies);
@@ -183,7 +203,7 @@ public class ResolvedFunction
     @Override
     public int hashCode()
     {
-        return Objects.hash(signature, catalogHandle, functionId, functionKind, deterministic, functionNullability, typeDependencies, functionDependencies);
+        return Objects.hash(signature, catalogHandle, functionId, functionKind, deterministic, deprecated, description, functionNullability, typeDependencies, functionDependencies);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -36,7 +36,6 @@ import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoWarning;
 import io.trino.spi.function.BoundSignature;
-import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DateType;
@@ -1313,12 +1312,11 @@ public class ExpressionAnalyzer
 
             resolvedFunctions.put(NodeRef.of(node), function);
 
-            FunctionMetadata functionMetadata = plannerContext.getMetadata().getFunctionMetadata(session, function);
-            if (functionMetadata.isDeprecated()) {
+            if (function.isDeprecated()) {
                 warningCollector.add(new TrinoWarning(DEPRECATED_FUNCTION,
                         format("Use of deprecated function: %s: %s",
-                                functionMetadata.getSignature().getName(),
-                                functionMetadata.getDescription())));
+                                function.getSignature().toSignature().getName(),
+                                function.getDescription().get())));
             }
 
             Type type = signature.getReturnType();

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -754,6 +754,8 @@ public abstract class AbstractMockMetadata
                     toFunctionId(boundSignature.toSignature()),
                     SCALAR,
                     true,
+                    false,
+                    Optional.empty(),
                     new FunctionNullability(false, ImmutableList.of()),
                     ImmutableMap.of(),
                     ImmutableSet.of());

--- a/core/trino-main/src/test/java/io/trino/metadata/TestResolvedFunction.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestResolvedFunction.java
@@ -65,6 +65,8 @@ public class TestResolvedFunction
                         .build()),
                 SCALAR,
                 true,
+                false,
+                Optional.empty(),
                 new FunctionNullability(false, ImmutableList.of(false, false)),
                 ImmutableSet.of(createVarcharType(11), createVarcharType(12), createVarcharType(13)).stream()
                         .collect(toImmutableMap(Type::getTypeSignature, Function.identity())),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -1214,6 +1214,8 @@ public class TestEffectivePredicateExtractor
                 toFunctionId(boundSignature.toSignature()),
                 SCALAR,
                 true,
+                false,
+                Optional.empty(),
                 new FunctionNullability(false, ImmutableList.of()),
                 ImmutableMap.of(),
                 ImmutableSet.of());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiPredicate;
 
 import static com.google.common.base.Verify.verify;
@@ -90,6 +91,8 @@ public class TestLiteralEncoder
             new LiteralFunction(PLANNER_CONTEXT.getBlockEncodingSerde()).getFunctionMetadata().getFunctionId(),
             SCALAR,
             true,
+            false,
+            Optional.empty(),
             new FunctionNullability(false, ImmutableList.of(false)),
             ImmutableMap.of(),
             ImmutableSet.of());
@@ -104,6 +107,8 @@ public class TestLiteralEncoder
                     .build()),
             SCALAR,
             true,
+            false,
+            Optional.empty(),
             new FunctionNullability(false, ImmutableList.of(false)),
             ImmutableMap.of(),
             ImmutableSet.of());


### PR DESCRIPTION
I am trying to use SQL path in production and have bumped into some issues. At the moment we only need to support scalar functions via this way so I did not look into the parts where `getAggregationFunctionMetadata` is used. The changes in this PR may not align with the community's plan to resolve them but I would like to collect some thoughts so that we can move along with it internally for the short term. Thanks.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
* Using catalog provided functions with SQL paths in the session causes query fail on worker node on code paths involving operations not allowed on workers
* `deterministic` is included in `ResolvedFunction` but not used in `ExpressionOptimizer` and `ExpressionInterpreter`. Instead we make other method calls to get function metadata. 
* Similar to `deterministic` I think we can carry `deprecated` in `ResolvedFunction`, and `description` only when the function is deprecated, so for most cases the size of the corresponding `QualifiedName` object would not increase much.
* Related to #17644 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: