### PR TITLE
Improve error message when creating tables or adding columns using row type without field names in Delta

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -917,7 +917,7 @@ public class DeltaLakeMetadata
                 boolean containsTimestampType = false;
                 for (ColumnMetadata column : tableMetadata.getColumns()) {
                     columnNames.add(column.getName());
-                    columnTypes.put(column.getName(), serializeColumnType(columnMappingMode, fieldId, column.getType()));
+                    columnTypes.put(column.getName(), serializeColumnType(columnMappingMode, fieldId, column.getType(), column.getName()));
                     columnsMetadata.put(column.getName(), generateColumnMetadata(columnMappingMode, fieldId));
                     if (!containsTimestampType) {
                         containsTimestampType = containsTimestampType(column.getType());
@@ -1053,7 +1053,7 @@ public class DeltaLakeMetadata
             columnNullabilities.put(column.getName(), column.isNullable());
             containsTimestampType |= containsTimestampType(column.getType());
 
-            Object serializedType = serializeColumnType(columnMappingMode, fieldId, column.getType());
+            Object serializedType = serializeColumnType(columnMappingMode, fieldId, column.getType(), column.getName());
             Type physicalType = deserializeType(typeManager, serializedType, usePhysicalName);
             columnTypes.put(column.getName(), serializedType);
 
@@ -1428,7 +1428,7 @@ public class DeltaLakeMetadata
             columnsNullability.put(newColumnMetadata.getName(), newColumnMetadata.isNullable());
             Map<String, Object> columnTypes = ImmutableMap.<String, Object>builderWithExpectedSize(columnNames.size())
                     .putAll(getColumnTypes(handle.getMetadataEntry()))
-                    .put(Map.entry(newColumnMetadata.getName(), serializeColumnType(columnMappingMode, maxColumnId, newColumnMetadata.getType())))
+                    .put(Map.entry(newColumnMetadata.getName(), serializeColumnType(columnMappingMode, maxColumnId, newColumnMetadata.getType(), newColumnMetadata.getName())))
                     .buildOrThrow();
 
             ImmutableMap.Builder<String, Map<String, Object>> columnMetadata = ImmutableMap.builder();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -304,9 +304,11 @@ public final class DeltaLakeSchemaSupport
         fields.put("type", "struct");
         fields.put("fields", rowType.getFields().stream()
                 .map(field -> {
+                    String fieldName = field.getName()
+                            .orElseThrow(() -> new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Anonymous row type is not supported in Delta Lake connector"));
                     Object fieldType = serializeColumnType(columnMappingMode, maxColumnId, field.getType());
                     Map<String, Object> metadata = generateColumnMetadata(columnMappingMode, maxColumnId);
-                    return serializeStructField(field.getName().orElse(null), fieldType, null, null, metadata);
+                    return serializeStructField(fieldName, fieldType, null, null, metadata);
                 })
                 .collect(toImmutableList()));
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -2852,6 +2852,17 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("DROP TABLE " + table);
     }
 
+    @Test
+    public void testAnonymousRowTypeFailure()
+    {
+        String tableName = "test_table_anonymous_row_type_" + randomNameSuffix();
+        assertQueryFails("CREATE TABLE " + tableName + " AS SELECT ROW(123) AS c1", "Anonymous row type is not supported in Delta Lake connector");
+
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_table_anonymous_row_type_", "(c1 INTEGER)")) {
+            assertQueryFails("ALTER TABLE " + table.getName() + " ADD COLUMN c2 ROW(INTEGER)", "Unable to add '(\\w+)' column for: (\\w+\\.\\w+)");
+        }
+    }
+
     @Override
     protected void verifyAddNotNullColumnToNonEmptyTableFailurePermissible(Throwable e)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -2856,7 +2856,7 @@ public class TestDeltaLakeConnectorTest
     public void testAnonymousRowTypeFailure()
     {
         String tableName = "test_table_anonymous_row_type_" + randomNameSuffix();
-        assertQueryFails("CREATE TABLE " + tableName + " AS SELECT ROW(123) AS c1", "Anonymous row type is not supported in Delta Lake connector");
+        assertQueryFails("CREATE TABLE " + tableName + " AS SELECT ROW(123) AS c1", "Anonymous row type is not supported in Delta Lake connector for column: (\\w+)");
 
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_table_anonymous_row_type_", "(c1 INTEGER)")) {
             assertQueryFails("ALTER TABLE " + table.getName() + " ADD COLUMN c2 ROW(INTEGER)", "Unable to add '(\\w+)' column for: (\\w+\\.\\w+)");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -162,7 +162,7 @@ public class TestDeltaLakePageSink
         String schemaString = serializeSchemaAsJson(
                 getColumnHandles().stream().map(DeltaLakeColumnHandle::getColumnName).collect(toImmutableList()),
                 getColumnHandles().stream()
-                        .map(column -> Map.entry(column.getColumnName(), serializeColumnType(NONE, new AtomicInteger(), column.getType())))
+                        .map(column -> Map.entry(column.getColumnName(), serializeColumnType(NONE, new AtomicInteger(), column.getType(), column.getColumnName())))
                         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)),
                 ImmutableMap.of(),
                 ImmutableMap.of(),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/TestDeltaLakeSchemaSupport.java
@@ -239,7 +239,7 @@ public class TestDeltaLakeSchemaSupport
         ImmutableMap.Builder<String, Object> columnTypes = ImmutableMap.builderWithExpectedSize(columnHandles.size());
         for (DeltaLakeColumnHandle column : columnHandles) {
             columnNames.add(column.getColumnName());
-            columnTypes.put(column.getColumnName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getBaseType()));
+            columnTypes.put(column.getColumnName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getBaseType(), column.getColumnName()));
         }
 
         String jsonEncoding = serializeSchemaAsJson(columnNames.build(), columnTypes.buildOrThrow(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
@@ -261,7 +261,7 @@ public class TestDeltaLakeSchemaSupport
         ImmutableMap.Builder<String, Object> columnTypes = ImmutableMap.builderWithExpectedSize(schema.size());
         for (ColumnMetadata column : schema) {
             columnNames.add(column.getName());
-            columnTypes.put(column.getName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getType()));
+            columnTypes.put(column.getName(), serializeColumnType(ColumnMappingMode.NONE, new AtomicInteger(), column.getType(), column.getName()));
         }
 
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR Improves the error messaging for cases where row fields are not named during the creating table or addition of columns in Delta. If a field name is not present, an TrinoException is thrown, stating: "Anonymous row type is not supported in Delta Lake connector  for column: 'column name'".


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #17549


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.