### PR TITLE
Use `containsExactlyInOrder` in `TestDeltaLakeDatabricksUpdates`

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUpdates.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUpdates.java
@@ -78,22 +78,22 @@ public class TestDeltaLakeDatabricksUpdates
         try {
             QueryResult databricksResult = onDelta().executeQuery(format("SELECT * FROM default.%s ORDER BY id", tableName));
             QueryResult prestoResult = onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s\" ORDER BY id", tableName));
-            assertThat(databricksResult).containsExactly(toRows(prestoResult));
+            assertThat(databricksResult).containsExactlyInOrder(toRows(prestoResult));
 
             onDelta().executeQuery(format("UPDATE default.%s SET value = 'France' WHERE id = 2", tableName));
             databricksResult = onDelta().executeQuery(format("SELECT * FROM default.%s ORDER BY id", tableName));
             prestoResult = onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s\" ORDER BY id", tableName));
-            assertThat(databricksResult).containsExactly(toRows(prestoResult));
+            assertThat(databricksResult).containsExactlyInOrder(toRows(prestoResult));
 
             onDelta().executeQuery(format("UPDATE default.%s SET value = 'Spain' WHERE id = 2", tableName));
             databricksResult = onDelta().executeQuery(format("SELECT * FROM default.%s ORDER BY id", tableName));
             prestoResult = onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s\" ORDER BY id", tableName));
-            assertThat(databricksResult).containsExactly(toRows(prestoResult));
+            assertThat(databricksResult).containsExactlyInOrder(toRows(prestoResult));
 
             onDelta().executeQuery(format("UPDATE default.%s SET value = 'Portugal' WHERE id = 2", tableName));
             databricksResult = onDelta().executeQuery(format("SELECT * FROM default.%s ORDER BY id", tableName));
             prestoResult = onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s\" ORDER BY id", tableName));
-            assertThat(databricksResult).containsExactly(toRows(prestoResult));
+            assertThat(databricksResult).containsExactlyInOrder(toRows(prestoResult));
         }
         finally {
             dropDeltaTableWithRetry("default." + tableName);


### PR DESCRIPTION
## Description

Use `containsExactlyInOrder` in `TestDeltaLakeDatabricksUpdates` to avoid deprecated `containsExactly` method. 

## Release notes

(x) This is not user-visible or docs only and no release notes are required.