### PR TITLE
Improve details in SHOW STATS documentation

### DIFF
--- a/docs/src/main/sphinx/language/types.rst
+++ b/docs/src/main/sphinx/language/types.rst
@@ -176,6 +176,8 @@ Date and time
 
 See also :doc:`/functions/datetime`
 
+.. _date-data-type:
+
 ``DATE``
 ^^^^^^^^
 

--- a/docs/src/main/sphinx/sql/show-stats.rst
+++ b/docs/src/main/sphinx/sql/show-stats.rst
@@ -23,14 +23,34 @@ table lists the returned columns and what statistics they represent. Any
 additional statistics collected on the data source, other than those listed
 here, are not included.
 
-==========================  ============================================================= =================================
-Column                      Description                                                   Notes
-==========================  ============================================================= =================================
-``column_name``             The name of the column                                        ``NULL`` in the table summary row
-``data_size``               The total size in bytes of all of the values in the column    ``NULL`` in the table summary row. Available for columns of textual types (``CHAR``, ``VARCHAR``, etc)
-``distinct_values_count``   The estimated number of distinct values in the column m       ``NULL`` in the table summary row
-``nulls_fractions``         The portion of the values in the column that are ``NULL``     ``NULL`` in the table summary row.
-``row_count``               The estimated number of rows in the table                     ``NULL`` in column statistic rows
-``low_value``               The lowest value found in this column                         ``NULL`` in the table summary row. Available for columns of numeric types (``BIGINT``, ``DECIMAL``, etc)
-``high_value``              The highest value found in this column                        ``NULL`` in the table summary row. Available for columns of numeric types (``BIGINT``, ``DECIMAL``, etc)
-==========================  ============================================================= =================================
+.. list-table:: Statistics
+  :widths: 20, 40, 40
+  :header-rows: 1
+
+  * - Column
+    - Description
+    - Notes
+  * - ``column_name``
+    - The name of the column
+    - ``NULL`` in the table summary row
+  * - ``data_size``
+    - The total size in bytes of all of the values in the column
+    - ``NULL`` in the table summary row. Available for columns of textual types
+      (``CHAR``, ``VARCHAR``, etc)
+  * - ``distinct_values_count``
+    - The estimated number of distinct values in the column
+    - ``NULL`` in the table summary row
+  * - ``nulls_fractions``
+    - The portion of the values in the column that are ``NULL``
+    - ``NULL`` in the table summary row.
+  * - ``row_count``
+    - The estimated number of rows in the table
+    - ``NULL`` in column statistic rows
+  * - ``low_value``
+    - The lowest value found in this column
+    - ``NULL`` in the table summary row. Available for columns of numeric types
+      (``BIGINT``, ``DECIMAL``, etc)
+  * - ``high_value``
+    - The highest value found in this column
+    - ``NULL`` in the table summary row. Available for columns of numeric types
+      (``BIGINT``, ``DECIMAL``, etc)

--- a/docs/src/main/sphinx/sql/show-stats.rst
+++ b/docs/src/main/sphinx/sql/show-stats.rst
@@ -35,8 +35,8 @@ here, are not included.
     - ``NULL`` in the table summary row
   * - ``data_size``
     - The total size in bytes of all of the values in the column
-    - ``NULL`` in the table summary row. Available for columns of textual types
-      (``CHAR``, ``VARCHAR``, etc)
+    - ``NULL`` in the table summary row. Available for columns of :ref:`string
+      <string-data-types>` data types with variable widths.
   * - ``distinct_values_count``
     - The estimated number of distinct values in the column
     - ``NULL`` in the table summary row
@@ -48,9 +48,13 @@ here, are not included.
     - ``NULL`` in column statistic rows
   * - ``low_value``
     - The lowest value found in this column
-    - ``NULL`` in the table summary row. Available for columns of numeric types
-      (``BIGINT``, ``DECIMAL``, etc)
+    - ``NULL`` in the table summary row. Available for columns of :ref:`DATE
+      <date-data-type>`, :ref:`integer <integer-data-types>`,
+      :ref:`floating-point <floating-point-data-types>`, and
+      :ref:`fixed-precision <fixed-precision-data-types>` data types.
   * - ``high_value``
     - The highest value found in this column
-    - ``NULL`` in the table summary row. Available for columns of numeric types
-      (``BIGINT``, ``DECIMAL``, etc)
+    - ``NULL`` in the table summary row. Available for columns of :ref:`DATE
+      <date-data-type>`, :ref:`integer <integer-data-types>`,
+      :ref:`floating-point <floating-point-data-types>`, and
+      :ref:`fixed-precision <fixed-precision-data-types>` data types.


### PR DESCRIPTION
## Description

Date and time support was missing. You can verify that some of these at least work with 

```
SHOW STATS FOR tpch.sf1.orders
```

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
