### PR TITLE
Implement dereference pushdown for MongoDB connector

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ApplyProjectionUtil.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/projection/ApplyProjectionUtil.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.projection;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FieldDereference;
+import io.trino.spi.expression.Variable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public final class ApplyProjectionUtil
+{
+    private ApplyProjectionUtil() {}
+
+    public static List<ConnectorExpression> extractSupportedProjectedColumns(ConnectorExpression expression)
+    {
+        requireNonNull(expression, "expression is null");
+        ImmutableList.Builder<ConnectorExpression> supportedSubExpressions = ImmutableList.builder();
+        fillSupportedProjectedColumns(expression, supportedSubExpressions);
+        return supportedSubExpressions.build();
+    }
+
+    private static void fillSupportedProjectedColumns(ConnectorExpression expression, ImmutableList.Builder<ConnectorExpression> supportedSubExpressions)
+    {
+        if (isPushDownSupported(expression)) {
+            supportedSubExpressions.add(expression);
+            return;
+        }
+
+        // If the whole expression is not supported, look for a partially supported projection
+        for (ConnectorExpression child : expression.getChildren()) {
+            fillSupportedProjectedColumns(child, supportedSubExpressions);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean isPushDownSupported(ConnectorExpression expression)
+    {
+        return expression instanceof Variable ||
+                (expression instanceof FieldDereference fieldDereference && isPushDownSupported(fieldDereference.getTarget()));
+    }
+
+    public static ProjectedColumnRepresentation createProjectedColumnRepresentation(ConnectorExpression expression)
+    {
+        ImmutableList.Builder<Integer> ordinals = ImmutableList.builder();
+
+        Variable target;
+        while (true) {
+            if (expression instanceof Variable variable) {
+                target = variable;
+                break;
+            }
+            if (expression instanceof FieldDereference dereference) {
+                ordinals.add(dereference.getField());
+                expression = dereference.getTarget();
+            }
+            else {
+                throw new IllegalArgumentException("expression is not a valid dereference chain");
+            }
+        }
+
+        return new ProjectedColumnRepresentation(target, ordinals.build().reverse());
+    }
+
+    /**
+     * Replace all connector expressions with variables as given by {@param expressionToVariableMappings} in a top down manner.
+     * i.e. if the replacement occurs for the parent, the children will not be visited.
+     */
+    public static ConnectorExpression replaceWithNewVariables(ConnectorExpression expression, Map<ConnectorExpression, Variable> expressionToVariableMappings)
+    {
+        if (expressionToVariableMappings.containsKey(expression)) {
+            return expressionToVariableMappings.get(expression);
+        }
+
+        if (expression instanceof Constant || expression instanceof Variable) {
+            return expression;
+        }
+
+        if (expression instanceof FieldDereference fieldDereference) {
+            ConnectorExpression newTarget = replaceWithNewVariables(fieldDereference.getTarget(), expressionToVariableMappings);
+            return new FieldDereference(expression.getType(), newTarget, fieldDereference.getField());
+        }
+
+        if (expression instanceof Call call) {
+            return new Call(
+                    call.getType(),
+                    call.getFunctionName(),
+                    call.getArguments().stream()
+                            .map(argument -> replaceWithNewVariables(argument, expressionToVariableMappings))
+                            .collect(toImmutableList()));
+        }
+
+        // We cannot skip processing for unsupported expression shapes. This may lead to variables being left in ProjectionApplicationResult
+        // which are no longer bound.
+        throw new UnsupportedOperationException("Unsupported expression: " + expression);
+    }
+
+    public static class ProjectedColumnRepresentation
+    {
+        private final Variable variable;
+        private final List<Integer> dereferenceIndices;
+
+        public ProjectedColumnRepresentation(Variable variable, List<Integer> dereferenceIndices)
+        {
+            this.variable = requireNonNull(variable, "variable is null");
+            this.dereferenceIndices = ImmutableList.copyOf(requireNonNull(dereferenceIndices, "dereferenceIndices is null"));
+        }
+
+        public Variable getVariable()
+        {
+            return variable;
+        }
+
+        public List<Integer> getDereferenceIndices()
+        {
+            return dereferenceIndices;
+        }
+
+        public boolean isVariable()
+        {
+            return dereferenceIndices.isEmpty();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if ((obj == null) || (getClass() != obj.getClass())) {
+                return false;
+            }
+            ProjectedColumnRepresentation that = (ProjectedColumnRepresentation) obj;
+            return Objects.equals(variable, that.variable) &&
+                    Objects.equals(dereferenceIndices, that.dereferenceIndices);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(variable, dereferenceIndices);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.hive;
+package io.trino.plugin.base.projection;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.expression.ConnectorExpression;
@@ -20,8 +20,8 @@ import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.Variable;
 import org.testng.annotations.Test;
 
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.isPushDownSupported;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.isPushDownSupported;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.RowType.rowType;
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class TestHiveApplyProjectionUtil
+public class TestApplyProjectionUtil
 {
     private static final ConnectorExpression ROW_OF_ROW_VARIABLE = new Variable("a", rowType(field("b", rowType(field("c", INTEGER)))));
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/projection/TestApplyProjectionUtil.java
@@ -18,10 +18,11 @@ import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.FieldDereference;
 import io.trino.spi.expression.Variable;
+import io.trino.spi.type.RowType;
 import org.testng.annotations.Test;
 
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
-import static io.trino.plugin.base.projection.ApplyProjectionUtil.isPushDownSupported;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.isPushdownSupported;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.RowType.rowType;
@@ -32,6 +33,8 @@ import static org.testng.Assert.assertTrue;
 public class TestApplyProjectionUtil
 {
     private static final ConnectorExpression ROW_OF_ROW_VARIABLE = new Variable("a", rowType(field("b", rowType(field("c", INTEGER)))));
+    private static final ConnectorExpression LEAF_DOTTED_ROW_OF_ROW_VARIABLE = new Variable("a", rowType(field("b", rowType(field("c.x", INTEGER)))));
+    private static final ConnectorExpression MID_DOTTED_ROW_OF_ROW_VARIABLE = new Variable("a", rowType(field("b.x", rowType(field("c", INTEGER)))));
 
     private static final ConnectorExpression ONE_LEVEL_DEREFERENCE = new FieldDereference(
             rowType(field("c", INTEGER)),
@@ -43,16 +46,46 @@ public class TestApplyProjectionUtil
             ONE_LEVEL_DEREFERENCE,
             0);
 
+    private static final ConnectorExpression LEAF_DOTTED_ONE_LEVEL_DEREFERENCE = new FieldDereference(
+            rowType(field("c.x", INTEGER)),
+            LEAF_DOTTED_ROW_OF_ROW_VARIABLE,
+            0);
+
+    private static final ConnectorExpression LEAF_DOTTED_TWO_LEVEL_DEREFERENCE = new FieldDereference(
+            INTEGER,
+            LEAF_DOTTED_ONE_LEVEL_DEREFERENCE,
+            0);
+
+    private static final ConnectorExpression MID_DOTTED_ONE_LEVEL_DEREFERENCE = new FieldDereference(
+            rowType(field("c.x", INTEGER)),
+            MID_DOTTED_ROW_OF_ROW_VARIABLE,
+            0);
+
+    private static final ConnectorExpression MID_DOTTED_TWO_LEVEL_DEREFERENCE = new FieldDereference(
+            INTEGER,
+            MID_DOTTED_ONE_LEVEL_DEREFERENCE,
+            0);
+
     private static final ConnectorExpression INT_VARIABLE = new Variable("a", INTEGER);
     private static final ConnectorExpression CONSTANT = new Constant(5, INTEGER);
 
     @Test
     public void testIsProjectionSupported()
     {
-        assertTrue(isPushDownSupported(ONE_LEVEL_DEREFERENCE));
-        assertTrue(isPushDownSupported(TWO_LEVEL_DEREFERENCE));
-        assertTrue(isPushDownSupported(INT_VARIABLE));
-        assertFalse(isPushDownSupported(CONSTANT));
+        assertTrue(isPushdownSupported(ONE_LEVEL_DEREFERENCE, connectorExpression -> true));
+        assertTrue(isPushdownSupported(TWO_LEVEL_DEREFERENCE, connectorExpression -> true));
+        assertTrue(isPushdownSupported(INT_VARIABLE, connectorExpression -> true));
+        assertFalse(isPushdownSupported(CONSTANT, connectorExpression -> true));
+
+        assertFalse(isPushdownSupported(ONE_LEVEL_DEREFERENCE, connectorExpression -> false));
+        assertFalse(isPushdownSupported(TWO_LEVEL_DEREFERENCE, connectorExpression -> false));
+        assertFalse(isPushdownSupported(INT_VARIABLE, connectorExpression -> false));
+        assertFalse(isPushdownSupported(CONSTANT, connectorExpression -> false));
+
+        assertTrue(isPushdownSupported(LEAF_DOTTED_ONE_LEVEL_DEREFERENCE, this::isSupportedForPushDown));
+        assertFalse(isPushdownSupported(LEAF_DOTTED_TWO_LEVEL_DEREFERENCE, this::isSupportedForPushDown));
+        assertFalse(isPushdownSupported(MID_DOTTED_ONE_LEVEL_DEREFERENCE, this::isSupportedForPushDown));
+        assertFalse(isPushdownSupported(MID_DOTTED_TWO_LEVEL_DEREFERENCE, this::isSupportedForPushDown));
     }
 
     @Test
@@ -62,5 +95,32 @@ public class TestApplyProjectionUtil
         assertEquals(extractSupportedProjectedColumns(TWO_LEVEL_DEREFERENCE), ImmutableList.of(TWO_LEVEL_DEREFERENCE));
         assertEquals(extractSupportedProjectedColumns(INT_VARIABLE), ImmutableList.of(INT_VARIABLE));
         assertEquals(extractSupportedProjectedColumns(CONSTANT), ImmutableList.of());
+
+        assertEquals(extractSupportedProjectedColumns(ONE_LEVEL_DEREFERENCE, connectorExpression -> false), ImmutableList.of());
+        assertEquals(extractSupportedProjectedColumns(TWO_LEVEL_DEREFERENCE, connectorExpression -> false), ImmutableList.of());
+        assertEquals(extractSupportedProjectedColumns(INT_VARIABLE, connectorExpression -> false), ImmutableList.of());
+        assertEquals(extractSupportedProjectedColumns(CONSTANT, connectorExpression -> false), ImmutableList.of());
+
+        // Partial supported projection
+        assertEquals(extractSupportedProjectedColumns(LEAF_DOTTED_ONE_LEVEL_DEREFERENCE, this::isSupportedForPushDown), ImmutableList.of(LEAF_DOTTED_ONE_LEVEL_DEREFERENCE));
+        assertEquals(extractSupportedProjectedColumns(LEAF_DOTTED_TWO_LEVEL_DEREFERENCE, this::isSupportedForPushDown), ImmutableList.of(LEAF_DOTTED_ONE_LEVEL_DEREFERENCE));
+        assertEquals(extractSupportedProjectedColumns(MID_DOTTED_ONE_LEVEL_DEREFERENCE, this::isSupportedForPushDown), ImmutableList.of(MID_DOTTED_ROW_OF_ROW_VARIABLE));
+        assertEquals(extractSupportedProjectedColumns(MID_DOTTED_TWO_LEVEL_DEREFERENCE, this::isSupportedForPushDown), ImmutableList.of(MID_DOTTED_ROW_OF_ROW_VARIABLE));
+    }
+
+    /**
+     * This method is used to simulate the behavior when the field passed in the connectorExpression might not supported for pushdown.
+     */
+    private boolean isSupportedForPushDown(ConnectorExpression connectorExpression)
+    {
+        if (connectorExpression instanceof FieldDereference fieldDereference) {
+            RowType rowType = (RowType) fieldDereference.getTarget().getType();
+            RowType.Field field = rowType.getFields().get(fieldDereference.getField());
+            String fieldName = field.getName().get();
+            if (fieldName.contains(".") || fieldName.contains("$")) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -32,6 +32,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
+import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode;
 import io.trino.plugin.deltalake.expression.ParsingException;
 import io.trino.plugin.deltalake.expression.SparkExpressionParser;
@@ -62,7 +63,6 @@ import io.trino.plugin.deltalake.transactionlog.statistics.DeltaLakeFileStatisti
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionConflictException;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriter;
 import io.trino.plugin.deltalake.transactionlog.writer.TransactionLogWriterFactory;
-import io.trino.plugin.hive.HiveApplyProjectionUtil;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.SchemaAlreadyExistsException;
 import io.trino.plugin.hive.TableAlreadyExistsException;
@@ -168,6 +168,9 @@ import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.primitives.Ints.max;
 import static io.trino.filesystem.Locations.appendPath;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.deltalake.DataFileInfo.DataFileType.DATA;
 import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode.FULL_REFRESH;
 import static io.trino.plugin.deltalake.DeltaLakeAnalyzeProperties.AnalyzeMode.INCREMENTAL;
@@ -231,9 +234,6 @@ import static io.trino.plugin.deltalake.transactionlog.MetadataEntry.DELTA_CHANG
 import static io.trino.plugin.deltalake.transactionlog.MetadataEntry.configurationForNewTable;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.getMandatoryCurrentVersion;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.getTransactionLogDir;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.ProjectedColumnRepresentation;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
@@ -2372,7 +2372,7 @@ public class DeltaLakeMetadata
                 .collect(toImmutableSet());
 
         Map<ConnectorExpression, ProjectedColumnRepresentation> columnProjections = projectedExpressions.stream()
-                .collect(toImmutableMap(Function.identity(), HiveApplyProjectionUtil::createProjectedColumnRepresentation));
+                .collect(toImmutableMap(Function.identity(), ApplyProjectionUtil::createProjectedColumnRepresentation));
 
         // all references are simple variables
         if (!isProjectionPushdownEnabled(session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
@@ -13,109 +13,18 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.expression.Call;
-import io.trino.spi.expression.ConnectorExpression;
-import io.trino.spi.expression.Constant;
-import io.trino.spi.expression.FieldDereference;
-import io.trino.spi.expression.Variable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Objects.requireNonNull;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 
 public final class HiveApplyProjectionUtil
 {
     private HiveApplyProjectionUtil() {}
-
-    public static List<ConnectorExpression> extractSupportedProjectedColumns(ConnectorExpression expression)
-    {
-        requireNonNull(expression, "expression is null");
-        ImmutableList.Builder<ConnectorExpression> supportedSubExpressions = ImmutableList.builder();
-        fillSupportedProjectedColumns(expression, supportedSubExpressions);
-        return supportedSubExpressions.build();
-    }
-
-    private static void fillSupportedProjectedColumns(ConnectorExpression expression, ImmutableList.Builder<ConnectorExpression> supportedSubExpressions)
-    {
-        if (isPushDownSupported(expression)) {
-            supportedSubExpressions.add(expression);
-            return;
-        }
-
-        // If the whole expression is not supported, look for a partially supported projection
-        for (ConnectorExpression child : expression.getChildren()) {
-            fillSupportedProjectedColumns(child, supportedSubExpressions);
-        }
-    }
-
-    @VisibleForTesting
-    static boolean isPushDownSupported(ConnectorExpression expression)
-    {
-        return expression instanceof Variable ||
-                (expression instanceof FieldDereference fieldDereference && isPushDownSupported(fieldDereference.getTarget()));
-    }
-
-    public static ProjectedColumnRepresentation createProjectedColumnRepresentation(ConnectorExpression expression)
-    {
-        ImmutableList.Builder<Integer> ordinals = ImmutableList.builder();
-
-        Variable target;
-        while (true) {
-            if (expression instanceof Variable variable) {
-                target = variable;
-                break;
-            }
-            if (expression instanceof FieldDereference dereference) {
-                ordinals.add(dereference.getField());
-                expression = dereference.getTarget();
-            }
-            else {
-                throw new IllegalArgumentException("expression is not a valid dereference chain");
-            }
-        }
-
-        return new ProjectedColumnRepresentation(target, ordinals.build().reverse());
-    }
-
-    /**
-     * Replace all connector expressions with variables as given by {@param expressionToVariableMappings} in a top down manner.
-     * i.e. if the replacement occurs for the parent, the children will not be visited.
-     */
-    public static ConnectorExpression replaceWithNewVariables(ConnectorExpression expression, Map<ConnectorExpression, Variable> expressionToVariableMappings)
-    {
-        if (expressionToVariableMappings.containsKey(expression)) {
-            return expressionToVariableMappings.get(expression);
-        }
-
-        if (expression instanceof Constant || expression instanceof Variable) {
-            return expression;
-        }
-
-        if (expression instanceof FieldDereference fieldDereference) {
-            ConnectorExpression newTarget = replaceWithNewVariables(fieldDereference.getTarget(), expressionToVariableMappings);
-            return new FieldDereference(expression.getType(), newTarget, fieldDereference.getField());
-        }
-
-        if (expression instanceof Call call) {
-            return new Call(
-                    call.getType(),
-                    call.getFunctionName(),
-                    call.getArguments().stream()
-                            .map(argument -> replaceWithNewVariables(argument, expressionToVariableMappings))
-                            .collect(toImmutableList()));
-        }
-
-        // We cannot skip processing for unsupported expression shapes. This may lead to variables being left in ProjectionApplicationResult
-        // which are no longer bound.
-        throw new UnsupportedOperationException("Unsupported expression: " + expression);
-    }
 
     /**
      * Returns the assignment key corresponding to the column represented by {@param projectedColumn} in the {@param assignments}, if one exists.
@@ -155,52 +64,5 @@ public final class HiveApplyProjectionUtil
         }
 
         return Optional.empty();
-    }
-
-    public static class ProjectedColumnRepresentation
-    {
-        private final Variable variable;
-        private final List<Integer> dereferenceIndices;
-
-        public ProjectedColumnRepresentation(Variable variable, List<Integer> dereferenceIndices)
-        {
-            this.variable = requireNonNull(variable, "variable is null");
-            this.dereferenceIndices = ImmutableList.copyOf(requireNonNull(dereferenceIndices, "dereferenceIndices is null"));
-        }
-
-        public Variable getVariable()
-        {
-            return variable;
-        }
-
-        public List<Integer> getDereferenceIndices()
-        {
-            return dereferenceIndices;
-        }
-
-        public boolean isVariable()
-        {
-            return dereferenceIndices.isEmpty();
-        }
-
-        @Override
-        public boolean equals(Object obj)
-        {
-            if (this == obj) {
-                return true;
-            }
-            if ((obj == null) || (getClass() != obj.getClass())) {
-                return false;
-            }
-            ProjectedColumnRepresentation that = (ProjectedColumnRepresentation) obj;
-            return Objects.equals(variable, that.variable) &&
-                    Objects.equals(dereferenceIndices, that.dereferenceIndices);
-        }
-
-        @Override
-        public int hashCode()
-        {
-            return Objects.hash(variable, dereferenceIndices);
-        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -35,7 +35,8 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.base.CatalogName;
-import io.trino.plugin.hive.HiveApplyProjectionUtil.ProjectedColumnRepresentation;
+import io.trino.plugin.base.projection.ApplyProjectionUtil;
+import io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 import io.trino.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior;
 import io.trino.plugin.hive.LocationService.WriteInfo;
 import io.trino.plugin.hive.acid.AcidOperation;
@@ -166,11 +167,11 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.hdfs.ConfigurationUtils.toJobConf;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.hive.HiveAnalyzeProperties.getColumnNames;
 import static io.trino.plugin.hive.HiveAnalyzeProperties.getPartitionList;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.hive.HiveApplyProjectionUtil.find;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.hive.HiveBasicStatistics.createEmptyStatistics;
 import static io.trino.plugin.hive.HiveBasicStatistics.createZeroStatistics;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
@@ -3007,7 +3008,7 @@ public class HiveMetadata
                 .collect(toImmutableSet());
 
         Map<ConnectorExpression, ProjectedColumnRepresentation> columnProjections = projectedExpressions.stream()
-                .collect(toImmutableMap(Function.identity(), HiveApplyProjectionUtil::createProjectedColumnRepresentation));
+                .collect(toImmutableMap(Function.identity(), ApplyProjectionUtil::createProjectedColumnRepresentation));
 
         HiveTableHandle hiveTableHandle = (HiveTableHandle) handle;
         // all references are simple variables

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetComplexTypePredicatePushDown.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestHiveParquetComplexTypePredicatePushDown.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.hive.parquet;
 
 import io.trino.plugin.hive.HiveQueryRunner;
-import io.trino.testing.BaseTestFileFormatComplexTypesPredicatePushDown;
+import io.trino.testing.BaseComplexTypesPredicatePushDownTest;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
@@ -22,7 +22,7 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestHiveParquetComplexTypePredicatePushDown
-        extends BaseTestFileFormatComplexTypesPredicatePushDown
+        extends BaseComplexTypesPredicatePushDownTest
 {
     @Override
     protected QueryRunner createQueryRunner()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -33,8 +33,8 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
-import io.trino.plugin.hive.HiveApplyProjectionUtil;
-import io.trino.plugin.hive.HiveApplyProjectionUtil.ProjectedColumnRepresentation;
+import io.trino.plugin.base.projection.ApplyProjectionUtil;
+import io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 import io.trino.plugin.hive.HiveWrittenPartitions;
 import io.trino.plugin.iceberg.aggregation.DataSketchStateSerializer;
 import io.trino.plugin.iceberg.aggregation.IcebergThetaSketchForStats;
@@ -182,9 +182,9 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.collect.Sets.difference;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
-import static io.trino.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.plugin.iceberg.ConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
@@ -2426,7 +2426,7 @@ public class IcebergMetadata
                 .collect(toImmutableSet());
 
         Map<ConnectorExpression, ProjectedColumnRepresentation> columnProjections = projectedExpressions.stream()
-                .collect(toImmutableMap(identity(), HiveApplyProjectionUtil::createProjectedColumnRepresentation));
+                .collect(toImmutableMap(identity(), ApplyProjectionUtil::createProjectedColumnRepresentation));
 
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) handle;
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
@@ -44,6 +45,7 @@ public class MongoClientConfig
     private WriteConcernType writeConcern = WriteConcernType.ACKNOWLEDGED;
     private String requiredReplicaSetName;
     private String implicitRowFieldPrefix = "_pos";
+    private boolean projectionPushDownEnabled = true;
 
     @NotNull
     public String getSchemaCollection()
@@ -235,6 +237,19 @@ public class MongoClientConfig
     public MongoClientConfig setMaxConnectionIdleTime(int maxConnectionIdleTime)
     {
         this.maxConnectionIdleTime = maxConnectionIdleTime;
+        return this;
+    }
+
+    public boolean isProjectionPushdownEnabled()
+    {
+        return projectionPushDownEnabled;
+    }
+
+    @Config("mongodb.projection-pushdown-enabled")
+    @ConfigDescription("Read only required fields from a row type")
+    public MongoClientConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
+    {
+        this.projectionPushDownEnabled = projectionPushDownEnabled;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.mongodb.ptf.Query;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
@@ -44,6 +45,7 @@ public class MongoClientModule
         binder.bind(MongoSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(MongoPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(MongoPageSinkProvider.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(MongoSessionProperties.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(MongoClientConfig.class);
         newSetBinder(binder, MongoClientSettingConfigurator.class);

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -23,13 +24,16 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static java.util.Objects.requireNonNull;
@@ -42,6 +46,7 @@ public class MongoConnector
     private final MongoPageSourceProvider pageSourceProvider;
     private final MongoPageSinkProvider pageSinkProvider;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
+    private final List<PropertyMetadata<?>> sessionProperties;
 
     private final ConcurrentMap<ConnectorTransactionHandle, MongoMetadata> transactions = new ConcurrentHashMap<>();
 
@@ -51,13 +56,17 @@ public class MongoConnector
             MongoSplitManager splitManager,
             MongoPageSourceProvider pageSourceProvider,
             MongoPageSinkProvider pageSinkProvider,
-            Set<ConnectorTableFunction> connectorTableFunctions)
+            Set<ConnectorTableFunction> connectorTableFunctions,
+            Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
         this.mongoSession = mongoSession;
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
         this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
+        this.sessionProperties = sessionPropertiesProviders.stream()
+                .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
     }
 
     @Override
@@ -113,6 +122,12 @@ public class MongoConnector
     public Set<ConnectorTableFunction> getTableFunctions()
     {
         return connectorTableFunctions;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -15,14 +15,17 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.io.Closer;
 import com.mongodb.client.MongoCollection;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.mongodb.MongoIndex.MongodbIndexKey;
 import io.trino.plugin.mongodb.ptf.Query.QueryFunctionHandle;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
@@ -39,12 +42,16 @@ import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.NotFoundException;
+import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortingProperty;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FieldDereference;
+import io.trino.spi.expression.Variable;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
@@ -74,6 +81,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.mongodb.client.model.Aggregates.lookup;
@@ -83,6 +91,13 @@ import static com.mongodb.client.model.Aggregates.project;
 import static com.mongodb.client.model.Filters.ne;
 import static com.mongodb.client.model.Projections.exclude;
 import static io.trino.plugin.base.TemporaryTables.generateTemporaryTableName;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
+import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
+import static io.trino.plugin.mongodb.MongoSession.COLLECTION_NAME;
+import static io.trino.plugin.mongodb.MongoSession.DATABASE_NAME;
+import static io.trino.plugin.mongodb.MongoSession.ID;
+import static io.trino.plugin.mongodb.MongoSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.mongodb.TypeUtils.isPushdownSupportedType;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -92,11 +107,13 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 
 public class MongoMetadata
@@ -178,7 +195,7 @@ public class MongoMetadata
 
         ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
         for (MongoColumnHandle columnHandle : columns) {
-            columnHandles.put(columnHandle.getName().toLowerCase(ENGLISH), columnHandle);
+            columnHandles.put(columnHandle.getBaseName().toLowerCase(ENGLISH), columnHandle);
         }
         return columnHandles.buildOrThrow();
     }
@@ -240,7 +257,7 @@ public class MongoMetadata
     {
         MongoTableHandle table = (MongoTableHandle) tableHandle;
         MongoColumnHandle column = (MongoColumnHandle) columnHandle;
-        mongoSession.setColumnComment(table, column.getName(), comment);
+        mongoSession.setColumnComment(table, column.getBaseName(), comment);
     }
 
     @Override
@@ -262,13 +279,13 @@ public class MongoMetadata
     @Override
     public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
     {
-        mongoSession.renameColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) source).getName(), target);
+        mongoSession.renameColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) source).getBaseName(), target);
     }
 
     @Override
     public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
     {
-        mongoSession.dropColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) column).getName());
+        mongoSession.dropColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) column).getBaseName());
     }
 
     @Override
@@ -279,7 +296,7 @@ public class MongoMetadata
         if (!canChangeColumnType(column.getType(), type)) {
             throw new TrinoException(NOT_SUPPORTED, "Cannot change type from %s to %s".formatted(column.getType(), type));
         }
-        mongoSession.setColumnType(table, column.getName(), type);
+        mongoSession.setColumnType(table, column.getBaseName(), type);
     }
 
     private static boolean canChangeColumnType(Type sourceType, Type newType)
@@ -375,7 +392,7 @@ public class MongoMetadata
                     Optional.empty());
         }
 
-        MongoColumnHandle pageSinkIdColumn = buildPageSinkIdColumn(columns.stream().map(MongoColumnHandle::getName).collect(toImmutableSet()));
+        MongoColumnHandle pageSinkIdColumn = buildPageSinkIdColumn(columns.stream().map(MongoColumnHandle::getBaseName).collect(toImmutableSet()));
         List<MongoColumnHandle> allTemporaryTableColumns = ImmutableList.<MongoColumnHandle>builderWithExpectedSize(columns.size() + 1)
                 .addAll(columns)
                 .add(pageSinkIdColumn)
@@ -388,7 +405,7 @@ public class MongoMetadata
                 remoteTableName,
                 handleColumns,
                 Optional.of(temporaryTable.getCollectionName()),
-                Optional.of(pageSinkIdColumn.getName()));
+                Optional.of(pageSinkIdColumn.getBaseName()));
     }
 
     @Override
@@ -410,7 +427,7 @@ public class MongoMetadata
         List<MongoColumnHandle> columns = table.getColumns();
         List<MongoColumnHandle> handleColumns = columns.stream()
                 .filter(column -> !column.isHidden())
-                .peek(column -> validateColumnNameForInsert(column.getName()))
+                .peek(column -> validateColumnNameForInsert(column.getBaseName()))
                 .collect(toImmutableList());
 
         if (retryMode == RetryMode.NO_RETRIES) {
@@ -420,7 +437,7 @@ public class MongoMetadata
                     Optional.empty(),
                     Optional.empty());
         }
-        MongoColumnHandle pageSinkIdColumn = buildPageSinkIdColumn(columns.stream().map(MongoColumnHandle::getName).collect(toImmutableSet()));
+        MongoColumnHandle pageSinkIdColumn = buildPageSinkIdColumn(columns.stream().map(MongoColumnHandle::getBaseName).collect(toImmutableSet()));
         List<MongoColumnHandle> allColumns = ImmutableList.<MongoColumnHandle>builderWithExpectedSize(columns.size() + 1)
                 .addAll(columns)
                 .add(pageSinkIdColumn)
@@ -435,7 +452,7 @@ public class MongoMetadata
                 handle.getRemoteTableName(),
                 handleColumns,
                 Optional.of(temporaryTable.getCollectionName()),
-                Optional.of(pageSinkIdColumn.getName()));
+                Optional.of(pageSinkIdColumn.getBaseName()));
     }
 
     @Override
@@ -462,7 +479,7 @@ public class MongoMetadata
         try {
             // Create the temporary page sink ID table
             RemoteTableName pageSinkIdsTable = new RemoteTableName(temporaryTable.getDatabaseName(), generateTemporaryTableName(session));
-            MongoColumnHandle pageSinkIdColumn = new MongoColumnHandle(pageSinkIdColumnName, TRINO_PAGE_SINK_ID_COLUMN_TYPE, false, Optional.empty());
+            MongoColumnHandle pageSinkIdColumn = new MongoColumnHandle(pageSinkIdColumnName, ImmutableList.of(), TRINO_PAGE_SINK_ID_COLUMN_TYPE, false, false, Optional.empty());
             mongoSession.createTable(pageSinkIdsTable, ImmutableList.of(pageSinkIdColumn), Optional.empty());
             closer.register(() -> mongoSession.dropTable(pageSinkIdsTable));
 
@@ -494,7 +511,7 @@ public class MongoMetadata
     @Override
     public ColumnHandle getMergeRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return new MongoColumnHandle("$merge_row_id", BIGINT, true, Optional.empty());
+        return new MongoColumnHandle("$merge_row_id", ImmutableList.of(), BIGINT, true, false, Optional.empty());
     }
 
     @Override
@@ -558,7 +575,13 @@ public class MongoMetadata
         }
 
         return Optional.of(new LimitApplicationResult<>(
-                new MongoTableHandle(handle.getSchemaTableName(), handle.getRemoteTableName(), handle.getFilter(), handle.getConstraint(), OptionalInt.of(toIntExact(limit))),
+                new MongoTableHandle(
+                        handle.getSchemaTableName(),
+                        handle.getRemoteTableName(),
+                        handle.getFilter(),
+                        handle.getConstraint(),
+                        handle.getProjectedColumns(),
+                        OptionalInt.of(toIntExact(limit))),
                 true,
                 false));
     }
@@ -605,9 +628,160 @@ public class MongoMetadata
                 handle.getRemoteTableName(),
                 handle.getFilter(),
                 newDomain,
+                handle.getProjectedColumns(),
                 handle.getLimit());
 
         return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+    }
+
+    @Override
+    public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(
+            ConnectorSession session,
+            ConnectorTableHandle handle,
+            List<ConnectorExpression> projections,
+            Map<String, ColumnHandle> assignments)
+    {
+        if (!isProjectionPushdownEnabled(session)) {
+            return Optional.empty();
+        }
+        // Create projected column representations for supported sub expressions. Simple column references and chain of
+        // dereferences on a variable are supported right now.
+        Set<ConnectorExpression> projectedExpressions = projections.stream()
+                .flatMap(expression -> extractSupportedProjectedColumns(expression, MongoMetadata::isSupportedForPushdown).stream())
+                .collect(toImmutableSet());
+
+        Map<ConnectorExpression, ProjectedColumnRepresentation> columnProjections = projectedExpressions.stream()
+                .collect(toImmutableMap(identity(), ApplyProjectionUtil::createProjectedColumnRepresentation));
+
+        MongoTableHandle mongoTableHandle = (MongoTableHandle) handle;
+
+        // all references are simple variables
+        if (columnProjections.values().stream().allMatch(ProjectedColumnRepresentation::isVariable)) {
+            Set<MongoColumnHandle> projectedColumns = assignments.values().stream()
+                    .map(MongoColumnHandle.class::cast)
+                    .collect(toImmutableSet());
+            if (mongoTableHandle.getProjectedColumns().equals(projectedColumns)) {
+                return Optional.empty();
+            }
+            List<Assignment> assignmentsList = assignments.entrySet().stream()
+                    .map(assignment -> new Assignment(
+                            assignment.getKey(),
+                            assignment.getValue(),
+                            ((MongoColumnHandle) assignment.getValue()).getType()))
+                    .collect(toImmutableList());
+
+            return Optional.of(new ProjectionApplicationResult<>(
+                    mongoTableHandle.withProjectedColumns(projectedColumns),
+                    projections,
+                    assignmentsList,
+                    false));
+        }
+
+        Map<String, Assignment> newAssignments = new HashMap<>();
+        ImmutableMap.Builder<ConnectorExpression, Variable> newVariablesBuilder = ImmutableMap.builder();
+        ImmutableSet.Builder<MongoColumnHandle> projectedColumnsBuilder = ImmutableSet.builder();
+
+        for (Map.Entry<ConnectorExpression, ProjectedColumnRepresentation> entry : columnProjections.entrySet()) {
+            ConnectorExpression expression = entry.getKey();
+            ProjectedColumnRepresentation projectedColumn = entry.getValue();
+
+            MongoColumnHandle baseColumnHandle = (MongoColumnHandle) assignments.get(projectedColumn.getVariable().getName());
+            MongoColumnHandle projectedColumnHandle = projectColumn(baseColumnHandle, projectedColumn.getDereferenceIndices(), expression.getType());
+            String projectedColumnName = projectedColumnHandle.getQualifiedName();
+
+            Variable projectedColumnVariable = new Variable(projectedColumnName, expression.getType());
+            Assignment newAssignment = new Assignment(projectedColumnName, projectedColumnHandle, expression.getType());
+            newAssignments.putIfAbsent(projectedColumnName, newAssignment);
+
+            newVariablesBuilder.put(expression, projectedColumnVariable);
+            projectedColumnsBuilder.add(projectedColumnHandle);
+        }
+
+        // Modify projections to refer to new variables
+        Map<ConnectorExpression, Variable> newVariables = newVariablesBuilder.buildOrThrow();
+        List<ConnectorExpression> newProjections = projections.stream()
+                .map(expression -> replaceWithNewVariables(expression, newVariables))
+                .collect(toImmutableList());
+
+        List<Assignment> outputAssignments = newAssignments.values().stream().collect(toImmutableList());
+        return Optional.of(new ProjectionApplicationResult<>(
+                mongoTableHandle.withProjectedColumns(projectedColumnsBuilder.build()),
+                newProjections,
+                outputAssignments,
+                false));
+    }
+
+    private static boolean isSupportedForPushdown(ConnectorExpression connectorExpression)
+    {
+        if (connectorExpression instanceof Variable) {
+            return true;
+        }
+        if (connectorExpression instanceof FieldDereference fieldDereference) {
+            RowType rowType = (RowType) fieldDereference.getTarget().getType();
+            if (isDBRefField(rowType)) {
+                return false;
+            }
+            Field field = rowType.getFields().get(fieldDereference.getField());
+            if (field.getName().isEmpty()) {
+                return false;
+            }
+            String fieldName = field.getName().get();
+            if (fieldName.contains(".") || fieldName.contains("$")) {
+                return false;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private static MongoColumnHandle projectColumn(MongoColumnHandle baseColumn, List<Integer> indices, Type projectedColumnType)
+    {
+        if (indices.isEmpty()) {
+            return baseColumn;
+        }
+        ImmutableList.Builder<String> dereferenceNamesBuilder = ImmutableList.builder();
+        dereferenceNamesBuilder.addAll(baseColumn.getDereferenceNames());
+
+        Type type = baseColumn.getType();
+        RowType parentType = null;
+        for (int index : indices) {
+            checkArgument(type instanceof RowType, "type should be Row type");
+            RowType rowType = (RowType) type;
+            Field field = rowType.getFields().get(index);
+            dereferenceNamesBuilder.add(field.getName()
+                    .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "ROW type does not have field names declared: " + rowType)));
+            parentType = rowType;
+            type = field.getType();
+        }
+        return new MongoColumnHandle(
+                baseColumn.getBaseName(),
+                dereferenceNamesBuilder.build(),
+                projectedColumnType,
+                baseColumn.isHidden(),
+                isDBRefField(parentType),
+                baseColumn.getComment());
+    }
+
+    /**
+     * This method may return a wrong flag when row type use the same field names and types as dbref.
+     */
+    private static boolean isDBRefField(Type type)
+    {
+        if (!(type instanceof RowType rowType)) {
+            return false;
+        }
+        requireNonNull(type, "type is null");
+        // When projected field is inside DBRef type field
+        List<RowType.Field> fields = rowType.getFields();
+        if (fields.size() != 3) {
+            return false;
+        }
+        return fields.get(0).getName().orElseThrow().equals(DATABASE_NAME)
+                && fields.get(0).getType().equals(VARCHAR)
+                && fields.get(1).getName().orElseThrow().equals(COLLECTION_NAME)
+                && fields.get(1).getType().equals(VARCHAR)
+                && fields.get(2).getName().orElseThrow().equals(ID);
+               // Id type can be of any type
     }
 
     @Override
@@ -658,7 +832,7 @@ public class MongoMetadata
     private static List<MongoColumnHandle> buildColumnHandles(ConnectorTableMetadata tableMetadata)
     {
         return tableMetadata.getColumns().stream()
-                .map(m -> new MongoColumnHandle(m.getName(), m.getType(), m.isHidden(), Optional.ofNullable(m.getComment())))
+                .map(m -> new MongoColumnHandle(m.getName(), ImmutableList.of(), m.getType(), m.isHidden(), false, Optional.ofNullable(m.getComment())))
                 .collect(toList());
     }
 
@@ -680,6 +854,6 @@ public class MongoMetadata
             columnName = baseColumnName + "_" + suffix;
             suffix++;
         }
-        return new MongoColumnHandle(columnName, TRINO_PAGE_SINK_ID_COLUMN_TYPE, false, Optional.empty());
+        return new MongoColumnHandle(columnName, ImmutableList.of(), TRINO_PAGE_SINK_ID_COLUMN_TYPE, false, false, Optional.empty());
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -116,7 +116,7 @@ public class MongoPageSink
 
             for (int channel = 0; channel < page.getChannelCount(); channel++) {
                 MongoColumnHandle column = columns.get(channel);
-                doc.append(column.getName(), getObjectValue(columns.get(channel).getType(), page.getBlock(channel), position));
+                doc.append(column.getBaseName(), getObjectValue(columns.get(channel).getType(), page.getBlock(channel), position));
             }
             batch.add(doc);
         }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
+public final class MongoSessionProperties
+        implements SessionPropertiesProvider
+{
+    private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public MongoSessionProperties(MongoClientConfig mongoConfig)
+    {
+        sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(booleanProperty(
+                        PROJECTION_PUSHDOWN_ENABLED,
+                        "Read only required fields from a row type",
+                        mongoConfig.isProjectionPushdownEnabled(),
+                        false))
+                .build();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    public static boolean isProjectionPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -32,8 +32,8 @@ public class MongoTableHandle
 {
     private final SchemaTableName schemaTableName;
     private final RemoteTableName remoteTableName;
-    private final TupleDomain<ColumnHandle> constraint;
     private final Optional<String> filter;
+    private final TupleDomain<ColumnHandle> constraint;
     private final OptionalInt limit;
 
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
@@ -116,8 +116,8 @@ public class MongoTableHandle
                 .add("schemaTableName", schemaTableName)
                 .add("remoteTableName", remoteTableName)
                 .add("filter", filter)
-                .add("limit", limit)
                 .add("constraint", constraint)
+                .add("limit", limit)
                 .toString();
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
@@ -23,6 +24,7 @@ import io.trino.spi.predicate.TupleDomain;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -34,11 +36,12 @@ public class MongoTableHandle
     private final RemoteTableName remoteTableName;
     private final Optional<String> filter;
     private final TupleDomain<ColumnHandle> constraint;
+    private final Set<MongoColumnHandle> projectedColumns;
     private final OptionalInt limit;
 
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
     }
 
     @JsonCreator
@@ -47,12 +50,14 @@ public class MongoTableHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("filter") Optional<String> filter,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("projectedColumns") Set<MongoColumnHandle> projectedColumns,
             @JsonProperty("limit") OptionalInt limit)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.filter = requireNonNull(filter, "filter is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         this.limit = requireNonNull(limit, "limit is null");
     }
 
@@ -81,15 +86,32 @@ public class MongoTableHandle
     }
 
     @JsonProperty
+    public Set<MongoColumnHandle> getProjectedColumns()
+    {
+        return projectedColumns;
+    }
+
+    @JsonProperty
     public OptionalInt getLimit()
     {
         return limit;
     }
 
+    public MongoTableHandle withProjectedColumns(Set<MongoColumnHandle> projectedColumns)
+    {
+        return new MongoTableHandle(
+                schemaTableName,
+                remoteTableName,
+                filter,
+                constraint,
+                projectedColumns,
+                limit);
+    }
+
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, filter, constraint, limit);
+        return Objects.hash(schemaTableName, filter, constraint, projectedColumns, limit);
     }
 
     @Override
@@ -106,6 +128,7 @@ public class MongoTableHandle
                 Objects.equals(this.remoteTableName, other.remoteTableName) &&
                 Objects.equals(this.filter, other.filter) &&
                 Objects.equals(this.constraint, other.constraint) &&
+                Objects.equals(this.projectedColumns, other.projectedColumns) &&
                 Objects.equals(this.limit, other.limit);
     }
 
@@ -117,6 +140,7 @@ public class MongoTableHandle
                 .add("remoteTableName", remoteTableName)
                 .add("filter", filter)
                 .add("constraint", constraint)
+                .add("projectedColumns", projectedColumns)
                 .add("limit", limit)
                 .toString();
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
@@ -138,7 +138,7 @@ public class Query
 
             Descriptor returnedType = new Descriptor(columns.stream()
                     .map(MongoColumnHandle.class::cast)
-                    .map(column -> new Descriptor.Field(column.getName(), Optional.of(column.getType())))
+                    .map(column -> new Descriptor.Field(column.getBaseName(), Optional.of(column.getType())))
                     .collect(toImmutableList()));
 
             QueryFunctionHandle handle = new QueryFunctionHandle(tableHandle);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
@@ -13,8 +13,13 @@
  */
 package io.trino.plugin.mongodb;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.testing.BaseConnectorSmokeTest;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.TestTable;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class BaseMongoConnectorSmokeTest
         extends BaseConnectorSmokeTest
@@ -41,6 +46,87 @@ public abstract class BaseMongoConnectorSmokeTest
 
             default:
                 return super.hasBehavior(connectorBehavior);
+        }
+    }
+
+    @Test
+    public void testProjectionPushdown()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_multiple_rows_",
+                "(id INT, nested1 ROW(child1 INT, child2 VARCHAR))",
+                ImmutableList.of(
+                        "(1, ROW(10, 'a'))",
+                        "(2, ROW(NULL, 'b'))",
+                        "(3, ROW(30, 'c'))",
+                        "(4, NULL)"))) {
+            assertThat(query("SELECT id, nested1.child1 FROM " + testTable.getName() + " WHERE nested1.child2 = 'c'"))
+                    .matches("VALUES (3, 30)")
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Test
+    public void testReadDottedField()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_read_dotted_field_",
+                "(root ROW(\"dotted.field\" VARCHAR, field VARCHAR))",
+                ImmutableList.of("ROW(ROW('foo', 'bar'))"))) {
+            assertThat(query("SELECT root.\"dotted.field\" FROM " + testTable.getName()))
+                    .matches("SELECT varchar 'foo'");
+
+            assertThat(query("SELECT root.\"dotted.field\", root.field FROM " + testTable.getName()))
+                    .matches("SELECT varchar 'foo', varchar 'bar'");
+        }
+    }
+
+    @Test
+    public void testReadDollarPrefixedField()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_read_dotted_field_",
+                "(root ROW(\"$field1\" VARCHAR, field2 VARCHAR))",
+                ImmutableList.of("ROW(ROW('foo', 'bar'))"))) {
+            assertThat(query("SELECT root.\"$field1\" FROM " + testTable.getName()))
+                    .matches("SELECT varchar 'foo'");
+
+            assertThat(query("SELECT root.\"$field1\", root.field2 FROM " + testTable.getName()))
+                    .matches("SELECT varchar 'foo', varchar 'bar'");
+        }
+    }
+
+    @Test
+    public void testProjectionPushdownWithHighlyNestedData()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_projection_pushdown_highly_nested_data_",
+                "(id INT, row1_t ROW(f1 INT, f2 INT, row2_t ROW (f1 INT, f2 INT, row3_t ROW(f1 INT, f2 INT))))",
+                ImmutableList.of("(1, ROW(2, 3, ROW(4, 5, ROW(6, 7))))",
+                        "(11, ROW(12, 13, ROW(14, 15, ROW(16, 17))))",
+                        "(21, ROW(22, 23, ROW(24, 25, ROW(26, 27))))"))) {
+            // Test select projected columns, with and without their parent column
+            assertQuery("SELECT id, row1_t.row2_t.row3_t.f2 FROM " + testTable.getName(), "VALUES (1, 7), (11, 17), (21, 27)");
+            assertQuery("SELECT id, row1_t.row2_t.row3_t.f2, CAST(row1_t AS JSON) FROM " + testTable.getName(),
+                    "VALUES (1, 7, '{\"f1\":2,\"f2\":3,\"row2_t\":{\"f1\":4,\"f2\":5,\"row3_t\":{\"f1\":6,\"f2\":7}}}'), " +
+                            "(11, 17, '{\"f1\":12,\"f2\":13,\"row2_t\":{\"f1\":14,\"f2\":15,\"row3_t\":{\"f1\":16,\"f2\":17}}}'), " +
+                            "(21, 27, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+
+            // Test predicates on immediate child column and deeper nested column
+            assertQuery("SELECT id, CAST(row1_t.row2_t.row3_t AS JSON) FROM " + testTable.getName() + " WHERE row1_t.row2_t.row3_t.f2 = 27", "VALUES (21, '{\"f1\":26,\"f2\":27}')");
+            assertQuery("SELECT id, CAST(row1_t.row2_t.row3_t AS JSON) FROM " + testTable.getName() + " WHERE row1_t.row2_t.row3_t.f2 > 20", "VALUES (21, '{\"f1\":26,\"f2\":27}')");
+            assertQuery("SELECT id, CAST(row1_t AS JSON) FROM " + testTable.getName() + " WHERE row1_t.row2_t.row3_t.f2 = 27",
+                    "VALUES (21, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+            assertQuery("SELECT id, CAST(row1_t AS JSON) FROM " + testTable.getName() + " WHERE row1_t.row2_t.row3_t.f2 > 20",
+                    "VALUES (21, '{\"f1\":22,\"f2\":23,\"row2_t\":{\"f1\":24,\"f2\":25,\"row3_t\":{\"f1\":26,\"f2\":27}}}')");
+
+            // Test predicates on parent columns
+            assertQuery("SELECT id, row1_t.row2_t.row3_t.f1 FROM " + testTable.getName() + " WHERE row1_t.row2_t.row3_t = ROW(16, 17)", "VALUES (11, 16)");
+            assertQuery("SELECT id, row1_t.row2_t.row3_t.f1 FROM " + testTable.getName() + " WHERE row1_t = ROW(22, 23, ROW(24, 25, ROW(26, 27)))", "VALUES (21, 26)");
         }
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -42,7 +42,8 @@ public class TestMongoClientConfig
                 .setReadPreference(ReadPreferenceType.PRIMARY)
                 .setWriteConcern(WriteConcernType.ACKNOWLEDGED)
                 .setRequiredReplicaSetName(null)
-                .setImplicitRowFieldPrefix("_pos"));
+                .setImplicitRowFieldPrefix("_pos")
+                .setProjectionPushdownEnabled(true));
     }
 
     @Test
@@ -65,6 +66,7 @@ public class TestMongoClientConfig
                 .put("mongodb.write-concern", "UNACKNOWLEDGED")
                 .put("mongodb.required-replica-set", "replica_set")
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
+                .put("mongodb.projection-pushdown-enabled", "false")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -82,7 +84,8 @@ public class TestMongoClientConfig
                 .setReadPreference(ReadPreferenceType.NEAREST)
                 .setWriteConcern(WriteConcernType.UNACKNOWLEDGED)
                 .setRequiredReplicaSetName("replica_set")
-                .setImplicitRowFieldPrefix("_prefix");
+                .setImplicitRowFieldPrefix("_prefix")
+                .setProjectionPushdownEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoComplexTypePredicatePushDown.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.BaseComplexTypesPredicatePushDownTest;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoQueryRunner;
+
+public class TestMongoComplexTypePredicatePushDown
+        extends BaseComplexTypesPredicatePushDownTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        MongoServer server = closeAfterClass(new MongoServer());
+        return createMongoQueryRunner(server, ImmutableMap.of(), ImmutableList.of());
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoProjectionPushdownPlans.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import com.mongodb.client.MongoClient;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.assertions.BasePushdownPlanTest;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Predicates.equalTo;
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.mongodb.MongoQueryRunner.createMongoClient;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.any;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoProjectionPushdownPlans
+        extends BasePushdownPlanTest
+{
+    private static final String CATALOG = "mongodb";
+    private static final String SCHEMA = "test";
+
+    private Closer closer;
+
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
+                .build();
+
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
+
+        closer = Closer.create();
+        MongoServer server = closer.register(new MongoServer());
+        MongoClient client = closer.register(createMongoClient(server));
+
+        try {
+            queryRunner.installPlugin(new MongoPlugin());
+            queryRunner.createCatalog(
+                    CATALOG,
+                    "mongodb",
+                    ImmutableMap.of("mongodb.connection-url", server.getConnectionString().toString()));
+            // Put an dummy schema collection because MongoDB doesn't support a database without collections
+            client.getDatabase(SCHEMA).createCollection("dummy");
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public final void destroy()
+            throws Exception
+    {
+        closer.close();
+        closer = null;
+    }
+
+    @Test
+    public void testPushdownDisabled()
+    {
+        String tableName = "test_pushdown_disabled_" + randomNameSuffix();
+
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(CATALOG, "projection_pushdown_enabled", "false")
+                .build();
+
+        getQueryRunner().execute("CREATE TABLE " + tableName + " (col0) AS SELECT CAST(row(5, 6) AS row(a bigint, b bigint)) AS col0 WHERE false");
+
+        assertPlan(
+                "SELECT col0.a expr_a, col0.b expr_b FROM " + tableName,
+                session,
+                any(
+                        project(
+                                ImmutableMap.of("expr_1", expression("col0[1]"), "expr_2", expression("col0[2]")),
+                                tableScan(tableName, ImmutableMap.of("col0", "col0")))));
+    }
+
+    @Test
+    public void testDereferencePushdown()
+    {
+        String tableName = "test_simple_projection_pushdown" + randomNameSuffix();
+        QualifiedObjectName completeTableName = new QualifiedObjectName(CATALOG, SCHEMA, tableName);
+
+        getQueryRunner().execute("CREATE TABLE " + tableName + " (col0, col1)" +
+                " AS SELECT CAST(row(5, 6) AS row(x BIGINT, y BIGINT)) AS col0, BIGINT '5' AS col1");
+
+        Session session = getQueryRunner().getDefaultSession();
+
+        Optional<TableHandle> tableHandle = getTableHandle(session, completeTableName);
+        assertThat(tableHandle).as("expected the table handle to be present").isPresent();
+
+        MongoTableHandle mongoTableHandle = (MongoTableHandle) tableHandle.get().getConnectorHandle();
+        Map<String, ColumnHandle> columns = getColumnHandles(session, completeTableName);
+
+        MongoColumnHandle column0Handle = (MongoColumnHandle) columns.get("col0");
+        MongoColumnHandle column1Handle = (MongoColumnHandle) columns.get("col1");
+
+        MongoColumnHandle columnX = createProjectedColumnHandle(column0Handle, ImmutableList.of("x"), BIGINT);
+        MongoColumnHandle columnY = createProjectedColumnHandle(column0Handle, ImmutableList.of("y"), BIGINT);
+
+        // Simple Projection pushdown
+        assertPlan(
+                "SELECT col0.x expr_x, col0.y expr_y FROM " + tableName,
+                any(
+                        tableScan(
+                                equalTo(mongoTableHandle.withProjectedColumns(Set.of(columnX, columnY))),
+                                TupleDomain.all(),
+                                ImmutableMap.of("col0.x", equalTo(columnX), "col0.y", equalTo(columnY)))));
+
+        // Projection and predicate pushdown
+        assertPlan(
+                "SELECT col0.x FROM " + tableName + " WHERE col0.x = col1 + 3 and col0.y = 2",
+                anyTree(
+                        filter(
+                                "x = col1 + BIGINT '3'",
+                                tableScan(
+                                        table -> {
+                                            MongoTableHandle actualTableHandle = (MongoTableHandle) table;
+                                            TupleDomain<ColumnHandle> constraint = actualTableHandle.getConstraint();
+                                            return actualTableHandle.getProjectedColumns().equals(ImmutableSet.of(column1Handle, columnX))
+                                                    && constraint.equals(TupleDomain.withColumnDomains(ImmutableMap.of(columnY, Domain.singleValue(BIGINT, 2L))));
+                                        },
+                                        TupleDomain.all(),
+                                        ImmutableMap.of("col1", equalTo(column1Handle), "x", equalTo(columnX))))));
+
+        // Projection and predicate pushdown with overlapping columns
+        assertPlan(
+                "SELECT col0, col0.y expr_y FROM " + tableName + " WHERE col0.x = 5",
+                anyTree(
+                        tableScan(
+                                table -> {
+                                    MongoTableHandle actualTableHandle = (MongoTableHandle) table;
+                                    TupleDomain<ColumnHandle> constraint = actualTableHandle.getConstraint();
+                                    return actualTableHandle.getProjectedColumns().equals(ImmutableSet.of(column0Handle, columnY))
+                                            && constraint.equals(TupleDomain.withColumnDomains(ImmutableMap.of(columnX, Domain.singleValue(BIGINT, 5L))));
+                                },
+                                TupleDomain.all(),
+                                ImmutableMap.of("col0", equalTo(column0Handle), "y", equalTo(columnY)))));
+
+        // Projection and predicate pushdown with joins
+        assertPlan(
+                "SELECT T.col0.x, T.col0, T.col0.y FROM " + tableName + " T join " + tableName + " S on T.col1 = S.col1 WHERE T.col0.x = 2",
+                anyTree(
+                        project(
+                                ImmutableMap.of(
+                                        "expr_0_x", expression("expr_0[1]"),
+                                        "expr_0", expression("expr_0"),
+                                        "expr_0_y", expression("expr_0[2]")),
+                                PlanMatchPattern.join(INNER, builder -> builder
+                                        .equiCriteria("t_expr_1", "s_expr_1")
+                                        .left(
+                                                anyTree(
+                                                        tableScan(
+                                                                table -> {
+                                                                    MongoTableHandle actualTableHandle = (MongoTableHandle) table;
+                                                                    TupleDomain<ColumnHandle> constraint = actualTableHandle.getConstraint();
+                                                                    Set<MongoColumnHandle> expectedProjections = ImmutableSet.of(column0Handle, column1Handle);
+                                                                    TupleDomain<MongoColumnHandle> expectedConstraint = TupleDomain.withColumnDomains(
+                                                                            ImmutableMap.of(columnX, Domain.singleValue(BIGINT, 2L)));
+                                                                    return actualTableHandle.getProjectedColumns().equals(expectedProjections)
+                                                                            && constraint.equals(expectedConstraint);
+                                                                },
+                                                                TupleDomain.all(),
+                                                                ImmutableMap.of("expr_0", equalTo(column0Handle), "t_expr_1", equalTo(column1Handle)))))
+                                        .right(
+                                                anyTree(
+                                                        tableScan(
+                                                                equalTo(mongoTableHandle.withProjectedColumns(Set.of(column1Handle))),
+                                                                TupleDomain.all(),
+                                                                ImmutableMap.of("s_expr_1", equalTo(column1Handle)))))))));
+    }
+
+    @Test
+    public void testDereferencePushdownWithDotAndDollarContainingField()
+    {
+        String tableName = "test_dereference_pushdown_with_dot_and_dollar_containing_field_" + randomNameSuffix();
+        QualifiedObjectName completeTableName = new QualifiedObjectName(CATALOG, SCHEMA, tableName);
+
+        getQueryRunner().execute(
+                "CREATE TABLE " + tableName + " (id, root1) AS" +
+                        " SELECT BIGINT '1', CAST(ROW(11, ROW(111, ROW(1111, varchar 'foo', varchar 'bar'))) AS" +
+                        " ROW(id BIGINT, root2 ROW(id BIGINT, root3 ROW(id BIGINT, \"dotted.field\" VARCHAR, \"$name\" VARCHAR))))");
+
+        Session session = getQueryRunner().getDefaultSession();
+
+        Optional<TableHandle> tableHandle = getTableHandle(session, completeTableName);
+        assertThat(tableHandle).as("expected the table handle to be present").isPresent();
+
+        MongoTableHandle mongoTableHandle = (MongoTableHandle) tableHandle.get().getConnectorHandle();
+        Map<String, ColumnHandle> columns = getColumnHandles(session, completeTableName);
+
+        RowType rowType = RowType.rowType(
+                RowType.field("id", BIGINT),
+                RowType.field("dotted.field", VARCHAR),
+                RowType.field("$name", VARCHAR));
+
+        MongoColumnHandle columnRoot1 = (MongoColumnHandle) columns.get("root1");
+        MongoColumnHandle columnRoot3 = createProjectedColumnHandle(columnRoot1, ImmutableList.of("root2", "root3"), rowType);
+
+        //  Dotted field will not get pushdown, But it's parent filed 'root1.root2.root3' will get pushdown
+        assertPlan(
+                "SELECT root1.root2.root3.\"dotted.field\" FROM " + tableName,
+                anyTree(
+                        tableScan(
+                                equalTo(mongoTableHandle.withProjectedColumns(Set.of(columnRoot3))),
+                                TupleDomain.all(),
+                                ImmutableMap.of("root1.root2.root3", equalTo(columnRoot3)))));
+
+        //  Dollar containing field will not get pushdown, But it's parent filed 'root1.root2.root3' will get pushdown
+        assertPlan(
+                "SELECT root1.root2.root3.\"$name\" FROM " + tableName,
+                anyTree(
+                        tableScan(
+                                equalTo(mongoTableHandle.withProjectedColumns(Set.of(columnRoot3))),
+                                TupleDomain.all(),
+                                ImmutableMap.of("root1.root2.root3", equalTo(columnRoot3)))));
+
+        assertPlan(
+                "SELECT 1 FROM " + tableName + " WHERE root1.root2.root3.\"dotted.field\" = 'foo'",
+                anyTree(
+                        tableScan(
+                                table -> {
+                                    MongoTableHandle actualTableHandle = (MongoTableHandle) table;
+                                    TupleDomain<ColumnHandle> constraint = actualTableHandle.getConstraint();
+                                    return actualTableHandle.getProjectedColumns().equals(ImmutableSet.of(columnRoot3))
+                                            && constraint.equals(TupleDomain.all()); // Predicate will not get pushdown for dollar containing field
+                                },
+                                TupleDomain.all(),
+                                ImmutableMap.of("root1.root2.root3", equalTo(columnRoot3)))));
+
+        assertPlan(
+                "SELECT 1 FROM " + tableName + " WHERE root1.root2.root3.\"$name\" = 'bar'",
+                anyTree(
+                        tableScan(
+                                table -> {
+                                    MongoTableHandle actualTableHandle = (MongoTableHandle) table;
+                                    TupleDomain<ColumnHandle> constraint = actualTableHandle.getConstraint();
+                                    return actualTableHandle.getProjectedColumns().equals(ImmutableSet.of(columnRoot3))
+                                            && constraint.equals(TupleDomain.all()); // Predicate will not get pushdown for dollar containing field
+                                },
+                                TupleDomain.all(),
+                                ImmutableMap.of("root1.root2.root3", equalTo(columnRoot3)))));
+    }
+
+    private MongoColumnHandle createProjectedColumnHandle(
+            MongoColumnHandle baseColumnHandle,
+            List<String> dereferenceNames,
+            Type type)
+    {
+        return new MongoColumnHandle(
+                baseColumnHandle.getBaseName(),
+                dereferenceNames,
+                type,
+                baseColumnHandle.isHidden(),
+                baseColumnHandle.isDbRefField(),
+                baseColumnHandle.getComment());
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -19,12 +19,15 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Type;
 import org.bson.Document;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.mongodb.MongoSession.projectSufficientColumns;
 import static io.trino.spi.predicate.Range.equal;
 import static io.trino.spi.predicate.Range.greaterThan;
 import static io.trino.spi.predicate.Range.greaterThanOrEqual;
@@ -34,14 +37,17 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestMongoSession
 {
-    private static final MongoColumnHandle COL1 = new MongoColumnHandle("col1", BIGINT, false, Optional.empty());
-    private static final MongoColumnHandle COL2 = new MongoColumnHandle("col2", createUnboundedVarcharType(), false, Optional.empty());
-    private static final MongoColumnHandle COL3 = new MongoColumnHandle("col3", createUnboundedVarcharType(), false, Optional.empty());
-    private static final MongoColumnHandle COL4 = new MongoColumnHandle("col4", BOOLEAN, false, Optional.empty());
+    private static final MongoColumnHandle COL1 = createColumnHandle("col1", BIGINT);
+    private static final MongoColumnHandle COL2 = createColumnHandle("col2", createUnboundedVarcharType());
+    private static final MongoColumnHandle COL3 = createColumnHandle("col3", createUnboundedVarcharType());
+    private static final MongoColumnHandle COL4 = createColumnHandle("col4", BOOLEAN);
+    private static final MongoColumnHandle COL5 = createColumnHandle("col5", BIGINT);
+    private static final MongoColumnHandle COL6 = createColumnHandle("grandparent", createUnboundedVarcharType(), "parent", "col6");
 
     @Test
     public void testBuildQuery()
@@ -52,8 +58,8 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document()
-                .append(COL1.getName(), new Document().append("$gt", 100L).append("$lte", 200L))
-                .append(COL2.getName(), new Document("$eq", "a value"));
+                .append(COL1.getBaseName(), new Document().append("$gt", 100L).append("$lte", 200L))
+                .append(COL2.getBaseName(), new Document("$eq", "a value"));
         assertEquals(query, expected);
     }
 
@@ -66,8 +72,8 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document()
-                .append(COL3.getName(), new Document().append("$gt", "hello").append("$lte", "world"))
-                .append(COL2.getName(), new Document("$gte", "a value"));
+                .append(COL3.getBaseName(), new Document().append("$gt", "hello").append("$lte", "world"))
+                .append(COL2.getBaseName(), new Document("$gte", "a value"));
         assertEquals(query, expected);
     }
 
@@ -78,7 +84,7 @@ public class TestMongoSession
                 COL2, Domain.create(ValueSet.ofRanges(equal(createUnboundedVarcharType(), utf8Slice("hello")), equal(createUnboundedVarcharType(), utf8Slice("world"))), false)));
 
         Document query = MongoSession.buildQuery(tupleDomain);
-        Document expected = new Document(COL2.getName(), new Document("$in", ImmutableList.of("hello", "world")));
+        Document expected = new Document(COL2.getBaseName(), new Document("$in", ImmutableList.of("hello", "world")));
         assertEquals(query, expected);
     }
 
@@ -90,8 +96,8 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document("$or", asList(
-                new Document(COL1.getName(), new Document("$lt", 100L)),
-                new Document(COL1.getName(), new Document("$gt", 200L))));
+                new Document(COL1.getBaseName(), new Document("$lt", 100L)),
+                new Document(COL1.getBaseName(), new Document("$gt", 200L))));
         assertEquals(query, expected);
     }
 
@@ -103,8 +109,8 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document("$or", asList(
-                new Document(COL1.getName(), new Document("$gt", 200L)),
-                new Document(COL1.getName(), new Document("$eq", null))));
+                new Document(COL1.getBaseName(), new Document("$gt", 200L)),
+                new Document(COL1.getBaseName(), new Document("$eq", null))));
         assertEquals(query, expected);
     }
 
@@ -114,7 +120,94 @@ public class TestMongoSession
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(COL4, Domain.singleValue(BOOLEAN, true)));
 
         Document query = MongoSession.buildQuery(tupleDomain);
-        Document expected = new Document().append(COL4.getName(), new Document("$eq", true));
+        Document expected = new Document().append(COL4.getBaseName(), new Document("$eq", true));
         assertEquals(query, expected);
+    }
+
+    @Test
+    public void testBuildQueryNestedField()
+    {
+        TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(
+                COL5, Domain.create(ValueSet.ofRanges(greaterThan(BIGINT, 200L)), true),
+                COL6, Domain.singleValue(createUnboundedVarcharType(), utf8Slice("a value"))));
+
+        Document query = MongoSession.buildQuery(tupleDomain);
+        Document expected = new Document()
+                .append("$or", asList(
+                        new Document(COL5.getQualifiedName(), new Document("$gt", 200L)),
+                        new Document(COL5.getQualifiedName(), new Document("$eq", null))))
+                .append(COL6.getQualifiedName(), new Document("$eq", "a value"));
+        assertEquals(query, expected);
+    }
+
+    @Test
+    public void testProjectSufficientColumns()
+    {
+        MongoColumnHandle col1 = createColumnHandle("x", BIGINT, "a", "b");
+        MongoColumnHandle col2 = createColumnHandle("x", BIGINT, "b");
+        MongoColumnHandle col3 = createColumnHandle("x", BIGINT, "c");
+        MongoColumnHandle col4 = createColumnHandle("x", BIGINT);
+
+        List<MongoColumnHandle> output = projectSufficientColumns(ImmutableList
+                .of(col1, col2, col4));
+        assertThat(output)
+                .containsExactly(col4)
+                .hasSize(1);
+
+        output = projectSufficientColumns(ImmutableList.of(col4, col2, col1));
+        assertThat(output)
+                .containsExactly(col4)
+                .hasSize(1);
+
+        output = projectSufficientColumns(ImmutableList.of(col2, col1, col4));
+        assertThat(output)
+                .containsExactly(col4)
+                .hasSize(1);
+
+        output = projectSufficientColumns(ImmutableList.of(col2, col3));
+        assertThat(output)
+                .containsExactly(col2, col3)
+                .hasSize(2);
+
+        MongoColumnHandle col5 = createColumnHandle("x", BIGINT, "a", "b", "c");
+        MongoColumnHandle col6 = createColumnHandle("x", BIGINT, "a", "c", "b");
+        MongoColumnHandle col7 = createColumnHandle("x", BIGINT, "c", "a", "b");
+        MongoColumnHandle col8 = createColumnHandle("x", BIGINT, "b", "a");
+        MongoColumnHandle col9 = createColumnHandle("x", BIGINT);
+
+        output = projectSufficientColumns(ImmutableList
+                .of(col5, col6));
+        assertThat(output)
+                .containsExactly(col5, col6)
+                .hasSize(2);
+
+        output = projectSufficientColumns(ImmutableList
+                .of(col6, col7));
+        assertThat(output)
+                .containsExactly(col6, col7)
+                .hasSize(2);
+
+        output = projectSufficientColumns(ImmutableList
+                .of(col5, col8));
+        assertThat(output)
+                .containsExactly(col8, col5)
+                .hasSize(2);
+
+        output = projectSufficientColumns(ImmutableList
+                .of(col5, col6, col7, col8, col9));
+        assertThat(output)
+                .containsExactly(col9)
+                .hasSize(1);
+    }
+
+    private static MongoColumnHandle createColumnHandle(String baseName, Type type, String... dereferenceNames)
+    {
+        return new MongoColumnHandle(
+                baseName,
+                ImmutableList.copyOf(dereferenceNames),
+                type,
+                false,
+                false,
+                Optional.empty());
     }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -13,17 +13,40 @@
  */
 package io.trino.plugin.mongodb;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.type.TypeDeserializer;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
 
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.testng.Assert.assertEquals;
 
 public class TestMongoTableHandle
 {
-    private final JsonCodec<MongoTableHandle> codec = JsonCodec.jsonCodec(MongoTableHandle.class);
+    private JsonCodec<MongoTableHandle> codec;
+
+    @BeforeClass
+    public void init()
+    {
+        ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
+        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new TypeDeserializer(TESTING_TYPE_MANAGER)));
+        codec = new JsonCodecFactory(objectMapperProvider).jsonCodec(MongoTableHandle.class);
+    }
 
     @Test
     public void testRoundTripWithoutQuery()
@@ -75,5 +98,36 @@ public class TestMongoTableHandle
         MongoTableHandle actual = codec.fromJson(json);
 
         assertEquals(actual.getSchemaTableName(), expected.getSchemaTableName());
+    }
+
+    @Test
+    public void testRoundTripWithProjectedColumns()
+    {
+        SchemaTableName schemaTableName = new SchemaTableName("schema", "table");
+        RemoteTableName remoteTableName = new RemoteTableName("Schema", "Table");
+        Set<MongoColumnHandle> projectedColumns = ImmutableSet.of(
+                new MongoColumnHandle("id", ImmutableList.of(), INTEGER, false, false, Optional.empty()),
+                new MongoColumnHandle("address", ImmutableList.of("street"), VARCHAR, false, false, Optional.empty()),
+                new MongoColumnHandle(
+                        "user",
+                        ImmutableList.of(),
+                        RowType.from(ImmutableList.of(new RowType.Field(Optional.of("first"), VARCHAR), new RowType.Field(Optional.of("last"), VARCHAR))),
+                        false,
+                        false,
+                        Optional.empty()),
+                new MongoColumnHandle("creator", ImmutableList.of("databasename"), VARCHAR, false, true, Optional.empty()));
+
+        MongoTableHandle expected = new MongoTableHandle(
+                schemaTableName,
+                remoteTableName,
+                Optional.empty(),
+                TupleDomain.all(),
+                projectedColumns,
+                OptionalInt.empty());
+
+        String json = codec.toJson(expected);
+        MongoTableHandle actual = codec.fromJson(json);
+
+        assertEquals(actual, expected);
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public abstract class BaseTestFileFormatComplexTypesPredicatePushDown
+public abstract class BaseComplexTypesPredicatePushDownTest
         extends AbstractTestQueryFramework
 {
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR implements dereference pushdown for Mongodb connector(similar to https://github.com/trinodb/trino/pull/17085).

This adds significant performance improvements for queries accessing nested fields inside struct/row columns. They have been optimized through the pushdown of dereference expressions. With this feature, the query execution prunes structural data eagerly, extracting the necessary fields.

More Details about dereference pushdown: https://trino.io/blog/2020/08/14/dereference-pushdown.html

Note: This PR merges the work of https://github.com/trinodb/trino/pull/14467 and https://github.com/trinodb/trino/pull/16790

## Additional context and related issues

The feature is enabled by default.

The feature can be disabled by setting `mongodb.projection-pushdown-enabled` configuration property or `mongodb.projection_pushdown_enabled` session property to `false`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Mongodb
* Improve read performance for tables with row (struct) columns when only subset of fields is needed by a query. ({issue}`issuenumber`)
```
