### PR TITLE
Fix DEFAULT_ON_NULL return convention to short circuit on null argument

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
-import static io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy.RETURN_NULL_ON_NULL;
 import static java.lang.String.format;
 import static java.util.Comparator.comparingInt;
 import static java.util.Objects.requireNonNull;
@@ -40,8 +39,6 @@ import static java.util.Objects.requireNonNull;
 public final class ChoicesSpecializedSqlScalarFunction
         implements SpecializedSqlScalarFunction
 {
-    private final ScalarFunctionAdapter functionAdapter = new ScalarFunctionAdapter(RETURN_NULL_ON_NULL);
-
     private final BoundSignature boundSignature;
     private final List<ScalarImplementationChoice> choices;
 
@@ -103,7 +100,7 @@ public final class ChoicesSpecializedSqlScalarFunction
         List<ScalarImplementationChoice> choices = new ArrayList<>();
         for (ScalarImplementationChoice choice : this.choices) {
             InvocationConvention callingConvention = choice.getInvocationConvention();
-            if (functionAdapter.canAdapt(callingConvention, invocationConvention)) {
+            if (ScalarFunctionAdapter.canAdapt(callingConvention, invocationConvention)) {
                 choices.add(choice);
             }
         }
@@ -113,7 +110,7 @@ public final class ChoicesSpecializedSqlScalarFunction
         }
 
         ScalarImplementationChoice bestChoice = Collections.max(choices, comparingInt(ScalarImplementationChoice::getScore));
-        MethodHandle methodHandle = functionAdapter.adapt(
+        MethodHandle methodHandle = ScalarFunctionAdapter.adapt(
                 bestChoice.getMethodHandle(),
                 boundSignature.getArgumentTypes(),
                 bestChoice.getInvocationConvention(),

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -273,6 +273,32 @@
                                     <code>java.method.finalMethodAddedToNonFinalClass</code>
                                     <new>method int io.trino.spi.type.AbstractIntType::getInt(io.trino.spi.block.Block, int)</new>
                                 </item>
+
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.class.removed</code>
+                                    <old>enum io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy</old>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.function.ScalarFunctionAdapter::&lt;init&gt;(io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy)</old>
+                                    <new>method void io.trino.spi.function.ScalarFunctionAdapter::&lt;init&gt;()</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>private</newVisibility>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowStatic</code>
+                                    <old>method java.lang.invoke.MethodHandle io.trino.spi.function.ScalarFunctionAdapter::adapt(java.lang.invoke.MethodHandle, java.util.List&lt;io.trino.spi.type.Type&gt;, io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</old>
+                                    <new>method java.lang.invoke.MethodHandle io.trino.spi.function.ScalarFunctionAdapter::adapt(java.lang.invoke.MethodHandle, java.util.List&lt;io.trino.spi.type.Type&gt;, io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.nowStatic</code>
+                                    <old>method boolean io.trino.spi.function.ScalarFunctionAdapter::canAdapt(io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</old>
+                                    <new>method boolean io.trino.spi.function.ScalarFunctionAdapter::canAdapt(io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
@@ -154,8 +154,26 @@ public class InvocationConvention
 
     public enum InvocationReturnConvention
     {
+        /**
+         * The function will never return a null value.
+         * It is not possible to adapt a NEVER_NULL argument to a
+         * BOXED_NULLABLE or NULL_FLAG argument when the this return
+         * convention is used.
+         */
         FAIL_ON_NULL(false),
+        /**
+         * When a null is passed to a never null argument, the function
+         * will not be invoked, and the Java default value for the return
+         * type will be returned.
+         * This can not be used as an actual function return convention,
+         * and instead is only used for adaptation.
+         */
         DEFAULT_ON_NULL(false),
+        /**
+         * The function may return a null value.
+         * When a null is passed to a never null argument, the function
+         * will not be invoked, and a null value is returned.
+         */
         NULLABLE_RETURN(true);
 
         private final boolean nullable;

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -274,7 +274,7 @@ public final class ScalarFunctionAdapter
             }
 
             if (actualArgumentConvention == NULL_FLAG) {
-                // actual method takes value and null flag, so change method handle to not have the flag and always pass false to the actual method
+                // actual method takes value and null flag, so change method handles to not have the flag and always pass false to the actual method
                 return insertArguments(methodHandle, parameterIndex + 1, false);
             }
 
@@ -306,7 +306,7 @@ public final class ScalarFunctionAdapter
                 // The conversion is described below in reverse order as this is how method handle adaptation works.  The provided example
                 // signature is based on a boxed Long argument.
 
-                // 3. unbox the value (if null the java default is sent)
+                // 3. unbox the value (if null, the java default is sent)
                 // long, boolean => Long, boolean
                 Class<?> parameterType = methodHandle.type().parameterType(parameterIndex);
                 methodHandle = explicitCastArguments(methodHandle, methodHandle.type().changeParameterType(parameterIndex, wrap(parameterType)));
@@ -338,7 +338,7 @@ public final class ScalarFunctionAdapter
                 if (returnConvention == FAIL_ON_NULL) {
                     throw new IllegalArgumentException("RETURN_NULL_ON_NULL adaptation can not be used with FAIL_ON_NULL return convention");
                 }
-                // add null flag to call
+                // add a null flag to call
                 methodHandle = dropArguments(methodHandle, parameterIndex + 1, boolean.class);
                 if (returnConvention == DEFAULT_ON_NULL) {
                     return methodHandle;
@@ -544,7 +544,7 @@ public final class ScalarFunctionAdapter
         }
         // Add boolean null flag
         handle = dropArguments(handle, 1, boolean.class);
-        // if flag is true, return null, otherwise invoke identity
+        // if the flag is true, return null, otherwise invoke identity
         return guardWithTest(
                 isTrueNullFlag(handle.type(), 0),
                 returnNull(handle.type()),
@@ -562,7 +562,7 @@ public final class ScalarFunctionAdapter
         MethodHandle isNull = IS_NULL_METHOD;
         // Cast in incoming type: isNull(T):boolean
         isNull = explicitCastArguments(isNull, methodType(boolean.class, methodType.parameterType(index)));
-        // Add extra argument to match expected method type
+        // Add extra argument to match the expected method type
         isNull = permuteArguments(isNull, methodType.changeReturnType(boolean.class), index);
         return isNull;
     }
@@ -577,7 +577,7 @@ public final class ScalarFunctionAdapter
         catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
-        // Add extra argument to match expected method type
+        // Add extra argument to match the expected method type
         isNull = permuteArguments(isNull, methodType.changeReturnType(boolean.class), index, index + 1);
         return isNull;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -37,16 +37,11 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.DEFAULT_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy.RETURN_NULL_ON_NULL;
-import static io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy.THROW_ON_NULL;
-import static io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy.UNDEFINED_VALUE_FOR_NULL;
-import static io.trino.spi.function.ScalarFunctionAdapter.NullAdaptationPolicy.UNSUPPORTED;
 import static java.lang.invoke.MethodHandles.collectArguments;
 import static java.lang.invoke.MethodHandles.constant;
 import static java.lang.invoke.MethodHandles.dropArguments;
 import static java.lang.invoke.MethodHandles.explicitCastArguments;
 import static java.lang.invoke.MethodHandles.filterArguments;
-import static java.lang.invoke.MethodHandles.filterReturnValue;
 import static java.lang.invoke.MethodHandles.guardWithTest;
 import static java.lang.invoke.MethodHandles.identity;
 import static java.lang.invoke.MethodHandles.insertArguments;
@@ -61,17 +56,12 @@ public final class ScalarFunctionAdapter
 {
     private static final MethodHandle IS_NULL_METHOD = lookupIsNullMethod();
 
-    private final NullAdaptationPolicy nullAdaptationPolicy;
-
-    public ScalarFunctionAdapter(NullAdaptationPolicy nullAdaptationPolicy)
-    {
-        this.nullAdaptationPolicy = requireNonNull(nullAdaptationPolicy, "nullAdaptationPolicy is null");
-    }
+    private ScalarFunctionAdapter() {}
 
     /**
      * Can the actual calling convention of a method be converted to the expected calling convention?
      */
-    public boolean canAdapt(InvocationConvention actualConvention, InvocationConvention expectedConvention)
+    public static boolean canAdapt(InvocationConvention actualConvention, InvocationConvention expectedConvention)
     {
         requireNonNull(actualConvention, "actualConvention is null");
         requireNonNull(expectedConvention, "expectedConvention is null");
@@ -104,7 +94,7 @@ public final class ScalarFunctionAdapter
         return true;
     }
 
-    private boolean canAdaptReturn(
+    private static boolean canAdaptReturn(
             InvocationReturnConvention actualReturnConvention,
             InvocationReturnConvention expectedReturnConvention)
     {
@@ -116,28 +106,15 @@ public final class ScalarFunctionAdapter
             return true;
         }
 
-        if (expectedReturnConvention == FAIL_ON_NULL && actualReturnConvention == NULLABLE_RETURN) {
-            switch (nullAdaptationPolicy) {
-                case THROW_ON_NULL:
-                case UNDEFINED_VALUE_FOR_NULL:
-                    return true;
-                case UNSUPPORTED:
-                case RETURN_NULL_ON_NULL:
-                    return false;
-                default:
-                    return false;
-            }
-        }
-
         if (expectedReturnConvention == DEFAULT_ON_NULL
                 && (actualReturnConvention == NULLABLE_RETURN || actualReturnConvention == FAIL_ON_NULL)) {
-            return nullAdaptationPolicy == RETURN_NULL_ON_NULL;
+            return true;
         }
 
         return false;
     }
 
-    private boolean canAdaptParameter(
+    private static boolean canAdaptParameter(
             InvocationArgumentConvention actualArgumentConvention,
             InvocationArgumentConvention expectedArgumentConvention,
             InvocationReturnConvention returnConvention)
@@ -166,17 +143,7 @@ public final class ScalarFunctionAdapter
         if (expectedArgumentConvention == BOXED_NULLABLE || expectedArgumentConvention == NULL_FLAG) {
             // null able to not nullable has special handling
             if (actualArgumentConvention == NEVER_NULL) {
-                switch (nullAdaptationPolicy) {
-                    case THROW_ON_NULL:
-                    case UNDEFINED_VALUE_FOR_NULL:
-                        return true;
-                    case RETURN_NULL_ON_NULL:
-                        return returnConvention != FAIL_ON_NULL;
-                    case UNSUPPORTED:
-                        return false;
-                    default:
-                        return false;
-                }
+                return returnConvention != FAIL_ON_NULL;
             }
 
             return true;
@@ -188,7 +155,7 @@ public final class ScalarFunctionAdapter
     /**
      * Adapt the method handle from the actual calling convention of a method be converted to the expected calling convention?
      */
-    public MethodHandle adapt(
+    public static MethodHandle adapt(
             MethodHandle methodHandle,
             List<Type> actualArgumentTypes,
             InvocationConvention actualConvention,
@@ -240,7 +207,7 @@ public final class ScalarFunctionAdapter
         return methodHandle;
     }
 
-    private MethodHandle adaptReturn(
+    private static MethodHandle adaptReturn(
             MethodHandle methodHandle,
             InvocationReturnConvention actualReturnConvention,
             InvocationReturnConvention expectedReturnConvention)
@@ -257,36 +224,11 @@ public final class ScalarFunctionAdapter
             }
         }
 
-        if (expectedReturnConvention == FAIL_ON_NULL) {
-            if (actualReturnConvention == NULLABLE_RETURN) {
-                if (nullAdaptationPolicy == UNSUPPORTED || nullAdaptationPolicy == RETURN_NULL_ON_NULL) {
-                    throw new IllegalArgumentException("Nullable return can not be adapted fail on null");
-                }
-
-                if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
-                    // currently, we just perform unboxing, which converts nulls to Java primitive default value
-                    methodHandle = explicitCastArguments(methodHandle, methodHandle.type().changeReturnType(unwrap(returnType)));
-                    return methodHandle;
-                }
-
-                if (nullAdaptationPolicy == THROW_ON_NULL) {
-                    MethodHandle adapter = identity(returnType);
-                    adapter = explicitCastArguments(adapter, adapter.type().changeReturnType(unwrap(returnType)));
-                    adapter = guardWithTest(
-                            isNullArgument(adapter.type(), 0),
-                            throwTrinoNullArgumentException(adapter.type()),
-                            adapter);
-
-                    return filterReturnValue(methodHandle, adapter);
-                }
-            }
+        if (expectedReturnConvention == FAIL_ON_NULL && actualReturnConvention == NULLABLE_RETURN) {
+            throw new IllegalArgumentException("Nullable return can not be adapted fail on null");
         }
 
         if (expectedReturnConvention == DEFAULT_ON_NULL) {
-            if (nullAdaptationPolicy != RETURN_NULL_ON_NULL) {
-                throw new IllegalArgumentException(actualReturnConvention + " return can not be adapted to " + expectedReturnConvention);
-            }
-
             if (actualReturnConvention == FAIL_ON_NULL) {
                 return methodHandle;
             }
@@ -299,7 +241,7 @@ public final class ScalarFunctionAdapter
         throw new IllegalArgumentException("Unsupported return convention: " + actualReturnConvention);
     }
 
-    private MethodHandle adaptParameter(
+    private static MethodHandle adaptParameter(
             MethodHandle methodHandle,
             int parameterIndex,
             Type argumentType,
@@ -342,43 +284,22 @@ public final class ScalarFunctionAdapter
         // caller will pass Java null for SQL null
         if (expectedArgumentConvention == BOXED_NULLABLE) {
             if (actualArgumentConvention == NEVER_NULL) {
-                if (nullAdaptationPolicy == UNSUPPORTED) {
-                    throw new IllegalArgumentException("Not null argument can not be adapted to nullable");
-                }
-
                 // box argument
                 Class<?> boxedType = wrap(methodHandle.type().parameterType(parameterIndex));
                 MethodType targetType = methodHandle.type().changeParameterType(parameterIndex, boxedType);
                 methodHandle = explicitCastArguments(methodHandle, targetType);
 
-                if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
-                    // currently, we just perform unboxing, which converts nulls to Java primitive default value
+                if (returnConvention == FAIL_ON_NULL) {
+                    throw new IllegalArgumentException("RETURN_NULL_ON_NULL adaptation can not be used with FAIL_ON_NULL return convention");
+                }
+                if (returnConvention == DEFAULT_ON_NULL) {
+                    // perform unboxing, which converts nulls to Java primitive default value
                     return methodHandle;
                 }
-
-                if (nullAdaptationPolicy == RETURN_NULL_ON_NULL) {
-                    if (returnConvention == FAIL_ON_NULL) {
-                        throw new IllegalArgumentException("RETURN_NULL_ON_NULL adaptation can not be used with FAIL_ON_NULL return convention");
-                    }
-                    if (returnConvention == DEFAULT_ON_NULL) {
-                        // perform unboxing, which converts nulls to Java primitive default value
-                        return methodHandle;
-                    }
-                    return guardWithTest(
-                            isNullArgument(methodHandle.type(), parameterIndex),
-                            returnNull(methodHandle.type()),
-                            methodHandle);
-                }
-
-                if (nullAdaptationPolicy == THROW_ON_NULL) {
-                    MethodType adapterType = methodType(boxedType, boxedType);
-                    MethodHandle adapter = guardWithTest(
-                            isNullArgument(adapterType, 0),
-                            throwTrinoNullArgumentException(adapterType),
-                            identity(boxedType));
-
-                    return collectArguments(methodHandle, parameterIndex, adapter);
-                }
+                return guardWithTest(
+                        isNullArgument(methodHandle.type(), parameterIndex),
+                        returnNull(methodHandle.type()),
+                        methodHandle);
             }
 
             if (actualArgumentConvention == NULL_FLAG) {
@@ -413,42 +334,19 @@ public final class ScalarFunctionAdapter
         // caller will pass boolean true in the next argument for SQL null
         if (expectedArgumentConvention == NULL_FLAG) {
             if (actualArgumentConvention == NEVER_NULL) {
-                if (nullAdaptationPolicy == UNSUPPORTED) {
-                    throw new IllegalArgumentException("Not null argument can not be adapted to nullable");
+                // if caller sets null flag, return null, otherwise invoke target
+                if (returnConvention == FAIL_ON_NULL) {
+                    throw new IllegalArgumentException("RETURN_NULL_ON_NULL adaptation can not be used with FAIL_ON_NULL return convention");
                 }
-
-                if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
-                    // add null flag to call
-                    methodHandle = dropArguments(methodHandle, parameterIndex + 1, boolean.class);
+                // add null flag to call
+                methodHandle = dropArguments(methodHandle, parameterIndex + 1, boolean.class);
+                if (returnConvention == DEFAULT_ON_NULL) {
                     return methodHandle;
                 }
-
-                // if caller sets null flag, return null, otherwise invoke target
-                if (nullAdaptationPolicy == RETURN_NULL_ON_NULL) {
-                    if (returnConvention == FAIL_ON_NULL) {
-                        throw new IllegalArgumentException("RETURN_NULL_ON_NULL adaptation can not be used with FAIL_ON_NULL return convention");
-                    }
-                    // add null flag to call
-                    methodHandle = dropArguments(methodHandle, parameterIndex + 1, boolean.class);
-                    if (returnConvention == DEFAULT_ON_NULL) {
-                        return methodHandle;
-                    }
-                    return guardWithTest(
-                            isTrueNullFlag(methodHandle.type(), parameterIndex),
-                            returnNull(methodHandle.type()),
-                            methodHandle);
-                }
-
-                if (nullAdaptationPolicy == THROW_ON_NULL) {
-                    MethodHandle adapter = identity(methodHandle.type().parameterType(parameterIndex));
-                    adapter = dropArguments(adapter, 1, boolean.class);
-                    adapter = guardWithTest(
-                            isTrueNullFlag(adapter.type(), 0),
-                            throwTrinoNullArgumentException(adapter.type()),
-                            adapter);
-
-                    return collectArguments(methodHandle, parameterIndex, adapter);
-                }
+                return guardWithTest(
+                        isTrueNullFlag(methodHandle.type(), parameterIndex),
+                        returnNull(methodHandle.type()),
+                        methodHandle);
             }
 
             if (actualArgumentConvention == BOXED_NULLABLE) {
@@ -463,13 +361,7 @@ public final class ScalarFunctionAdapter
             MethodHandle getBlockValue = getBlockValue(argumentType, methodHandle.type().parameterType(parameterIndex));
 
             if (actualArgumentConvention == NEVER_NULL) {
-                if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
-                    // Current, null is not checked, so whatever type returned is passed through
-                    methodHandle = collectArguments(methodHandle, parameterIndex, getBlockValue);
-                    return methodHandle;
-                }
-
-                if (nullAdaptationPolicy == RETURN_NULL_ON_NULL && returnConvention != FAIL_ON_NULL) {
+                if (returnConvention != FAIL_ON_NULL) {
                     // if caller sets null flag, return null, otherwise invoke target
                     methodHandle = collectArguments(methodHandle, parameterIndex, getBlockValue);
                     if (returnConvention == DEFAULT_ON_NULL) {
@@ -481,14 +373,12 @@ public final class ScalarFunctionAdapter
                             methodHandle);
                 }
 
-                if (nullAdaptationPolicy == THROW_ON_NULL || nullAdaptationPolicy == UNSUPPORTED || nullAdaptationPolicy == RETURN_NULL_ON_NULL) {
-                    MethodHandle adapter = guardWithTest(
-                            isBlockPositionNull(getBlockValue.type(), 0),
-                            throwTrinoNullArgumentException(getBlockValue.type()),
-                            getBlockValue);
+                MethodHandle adapter = guardWithTest(
+                        isBlockPositionNull(getBlockValue.type(), 0),
+                        throwTrinoNullArgumentException(getBlockValue.type()),
+                        getBlockValue);
 
-                    return collectArguments(methodHandle, parameterIndex, adapter);
-                }
+                return collectArguments(methodHandle, parameterIndex, adapter);
             }
 
             if (actualArgumentConvention == BOXED_NULLABLE) {
@@ -529,13 +419,7 @@ public final class ScalarFunctionAdapter
             MethodHandle getInOutValue = getInOutValue(argumentType, methodHandle.type().parameterType(parameterIndex));
 
             if (actualArgumentConvention == NEVER_NULL) {
-                if (nullAdaptationPolicy == UNDEFINED_VALUE_FOR_NULL) {
-                    // Current, null is not checked, so whatever value returned is passed through
-                    methodHandle = collectArguments(methodHandle, parameterIndex, getInOutValue);
-                    return methodHandle;
-                }
-
-                if (nullAdaptationPolicy == RETURN_NULL_ON_NULL && returnConvention != FAIL_ON_NULL) {
+                if (returnConvention != FAIL_ON_NULL) {
                     // if caller sets null flag, return null, otherwise invoke target
                     methodHandle = collectArguments(methodHandle, parameterIndex, getInOutValue);
                     if (returnConvention == DEFAULT_ON_NULL) {
@@ -547,14 +431,12 @@ public final class ScalarFunctionAdapter
                             methodHandle);
                 }
 
-                if (nullAdaptationPolicy == THROW_ON_NULL || nullAdaptationPolicy == UNSUPPORTED || nullAdaptationPolicy == RETURN_NULL_ON_NULL) {
-                    MethodHandle adapter = guardWithTest(
-                            isInOutNull(getInOutValue.type(), 0),
-                            throwTrinoNullArgumentException(getInOutValue.type()),
-                            getInOutValue);
+                MethodHandle adapter = guardWithTest(
+                        isInOutNull(getInOutValue.type(), 0),
+                        throwTrinoNullArgumentException(getInOutValue.type()),
+                        getInOutValue);
 
-                    return collectArguments(methodHandle, parameterIndex, adapter);
-                }
+                return collectArguments(methodHandle, parameterIndex, adapter);
             }
 
             if (actualArgumentConvention == BOXED_NULLABLE) {
@@ -769,13 +651,5 @@ public final class ScalarFunctionAdapter
     private static Class<?> unwrap(Class<?> type)
     {
         return methodType(type).unwrap().returnType();
-    }
-
-    public enum NullAdaptationPolicy
-    {
-        UNSUPPORTED,
-        THROW_ON_NULL,
-        RETURN_NULL_ON_NULL,
-        UNDEFINED_VALUE_FOR_NULL
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -30,9 +30,7 @@ import java.lang.invoke.MethodType;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -58,7 +56,6 @@ import static java.lang.invoke.MethodHandles.lookup;
 import static java.lang.invoke.MethodHandles.permuteArguments;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class TypeOperators
 {
@@ -199,32 +196,32 @@ public class TypeOperators
             return methodHandle;
         }
 
-        private MethodHandle adaptOperator(OperatorConvention operatorConvention, OperatorMethodHandle operatorMethodHandle)
+        private static MethodHandle adaptOperator(OperatorConvention operatorConvention, OperatorMethodHandle operatorMethodHandle)
         {
             return ScalarFunctionAdapter.adapt(
                     operatorMethodHandle.getMethodHandle(),
                     getOperatorArgumentTypes(operatorConvention),
                     operatorMethodHandle.getCallingConvention(),
-                    operatorConvention.getCallingConvention());
+                    operatorConvention.callingConvention());
         }
 
         private OperatorMethodHandle selectOperatorMethodHandleToAdapt(OperatorConvention operatorConvention)
         {
             List<OperatorMethodHandle> operatorMethodHandles = getOperatorMethodHandles(operatorConvention).stream()
                     .sorted(Comparator.comparing(TypeOperators::getScore).reversed())
-                    .collect(toUnmodifiableList());
+                    .toList();
 
             for (OperatorMethodHandle operatorMethodHandle : operatorMethodHandles) {
-                if (ScalarFunctionAdapter.canAdapt(operatorMethodHandle.getCallingConvention(), operatorConvention.getCallingConvention())) {
+                if (ScalarFunctionAdapter.canAdapt(operatorMethodHandle.getCallingConvention(), operatorConvention.callingConvention())) {
                     return operatorMethodHandle;
                 }
             }
 
             throw new TrinoException(FUNCTION_NOT_FOUND, format(
                     "%s %s operator can not be adapted to convention (%s). Available implementations: %s",
-                    operatorConvention.getType(),
-                    operatorConvention.getOperatorType(),
-                    operatorConvention.getCallingConvention(),
+                    operatorConvention.type(),
+                    operatorConvention.operatorType(),
+                    operatorConvention.callingConvention(),
                     operatorMethodHandles.stream()
                             .map(OperatorMethodHandle::getCallingConvention)
                             .map(Object::toString)
@@ -233,77 +230,81 @@ public class TypeOperators
 
         private Collection<OperatorMethodHandle> getOperatorMethodHandles(OperatorConvention operatorConvention)
         {
-            TypeOperatorDeclaration typeOperatorDeclaration = operatorConvention.getType().getTypeOperatorDeclaration(TypeOperators.this);
-            requireNonNull(typeOperatorDeclaration, "typeOperators is null for " + operatorConvention.getType());
-            switch (operatorConvention.getOperatorType()) {
-                case EQUAL:
-                    return typeOperatorDeclaration.getEqualOperators();
-                case HASH_CODE:
+            TypeOperatorDeclaration typeOperatorDeclaration = operatorConvention.type().getTypeOperatorDeclaration(TypeOperators.this);
+            requireNonNull(typeOperatorDeclaration, "typeOperators is null for " + operatorConvention.type());
+            return switch (operatorConvention.operatorType()) {
+                case EQUAL -> typeOperatorDeclaration.getEqualOperators();
+                case HASH_CODE -> {
                     Collection<OperatorMethodHandle> hashCodeOperators = typeOperatorDeclaration.getHashCodeOperators();
                     if (hashCodeOperators.isEmpty()) {
-                        return typeOperatorDeclaration.getXxHash64Operators();
+                        yield typeOperatorDeclaration.getXxHash64Operators();
                     }
-                    return hashCodeOperators;
-                case XX_HASH_64:
-                    return typeOperatorDeclaration.getXxHash64Operators();
-                case IS_DISTINCT_FROM:
+                    yield hashCodeOperators;
+                }
+                case XX_HASH_64 -> typeOperatorDeclaration.getXxHash64Operators();
+                case IS_DISTINCT_FROM -> {
                     Collection<OperatorMethodHandle> distinctFromOperators = typeOperatorDeclaration.getDistinctFromOperators();
                     if (distinctFromOperators.isEmpty()) {
-                        return List.of(generateDistinctFromOperator(operatorConvention));
+                        yield List.of(generateDistinctFromOperator(operatorConvention));
                     }
-                    return distinctFromOperators;
-                case INDETERMINATE:
+                    yield distinctFromOperators;
+                }
+                case INDETERMINATE -> {
                     Collection<OperatorMethodHandle> indeterminateOperators = typeOperatorDeclaration.getIndeterminateOperators();
                     if (indeterminateOperators.isEmpty()) {
-                        return List.of(defaultIndeterminateOperator(operatorConvention.getType().getJavaType()));
+                        yield List.of(defaultIndeterminateOperator(operatorConvention.type().getJavaType()));
                     }
-                    return indeterminateOperators;
-                case COMPARISON_UNORDERED_LAST:
-                    if (operatorConvention.getSortOrder().isPresent()) {
-                        return List.of(generateOrderingOperator(operatorConvention));
+                    yield indeterminateOperators;
+                }
+                case COMPARISON_UNORDERED_LAST -> {
+                    if (operatorConvention.sortOrder().isPresent()) {
+                        yield List.of(generateOrderingOperator(operatorConvention));
                     }
                     Collection<OperatorMethodHandle> comparisonUnorderedLastOperators = typeOperatorDeclaration.getComparisonUnorderedLastOperators();
                     if (comparisonUnorderedLastOperators.isEmpty()) {
-                        // if a type only provides one comparison operator it is assumed that the type does not have unordered values
-                        return typeOperatorDeclaration.getComparisonUnorderedFirstOperators();
+                        // if a type only provides one comparison operator, it is assumed that the type does not have unordered values
+                        yield typeOperatorDeclaration.getComparisonUnorderedFirstOperators();
                     }
-                    return comparisonUnorderedLastOperators;
-                case COMPARISON_UNORDERED_FIRST:
-                    if (operatorConvention.getSortOrder().isPresent()) {
-                        return List.of(generateOrderingOperator(operatorConvention));
+                    yield comparisonUnorderedLastOperators;
+                }
+                case COMPARISON_UNORDERED_FIRST -> {
+                    if (operatorConvention.sortOrder().isPresent()) {
+                        yield List.of(generateOrderingOperator(operatorConvention));
                     }
                     Collection<OperatorMethodHandle> comparisonUnorderedFirstOperators = typeOperatorDeclaration.getComparisonUnorderedFirstOperators();
                     if (comparisonUnorderedFirstOperators.isEmpty()) {
-                        // if a type only provides one comparison operator it is assumed that the type does not have unordered values
-                        return typeOperatorDeclaration.getComparisonUnorderedLastOperators();
+                        // if a type only provides one comparison operator, it is assumed that the type does not have unordered values
+                        yield typeOperatorDeclaration.getComparisonUnorderedLastOperators();
                     }
-                    return comparisonUnorderedFirstOperators;
-                case LESS_THAN:
+                    yield comparisonUnorderedFirstOperators;
+                }
+                case LESS_THAN -> {
                     Collection<OperatorMethodHandle> lessThanOperators = typeOperatorDeclaration.getLessThanOperators();
                     if (lessThanOperators.isEmpty()) {
-                        return List.of(generateLessThanOperator(operatorConvention, false));
+                        yield List.of(generateLessThanOperator(operatorConvention, false));
                     }
-                    return lessThanOperators;
-                case LESS_THAN_OR_EQUAL:
+                    yield lessThanOperators;
+                }
+                case LESS_THAN_OR_EQUAL -> {
                     Collection<OperatorMethodHandle> lessThanOrEqualOperators = typeOperatorDeclaration.getLessThanOrEqualOperators();
                     if (lessThanOrEqualOperators.isEmpty()) {
-                        return List.of(generateLessThanOperator(operatorConvention, true));
+                        yield List.of(generateLessThanOperator(operatorConvention, true));
                     }
-                    return lessThanOrEqualOperators;
-                default:
-                    throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.getOperatorType());
-            }
+                    yield lessThanOrEqualOperators;
+                }
+                default -> throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.operatorType());
+            };
         }
 
         private OperatorMethodHandle generateDistinctFromOperator(OperatorConvention operatorConvention)
         {
-            if (operatorConvention.getCallingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
-                OperatorConvention equalOperator = new OperatorConvention(operatorConvention.getType(), EQUAL, Optional.empty(), simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
+            if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
+                OperatorConvention equalOperator = new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), simpleConvention(NULLABLE_RETURN, BLOCK_POSITION, BLOCK_POSITION));
                 MethodHandle equalMethodHandle = adaptOperator(equalOperator);
                 return adaptBlockPositionEqualToDistinctFrom(equalMethodHandle);
             }
 
-            OperatorConvention equalOperator = new OperatorConvention(operatorConvention.getType(), EQUAL, Optional.empty(), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL));
+            OperatorConvention equalOperator = new OperatorConvention(operatorConvention.type(), EQUAL, Optional.empty(), simpleConvention(NULLABLE_RETURN, NEVER_NULL, NEVER_NULL));
             MethodHandle equalMethodHandle = adaptOperator(equalOperator);
             return adaptNeverNullEqualToDistinctFrom(equalMethodHandle);
         }
@@ -311,14 +312,14 @@ public class TypeOperators
         private OperatorMethodHandle generateLessThanOperator(OperatorConvention operatorConvention, boolean orEqual)
         {
             InvocationConvention comparisonCallingConvention;
-            if (operatorConvention.getCallingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
+            if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
                 comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
             }
             else {
                 comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
             }
 
-            OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.getType(), COMPARISON_UNORDERED_LAST, Optional.empty(), comparisonCallingConvention);
+            OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), COMPARISON_UNORDERED_LAST, Optional.empty(), comparisonCallingConvention);
             MethodHandle comparisonMethod = adaptOperator(comparisonOperator);
             if (orEqual) {
                 return adaptComparisonToLessThanOrEqual(new OperatorMethodHandle(comparisonCallingConvention, comparisonMethod));
@@ -328,36 +329,28 @@ public class TypeOperators
 
         private OperatorMethodHandle generateOrderingOperator(OperatorConvention operatorConvention)
         {
-            SortOrder sortOrder = operatorConvention.getSortOrder().orElseThrow(() -> new IllegalArgumentException("Operator convention does not contain a sort order"));
-            OperatorType comparisonType = operatorConvention.getOperatorType();
-            if (operatorConvention.getCallingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
-                OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.getType(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
+            SortOrder sortOrder = operatorConvention.sortOrder().orElseThrow(() -> new IllegalArgumentException("Operator convention does not contain a sort order"));
+            OperatorType comparisonType = operatorConvention.operatorType();
+            if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
+                OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
                 MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
                 return adaptBlockPositionComparisonToOrdering(sortOrder, comparisonInvoker);
             }
 
-            OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.getType(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG));
+            OperatorConvention comparisonOperator = new OperatorConvention(operatorConvention.type(), comparisonType, Optional.empty(), simpleConvention(FAIL_ON_NULL, NULL_FLAG, NULL_FLAG));
             MethodHandle comparisonInvoker = adaptOperator(comparisonOperator);
             return adaptNeverNullComparisonToOrdering(sortOrder, comparisonInvoker);
         }
 
-        private List<Type> getOperatorArgumentTypes(OperatorConvention operatorConvention)
+        private static List<Type> getOperatorArgumentTypes(OperatorConvention operatorConvention)
         {
-            switch (operatorConvention.getOperatorType()) {
-                case EQUAL:
-                case IS_DISTINCT_FROM:
-                case COMPARISON_UNORDERED_LAST:
-                case COMPARISON_UNORDERED_FIRST:
-                case LESS_THAN:
-                case LESS_THAN_OR_EQUAL:
-                    return List.of(operatorConvention.getType(), operatorConvention.getType());
-                case HASH_CODE:
-                case XX_HASH_64:
-                case INDETERMINATE:
-                    return List.of(operatorConvention.getType());
-                default:
-                    throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.getOperatorType());
-            }
+            return switch (operatorConvention.operatorType()) {
+                case EQUAL, IS_DISTINCT_FROM, COMPARISON_UNORDERED_LAST, COMPARISON_UNORDERED_FIRST, LESS_THAN, LESS_THAN_OR_EQUAL ->
+                        List.of(operatorConvention.type(), operatorConvention.type());
+                case HASH_CODE, XX_HASH_64, INDETERMINATE ->
+                        List.of(operatorConvention.type());
+                default -> throw new IllegalArgumentException("Unsupported operator type: " + operatorConvention.operatorType());
+            };
         }
     }
 
@@ -375,71 +368,14 @@ public class TypeOperators
         return score;
     }
 
-    private static final class OperatorConvention
+    private record OperatorConvention(Type type, OperatorType operatorType, Optional<SortOrder> sortOrder, InvocationConvention callingConvention)
     {
-        private final Type type;
-        private final OperatorType operatorType;
-        private final Optional<SortOrder> sortOrder;
-        private final InvocationConvention callingConvention;
-
-        public OperatorConvention(Type type, OperatorType operatorType, Optional<SortOrder> sortOrder, InvocationConvention callingConvention)
+        private OperatorConvention
         {
-            this.type = requireNonNull(type, "type is null");
-            this.operatorType = requireNonNull(operatorType, "operatorType is null");
-            this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
-            this.callingConvention = requireNonNull(callingConvention, "callingConvention is null");
-        }
-
-        @Override
-        public boolean equals(Object o)
-        {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            OperatorConvention operatorConvention = (OperatorConvention) o;
-            return type.equals(operatorConvention.type) &&
-                    operatorType == operatorConvention.operatorType &&
-                    sortOrder.equals(operatorConvention.sortOrder) &&
-                    callingConvention.equals(operatorConvention.callingConvention);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(type, operatorType, sortOrder, callingConvention);
-        }
-
-        @Override
-        public String toString()
-        {
-            return new StringJoiner(", ", OperatorConvention.class.getSimpleName() + "[", "]")
-                    .add("type=" + type)
-                    .add("operatorType=" + sortOrder.map(order -> "ORDER_" + order).orElseGet(operatorType::toString))
-                    .add("callingConvention=" + callingConvention)
-                    .toString();
-        }
-
-        public Type getType()
-        {
-            return type;
-        }
-
-        public OperatorType getOperatorType()
-        {
-            return operatorType;
-        }
-
-        public Optional<SortOrder> getSortOrder()
-        {
-            return sortOrder;
-        }
-
-        public InvocationConvention getCallingConvention()
-        {
-            return callingConvention;
+            requireNonNull(type, "type is null");
+            requireNonNull(operatorType, "operatorType is null");
+            requireNonNull(sortOrder, "sortOrder is null");
+            requireNonNull(callingConvention, "callingConvention is null");
         }
     }
 


### PR DESCRIPTION
The `DEFAULT_ON_NULL` return convention should not cause the function to
be invoked when there is a null passed to a never null argument.
Instead, as with `NULLABLE_RETURN`, the invocation should be
short- circuited and the default value should be returned.

Additionally, this PR removed the unused `NullAdaptationPolicy`

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# SPI
* Fix adaptation of a function argument from`NEVER_NULL` to a nullable type when using the `DEFAULT_ON_NULL`, to short-circuit the function invocation. ({issue}`issuenumber`)
* Remove unused `NullAdaptationPolicy` from `ScalarFunctionAdapter`. ({issue}`issuenumber`)
```
