### PR TITLE
Add Markdown output format to the CLI

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -285,6 +285,7 @@ public class ClientOptions
         CSV_UNQUOTED,
         CSV_HEADER_UNQUOTED,
         JSON,
+        MARKDOWN,
         NULL
     }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/CsvPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/CsvPrinter.java
@@ -15,17 +15,12 @@ package io.trino.cli;
 
 import au.com.bytecode.opencsv.CSVWriter;
 import com.google.common.collect.ImmutableList;
-import io.trino.client.Row;
 
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Map;
 
-import static io.trino.cli.AlignedTablePrinter.formatHexDump;
-import static io.trino.cli.AlignedTablePrinter.formatList;
-import static io.trino.cli.AlignedTablePrinter.formatMap;
-import static io.trino.cli.AlignedTablePrinter.formatRow;
+import static io.trino.cli.FormatUtils.formatValue;
 import static java.util.Objects.requireNonNull;
 
 public class CsvPrinter
@@ -114,33 +109,8 @@ public class CsvPrinter
             array = new String[rowSize];
         }
         for (int i = 0; i < rowSize; i++) {
-            array[i] = formatValue(values.get(i));
+            array[i] = formatValue(values.get(i), "", -1);
         }
         return array;
-    }
-
-    static String formatValue(Object o)
-    {
-        if (o == null) {
-            return "";
-        }
-
-        if (o instanceof Map) {
-            return formatMap((Map<?, ?>) o);
-        }
-
-        if (o instanceof List) {
-            return formatList((List<?>) o);
-        }
-
-        if (o instanceof Row) {
-            return formatRow((Row) o);
-        }
-
-        if (o instanceof byte[]) {
-            return formatHexDump((byte[]) o);
-        }
-
-        return o.toString();
     }
 }

--- a/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/FormatUtils.java
@@ -13,23 +13,36 @@
  */
 package io.trino.cli;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.client.Row;
 
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.repeat;
+import static com.google.common.collect.Iterables.partition;
+import static com.google.common.collect.Iterables.transform;
+import static com.google.common.io.BaseEncoding.base16;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.joining;
 
 public final class FormatUtils
 {
+    private static final Splitter HEX_SPLITTER = Splitter.fixedLength(2);
+    private static final Joiner HEX_BYTE_JOINER = Joiner.on(' ');
+    private static final Joiner HEX_LINE_JOINER = Joiner.on('\n');
+
     private FormatUtils() {}
 
     public static String formatCount(long count)
@@ -237,5 +250,94 @@ public final class FormatUtils
     private static int ceil(int dividend, int divisor)
     {
         return ((dividend + divisor) - 1) / divisor;
+    }
+
+    static String formatValue(Object o)
+    {
+        return formatValue(o, "NULL", 16);
+    }
+
+    static String formatValue(Object o, String nullValue, int bytesPerLine)
+    {
+        if (o == null) {
+            return nullValue;
+        }
+
+        if (o instanceof Map) {
+            return formatMap((Map<?, ?>) o);
+        }
+
+        if (o instanceof List) {
+            return formatList((List<?>) o);
+        }
+
+        if (o instanceof Row) {
+            return formatRow(((Row) o));
+        }
+
+        if (o instanceof byte[]) {
+            return formatHexDump((byte[]) o, bytesPerLine);
+        }
+
+        return o.toString();
+    }
+
+    private static String formatHexDump(byte[] bytes, int bytesPerLine)
+    {
+        if (bytesPerLine <= 0) {
+            return formatHexDump(bytes);
+        }
+        // hex pairs: ["61", "62", "63"]
+        Iterable<String> hexPairs = createHexPairs(bytes);
+
+        // hex lines: [["61", "62", "63], [...]]
+        Iterable<List<String>> hexLines = partition(hexPairs, bytesPerLine);
+
+        // lines: ["61 62 63", ...]
+        Iterable<String> lines = transform(hexLines, HEX_BYTE_JOINER::join);
+
+        // joined: "61 62 63\n..."
+        return HEX_LINE_JOINER.join(lines);
+    }
+
+    static String formatHexDump(byte[] bytes)
+    {
+        return HEX_BYTE_JOINER.join(createHexPairs(bytes));
+    }
+
+    private static Iterable<String> createHexPairs(byte[] bytes)
+    {
+        // hex dump: "616263"
+        String hexDump = base16().lowerCase().encode(bytes);
+
+        // hex pairs: ["61", "62", "63"]
+        return HEX_SPLITTER.split(hexDump);
+    }
+
+    static String formatList(List<? extends Object> list)
+    {
+        return list.stream()
+                .map(FormatUtils::formatValue)
+                .collect(joining(", ", "[", "]"));
+    }
+
+    static String formatMap(Map<? extends Object, ? extends Object> map)
+    {
+        return map.entrySet().stream()
+                .map(entry -> format("%s=%s", formatValue(entry.getKey()), formatValue(entry.getValue())))
+                .collect(joining(", ", "{", "}"));
+    }
+
+    static String formatRow(Row row)
+    {
+        return row.getFields().stream()
+                .map(field -> {
+                    String formattedValue = formatValue(field.getValue());
+                    if (field.getName().isPresent()) {
+                        return format("%s=%s", formatValue(field.getName().get()), formattedValue);
+                    }
+                    return formattedValue;
+                })
+                .collect(joining(", ", "{", "}"));
     }
 }

--- a/client/trino-cli/src/main/java/io/trino/cli/JsonPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/JsonPrinter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
 
-import static io.trino.cli.AlignedTablePrinter.formatHexDump;
+import static io.trino.cli.FormatUtils.formatHexDump;
 import static java.util.Objects.requireNonNull;
 
 public class JsonPrinter

--- a/client/trino-cli/src/main/java/io/trino/cli/MarkdownTablePrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/MarkdownTablePrinter.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.client.Column;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.repeat;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static io.trino.client.ClientStandardTypes.DECIMAL;
+import static io.trino.client.ClientStandardTypes.DOUBLE;
+import static io.trino.client.ClientStandardTypes.INTEGER;
+import static io.trino.client.ClientStandardTypes.REAL;
+import static io.trino.client.ClientStandardTypes.SMALLINT;
+import static io.trino.client.ClientStandardTypes.TINYINT;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+import static org.jline.utils.AttributedString.stripAnsi;
+import static org.jline.utils.WCWidth.wcwidth;
+
+public class MarkdownTablePrinter
+        implements OutputPrinter
+{
+    private static final Set<String> NUMERIC_TYPES = ImmutableSet.of(TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, DECIMAL);
+    private final List<String> fieldNames;
+    private final List<Align> alignments;
+    private final Writer writer;
+
+    private boolean headerOutput;
+
+    public MarkdownTablePrinter(List<Column> columns, Writer writer)
+    {
+        requireNonNull(columns, "columns is null");
+        this.fieldNames = columns.stream()
+                .map(Column::getName)
+                .collect(toImmutableList());
+        this.alignments = columns.stream()
+                .map(Column::getTypeSignature)
+                .map(signature -> NUMERIC_TYPES.contains(signature.getRawType()) ? Align.RIGHT : Align.LEFT)
+                .collect(toImmutableList());
+        this.writer = requireNonNull(writer, "writer is null");
+    }
+
+    private enum Align
+    {
+        LEFT,
+        RIGHT;
+    }
+
+    @Override
+    public void printRows(List<List<?>> rows, boolean complete)
+            throws IOException
+    {
+        int columns = fieldNames.size();
+
+        int[] maxWidth = new int[columns];
+        for (int i = 0; i < columns; i++) {
+            maxWidth[i] = max(1, consoleWidth(fieldNames.get(i)));
+        }
+        for (List<?> row : rows) {
+            for (int i = 0; i < row.size(); i++) {
+                String s = formatValue(row.get(i));
+                maxWidth[i] = max(maxWidth[i], consoleWidth(s));
+            }
+        }
+
+        if (!headerOutput) {
+            headerOutput = true;
+
+            for (int i = 0; i < columns; i++) {
+                writer.append('|');
+                writer.append(align(fieldNames.get(i), maxWidth[i], alignments.get(i)));
+            }
+            writer.append("|\n");
+
+            for (int i = 0; i < columns; i++) {
+                writer.append("| ");
+                writer.append(repeat("-", maxWidth[i]));
+                writer.write(alignments.get(i) == Align.RIGHT ? ':' : ' ');
+            }
+            writer.append("|\n");
+        }
+
+        for (List<?> row : rows) {
+            for (int column = 0; column < columns; column++) {
+                writer.append('|');
+                writer.append(align(formatValue(row.get(column)), maxWidth[column], alignments.get(column)));
+            }
+            writer.append("|\n");
+        }
+        writer.flush();
+    }
+
+    static String formatValue(Object o)
+    {
+        return FormatUtils.formatValue(o)
+                .replaceAll("([\\\\`*_{}\\[\\]<>()#+!|])", "\\\\$1")
+                .replace("\n", "<br>");
+    }
+
+    @Override
+    public void finish()
+            throws IOException
+    {
+        writer.flush();
+    }
+
+    private static String align(String value, int maxWidth, Align align)
+    {
+        int width = consoleWidth(value);
+        checkState(width <= maxWidth, "Variable width %s is greater than column width %s", width, maxWidth);
+        String large = repeat(" ", (maxWidth - width) + 1);
+        String small = repeat(" ", 1);
+        return align == Align.RIGHT ? (large + value + small) : (small + value + large);
+    }
+
+    static int consoleWidth(String value)
+    {
+        CharSequence plain = stripAnsi(value);
+        int n = 0;
+        for (int i = 0; i < plain.length(); i++) {
+            n += max(wcwidth(plain.charAt(i)), 0);
+        }
+        return n;
+    }
+}

--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -347,6 +347,8 @@ public class Query
                 return new TsvPrinter(fieldNames, writer, true);
             case JSON:
                 return new JsonPrinter(fieldNames, writer);
+            case MARKDOWN:
+                return new MarkdownTablePrinter(columns, writer);
             case NULL:
                 return new NullPrinter();
         }

--- a/client/trino-cli/src/main/java/io/trino/cli/TsvPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/TsvPrinter.java
@@ -20,7 +20,7 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 
-import static io.trino.cli.CsvPrinter.formatValue;
+import static io.trino.cli.FormatUtils.formatValue;
 import static java.util.Objects.requireNonNull;
 
 public class TsvPrinter
@@ -65,7 +65,7 @@ public class TsvPrinter
         StringBuilder sb = new StringBuilder();
         Iterator<?> iter = row.iterator();
         while (iter.hasNext()) {
-            String s = formatValue(iter.next());
+            String s = formatValue(iter.next(), "", -1);
 
             for (int i = 0; i < s.length(); i++) {
                 escapeCharacter(sb, s.charAt(i));

--- a/client/trino-cli/src/main/java/io/trino/cli/VerticalRecordPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/VerticalRecordPrinter.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import static com.google.common.base.Strings.repeat;
 import static io.trino.cli.AlignedTablePrinter.consoleWidth;
-import static io.trino.cli.AlignedTablePrinter.formatValue;
 import static io.trino.cli.AlignedTablePrinter.maxLineLength;
+import static io.trino.cli.FormatUtils.formatValue;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestMarkdownTablePrinter.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestMarkdownTablePrinter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.client.ClientTypeSignature;
+import io.trino.client.Column;
+import org.testng.annotations.Test;
+
+import java.io.StringWriter;
+import java.util.List;
+
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static io.trino.client.ClientStandardTypes.VARBINARY;
+import static io.trino.client.ClientStandardTypes.VARCHAR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.testng.Assert.assertEquals;
+
+public class TestMarkdownTablePrinter
+{
+    @Test
+    public void testMarkdownPrinting()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("last", VARCHAR))
+                .add(column("quantity", BIGINT))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new MarkdownTablePrinter(columns, writer);
+
+        printer.printRows(rows(
+                        row("hello", "world", 123),
+                        row("a", null, 4.5),
+                        row("b", null, null),
+                        row("some long\ntext that\ndoes not\nfit on\none line", "more\ntext", 4567),
+                        row("bye | not **& <a>**", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "| first                                                    | last         | quantity |\n" +
+                "| -------------------------------------------------------- | ------------ | --------:|\n" +
+                "| hello                                                    | world        |      123 |\n" +
+                "| a                                                        | NULL         |      4.5 |\n" +
+                "| b                                                        | NULL         |     NULL |\n" +
+                "| some long<br>text that<br>does not<br>fit on<br>one line | more<br>text |     4567 |\n" +
+                "| bye \\| not \\*\\*& \\<a\\>\\*\\*                               | done         |      -15 |\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testMarkdownPrintingOneRow()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("last", VARCHAR))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new MarkdownTablePrinter(columns, writer);
+
+        printer.printRows(rows(row("a long line\nwithout wrapping", "text")), true);
+        printer.finish();
+
+        String expected = "" +
+                "| first                           | last |\n" +
+                "| ------------------------------- | ---- |\n" +
+                "| a long line<br>without wrapping | text |\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testMarkdownPrintingNoRows()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("last", VARCHAR))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new MarkdownTablePrinter(columns, writer);
+
+        printer.finish();
+
+        String expected = "";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testMarkdownPrintingHex()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("first", VARCHAR))
+                .add(column("binary", VARBINARY))
+                .add(column("last", VARCHAR))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new MarkdownTablePrinter(columns, writer);
+
+        printer.printRows(rows(
+                        row("hello", bytes("hello"), "world"),
+                        row("a", bytes("some long text that is more than 16 bytes"), "b"),
+                        row("cat", bytes(""), "dog")),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "| first | binary                                                                                                                           | last  |\n" +
+                "| ----- | -------------------------------------------------------------------------------------------------------------------------------- | ----- |\n" +
+                "| hello | 68 65 6c 6c 6f                                                                                                                   | world |\n" +
+                "| a     | 73 6f 6d 65 20 6c 6f 6e 67 20 74 65 78 74 20 74<br>68 61 74 20 69 73 20 6d 6f 72 65 20 74 68 61 6e<br>20 31 36 20 62 79 74 65 73 | b     |\n" +
+                "| cat   |                                                                                                                                  | dog   |\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testMarkdownPrintingWideCharacters()
+            throws Exception
+    {
+        List<Column> columns = ImmutableList.<Column>builder()
+                .add(column("go\u7f51", VARCHAR))
+                .add(column("last", VARCHAR))
+                .add(column("quantity\u7f51", BIGINT))
+                .build();
+        StringWriter writer = new StringWriter();
+        OutputPrinter printer = new MarkdownTablePrinter(columns, writer);
+
+        printer.printRows(rows(
+                        row("hello", "wide\u7f51", 123),
+                        row("some long\ntext \u7f51\ndoes not\u7f51\nfit", "more\ntext", 4567),
+                        row("bye", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "| go\u7f51                                      | last         | quantity\u7f51 |\n" +
+                "| ----------------------------------------- | ------------ | ----------:|\n" +
+                "| hello                                     | wide\u7f51       |        123 |\n" +
+                "| some long<br>text \u7f51<br>does not\u7f51<br>fit | more<br>text |       4567 |\n" +
+                "| bye                                       | done         |        -15 |\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    static Column column(String name, String type)
+    {
+        return new Column(name, type, new ClientTypeSignature(type));
+    }
+
+    static List<?> row(Object... values)
+    {
+        return asList(values);
+    }
+
+    static List<List<?>> rows(List<?>... rows)
+    {
+        return asList(rows);
+    }
+
+    static byte[] bytes(String s)
+    {
+        return s.getBytes(UTF_8);
+    }
+}

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -643,6 +643,8 @@ and `CSV` in non-interactive mode.
   * - ``AUTO``
     - Same as ``ALIGNED`` if output would fit the current terminal width,
       and ``VERTICAL`` otherwise.
+  * - ``MARKDOWN``
+    - Output emitted as a Markdown table.
   * - ``NULL``
     - Suppresses normal query results. This can be useful during development
       to test a query's shell return code or to see whether it results in


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add Markdown output to avoid having to use external tools like `csv2md`.

Example usage:
```bash
./client/trino-cli/target/trino-cli-419-SNAPSHOT-executable.jar --output-format MARKDOWN \
  --execute="select * from (values (1234567, 'some longer strin'), (123, 'aa')) as t(one, two)"
```

Prints:
```
|     one | two               |
| -------:| ----------------- |
| 1234567 | some longer strin |
|     123 | aa                |
```

where the default `ALIGNED` format looks like:
```
   one   |        two        
---------+-------------------
 1234567 | some longer strin 
     123 | aa                
(2 rows)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
