### PR TITLE
add: iceberg.jdbc-catalog.initialize-catalog-tables property

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -249,6 +249,7 @@ When using any database besides PostgreSQL, a JDBC driver jar file must be place
     iceberg.jdbc-catalog.connection-user=admin
     iceberg.jdbc-catalog.connection-password=test
     iceberg.jdbc-catalog.default-warehouse-dir=s3://bucket
+    iceberg.jdbc-catalog.initialize-catalog-tables=true
 
 JDBC catalog does not support :doc:`views</sql/create-view>` or
 :doc:`materialized views</sql/create-materialized-view>`.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcCatalogConfig.java
@@ -30,6 +30,7 @@ public class IcebergJdbcCatalogConfig
     private String connectionPassword;
     private String catalogName;
     private String defaultWarehouseDir;
+    private boolean initializeCatalogTables;
 
     @NotNull
     public String getDriverClass()
@@ -113,6 +114,20 @@ public class IcebergJdbcCatalogConfig
     public IcebergJdbcCatalogConfig setDefaultWarehouseDir(String defaultWarehouseDir)
     {
         this.defaultWarehouseDir = defaultWarehouseDir;
+        return this;
+    }
+
+    @NotEmpty
+    public boolean getInitializeCatalogTables()
+    {
+        return initializeCatalogTables;
+    }
+
+    @Config("iceberg.jdbc-catalog.initialize-catalog-tables")
+    @ConfigDescription("Automatic creation of catalog tables (if missing)")
+    public IcebergJdbcCatalogConfig setInitializeCatalogTables(boolean initializeCatalogTables)
+    {
+        this.initializeCatalogTables = initializeCatalogTables;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalogFactory.java
@@ -47,6 +47,7 @@ public class TrinoJdbcCatalogFactory
     private final String jdbcCatalogName;
     private final String defaultWarehouseDir;
     private final boolean isUniqueTableLocation;
+    private final boolean initializeCatalogTables;
     private final Map<String, String> catalogProperties;
     private final JdbcClientPool clientPool;
 
@@ -68,6 +69,7 @@ public class TrinoJdbcCatalogFactory
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.jdbcCatalogName = jdbcConfig.getCatalogName();
         this.defaultWarehouseDir = jdbcConfig.getDefaultWarehouseDir();
+        this.initializeCatalogTables = jdbcConfig.getInitializeCatalogTables();
 
         ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
         properties.put(URI, jdbcConfig.getConnectionUrl());
@@ -91,7 +93,7 @@ public class TrinoJdbcCatalogFactory
         JdbcCatalog jdbcCatalog = new JdbcCatalog(
                 config -> new ForwardingFileIo(fileSystemFactory.create(identity)),
                 config -> clientPool,
-                false);
+                initializeCatalogTables);
 
         jdbcCatalog.initialize(jdbcCatalogName, catalogProperties);
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -366,6 +366,7 @@ public final class IcebergQueryRunner
                             .put("iceberg.jdbc-catalog.connection-password", PASSWORD)
                             .put("iceberg.jdbc-catalog.catalog-name", "tpch")
                             .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.getAbsolutePath())
+                            .put("iceberg.jdbc-catalog.initialize-catalog-tables", "false")
                             .buildOrThrow())
                     .setInitialTables(TpchTable.getTables())
                     .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -258,7 +258,8 @@ public class TestIcebergPlugin
                                 "iceberg.jdbc-catalog.driver-class", "org.postgresql.Driver",
                                 "iceberg.jdbc-catalog.connection-url", "jdbc:postgresql://localhost:5432/test",
                                 "iceberg.jdbc-catalog.catalog-name", "test",
-                                "iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket"),
+                                "iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket",
+                                "iceberg.jdbc-catalog.initialize-catalog-tables", "false"),
                         new TestingConnectorContext())
                 .shutdown();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConfig.java
@@ -33,7 +33,8 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionUser(null)
                 .setConnectionPassword(null)
                 .setCatalogName(null)
-                .setDefaultWarehouseDir(null));
+                .setDefaultWarehouseDir(null)
+                .setInitializeCatalogTables(false));
     }
 
     @Test
@@ -46,6 +47,7 @@ public class TestIcebergJdbcCatalogConfig
                 .put("iceberg.jdbc-catalog.connection-password", "bar")
                 .put("iceberg.jdbc-catalog.catalog-name", "test")
                 .put("iceberg.jdbc-catalog.default-warehouse-dir", "s3://bucket")
+                .put("iceberg.jdbc-catalog.initialize-catalog-tables", "true")
                 .buildOrThrow();
 
         IcebergJdbcCatalogConfig expected = new IcebergJdbcCatalogConfig()
@@ -54,7 +56,8 @@ public class TestIcebergJdbcCatalogConfig
                 .setConnectionUser("foo")
                 .setConnectionPassword("bar")
                 .setCatalogName("test")
-                .setDefaultWarehouseDir("s3://bucket");
+                .setDefaultWarehouseDir("s3://bucket")
+                .setInitializeCatalogTables(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -97,6 +97,7 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
                                 .put("iceberg.register-table-procedure.enabled", "true")
                                 .put("iceberg.writer-sort-buffer-size", "1MB")
                                 .put("iceberg.jdbc-catalog.default-warehouse-dir", warehouseLocation.getAbsolutePath())
+                                .put("iceberg.jdbc-catalog.initialize-catalog-tables", "false")
                                 .buildOrThrow())
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .build();

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg-jdbc-catalog/iceberg.properties
@@ -6,4 +6,5 @@ iceberg.jdbc-catalog.connection-user=test
 iceberg.jdbc-catalog.connection-password=test
 iceberg.jdbc-catalog.catalog-name=iceberg_test
 iceberg.jdbc-catalog.default-warehouse-dir=hdfs://hadoop-master:9000/user/hive/warehouse
+iceberg.jdbc-catalog.initialize-catalog-tables=true
 hive.hdfs.socks-proxy=hadoop-master:1180


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Adding `iceberg.jdbc-catalog.initialize-catalog-tables` property to make creation of the catalog tables configurable.

Fixing #17744


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Added `iceberg.jdbc-catalog.initialize-catalog-tables` property
```
