### PR TITLE
Use client-provided OAuth token to access Google BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/CredentialsConfig.java
@@ -24,10 +24,12 @@ import javax.validation.constraints.AssertTrue;
 import java.io.IOException;
 import java.util.Optional;
 
-public class StaticCredentialsConfig
+public class CredentialsConfig
 {
+    public static final String OAUTH_TOKEN_KEY = "bigquery.oauth";
     private Optional<String> credentialsKey = Optional.empty();
     private Optional<String> credentialsFile = Optional.empty();
+    private boolean useAccessToken;
 
     @AssertTrue(message = "Exactly one of 'bigquery.credentials-key' or 'bigquery.credentials-file' must be specified, or the default GoogleCredentials could be created")
     public boolean isCredentialsConfigurationValid()
@@ -56,7 +58,7 @@ public class StaticCredentialsConfig
     @Config("bigquery.credentials-key")
     @ConfigDescription("The base64 encoded credentials key")
     @ConfigSecuritySensitive
-    public StaticCredentialsConfig setCredentialsKey(String credentialsKey)
+    public CredentialsConfig setCredentialsKey(String credentialsKey)
     {
         this.credentialsKey = Optional.ofNullable(credentialsKey);
         return this;
@@ -69,9 +71,22 @@ public class StaticCredentialsConfig
 
     @Config("bigquery.credentials-file")
     @ConfigDescription("The path to the JSON credentials file")
-    public StaticCredentialsConfig setCredentialsFile(String credentialsFile)
+    public CredentialsConfig setCredentialsFile(String credentialsFile)
     {
         this.credentialsFile = Optional.ofNullable(credentialsFile);
+        return this;
+    }
+
+    public boolean isUseAccessToken()
+    {
+        return useAccessToken;
+    }
+
+    @Config("bigquery.use-access-token")
+    @ConfigDescription("Use client-provided OAuth token to access Google BigQuery")
+    public CredentialsConfig setUseAccessToken(boolean useAccessToken)
+    {
+        this.useAccessToken = useAccessToken;
         return this;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/OAuthBigQueryCredentialsSupplier.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/OAuthBigQueryCredentialsSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.util.Optional;
+
+public class OAuthBigQueryCredentialsSupplier
+        implements BigQueryCredentialsSupplier
+{
+    @Override
+    public Optional<Credentials> getCredentials(ConnectorSession session)
+    {
+        var id = session.getIdentity();
+        return Optional.ofNullable(id.getExtraCredentials().get(CredentialsConfig.OAUTH_TOKEN_KEY))
+            .map(oauthToken -> AccessToken.newBuilder().setTokenValue(oauthToken).build())
+            .map(GoogleCredentials::create);
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
@@ -34,7 +34,7 @@ public class StaticBigQueryCredentialsSupplier
     private final Supplier<Optional<Credentials>> credentialsCreator;
 
     @Inject
-    public StaticBigQueryCredentialsSupplier(StaticCredentialsConfig config)
+    public StaticBigQueryCredentialsSupplier(CredentialsConfig config)
     {
         // lazy creation, cache once it's created
         Optional<Credentials> credentialsKey = config.getCredentialsKey()

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestStaticCredentialsConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestStaticCredentialsConfig.java
@@ -35,9 +35,10 @@ public class TestStaticCredentialsConfig
     @Test
     public void testDefaults()
     {
-        assertRecordedDefaults(recordDefaults(StaticCredentialsConfig.class)
+        assertRecordedDefaults(recordDefaults(CredentialsConfig.class)
                 .setCredentialsKey(null)
-                .setCredentialsFile(null));
+                .setCredentialsFile(null)
+                .setUseAccessToken(false));
     }
 
     @Test
@@ -46,7 +47,7 @@ public class TestStaticCredentialsConfig
         Map<String, String> properties = ImmutableMap.of("bigquery.credentials-key", "key");
 
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
-        StaticCredentialsConfig config = configurationFactory.build(StaticCredentialsConfig.class);
+        CredentialsConfig config = configurationFactory.build(CredentialsConfig.class);
 
         assertEquals(config.getCredentialsKey(), Optional.of("key"));
         assertEquals(config.getCredentialsFile(), Optional.empty());
@@ -61,7 +62,7 @@ public class TestStaticCredentialsConfig
             Map<String, String> properties = ImmutableMap.of("bigquery.credentials-file", file.toString());
 
             ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
-            StaticCredentialsConfig config = configurationFactory.build(StaticCredentialsConfig.class);
+            CredentialsConfig config = configurationFactory.build(CredentialsConfig.class);
 
             assertEquals(config.getCredentialsKey(), Optional.empty());
             assertEquals(config.getCredentialsFile(), Optional.of(file.toString()));
@@ -80,7 +81,7 @@ public class TestStaticCredentialsConfig
                 .buildOrThrow();
 
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
-        assertThatThrownBy(() -> configurationFactory.build(StaticCredentialsConfig.class))
+        assertThatThrownBy(() -> configurationFactory.build(CredentialsConfig.class))
                 .isInstanceOf(ConfigurationException.class)
                 .hasMessageContaining("Exactly one of 'bigquery.credentials-key' or 'bigquery.credentials-file' must be specified");
     }


### PR DESCRIPTION
## Description
Allow the usage of client-provided OAuth token to access Google BigQuery.

```properties
connector.name=bigquery
bigquery.project-id=foobar
bigquery.parent-project-id=barfoo
bigquery.use-access-token=true
```

```sh
trino \
   --server https://trino.io/ \
   --user=regadas \
   --extra-credential="bigquery.oauth=$TOKEN"
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#17716 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:


