### PR TITLE
Added documentation for array_join(x, delimiter)

### DIFF
--- a/docs/src/main/sphinx/functions/array.rst
+++ b/docs/src/main/sphinx/functions/array.rst
@@ -77,6 +77,10 @@ Array functions
 .. function:: array_join(x, delimiter, null_replacement) -> varchar
 
     Concatenates the elements of the given array using the delimiter and an optional string to replace nulls.
+    
+.. function:: array_join(x, delimiter) -> varchar
+
+    Concatenates the elements of the given array using the delimiter. Does not replace nulls.
 
 .. function:: array_max(x) -> x
 


### PR DESCRIPTION
## Description
array_join(x, delimiter, null_replacement) was in the docs, but array_join(x, delimiter) was not.
Fixes #17521

## Release notes

(x) This is not user-visible or docs only and no release notes are required.