### PR TITLE
Support additional configurations for Nessie catalog

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -422,10 +422,19 @@ properties:
     - Nessie API endpoint URI (required).
       Example: ``https://localhost:19120/api/v1``
   * - ``iceberg.nessie-catalog.ref``
-    - The branch/tag to use for Nessie, defaults to ``main``.
+    - The branch/tag to use for Nessie. Defaults to ``main``.
   * - ``iceberg.nessie-catalog.default-warehouse-dir``
     - Default warehouse directory for schemas created without an explicit
       ``location`` property. Example: ``/tmp``
+  * - ``iceberg.nessie-catalog.read-timeout``
+    - The read timeout :ref:`duration <prop-type-duration>` for requests
+      to the Nessie server. Defaults to ``25s``.
+  * - ``iceberg.nessie-catalog.connection-timeout``
+    - The connection timeout :ref:`duration <prop-type-duration>` for
+      connection requests to the Nessie server. Defaults to ``5s``.
+  * - ``iceberg.nessie-catalog.enable-compression``
+    - Configure whether compression should be enabled or not for
+      requests to the Nessie server. Defaults to ``true``.
 ```
 
 ```text

--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -435,6 +435,12 @@ properties:
   * - ``iceberg.nessie-catalog.enable-compression``
     - Configure whether compression should be enabled or not for
       requests to the Nessie server. Defaults to ``true``.
+  * - ``iceberg.nessie-catalog.authentication.type``
+    - The authentication type to use.
+      Available value is ``BEARER``. Defaults to no authentication.
+  * - ``iceberg.nessie-catalog.authentication.token``
+    - The token to use with ``BEARER`` authentication.
+      Example: ``SXVLUXUhIExFQ0tFUiEK``
 ```
 
 ```text

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -24,6 +24,7 @@
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
         <air.test.parallel>instances</air.test.parallel>
+        <dep.keycloak.version>21.1.2</dep.keycloak.version>
         <!-- Nessie version (matching to Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
         <dep.nessie.version>0.71.0</dep.nessie.version>
     </properties>
@@ -574,6 +575,30 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-admin-client-jakarta</artifactId>
+            <version>${dep.keycloak.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jaxb-provider</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                    <artifactId>jboss-jaxrs-api_3.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>${dep.keycloak.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogConfig.java
@@ -15,16 +15,25 @@ package io.trino.plugin.iceberg.catalog.nessie;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.projectnessie.client.NessieConfigConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
+import static org.projectnessie.client.NessieConfigConstants.DEFAULT_READ_TIMEOUT_MILLIS;
 
 public class IcebergNessieCatalogConfig
 {
     private String defaultReferenceName = "main";
     private String defaultWarehouseDir;
     private URI serverUri;
+    private Duration readTimeout = new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS);
+    private Duration connectionTimeout = new Duration(DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS);
+    private boolean enableCompression = true;
 
     @NotNull
     public String getDefaultReferenceName()
@@ -65,6 +74,47 @@ public class IcebergNessieCatalogConfig
     public IcebergNessieCatalogConfig setDefaultWarehouseDir(String defaultWarehouseDir)
     {
         this.defaultWarehouseDir = defaultWarehouseDir;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    @Config("iceberg.nessie-catalog.read-timeout")
+    @ConfigDescription("The read timeout for the client.")
+    public IcebergNessieCatalogConfig setReadTimeout(Duration readTimeout)
+    {
+        this.readTimeout = readTimeout;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getConnectionTimeout()
+    {
+        return connectionTimeout;
+    }
+
+    @Config("iceberg.nessie-catalog.connection-timeout")
+    @ConfigDescription("The connection timeout for the client.")
+    public IcebergNessieCatalogConfig setConnectionTimeout(Duration connectionTimeout)
+    {
+        this.connectionTimeout = connectionTimeout;
+        return this;
+    }
+
+    public boolean isCompressionEnabled()
+    {
+        return enableCompression;
+    }
+
+    @Config("iceberg.nessie-catalog.enable-compression")
+    @ConfigDescription("Configure whether compression should be enabled or not.")
+    public IcebergNessieCatalogConfig setCompressionEnabled(boolean enableCompression)
+    {
+        this.enableCompression = enableCompression;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogConfig.java
@@ -15,25 +15,37 @@ package io.trino.plugin.iceberg.catalog.nessie;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
+import java.util.Optional;
 
+import static io.trino.plugin.iceberg.catalog.nessie.IcebergNessieCatalogConfig.Security.BEARER;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.function.Predicate.isEqual;
 import static org.projectnessie.client.NessieConfigConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
 import static org.projectnessie.client.NessieConfigConstants.DEFAULT_READ_TIMEOUT_MILLIS;
 
 public class IcebergNessieCatalogConfig
 {
+    public enum Security
+    {
+        BEARER,
+    }
+
     private String defaultReferenceName = "main";
     private String defaultWarehouseDir;
     private URI serverUri;
     private Duration readTimeout = new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS);
     private Duration connectionTimeout = new Duration(DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS);
     private boolean enableCompression = true;
+    private Security security;
+    private Optional<String> bearerToken = Optional.empty();
 
     @NotNull
     public String getDefaultReferenceName()
@@ -116,5 +128,44 @@ public class IcebergNessieCatalogConfig
     {
         this.enableCompression = enableCompression;
         return this;
+    }
+
+    public Optional<Security> getSecurity()
+    {
+        return Optional.ofNullable(security);
+    }
+
+    @Config("iceberg.nessie-catalog.authentication.type")
+    @ConfigDescription("The authentication type to use")
+    public IcebergNessieCatalogConfig setSecurity(Security security)
+    {
+        this.security = security;
+        return this;
+    }
+
+    public Optional<String> getBearerToken()
+    {
+        return bearerToken;
+    }
+
+    @Config("iceberg.nessie-catalog.authentication.token")
+    @ConfigDescription("The token to use with BEARER authentication")
+    @ConfigSecuritySensitive
+    public IcebergNessieCatalogConfig setBearerToken(String token)
+    {
+        this.bearerToken = Optional.ofNullable(token);
+        return this;
+    }
+
+    @AssertTrue(message = "'iceberg.nessie-catalog.authentication.token' must be configured only with 'iceberg.nessie-catalog.authentication.type' BEARER")
+    public boolean isTokenConfiguredWithoutType()
+    {
+        return getSecurity().filter(isEqual(BEARER)).isPresent() || getBearerToken().isEmpty();
+    }
+
+    @AssertTrue(message = "'iceberg.nessie-catalog.authentication.token' must be configured with 'iceberg.nessie-catalog.authentication.type' BEARER")
+    public boolean isMissingTokenForBearerAuth()
+    {
+        return getSecurity().filter(isEqual(BEARER)).isEmpty() || getBearerToken().isPresent();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
@@ -23,6 +23,7 @@ import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import org.apache.iceberg.nessie.NessieIcebergClient;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.auth.BearerAuthenticationProvider;
 import org.projectnessie.client.http.HttpClientBuilder;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
@@ -51,6 +52,9 @@ public class IcebergNessieCatalogModule
                 .withDisableCompression(!icebergNessieCatalogConfig.isCompressionEnabled())
                 .withReadTimeout(toIntExact(icebergNessieCatalogConfig.getReadTimeout().toMillis()))
                 .withConnectionTimeout(toIntExact(icebergNessieCatalogConfig.getConnectionTimeout().toMillis()));
+
+        icebergNessieCatalogConfig.getBearerToken()
+                .ifPresent(token -> builder.withAuthentication(BearerAuthenticationProvider.create(token)));
 
         return new NessieIcebergClient(builder.build(NessieApiV1.class),
                 icebergNessieCatalogConfig.getDefaultReferenceName(),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
@@ -26,6 +26,7 @@ import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.lang.Math.toIntExact;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class IcebergNessieCatalogModule
@@ -45,10 +46,13 @@ public class IcebergNessieCatalogModule
     @Singleton
     public static NessieIcebergClient createNessieIcebergClient(IcebergNessieCatalogConfig icebergNessieCatalogConfig)
     {
-        return new NessieIcebergClient(
-                HttpClientBuilder.builder()
-                        .withUri(icebergNessieCatalogConfig.getServerUri())
-                        .build(NessieApiV1.class),
+        HttpClientBuilder builder = HttpClientBuilder.builder()
+                .withUri(icebergNessieCatalogConfig.getServerUri())
+                .withDisableCompression(!icebergNessieCatalogConfig.isCompressionEnabled())
+                .withReadTimeout(toIntExact(icebergNessieCatalogConfig.getReadTimeout().toMillis()))
+                .withConnectionTimeout(toIntExact(icebergNessieCatalogConfig.getConnectionTimeout().toMillis()));
+
+        return new NessieIcebergClient(builder.build(NessieApiV1.class),
                 icebergNessieCatalogConfig.getDefaultReferenceName(),
                 null,
                 ImmutableMap.of());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -288,6 +288,59 @@ public class TestIcebergPlugin
                 .shutdown();
     }
 
+    @Test
+    public void testNessieCatalogWithBearerAuth()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "nessie",
+                                "iceberg.nessie-catalog.default-warehouse-dir", "/tmp",
+                                "iceberg.nessie-catalog.uri", "http://foo:1234",
+                                "iceberg.nessie-catalog.authentication.type", "BEARER",
+                                "iceberg.nessie-catalog.authentication.token", "someToken"),
+                        new TestingConnectorContext())
+                .shutdown();
+    }
+
+    @Test
+    public void testNessieCatalogWithNoAuthAndAccessToken()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        assertThatThrownBy(() -> factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "nessie",
+                                "iceberg.nessie-catalog.uri", "nessieUri",
+                                "iceberg.nessie-catalog.default-warehouse-dir", "/tmp",
+                                "iceberg.nessie-catalog.authentication.token", "someToken"),
+                        new TestingConnectorContext())
+                .shutdown())
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining("'iceberg.nessie-catalog.authentication.token' must be configured only with 'iceberg.nessie-catalog.authentication.type' BEARER");
+    }
+
+    @Test
+    public void testNessieCatalogWithNoAccessToken()
+    {
+        ConnectorFactory factory = getConnectorFactory();
+
+        assertThatThrownBy(() -> factory.create(
+                        "test",
+                        Map.of(
+                                "iceberg.catalog.type", "nessie",
+                                "iceberg.nessie-catalog.uri", "nessieUri",
+                                "iceberg.nessie-catalog.default-warehouse-dir", "/tmp",
+                                "iceberg.nessie-catalog.authentication.type", "BEARER"),
+                        new TestingConnectorContext())
+                .shutdown())
+                .isInstanceOf(ApplicationConfigurationException.class)
+                .hasMessageContaining("'iceberg.nessie-catalog.authentication.token' must be configured with 'iceberg.nessie-catalog.authentication.type' BEARER");
+    }
+
     private static ConnectorFactory getConnectorFactory()
     {
         return getOnlyElement(new IcebergPlugin().getConnectorFactories());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
@@ -14,14 +14,19 @@
 package io.trino.plugin.iceberg.catalog.nessie;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.projectnessie.client.NessieConfigConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
+import static org.projectnessie.client.NessieConfigConstants.DEFAULT_READ_TIMEOUT_MILLIS;
 
 public class TestIcebergNessieCatalogConfig
 {
@@ -31,7 +36,10 @@ public class TestIcebergNessieCatalogConfig
         assertRecordedDefaults(recordDefaults(IcebergNessieCatalogConfig.class)
                 .setDefaultWarehouseDir(null)
                 .setServerUri(null)
-                .setDefaultReferenceName("main"));
+                .setDefaultReferenceName("main")
+                .setCompressionEnabled(true)
+                .setConnectionTimeout(new Duration(DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS))
+                .setReadTimeout(new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS)));
     }
 
     @Test
@@ -41,12 +49,18 @@ public class TestIcebergNessieCatalogConfig
                 .put("iceberg.nessie-catalog.default-warehouse-dir", "/tmp")
                 .put("iceberg.nessie-catalog.uri", "http://localhost:xxx/api/v1")
                 .put("iceberg.nessie-catalog.ref", "someRef")
+                .put("iceberg.nessie-catalog.enable-compression", "false")
+                .put("iceberg.nessie-catalog.connection-timeout", "2s")
+                .put("iceberg.nessie-catalog.read-timeout", "5m")
                 .buildOrThrow();
 
         IcebergNessieCatalogConfig expected = new IcebergNessieCatalogConfig()
                 .setDefaultWarehouseDir("/tmp")
                 .setServerUri(URI.create("http://localhost:xxx/api/v1"))
-                .setDefaultReferenceName("someRef");
+                .setDefaultReferenceName("someRef")
+                .setCompressionEnabled(false)
+                .setConnectionTimeout(new Duration(2, TimeUnit.SECONDS))
+                .setReadTimeout(new Duration(5, TimeUnit.MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConfig.java
@@ -39,7 +39,9 @@ public class TestIcebergNessieCatalogConfig
                 .setDefaultReferenceName("main")
                 .setCompressionEnabled(true)
                 .setConnectionTimeout(new Duration(DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS))
-                .setReadTimeout(new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS)));
+                .setReadTimeout(new Duration(DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS))
+                .setSecurity(null)
+                .setBearerToken(null));
     }
 
     @Test
@@ -52,6 +54,8 @@ public class TestIcebergNessieCatalogConfig
                 .put("iceberg.nessie-catalog.enable-compression", "false")
                 .put("iceberg.nessie-catalog.connection-timeout", "2s")
                 .put("iceberg.nessie-catalog.read-timeout", "5m")
+                .put("iceberg.nessie-catalog.authentication.type", "BEARER")
+                .put("iceberg.nessie-catalog.authentication.token", "bearerToken")
                 .buildOrThrow();
 
         IcebergNessieCatalogConfig expected = new IcebergNessieCatalogConfig()
@@ -60,7 +64,9 @@ public class TestIcebergNessieCatalogConfig
                 .setDefaultReferenceName("someRef")
                 .setCompressionEnabled(false)
                 .setConnectionTimeout(new Duration(2, TimeUnit.SECONDS))
-                .setReadTimeout(new Duration(5, TimeUnit.MINUTES));
+                .setReadTimeout(new Duration(5, TimeUnit.MINUTES))
+                .setSecurity(IcebergNessieCatalogConfig.Security.BEARER)
+                .setBearerToken("bearerToken");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogWithBearerAuth.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogWithBearerAuth.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.catalog.nessie;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.iceberg.IcebergQueryRunner;
+import io.trino.plugin.iceberg.containers.KeycloakContainer;
+import io.trino.plugin.iceberg.containers.NessieContainer;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+
+public class TestIcebergNessieCatalogWithBearerAuth
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Network network = closeAfterClass(Network.newNetwork());
+
+        KeycloakContainer keycloakContainer = closeAfterClass(KeycloakContainer.builder().withNetwork(network).build());
+        keycloakContainer.start();
+
+        Map<String, String> envVars = ImmutableMap.<String, String>builder()
+                .putAll(NessieContainer.DEFAULT_ENV_VARS)
+                .put("QUARKUS_OIDC_AUTH_SERVER_URL", KeycloakContainer.SERVER_URL + "/realms/master")
+                .put("QUARKUS_OIDC_CLIENT_ID", "projectnessie")
+                .put("NESSIE_SERVER_AUTHENTICATION_ENABLED", "true")
+                .buildOrThrow();
+
+        NessieContainer nessieContainer = closeAfterClass(NessieContainer.builder().withEnvVars(envVars).withNetwork(network).build());
+        nessieContainer.start();
+
+        Path tempDir = Files.createTempDirectory("test_trino_nessie_catalog");
+        closeAfterClass(() -> deleteRecursively(tempDir, ALLOW_INSECURE));
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.catalog.type", "nessie")
+                .put("iceberg.nessie-catalog.uri", nessieContainer.getRestApiUri())
+                .put("iceberg.nessie-catalog.default-warehouse-dir", tempDir.toString())
+                .put("iceberg.nessie-catalog.authentication.type", "BEARER")
+                .put("iceberg.nessie-catalog.authentication.token", keycloakContainer.getAccessToken())
+                .buildOrThrow();
+
+        return IcebergQueryRunner.builder()
+                .setBaseDataDir(Optional.of(tempDir))
+                .setIcebergProperties(properties)
+                .build();
+    }
+
+    @Test
+    public void testWithValidAccessToken()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_valid_access_token", "(a INT, b VARCHAR)", ImmutableList.of("(1, 'a')"))) {
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES(1, 'a')");
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/KeycloakContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/KeycloakContainer.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.containers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
+import io.trino.testing.containers.BaseTestContainer;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class KeycloakContainer
+        extends BaseTestContainer
+{
+    private static final Logger log = Logger.get(KeycloakContainer.class);
+
+    public static final String DEFAULT_IMAGE = "quay.io/keycloak/keycloak:21.1.2";
+    public static final String DEFAULT_HOST_NAME = "keycloak";
+
+    public static final String DEFAULT_USER_NAME = "admin";
+    public static final String DEFAULT_PASSWORD = "admin";
+
+    public static final int PORT = 8080;
+    public static final String SERVER_URL = "http://" + DEFAULT_HOST_NAME + ":" + PORT;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private KeycloakContainer(
+            String image,
+            String hostName,
+            Set<Integer> exposePorts,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int retryLimit)
+    {
+        super(image, hostName, exposePorts, filesToMount, envVars, network, retryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        withRunCommand(ImmutableList.of("start-dev"));
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        log.info("Keycloak container started with URL: %s", getUrl());
+    }
+
+    public String getUrl()
+    {
+        return "http://" + getMappedHostAndPortForExposedPort(PORT);
+    }
+
+    public String getAccessToken()
+    {
+        String realm = "master";
+        String clientId = "admin-cli";
+
+        try (Keycloak keycloak = KeycloakBuilder.builder()
+                .serverUrl(getUrl())
+                .realm(realm)
+                .clientId(clientId)
+                .username(DEFAULT_USER_NAME)
+                .password(DEFAULT_PASSWORD)
+                .build()) {
+            RealmResource master = keycloak.realms().realm(realm);
+            RealmRepresentation masterRep = master.toRepresentation();
+            // change access token lifespan from 1 minute (default) to 1 hour
+            // to keep the token alive in case testcase takes more than a minute to finish execution.
+            masterRep.setAccessTokenLifespan(3600);
+            master.update(masterRep);
+            return keycloak.tokenManager().grantToken().getToken();
+        }
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<KeycloakContainer.Builder, KeycloakContainer>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = DEFAULT_HOST_NAME;
+            this.exposePorts = ImmutableSet.of(PORT);
+            this.envVars = ImmutableMap.of(
+                    "KEYCLOAK_ADMIN", DEFAULT_USER_NAME,
+                    "KEYCLOAK_ADMIN_PASSWORD", DEFAULT_PASSWORD,
+                    "KC_HOSTNAME_URL", SERVER_URL);
+        }
+
+        @Override
+        public KeycloakContainer build()
+        {
+            return new KeycloakContainer(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -34,12 +34,23 @@ public class NessieContainer
 
     public static final int PORT = 19121;
 
+    public static final Map<String, String> DEFAULT_ENV_VARS = ImmutableMap.of(
+            "QUARKUS_HTTP_PORT", String.valueOf(PORT),
+            "NESSIE_VERSION_STORE_TYPE", VERSION_STORE_TYPE);
+
     public static Builder builder()
     {
         return new Builder();
     }
 
-    private NessieContainer(String image, String hostName, Set<Integer> exposePorts, Map<String, String> filesToMount, Map<String, String> envVars, Optional<Network> network, int retryLimit)
+    private NessieContainer(
+            String image,
+            String hostName,
+            Set<Integer> exposePorts,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int retryLimit)
     {
         super(image, hostName, exposePorts, filesToMount, envVars, network, retryLimit);
     }
@@ -64,7 +75,7 @@ public class NessieContainer
             this.image = DEFAULT_IMAGE;
             this.hostName = DEFAULT_HOST_NAME;
             this.exposePorts = ImmutableSet.of(PORT);
-            this.envVars = ImmutableMap.of("QUARKUS_HTTP_PORT", String.valueOf(PORT), "NESSIE_VERSION_STORE_TYPE", VERSION_STORE_TYPE);
+            this.envVars = DEFAULT_ENV_VARS;
         }
 
         @Override


### PR DESCRIPTION
## Description
Nessie server can be deployed with Auth mode like [keycloak](https://projectnessie.org/guides/keycloak/). 
So, need to expose the Nessie client configurations to handle the Auth. 
Along with that, some common Nessie server configurations like read-timeout-ms, 
connect-timeout-ms, and compression-enabled properties are exposed to have finer 
control over the Nessie commits. 

## Additional context and related issues
https://projectnessie.org/tools/client_config/

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for bearer authentication in the Nessie catalog. ({issue}`17725`)
```