### PR TITLE
Bump Iceberg from 1.2.1 to 1.3.0

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -25,7 +25,7 @@
           -->
         <air.test.parallel>instances</air.test.parallel>
         <!-- Nessie version (matching to Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
-        <dep.nessie.version>0.51.1</dep.nessie.version>
+        <dep.nessie.version>0.59.0</dep.nessie.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
@@ -48,6 +48,7 @@ public class IcebergNessieCatalogModule
         return new NessieIcebergClient(
                 HttpClientBuilder.builder()
                         .withUri(icebergNessieCatalogConfig.getServerUri())
+                        .withEnableApiCompatibilityCheck(false)
                         .build(NessieApiV1.class),
                 icebergNessieCatalogConfig.getDefaultReferenceName(),
                 null,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -28,7 +28,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.51.1";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.59.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dep.kafka-clients.version>3.3.2</dep.kafka-clients.version>
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>8.4.5</dep.minio.version>
-        <dep.iceberg.version>1.2.1</dep.iceberg.version>
+        <dep.iceberg.version>1.3.0</dep.iceberg.version>
         <dep.protobuf.version>3.22.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
         <dep.netty.version>4.1.92.Final</dep.netty.version>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
@@ -38,7 +38,7 @@ public class EnvSinglenodeSparkIcebergNessie
 {
     private static final int SPARK_THRIFT_PORT = 10213;
     private static final int NESSIE_PORT = 19120;
-    private static final String NESSIE_VERSION = "0.51.1";
+    private static final String NESSIE_VERSION = "0.59.0";
     private static final String SPARK = "spark";
 
     private final DockerFiles dockerFiles;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This updates Iceberg from 1.2.1 to 1.3.0 and also updates Nessie to the respective version that Iceberg is using.
Release notes can be found [here](https://iceberg.apache.org/releases/#130-release)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
