### PR TITLE
Add support for external db for schema management in mongodb connector

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.md
+++ b/docs/src/main/sphinx/connector/mongodb.md
@@ -40,8 +40,9 @@ will create a catalog named `sales` using the configured connector.
 The following configuration properties are available:
 
 | Property name                            | Description                                                                |
-| ---------------------------------------- | -------------------------------------------------------------------------- |
+| ---------------------------------------- |----------------------------------------------------------------------------|
 | `mongodb.connection-url`                 | The connection url that the driver uses to connect to a MongoDB deployment |
+| `mongodb.schema-database`                | The database to use for schema management                                  |
 | `mongodb.schema-collection`              | A collection which contains schema information                             |
 | `mongodb.case-insensitive-name-matching` | Match database and collection names case insensitively                     |
 | `mongodb.min-connections-per-host`       | The minimum size of the connection pool per host                           |
@@ -76,6 +77,15 @@ See the [MongoDB Connection URI](https://docs.mongodb.com/drivers/java/sync/curr
 
 This property is required; there is no default. A connection URL must be
 provided to connect to a MongoDB deployment.
+
+### `mongodb.schema-database`
+
+The name of the database used by the MongoDB connector to create schema
+collections for the metadata in a different database on the cluster.
+
+If not set, the schema collection is created on the same database being queried.
+
+This property is optional; only set one of `mongodb.schema-database` or `mongodb.schema-collection`.
 
 ### `mongodb.schema-collection`
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -18,14 +18,18 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import java.util.Optional;
 
 @DefunctConfig({"mongodb.connection-per-host", "mongodb.socket-keep-alive", "mongodb.seeds", "mongodb.credentials"})
 public class MongoClientConfig
 {
     private String schemaCollection = "_schema";
+    private Optional<String> schemaDatabase = Optional.empty();
     private boolean caseInsensitiveNameMatching;
     private String connectionUrl;
 
@@ -46,6 +50,26 @@ public class MongoClientConfig
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
     private boolean allowLocalScheduling;
+
+    @AssertTrue(message = "Exactly one of 'mongodb.schema-database' or 'mongodb.schema-collection' must be specified, or the default _schema could be created in the same database")
+    public boolean isSchemaManagementConfigValid()
+    {
+        return schemaDatabase.isEmpty() || schemaCollection.equals("_schema");
+    }
+
+    @NotNull
+    public Optional<String> getSchemaDatabase()
+    {
+        return schemaDatabase;
+    }
+
+    @ConfigDescription("Database name for managing schemas of collections in the different databases")
+    @Config("mongodb.schema-database")
+    public MongoClientConfig setSchemaDatabase(String schemaDatabase)
+    {
+        this.schemaDatabase = Optional.ofNullable(schemaDatabase);
+        return this;
+    }
 
     @NotNull
     public String getSchemaCollection()

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -53,6 +53,7 @@ public class TestMongoClientConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("mongodb.schema-collection", "_my_schema")
+                .put("mongodb.schema-database", "_my_schema_db")
                 .put("mongodb.case-insensitive-name-matching", "true")
                 .put("mongodb.connection-url", "mongodb://router1.example.com:27017,router2.example2.com:27017,router3.example3.com:27017/")
                 .put("mongodb.min-connections-per-host", "1")
@@ -73,6 +74,7 @@ public class TestMongoClientConfig
 
         MongoClientConfig expected = new MongoClientConfig()
                 .setSchemaCollection("_my_schema")
+                .setSchemaDatabase("_my_schema_db")
                 .setCaseInsensitiveNameMatching(true)
                 .setConnectionUrl("mongodb://router1.example.com:27017,router2.example2.com:27017,router3.example3.com:27017/")
                 .setMinConnectionsPerHost(1)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
**Aim:** Fixes https://github.com/trinodb/trino/issues/8887

- Added a configuration property to capture the name of the mongo database to be used by trino for schema management for the different other databases and collections on the mongodb cluster.

- The property is optional and in the case it is not provided, the default implementation of _schema collection will happen.

- The trino mongodb connector will create collections inside the configured db as trino_<<db_name>>_schema format and the collections will have documents of schemas of the collections in the <<db_name>>.
