### PR TITLE
Optimize writing of repetition levels in parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ArrayColumnWriter.java
@@ -16,8 +16,8 @@ package io.trino.parquet.writer;
 import com.google.common.collect.ImmutableList;
 import io.trino.parquet.writer.repdef.DefLevelWriterProvider;
 import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
-import io.trino.parquet.writer.repdef.RepLevelIterable;
-import io.trino.parquet.writer.repdef.RepLevelIterables;
+import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
+import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
 import io.trino.spi.block.ColumnarArray;
 
 import java.io.IOException;
@@ -53,9 +53,9 @@ public class ArrayColumnWriter
                                 .addAll(columnChunk.getDefLevelWriterProviders())
                                 .add(DefLevelWriterProviders.of(columnarArray, maxDefinitionLevel))
                                 .build(),
-                        ImmutableList.<RepLevelIterable>builder()
-                                .addAll(columnChunk.getRepLevelIterables())
-                                .add(RepLevelIterables.of(columnarArray, maxRepetitionLevel))
+                        ImmutableList.<RepLevelWriterProvider>builder()
+                                .addAll(columnChunk.getRepLevelWriterProviders())
+                                .add(RepLevelWriterProviders.of(columnarArray, maxRepetitionLevel))
                                 .build()));
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnChunk.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnChunk.java
@@ -15,7 +15,7 @@ package io.trino.parquet.writer;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.parquet.writer.repdef.DefLevelWriterProvider;
-import io.trino.parquet.writer.repdef.RepLevelIterable;
+import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
 import io.trino.spi.block.Block;
 
 import java.util.List;
@@ -26,18 +26,18 @@ public class ColumnChunk
 {
     private final Block block;
     private final List<DefLevelWriterProvider> defLevelWriterProviders;
-    private final List<RepLevelIterable> repLevelIterables;
+    private final List<RepLevelWriterProvider> repLevelWriterProviders;
 
     ColumnChunk(Block block)
     {
         this(block, ImmutableList.of(), ImmutableList.of());
     }
 
-    ColumnChunk(Block block, List<DefLevelWriterProvider> defLevelWriterProviders, List<RepLevelIterable> repLevelIterables)
+    ColumnChunk(Block block, List<DefLevelWriterProvider> defLevelWriterProviders, List<RepLevelWriterProvider> repLevelWriterProviders)
     {
         this.block = requireNonNull(block, "block is null");
         this.defLevelWriterProviders = ImmutableList.copyOf(defLevelWriterProviders);
-        this.repLevelIterables = ImmutableList.copyOf(repLevelIterables);
+        this.repLevelWriterProviders = ImmutableList.copyOf(repLevelWriterProviders);
     }
 
     List<DefLevelWriterProvider> getDefLevelWriterProviders()
@@ -45,9 +45,9 @@ public class ColumnChunk
         return defLevelWriterProviders;
     }
 
-    List<RepLevelIterable> getRepLevelIterables()
+    public List<RepLevelWriterProvider> getRepLevelWriterProviders()
     {
-        return repLevelIterables;
+        return repLevelWriterProviders;
     }
 
     public Block getBlock()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MapColumnWriter.java
@@ -16,8 +16,8 @@ package io.trino.parquet.writer;
 import com.google.common.collect.ImmutableList;
 import io.trino.parquet.writer.repdef.DefLevelWriterProvider;
 import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
-import io.trino.parquet.writer.repdef.RepLevelIterable;
-import io.trino.parquet.writer.repdef.RepLevelIterables;
+import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
+import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
 import io.trino.spi.block.ColumnarMap;
 
 import java.io.IOException;
@@ -54,9 +54,9 @@ public class MapColumnWriter
                 .addAll(columnChunk.getDefLevelWriterProviders())
                 .add(DefLevelWriterProviders.of(columnarMap, maxDefinitionLevel)).build();
 
-        ImmutableList<RepLevelIterable> repLevelIterables = ImmutableList.<RepLevelIterable>builder()
-                .addAll(columnChunk.getRepLevelIterables())
-                .add(RepLevelIterables.of(columnarMap, maxRepetitionLevel)).build();
+        ImmutableList<RepLevelWriterProvider> repLevelIterables = ImmutableList.<RepLevelWriterProvider>builder()
+                .addAll(columnChunk.getRepLevelWriterProviders())
+                .add(RepLevelWriterProviders.of(columnarMap, maxRepetitionLevel)).build();
 
         keyWriter.writeBlock(new ColumnChunk(columnarMap.getKeysBlock(), defLevelWriterProviders, repLevelIterables));
         valueWriter.writeBlock(new ColumnChunk(columnarMap.getValuesBlock(), defLevelWriterProviders, repLevelIterables));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/StructColumnWriter.java
@@ -16,8 +16,8 @@ package io.trino.parquet.writer;
 import com.google.common.collect.ImmutableList;
 import io.trino.parquet.writer.repdef.DefLevelWriterProvider;
 import io.trino.parquet.writer.repdef.DefLevelWriterProviders;
-import io.trino.parquet.writer.repdef.RepLevelIterable;
-import io.trino.parquet.writer.repdef.RepLevelIterables;
+import io.trino.parquet.writer.repdef.RepLevelWriterProvider;
+import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarRow;
 
@@ -54,15 +54,15 @@ public class StructColumnWriter
                 .addAll(columnChunk.getDefLevelWriterProviders())
                 .add(DefLevelWriterProviders.of(columnarRow, maxDefinitionLevel))
                 .build();
-        List<RepLevelIterable> repLevelIterables = ImmutableList.<RepLevelIterable>builder()
-                .addAll(columnChunk.getRepLevelIterables())
-                .add(RepLevelIterables.of(columnChunk.getBlock()))
+        List<RepLevelWriterProvider> repLevelWriterProviders = ImmutableList.<RepLevelWriterProvider>builder()
+                .addAll(columnChunk.getRepLevelWriterProviders())
+                .add(RepLevelWriterProviders.of(columnarRow))
                 .build();
 
         for (int i = 0; i < columnWriters.size(); ++i) {
             ColumnWriter columnWriter = columnWriters.get(i);
             Block block = columnarRow.getField(i);
-            columnWriter.writeBlock(new ColumnChunk(block, defLevelWriterProviders, repLevelIterables));
+            columnWriter.writeBlock(new ColumnChunk(block, defLevelWriterProviders, repLevelWriterProviders));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProvider.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.repdef;
+
+import com.google.common.collect.Iterables;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RepLevelWriterProvider
+{
+    RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ValuesWriter encoder);
+
+    /**
+     * Parent repetition level marks at which level either:
+     * 1. A new collection starts
+     * 2. A collection is null or empty
+     * 3. A primitive column stays
+     */
+    interface RepetitionLevelWriter
+    {
+        void writeRepetitionLevels(int parentLevel, int positionsCount);
+
+        void writeRepetitionLevels(int parentLevel);
+    }
+
+    static RepetitionLevelWriter getRootRepetitionLevelWriter(List<RepLevelWriterProvider> repLevelWriterProviders, ValuesWriter encoder)
+    {
+        // Constructs hierarchy of RepetitionLevelWriter from leaf to root
+        RepetitionLevelWriter rootRepetitionLevelWriter = Iterables.getLast(repLevelWriterProviders)
+                .getRepetitionLevelWriter(Optional.empty(), encoder);
+        for (int nestedLevel = repLevelWriterProviders.size() - 2; nestedLevel >= 0; nestedLevel--) {
+            RepetitionLevelWriter nestedWriter = rootRepetitionLevelWriter;
+            rootRepetitionLevelWriter = repLevelWriterProviders.get(nestedLevel)
+                    .getRepetitionLevelWriter(Optional.of(nestedWriter), encoder);
+        }
+        return rootRepetitionLevelWriter;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/repdef/RepLevelWriterProviders.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.repdef;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ColumnarArray;
+import io.trino.spi.block.ColumnarMap;
+import io.trino.spi.block.ColumnarRow;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class RepLevelWriterProviders
+{
+    private RepLevelWriterProviders() {}
+
+    public static RepLevelWriterProvider of(Block block)
+    {
+        return new PrimitiveRepLevelWriterProvider(block);
+    }
+
+    public static RepLevelWriterProvider of(ColumnarRow columnarRow)
+    {
+        return new ColumnRowRepLevelWriterProvider(columnarRow);
+    }
+
+    public static RepLevelWriterProvider of(ColumnarArray columnarArray, int maxRepetitionLevel)
+    {
+        return new ColumnArrayRepLevelWriterProvider(columnarArray, maxRepetitionLevel);
+    }
+
+    public static RepLevelWriterProvider of(ColumnarMap columnarMap, int maxRepetitionLevel)
+    {
+        return new ColumnMapRepLevelWriterProvider(columnarMap, maxRepetitionLevel);
+    }
+
+    static class PrimitiveRepLevelWriterProvider
+            implements RepLevelWriterProvider
+    {
+        private final Block block;
+
+        PrimitiveRepLevelWriterProvider(Block block)
+        {
+            this.block = requireNonNull(block, "block is null");
+        }
+
+        @Override
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriter, ValuesWriter encoder)
+        {
+            checkArgument(nestedWriter.isEmpty(), "nestedWriter should be empty for primitive repetition level writer");
+            return new RepetitionLevelWriter()
+            {
+                private int offset;
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel)
+                {
+                    writeRepetitionLevels(parentLevel, block.getPositionCount());
+                }
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel, int positionsCount)
+                {
+                    checkValidPosition(offset, positionsCount, block.getPositionCount());
+                    for (int i = 0; i < positionsCount; i++) {
+                        encoder.writeInteger(parentLevel);
+                    }
+                    offset += positionsCount;
+                }
+            };
+        }
+    }
+
+    static class ColumnRowRepLevelWriterProvider
+            implements RepLevelWriterProvider
+    {
+        private final ColumnarRow columnarRow;
+
+        ColumnRowRepLevelWriterProvider(ColumnarRow columnarRow)
+        {
+            this.columnarRow = requireNonNull(columnarRow, "columnarRow is null");
+        }
+
+        @Override
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        {
+            checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column row repetition level writer");
+            return new RepetitionLevelWriter()
+            {
+                private final RepetitionLevelWriter nestedWriter = nestedWriterOptional.orElseThrow();
+
+                private int offset;
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel)
+                {
+                    writeRepetitionLevels(parentLevel, columnarRow.getPositionCount());
+                }
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel, int positionsCount)
+                {
+                    checkValidPosition(offset, positionsCount, columnarRow.getPositionCount());
+                    if (!columnarRow.mayHaveNull()) {
+                        nestedWriter.writeRepetitionLevels(parentLevel, positionsCount);
+                        offset += positionsCount;
+                        return;
+                    }
+
+                    for (int position = offset; position < offset + positionsCount; ) {
+                        if (columnarRow.isNull(position)) {
+                            encoder.writeInteger(parentLevel);
+                            position++;
+                        }
+                        else {
+                            int consecutiveNonNullsCount = 1;
+                            position++;
+                            while (position < offset + positionsCount && !columnarRow.isNull(position)) {
+                                position++;
+                                consecutiveNonNullsCount++;
+                            }
+                            nestedWriter.writeRepetitionLevels(parentLevel, consecutiveNonNullsCount);
+                        }
+                    }
+                    offset += positionsCount;
+                }
+            };
+        }
+    }
+
+    static class ColumnMapRepLevelWriterProvider
+            implements RepLevelWriterProvider
+    {
+        private final ColumnarMap columnarMap;
+        private final int maxRepetitionLevel;
+
+        ColumnMapRepLevelWriterProvider(ColumnarMap columnarMap, int maxRepetitionLevel)
+        {
+            this.columnarMap = requireNonNull(columnarMap, "columnarMap is null");
+            this.maxRepetitionLevel = maxRepetitionLevel;
+        }
+
+        @Override
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        {
+            checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map repetition level writer");
+            return new RepetitionLevelWriter()
+            {
+                private final RepetitionLevelWriter nestedWriter = nestedWriterOptional.orElseThrow();
+
+                private int offset;
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel)
+                {
+                    writeRepetitionLevels(parentLevel, columnarMap.getPositionCount());
+                }
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel, int positionsCount)
+                {
+                    checkValidPosition(offset, positionsCount, columnarMap.getPositionCount());
+                    if (!columnarMap.mayHaveNull()) {
+                        for (int position = offset; position < offset + positionsCount; position++) {
+                            writeNonNullableLevels(parentLevel, position);
+                        }
+                    }
+                    else {
+                        for (int position = offset; position < offset + positionsCount; position++) {
+                            if (columnarMap.isNull(position)) {
+                                encoder.writeInteger(parentLevel);
+                                continue;
+                            }
+                            writeNonNullableLevels(parentLevel, position);
+                        }
+                    }
+                    offset += positionsCount;
+                }
+
+                private void writeNonNullableLevels(int parentLevel, int position)
+                {
+                    int entryLength = columnarMap.getEntryCount(position);
+                    if (entryLength == 0) {
+                        encoder.writeInteger(parentLevel);
+                    }
+                    else {
+                        nestedWriter.writeRepetitionLevels(parentLevel, 1);
+                        nestedWriter.writeRepetitionLevels(maxRepetitionLevel, entryLength - 1);
+                    }
+                }
+            };
+        }
+    }
+
+    static class ColumnArrayRepLevelWriterProvider
+            implements RepLevelWriterProvider
+    {
+        private final ColumnarArray columnarArray;
+        private final int maxRepetitionLevel;
+
+        ColumnArrayRepLevelWriterProvider(ColumnarArray columnarArray, int maxRepetitionLevel)
+        {
+            this.columnarArray = requireNonNull(columnarArray, "columnarArray is null");
+            this.maxRepetitionLevel = maxRepetitionLevel;
+        }
+
+        @Override
+        public RepetitionLevelWriter getRepetitionLevelWriter(Optional<RepetitionLevelWriter> nestedWriterOptional, ValuesWriter encoder)
+        {
+            checkArgument(nestedWriterOptional.isPresent(), "nestedWriter should be present for column map repetition level writer");
+            return new RepetitionLevelWriter()
+            {
+                private final RepetitionLevelWriter nestedWriter = nestedWriterOptional.orElseThrow();
+
+                private int offset;
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel)
+                {
+                    writeRepetitionLevels(parentLevel, columnarArray.getPositionCount());
+                }
+
+                @Override
+                public void writeRepetitionLevels(int parentLevel, int positionsCount)
+                {
+                    checkValidPosition(offset, positionsCount, columnarArray.getPositionCount());
+                    if (!columnarArray.mayHaveNull()) {
+                        for (int position = offset; position < offset + positionsCount; position++) {
+                            writeNonNullableLevels(parentLevel, position);
+                        }
+                    }
+                    else {
+                        for (int position = offset; position < offset + positionsCount; position++) {
+                            if (columnarArray.isNull(position)) {
+                                encoder.writeInteger(parentLevel);
+                                continue;
+                            }
+                            writeNonNullableLevels(parentLevel, position);
+                        }
+                    }
+                    offset += positionsCount;
+                }
+
+                private void writeNonNullableLevels(int parentLevel, int position)
+                {
+                    int arrayLength = columnarArray.getLength(position);
+                    if (arrayLength == 0) {
+                        encoder.writeInteger(parentLevel);
+                    }
+                    else {
+                        nestedWriter.writeRepetitionLevels(parentLevel, 1);
+                        nestedWriter.writeRepetitionLevels(maxRepetitionLevel, arrayLength - 1);
+                    }
+                }
+            };
+        }
+    }
+
+    private static void checkValidPosition(int offset, int positionsCount, int totalPositionsCount)
+    {
+        if (offset < 0 || positionsCount < 0 || offset + positionsCount > totalPositionsCount) {
+            throw new IndexOutOfBoundsException(format("Invalid offset %s and positionsCount %s in block with %s positions", offset, positionsCount, totalPositionsCount));
+        }
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -14,6 +14,7 @@
 package io.trino.parquet;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Booleans;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.parquet.writer.ParquetSchemaConverter;
@@ -22,21 +23,34 @@ import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
 import org.apache.parquet.format.CompressionCodec;
 import org.joda.time.DateTimeZone;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.block.ArrayBlock.fromElementBlock;
+import static io.trino.spi.block.MapBlock.fromKeyValueBlock;
+import static io.trino.spi.block.RowBlock.fromFieldBlocks;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static java.lang.Math.toIntExact;
 
 public class ParquetTestUtils
 {
+    private static final Random RANDOM = new Random(42);
+    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+
     private ParquetTestUtils() {}
 
     public static Slice writeParquetFile(ParquetWriterOptions writerOptions, List<Type> types, List<String> columnNames, List<io.trino.spi.Page> inputPages)
@@ -74,6 +88,79 @@ public class ParquetTestUtils
             pagesBuilder.add(new Page(blocks.toArray(Block[]::new)));
         }
         return pagesBuilder.build();
+    }
+
+    public static List<Integer> generateGroupSizes(int positionsCount)
+    {
+        int maxGroupSize = 17;
+        int offset = 0;
+        ImmutableList.Builder<Integer> groupsBuilder = ImmutableList.builder();
+        while (offset < positionsCount) {
+            int remaining = positionsCount - offset;
+            int groupSize = Math.min(RANDOM.nextInt(maxGroupSize) + 1, remaining);
+            groupsBuilder.add(groupSize);
+            offset += groupSize;
+        }
+        return groupsBuilder.build();
+    }
+
+    public static Block createRowBlock(Optional<boolean[]> rowIsNull, int positionCount)
+    {
+        int fieldPositionCount = rowIsNull.map(nulls -> toIntExact(Booleans.asList(nulls).stream().filter(isNull -> !isNull).count()))
+                .orElse(positionCount);
+        int fieldCount = 4;
+        Block[] fieldBlocks = new Block[fieldCount];
+        // no nulls block
+        fieldBlocks[0] = new LongArrayBlock(fieldPositionCount, Optional.empty(), new long[fieldPositionCount]);
+        // no nulls with mayHaveNull block
+        fieldBlocks[1] = new LongArrayBlock(fieldPositionCount, Optional.of(new boolean[fieldPositionCount]), new long[fieldPositionCount]);
+        // all nulls block
+        boolean[] allNulls = new boolean[fieldPositionCount];
+        Arrays.fill(allNulls, false);
+        fieldBlocks[2] = new LongArrayBlock(fieldPositionCount, Optional.of(allNulls), new long[fieldPositionCount]);
+        // random nulls block
+        fieldBlocks[3] = createLongsBlockWithRandomNulls(fieldPositionCount);
+
+        return fromFieldBlocks(positionCount, rowIsNull, fieldBlocks);
+    }
+
+    public static Block createArrayBlock(Optional<boolean[]> valueIsNull, int positionCount)
+    {
+        int[] arrayOffset = generateOffsets(valueIsNull, positionCount);
+        return fromElementBlock(positionCount, valueIsNull, arrayOffset, createLongsBlockWithRandomNulls(arrayOffset[positionCount]));
+    }
+
+    public static Block createMapBlock(Optional<boolean[]> mapIsNull, int positionCount)
+    {
+        int[] offsets = generateOffsets(mapIsNull, positionCount);
+        int entriesCount = offsets[positionCount];
+        Block keyBlock = new LongArrayBlock(entriesCount, Optional.empty(), new long[entriesCount]);
+        Block valueBlock = createLongsBlockWithRandomNulls(entriesCount);
+        return fromKeyValueBlock(mapIsNull, offsets, keyBlock, valueBlock, new MapType(BIGINT, BIGINT, TYPE_OPERATORS));
+    }
+
+    private static int[] generateOffsets(Optional<boolean[]> valueIsNull, int positionCount)
+    {
+        int maxCardinality = 7; // array length or map size at the current position
+        int[] offsets = new int[positionCount + 1];
+        for (int position = 0; position < positionCount; position++) {
+            if (valueIsNull.isPresent() && valueIsNull.get()[position]) {
+                offsets[position + 1] = offsets[position];
+            }
+            else {
+                offsets[position + 1] = offsets[position] + RANDOM.nextInt(maxCardinality);
+            }
+        }
+        return offsets;
+    }
+
+    private static Block createLongsBlockWithRandomNulls(int positionCount)
+    {
+        boolean[] valueIsNull = new boolean[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            valueIsNull[i] = RANDOM.nextBoolean();
+        }
+        return new LongArrayBlock(positionCount, Optional.of(valueIsNull), new long[positionCount]);
     }
 
     private static Block generateBlock(Type type, int positions)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/ParquetTestUtils.java
@@ -139,7 +139,7 @@ public class ParquetTestUtils
         return fromKeyValueBlock(mapIsNull, offsets, keyBlock, valueBlock, new MapType(BIGINT, BIGINT, TYPE_OPERATORS));
     }
 
-    private static int[] generateOffsets(Optional<boolean[]> valueIsNull, int positionCount)
+    public static int[] generateOffsets(Optional<boolean[]> valueIsNull, int positionCount)
     {
         int maxCardinality = 7; // array length or map size at the current position
         int[] offsets = new int[positionCount + 1];

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/NullsProvider.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/NullsProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import org.testng.annotations.DataProvider;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static io.trino.testing.DataProviders.toDataProvider;
+
+enum NullsProvider
+{
+    NO_NULLS {
+        @Override
+        Optional<boolean[]> getNulls(int positionCount)
+        {
+            return Optional.empty();
+        }
+    },
+    NO_NULLS_WITH_MAY_HAVE_NULL {
+        @Override
+        Optional<boolean[]> getNulls(int positionCount)
+        {
+            return Optional.of(new boolean[positionCount]);
+        }
+    },
+    ALL_NULLS {
+        @Override
+        Optional<boolean[]> getNulls(int positionCount)
+        {
+            boolean[] nulls = new boolean[positionCount];
+            Arrays.fill(nulls, true);
+            return Optional.of(nulls);
+        }
+    },
+    RANDOM_NULLS {
+        @Override
+        Optional<boolean[]> getNulls(int positionCount)
+        {
+            boolean[] nulls = new boolean[positionCount];
+            for (int i = 0; i < positionCount; i++) {
+                nulls[i] = RANDOM.nextBoolean();
+            }
+            return Optional.of(nulls);
+        }
+    },
+    GROUPED_NULLS {
+        @Override
+        Optional<boolean[]> getNulls(int positionCount)
+        {
+            boolean[] nulls = new boolean[positionCount];
+            int maxGroupSize = 23;
+            int position = 0;
+            while (position < positionCount) {
+                int remaining = positionCount - position;
+                int groupSize = Math.min(RANDOM.nextInt(maxGroupSize) + 1, remaining);
+                Arrays.fill(nulls, position, position + groupSize, RANDOM.nextBoolean());
+                position += groupSize;
+            }
+            return Optional.of(nulls);
+        }
+    };
+
+    private static final Random RANDOM = new Random(42);
+
+    abstract Optional<boolean[]> getNulls(int positionCount);
+
+    @DataProvider
+    public static Object[][] nullsProviders()
+    {
+        return Stream.of(NullsProvider.values())
+                .collect(toDataProvider());
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/RepLevelIterable.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/RepLevelIterable.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.parquet.writer.repdef;
+package io.trino.parquet.writer;
 
 import com.google.common.collect.AbstractIterator;
 
@@ -59,7 +59,7 @@ public interface RepLevelIterable
             return isNull;
         }
 
-        int value()
+        public int value()
         {
             return this.value;
         }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/RepLevelIterables.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/RepLevelIterables.java
@@ -11,11 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.parquet.writer.repdef;
+package io.trino.parquet.writer;
 
 import com.google.common.collect.AbstractIterator;
-import io.trino.parquet.writer.repdef.RepLevelIterable.RepValueIterator;
-import io.trino.parquet.writer.repdef.RepLevelIterable.RepetitionLevel;
+import io.trino.parquet.writer.RepLevelIterable.RepValueIterator;
+import io.trino.parquet.writer.RepLevelIterable.RepetitionLevel;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.ColumnarMap;

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestDefinitionLevelWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestDefinitionLevelWriter.java
@@ -22,11 +22,6 @@ import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.TypeOperators;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
-import org.apache.parquet.bytes.BytesInput;
-import org.apache.parquet.column.Encoding;
-import org.apache.parquet.column.values.ValuesWriter;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -396,59 +391,6 @@ public class TestDefinitionLevelWriter
             Block keyBlock = new LongArrayBlock(positionCount, Optional.empty(), new long[positionCount]);
             Block valueBlock = createLongsBlockWithRandomNulls(positionCount);
             return fromKeyValueBlock(mapIsNull, offsets, keyBlock, valueBlock, new MapType(BIGINT, BIGINT, TYPE_OPERATORS));
-        }
-    }
-
-    private static class TestingValuesWriter
-            extends ValuesWriter
-    {
-        private final IntList values = new IntArrayList();
-
-        @Override
-        public long getBufferedSize()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public BytesInput getBytes()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Encoding getEncoding()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void reset()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getAllocatedSize()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public String memUsageString(String prefix)
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void writeInteger(int v)
-        {
-            values.add(v);
-        }
-
-        List<Integer> getWrittenValues()
-        {
-            return values;
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestDefinitionLevelWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestDefinitionLevelWriter.java
@@ -20,62 +20,32 @@ import io.trino.spi.block.ColumnarArray;
 import io.trino.spi.block.ColumnarMap;
 import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.block.LongArrayBlock;
-import io.trino.spi.type.MapType;
-import io.trino.spi.type.TypeOperators;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
-import java.util.stream.Stream;
 
+import static io.trino.parquet.ParquetTestUtils.createArrayBlock;
+import static io.trino.parquet.ParquetTestUtils.createMapBlock;
+import static io.trino.parquet.ParquetTestUtils.createRowBlock;
+import static io.trino.parquet.ParquetTestUtils.generateGroupSizes;
 import static io.trino.parquet.writer.repdef.DefLevelWriterProvider.DefinitionLevelWriter;
 import static io.trino.parquet.writer.repdef.DefLevelWriterProvider.ValuesCount;
 import static io.trino.parquet.writer.repdef.DefLevelWriterProvider.getRootDefinitionLevelWriter;
-import static io.trino.spi.block.ArrayBlock.fromElementBlock;
 import static io.trino.spi.block.ColumnarArray.toColumnarArray;
 import static io.trino.spi.block.ColumnarMap.toColumnarMap;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static io.trino.spi.block.MapBlock.fromKeyValueBlock;
-import static io.trino.spi.block.RowBlock.fromFieldBlocks;
-import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.testing.DataProviders.toDataProvider;
-import static java.lang.Math.toIntExact;
 import static java.util.Collections.nCopies;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDefinitionLevelWriter
 {
     private static final int POSITIONS = 8096;
-    private static final Random RANDOM = new Random(42);
-    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
 
-    private static final boolean[] ALL_NULLS_ARRAY = new boolean[POSITIONS];
-    private static final boolean[] RANDOM_NULLS_ARRAY = new boolean[POSITIONS];
-    private static final boolean[] GROUPED_NULLS_ARRAY = new boolean[POSITIONS];
-
-    static {
-        Arrays.fill(ALL_NULLS_ARRAY, true);
-        for (int i = 0; i < POSITIONS; i++) {
-            RANDOM_NULLS_ARRAY[i] = RANDOM.nextBoolean();
-        }
-
-        int maxGroupSize = 23;
-        int position = 0;
-        while (position < POSITIONS) {
-            int remaining = POSITIONS - position;
-            int groupSize = Math.min(RANDOM.nextInt(maxGroupSize) + 1, remaining);
-            Arrays.fill(GROUPED_NULLS_ARRAY, position, position + groupSize, RANDOM.nextBoolean());
-            position += groupSize;
-        }
-    }
-
-    @Test(dataProvider = "primitiveBlockProvider")
-    public void testWritePrimitiveDefinitionLevels(PrimitiveBlockProvider blockProvider)
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWritePrimitiveDefinitionLevels(NullsProvider nullsProvider)
     {
-        Block block = blockProvider.getInputBlock();
+        Block block = new LongArrayBlock(POSITIONS, nullsProvider.getNulls(POSITIONS), new long[POSITIONS]);
         int maxDefinitionLevel = 3;
         // Write definition levels for all positions
         assertDefinitionLevels(block, ImmutableList.of(), maxDefinitionLevel);
@@ -87,58 +57,11 @@ public class TestDefinitionLevelWriter
         assertDefinitionLevels(block, generateGroupSizes(block.getPositionCount()), maxDefinitionLevel);
     }
 
-    @DataProvider
-    public static Object[][] primitiveBlockProvider()
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteRowDefinitionLevels(NullsProvider nullsProvider)
     {
-        return Stream.of(PrimitiveBlockProvider.values())
-                .collect(toDataProvider());
-    }
-
-    private enum PrimitiveBlockProvider
-    {
-        NO_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return new LongArrayBlock(POSITIONS, Optional.empty(), new long[POSITIONS]);
-            }
-        },
-        NO_NULLS_WITH_MAY_HAVE_NULL {
-            @Override
-            Block getInputBlock()
-            {
-                return new LongArrayBlock(POSITIONS, Optional.of(new boolean[POSITIONS]), new long[POSITIONS]);
-            }
-        },
-        ALL_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return new LongArrayBlock(POSITIONS, Optional.of(ALL_NULLS_ARRAY), new long[POSITIONS]);
-            }
-        },
-        RANDOM_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return new LongArrayBlock(POSITIONS, Optional.of(RANDOM_NULLS_ARRAY), new long[POSITIONS]);
-            }
-        },
-        GROUPED_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return new LongArrayBlock(POSITIONS, Optional.of(GROUPED_NULLS_ARRAY), new long[POSITIONS]);
-            }
-        };
-
-        abstract Block getInputBlock();
-    }
-
-    @Test(dataProvider = "rowBlockProvider")
-    public void testWriteRowDefinitionLevels(RowBlockProvider blockProvider)
-    {
-        ColumnarRow columnarRow = toColumnarRow(blockProvider.getInputBlock());
+        Block rowBlock = createRowBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarRow columnarRow = toColumnarRow(rowBlock);
         int fieldMaxDefinitionLevel = 2;
         // Write definition levels for all positions
         for (int field = 0; field < columnarRow.getFieldCount(); field++) {
@@ -164,77 +87,11 @@ public class TestDefinitionLevelWriter
         }
     }
 
-    @DataProvider
-    public static Object[][] rowBlockProvider()
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteArrayDefinitionLevels(NullsProvider nullsProvider)
     {
-        return Stream.of(RowBlockProvider.values())
-                .collect(toDataProvider());
-    }
-
-    private enum RowBlockProvider
-    {
-        NO_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createRowBlock(Optional.empty());
-            }
-        },
-        NO_NULLS_WITH_MAY_HAVE_NULL {
-            @Override
-            Block getInputBlock()
-            {
-                return createRowBlock(Optional.of(new boolean[POSITIONS]));
-            }
-        },
-        ALL_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createRowBlock(Optional.of(ALL_NULLS_ARRAY));
-            }
-        },
-        RANDOM_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createRowBlock(Optional.of(RANDOM_NULLS_ARRAY));
-            }
-        },
-        GROUPED_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createRowBlock(Optional.of(GROUPED_NULLS_ARRAY));
-            }
-        };
-
-        abstract Block getInputBlock();
-
-        private static Block createRowBlock(Optional<boolean[]> rowIsNull)
-        {
-            int positionCount = rowIsNull.map(isNull -> isNull.length).orElse(0) - toIntExact(rowIsNull.stream().count());
-            int fieldCount = 4;
-            Block[] fieldBlocks = new Block[fieldCount];
-            // no nulls block
-            fieldBlocks[0] = new LongArrayBlock(positionCount, Optional.empty(), new long[positionCount]);
-            // no nulls with mayHaveNull block
-            fieldBlocks[1] = new LongArrayBlock(positionCount, Optional.of(new boolean[positionCount]), new long[positionCount]);
-            // all nulls block
-            boolean[] allNulls = new boolean[positionCount];
-            Arrays.fill(allNulls, false);
-            fieldBlocks[2] = new LongArrayBlock(positionCount, Optional.of(allNulls), new long[positionCount]);
-            // random nulls block
-            fieldBlocks[3] = createLongsBlockWithRandomNulls(positionCount);
-
-            return fromFieldBlocks(positionCount, rowIsNull, fieldBlocks);
-        }
-    }
-
-    @Test(dataProvider = "arrayBlockProvider")
-    public void testWriteArrayDefinitionLevels(ArrayBlockProvider blockProvider)
-    {
-        ColumnarArray columnarArray = toColumnarArray(blockProvider.getInputBlock());
+        Block arrayBlock = createArrayBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarArray columnarArray = toColumnarArray(arrayBlock);
         int maxDefinitionLevel = 3;
         // Write definition levels for all positions
         assertDefinitionLevels(
@@ -255,64 +112,11 @@ public class TestDefinitionLevelWriter
                 maxDefinitionLevel);
     }
 
-    @DataProvider
-    public static Object[][] arrayBlockProvider()
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteMapDefinitionLevels(NullsProvider nullsProvider)
     {
-        return Stream.of(ArrayBlockProvider.values())
-                .collect(toDataProvider());
-    }
-
-    private enum ArrayBlockProvider
-    {
-        NO_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createArrayBlock(Optional.empty());
-            }
-        },
-        NO_NULLS_WITH_MAY_HAVE_NULL {
-            @Override
-            Block getInputBlock()
-            {
-                return createArrayBlock(Optional.of(new boolean[POSITIONS]));
-            }
-        },
-        ALL_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createArrayBlock(Optional.of(ALL_NULLS_ARRAY));
-            }
-        },
-        RANDOM_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createArrayBlock(Optional.of(RANDOM_NULLS_ARRAY));
-            }
-        },
-        GROUPED_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createArrayBlock(Optional.of(GROUPED_NULLS_ARRAY));
-            }
-        };
-
-        abstract Block getInputBlock();
-
-        private static Block createArrayBlock(Optional<boolean[]> valueIsNull)
-        {
-            int[] arrayOffset = generateOffsets(valueIsNull);
-            return fromElementBlock(POSITIONS, valueIsNull, arrayOffset, createLongsBlockWithRandomNulls(arrayOffset[POSITIONS]));
-        }
-    }
-
-    @Test(dataProvider = "mapBlockProvider")
-    public void testWriteMapDefinitionLevels(MapBlockProvider blockProvider)
-    {
-        ColumnarMap columnarMap = toColumnarMap(blockProvider.getInputBlock());
+        Block mapBlock = createMapBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarMap columnarMap = toColumnarMap(mapBlock);
         int keysMaxDefinitionLevel = 2;
         int valuesMaxDefinitionLevel = 3;
         // Write definition levels for all positions
@@ -335,63 +139,6 @@ public class TestDefinitionLevelWriter
                 generateGroupSizes(columnarMap.getPositionCount()),
                 keysMaxDefinitionLevel,
                 valuesMaxDefinitionLevel);
-    }
-
-    @DataProvider
-    public static Object[][] mapBlockProvider()
-    {
-        return Stream.of(MapBlockProvider.values())
-                .collect(toDataProvider());
-    }
-
-    private enum MapBlockProvider
-    {
-        NO_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createMapBlock(Optional.empty());
-            }
-        },
-        NO_NULLS_WITH_MAY_HAVE_NULL {
-            @Override
-            Block getInputBlock()
-            {
-                return createMapBlock(Optional.of(new boolean[POSITIONS]));
-            }
-        },
-        ALL_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createMapBlock(Optional.of(ALL_NULLS_ARRAY));
-            }
-        },
-        RANDOM_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createMapBlock(Optional.of(RANDOM_NULLS_ARRAY));
-            }
-        },
-        GROUPED_NULLS {
-            @Override
-            Block getInputBlock()
-            {
-                return createMapBlock(Optional.of(GROUPED_NULLS_ARRAY));
-            }
-        };
-
-        abstract Block getInputBlock();
-
-        private static Block createMapBlock(Optional<boolean[]> mapIsNull)
-        {
-            int[] offsets = generateOffsets(mapIsNull);
-            int positionCount = offsets[POSITIONS];
-            Block keyBlock = new LongArrayBlock(positionCount, Optional.empty(), new long[positionCount]);
-            Block valueBlock = createLongsBlockWithRandomNulls(positionCount);
-            return fromKeyValueBlock(mapIsNull, offsets, keyBlock, valueBlock, new MapType(BIGINT, BIGINT, TYPE_OPERATORS));
-        }
     }
 
     private static void assertDefinitionLevels(Block block, List<Integer> writePositionCounts, int maxDefinitionLevel)
@@ -638,43 +385,5 @@ public class TestDefinitionLevelWriter
         assertThat(valuesValueCount.totalValuesCount()).isEqualTo(totalValuesCount);
         assertThat(valuesValueCount.maxDefinitionLevelValuesCount()).isEqualTo(maxDefinitionValuesCount);
         assertThat(valuesWriter.getWrittenValues()).isEqualTo(valuesExpectedDefLevelsBuilder.build());
-    }
-
-    private static List<Integer> generateGroupSizes(int positionsCount)
-    {
-        int maxGroupSize = 17;
-        int offset = 0;
-        ImmutableList.Builder<Integer> groupsBuilder = ImmutableList.builder();
-        while (offset < positionsCount) {
-            int remaining = positionsCount - offset;
-            int groupSize = Math.min(RANDOM.nextInt(maxGroupSize) + 1, remaining);
-            groupsBuilder.add(groupSize);
-            offset += groupSize;
-        }
-        return groupsBuilder.build();
-    }
-
-    private static int[] generateOffsets(Optional<boolean[]> valueIsNull)
-    {
-        int maxCardinality = 7; // array length or map size at the current position
-        int[] offsets = new int[POSITIONS + 1];
-        for (int position = 0; position < POSITIONS; position++) {
-            if (valueIsNull.isPresent() && valueIsNull.get()[position]) {
-                offsets[position + 1] = offsets[position];
-            }
-            else {
-                offsets[position + 1] = offsets[position] + RANDOM.nextInt(maxCardinality);
-            }
-        }
-        return offsets;
-    }
-
-    private static Block createLongsBlockWithRandomNulls(int positionCount)
-    {
-        boolean[] valueIsNull = new boolean[positionCount];
-        for (int i = 0; i < positionCount; i++) {
-            valueIsNull[i] = RANDOM.nextBoolean();
-        }
-        return new LongArrayBlock(positionCount, Optional.of(valueIsNull), new long[positionCount]);
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRepetitionLevelWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestRepetitionLevelWriter.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Booleans;
+import io.trino.parquet.writer.repdef.RepLevelWriterProviders;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ColumnarArray;
+import io.trino.spi.block.ColumnarMap;
+import io.trino.spi.block.ColumnarRow;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.TypeOperators;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.parquet.ParquetTestUtils.createArrayBlock;
+import static io.trino.parquet.ParquetTestUtils.createMapBlock;
+import static io.trino.parquet.ParquetTestUtils.createRowBlock;
+import static io.trino.parquet.ParquetTestUtils.generateGroupSizes;
+import static io.trino.parquet.ParquetTestUtils.generateOffsets;
+import static io.trino.parquet.writer.NullsProvider.RANDOM_NULLS;
+import static io.trino.parquet.writer.repdef.RepLevelWriterProvider.RepetitionLevelWriter;
+import static io.trino.parquet.writer.repdef.RepLevelWriterProvider.getRootRepetitionLevelWriter;
+import static io.trino.spi.block.ArrayBlock.fromElementBlock;
+import static io.trino.spi.block.ColumnarArray.toColumnarArray;
+import static io.trino.spi.block.ColumnarMap.toColumnarMap;
+import static io.trino.spi.block.ColumnarRow.toColumnarRow;
+import static io.trino.spi.block.MapBlock.fromKeyValueBlock;
+import static io.trino.spi.block.RowBlock.fromFieldBlocks;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.Math.toIntExact;
+import static java.util.Collections.nCopies;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRepetitionLevelWriter
+{
+    private static final int POSITIONS = 1024;
+
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteRowRepetitionLevels(NullsProvider nullsProvider)
+    {
+        // Using an array of row blocks for testing as Structs don't have a repetition level by themselves
+        Optional<boolean[]> valueIsNull = RANDOM_NULLS.getNulls(POSITIONS);
+        int[] arrayOffsets = generateOffsets(valueIsNull, POSITIONS);
+        int rowBlockPositions = arrayOffsets[POSITIONS];
+        Block rowBlock = createRowBlock(nullsProvider.getNulls(rowBlockPositions), rowBlockPositions);
+        Block arrayBlock = fromElementBlock(POSITIONS, valueIsNull, arrayOffsets, rowBlock);
+
+        ColumnarArray columnarArray = toColumnarArray(arrayBlock);
+        ColumnarRow columnarRow = toColumnarRow(columnarArray.getElementsBlock());
+        // Write Repetition levels for all positions
+        for (int field = 0; field < columnarRow.getFieldCount(); field++) {
+            assertRepetitionLevels(columnarArray, columnarRow, field, ImmutableList.of());
+            assertRepetitionLevels(columnarArray, columnarRow, field, ImmutableList.of());
+
+            // Write Repetition levels for all positions one-at-a-time
+            assertRepetitionLevels(
+                    columnarArray,
+                    columnarRow,
+                    field,
+                    nCopies(columnarArray.getPositionCount(), 1));
+
+            // Write Repetition levels for all positions with different group sizes
+            assertRepetitionLevels(
+                    columnarArray,
+                    columnarRow,
+                    field,
+                    generateGroupSizes(columnarArray.getPositionCount()));
+        }
+    }
+
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteArrayRepetitionLevels(NullsProvider nullsProvider)
+    {
+        Block arrayBlock = createArrayBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarArray columnarArray = toColumnarArray(arrayBlock);
+        // Write Repetition levels for all positions
+        assertRepetitionLevels(columnarArray, ImmutableList.of());
+
+        // Write Repetition levels for all positions one-at-a-time
+        assertRepetitionLevels(columnarArray, nCopies(columnarArray.getPositionCount(), 1));
+
+        // Write Repetition levels for all positions with different group sizes
+        assertRepetitionLevels(columnarArray, generateGroupSizes(columnarArray.getPositionCount()));
+    }
+
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testWriteMapRepetitionLevels(NullsProvider nullsProvider)
+    {
+        Block mapBlock = createMapBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarMap columnarMap = toColumnarMap(mapBlock);
+        // Write Repetition levels for all positions
+        assertRepetitionLevels(columnarMap, ImmutableList.of());
+
+        // Write Repetition levels for all positions one-at-a-time
+        assertRepetitionLevels(columnarMap, nCopies(columnarMap.getPositionCount(), 1));
+
+        // Write Repetition levels for all positions with different group sizes
+        assertRepetitionLevels(columnarMap, generateGroupSizes(columnarMap.getPositionCount()));
+    }
+
+    @Test(dataProviderClass = NullsProvider.class, dataProvider = "nullsProviders")
+    public void testNestedStructRepetitionLevels(NullsProvider nullsProvider)
+    {
+        Block rowBlock = createNestedRowBlock(nullsProvider.getNulls(POSITIONS), POSITIONS);
+        ColumnarRow columnarRow = toColumnarRow(rowBlock);
+
+        for (int field = 0; field < columnarRow.getFieldCount(); field++) {
+            Block fieldBlock = columnarRow.getField(field);
+            ColumnarMap columnarMap = toColumnarMap(fieldBlock);
+            for (Block mapElements : ImmutableList.of(columnarMap.getKeysBlock(), columnarMap.getValuesBlock())) {
+                ColumnarArray columnarArray = toColumnarArray(mapElements);
+
+                // Write Repetition levels for all positions
+                assertRepetitionLevels(rowBlock, columnarMap, columnarArray, ImmutableList.of());
+
+                // Write Repetition levels for all positions one-at-a-time
+                assertRepetitionLevels(rowBlock, columnarMap, columnarArray, nCopies(columnarRow.getPositionCount(), 1));
+
+                // Write Repetition levels for all positions with different group sizes
+                assertRepetitionLevels(rowBlock, columnarMap, columnarArray, generateGroupSizes(columnarRow.getPositionCount()));
+            }
+        }
+    }
+
+    private static Block createNestedRowBlock(Optional<boolean[]> rowIsNull, int positionCount)
+    {
+        int fieldPositionCount = rowIsNull.map(nulls -> toIntExact(Booleans.asList(nulls).stream().filter(isNull -> !isNull).count()))
+                .orElse(positionCount);
+        Block[] fieldBlocks = new Block[2];
+        // no nulls map block
+        fieldBlocks[0] = createMapOfArraysBlock(Optional.empty(), fieldPositionCount);
+        // random nulls map block
+        fieldBlocks[1] = createMapOfArraysBlock(RANDOM_NULLS.getNulls(fieldPositionCount), fieldPositionCount);
+
+        return fromFieldBlocks(positionCount, rowIsNull, fieldBlocks);
+    }
+
+    private static Block createMapOfArraysBlock(Optional<boolean[]> mapIsNull, int positionCount)
+    {
+        int[] offsets = generateOffsets(mapIsNull, positionCount);
+        int entriesCount = offsets[positionCount];
+        Block keyBlock = createArrayBlock(Optional.empty(), entriesCount);
+        Block valueBlock = createArrayBlock(RANDOM_NULLS.getNulls(entriesCount), entriesCount);
+        return fromKeyValueBlock(mapIsNull, offsets, keyBlock, valueBlock, new MapType(BIGINT, BIGINT, new TypeOperators()));
+    }
+
+    private static void assertRepetitionLevels(
+            ColumnarArray columnarArray,
+            ColumnarRow columnarRow,
+            int field,
+            List<Integer> writePositionCounts)
+    {
+        int maxRepetitionLevel = 1;
+        // Write Repetition levels
+        TestingValuesWriter valuesWriter = new TestingValuesWriter();
+        RepetitionLevelWriter fieldRootRepLevelWriter = getRootRepetitionLevelWriter(
+                ImmutableList.of(
+                        RepLevelWriterProviders.of(columnarArray, maxRepetitionLevel),
+                        RepLevelWriterProviders.of(columnarRow),
+                        RepLevelWriterProviders.of(columnarRow.getField(field))),
+                valuesWriter);
+        if (writePositionCounts.isEmpty()) {
+            fieldRootRepLevelWriter.writeRepetitionLevels(0);
+        }
+        else {
+            for (int positionsCount : writePositionCounts) {
+                fieldRootRepLevelWriter.writeRepetitionLevels(0, positionsCount);
+            }
+        }
+
+        // Verify written Repetition levels
+        Iterator<Integer> expectedRepetitionLevelsIter = RepLevelIterables.getIterator(ImmutableList.<RepLevelIterable>builder()
+                .add(RepLevelIterables.of(columnarArray, maxRepetitionLevel))
+                .add(RepLevelIterables.of(columnarArray.getElementsBlock()))
+                .add(RepLevelIterables.of(columnarRow.getField(field)))
+                .build());
+        assertThat(valuesWriter.getWrittenValues()).isEqualTo(ImmutableList.copyOf(expectedRepetitionLevelsIter));
+    }
+
+    private static void assertRepetitionLevels(
+            ColumnarArray columnarArray,
+            List<Integer> writePositionCounts)
+    {
+        int maxRepetitionLevel = 1;
+        // Write Repetition levels
+        TestingValuesWriter valuesWriter = new TestingValuesWriter();
+        RepetitionLevelWriter elementsRootRepLevelWriter = getRootRepetitionLevelWriter(
+                ImmutableList.of(
+                        RepLevelWriterProviders.of(columnarArray, maxRepetitionLevel),
+                        RepLevelWriterProviders.of(columnarArray.getElementsBlock())),
+                valuesWriter);
+        if (writePositionCounts.isEmpty()) {
+            elementsRootRepLevelWriter.writeRepetitionLevels(0);
+        }
+        else {
+            for (int positionsCount : writePositionCounts) {
+                elementsRootRepLevelWriter.writeRepetitionLevels(0, positionsCount);
+            }
+        }
+
+        // Verify written Repetition levels
+        ImmutableList.Builder<Integer> expectedRepLevelsBuilder = ImmutableList.builder();
+        int elementsOffset = 0;
+        for (int position = 0; position < columnarArray.getPositionCount(); position++) {
+            if (columnarArray.isNull(position)) {
+                expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+                continue;
+            }
+            int arrayLength = columnarArray.getLength(position);
+            if (arrayLength == 0) {
+                expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+                continue;
+            }
+            expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+            for (int i = elementsOffset + 1; i < elementsOffset + arrayLength; i++) {
+                expectedRepLevelsBuilder.add(maxRepetitionLevel);
+            }
+            elementsOffset += arrayLength;
+        }
+        assertThat(valuesWriter.getWrittenValues()).isEqualTo(expectedRepLevelsBuilder.build());
+    }
+
+    private static void assertRepetitionLevels(
+            ColumnarMap columnarMap,
+            List<Integer> writePositionCounts)
+    {
+        int maxRepetitionLevel = 1;
+        // Write Repetition levels for map keys
+        TestingValuesWriter keysWriter = new TestingValuesWriter();
+        RepetitionLevelWriter keysRootRepLevelWriter = getRootRepetitionLevelWriter(
+                ImmutableList.of(
+                        RepLevelWriterProviders.of(columnarMap, maxRepetitionLevel),
+                        RepLevelWriterProviders.of(columnarMap.getKeysBlock())),
+                keysWriter);
+        if (writePositionCounts.isEmpty()) {
+            keysRootRepLevelWriter.writeRepetitionLevels(0);
+        }
+        else {
+            for (int positionsCount : writePositionCounts) {
+                keysRootRepLevelWriter.writeRepetitionLevels(0, positionsCount);
+            }
+        }
+
+        // Write Repetition levels for map values
+        TestingValuesWriter valuesWriter = new TestingValuesWriter();
+        RepetitionLevelWriter valuesRootRepLevelWriter = getRootRepetitionLevelWriter(
+                ImmutableList.of(
+                        RepLevelWriterProviders.of(columnarMap, maxRepetitionLevel),
+                        RepLevelWriterProviders.of(columnarMap.getValuesBlock())),
+                valuesWriter);
+        if (writePositionCounts.isEmpty()) {
+            valuesRootRepLevelWriter.writeRepetitionLevels(0);
+        }
+        else {
+            for (int positionsCount : writePositionCounts) {
+                valuesRootRepLevelWriter.writeRepetitionLevels(0, positionsCount);
+            }
+        }
+
+        // Verify written Repetition levels
+        ImmutableList.Builder<Integer> expectedRepLevelsBuilder = ImmutableList.builder();
+        for (int position = 0; position < columnarMap.getPositionCount(); position++) {
+            if (columnarMap.isNull(position)) {
+                expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+                continue;
+            }
+            int mapLength = columnarMap.getEntryCount(position);
+            if (mapLength == 0) {
+                expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+                continue;
+            }
+            expectedRepLevelsBuilder.add(maxRepetitionLevel - 1);
+            expectedRepLevelsBuilder.addAll(nCopies(mapLength - 1, maxRepetitionLevel));
+        }
+        assertThat(keysWriter.getWrittenValues()).isEqualTo(expectedRepLevelsBuilder.build());
+        assertThat(valuesWriter.getWrittenValues()).isEqualTo(expectedRepLevelsBuilder.build());
+    }
+
+    private static void assertRepetitionLevels(
+            Block rowBlock,
+            ColumnarMap columnarMap,
+            ColumnarArray columnarArray,
+            List<Integer> writePositionCounts)
+    {
+        // Write Repetition levels
+        TestingValuesWriter valuesWriter = new TestingValuesWriter();
+        RepetitionLevelWriter fieldRootRepLevelWriter = getRootRepetitionLevelWriter(
+                ImmutableList.of(
+                        RepLevelWriterProviders.of(toColumnarRow(rowBlock)),
+                        RepLevelWriterProviders.of(columnarMap, 1),
+                        RepLevelWriterProviders.of(columnarArray, 2),
+                        RepLevelWriterProviders.of(columnarArray.getElementsBlock())),
+                valuesWriter);
+        if (writePositionCounts.isEmpty()) {
+            fieldRootRepLevelWriter.writeRepetitionLevels(0);
+        }
+        else {
+            for (int positionsCount : writePositionCounts) {
+                fieldRootRepLevelWriter.writeRepetitionLevels(0, positionsCount);
+            }
+        }
+
+        // Verify written Repetition levels
+        Iterator<Integer> expectedRepetitionLevelsIter = RepLevelIterables.getIterator(ImmutableList.<RepLevelIterable>builder()
+                .add(RepLevelIterables.of(rowBlock))
+                .add(RepLevelIterables.of(columnarMap, 1))
+                .add(RepLevelIterables.of(columnarArray, 2))
+                .add(RepLevelIterables.of(columnarArray.getElementsBlock()))
+                .build());
+        assertThat(valuesWriter.getWrittenValues()).isEqualTo(ImmutableList.copyOf(expectedRepetitionLevelsIter));
+    }
+}

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestingValuesWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestingValuesWriter.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.values.ValuesWriter;
+
+import java.util.List;
+
+class TestingValuesWriter
+        extends ValuesWriter
+{
+    private final IntList values = new IntArrayList();
+
+    @Override
+    public long getBufferedSize()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BytesInput getBytes()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Encoding getEncoding()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void reset()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getAllocatedSize()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String memUsageString(String prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void writeInteger(int v)
+    {
+        values.add(v);
+    }
+
+    List<Integer> getWrittenValues()
+    {
+        return values;
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Avoid iterators and streams and take advantage of Block#mayHaveNull
when writing repetition levels to improve performance.

BenchmarkHiveFileFormat Before
```
write  MAP_VARCHAR_DOUBLE        NONE  TRINO_OPTIMIZED_PARQUET   98.6MB/s ±  1587.5kB/s ( 1.57%) (N = 20, α = 99.9%)
write  LARGE_MAP_VARCHAR_DOUBLE  NONE  TRINO_OPTIMIZED_PARQUET  121.4MB/s ±   548.9kB/s ( 0.44%) (N = 20, α = 99.9%)
write  MAP_INT_DOUBLE            NONE  TRINO_OPTIMIZED_PARQUET  107.8MB/s ±  1137.4kB/s ( 1.03%) (N = 20, α = 99.9%)
write  LARGE_MAP_INT_DOUBLE      NONE  TRINO_OPTIMIZED_PARQUET  110.1MB/s ±   901.0kB/s ( 0.80%) (N = 20, α = 99.9%)
write  LARGE_ARRAY_VARCHAR       NONE  TRINO_OPTIMIZED_PARQUET   91.7MB/s ±  1004.9kB/s ( 1.07%) (N = 20, α = 99.9%)
```

BenchmarkHiveFileFormat After
```
write  MAP_VARCHAR_DOUBLE        NONE  TRINO_OPTIMIZED_PARQUET  214.1MB/s ±  6374.1kB/s ( 2.91%) (N = 20, α = 99.9%)
write  LARGE_MAP_VARCHAR_DOUBLE  NONE  TRINO_OPTIMIZED_PARQUET  247.5MB/s ±  2576.0kB/s ( 1.02%) (N = 20, α = 99.9%)
write  MAP_INT_DOUBLE            NONE  TRINO_OPTIMIZED_PARQUET  319.2MB/s ±  2895.2kB/s ( 0.89%) (N = 20, α = 99.9%)
write  LARGE_MAP_INT_DOUBLE      NONE  TRINO_OPTIMIZED_PARQUET  277.8MB/s ±  4441.1kB/s ( 1.56%) (N = 20, α = 99.9%)
write  LARGE_ARRAY_VARCHAR       NONE  TRINO_OPTIMIZED_PARQUET  167.6MB/s ±  1290.7kB/s ( 0.75%) (N = 20, α = 99.9%)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hudi, Hive, Delta, Iceberg
* Improve performance of writing structural types in parquet writer. ({issue}`17665`)
```
