### PR TITLE
Remove deprecated google Base64 class usage

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.api.client.util.Base64;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Supplier;
@@ -26,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Base64;
 import java.util.Optional;
 
 public class StaticBigQueryCredentialsSupplier
@@ -55,7 +55,7 @@ public class StaticBigQueryCredentialsSupplier
     private static Credentials createCredentialsFromKey(String key)
     {
         try {
-            return GoogleCredentials.fromStream(new ByteArrayInputStream(Base64.decodeBase64(key)));
+            return GoogleCredentials.fromStream(new ByteArrayInputStream(Base64.getDecoder().decode(key)));
         }
         catch (IOException e) {
             throw new UncheckedIOException("Failed to create Credentials from key", e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Replaces `com.google.api.client.util.Base64` usage with `java.util.Base64` which seems to be favored throughout the codebase.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
