### PR TITLE
Disable creation of reduced pom during shading

### DIFF
--- a/testing/trino-plugin-reader/pom.xml
+++ b/testing/trino-plugin-reader/pom.xml
@@ -111,6 +111,7 @@
                         <configuration>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>executable</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Maven-shade-plugin after
https://issues.apache.org/jira/browse/MSHADE-321 by default creates reduced pom. So all dependencies are removed. This works well when you want when you only provide shaded binary as the target artifact. Here we use shading to generate executable jar, and still we would like to provide regular jar artifact so it can be used as a library. In library case reduced pom is undesired.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
