### PR TITLE
Calculate Physical Input Byte Size for queries in MongoDB Connector

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -25,6 +25,9 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.mongodb.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
 
 import javax.inject.Singleton;
 
@@ -61,7 +64,12 @@ public class MongoClientModule
     @Provides
     public static MongoSession createMongoSession(TypeManager typeManager, MongoClientConfig config, Set<MongoClientSettingConfigurator> configurators)
     {
-        MongoClientSettings.Builder options = MongoClientSettings.builder();
+        CodecRegistry pojoCodecRegistry = CodecRegistries.fromRegistries(
+                MongoClientSettings.getDefaultCodecRegistry(),
+                CodecRegistries.fromProviders(PojoCodecProvider.builder().automatic(true).build()));
+
+        MongoClientSettings.Builder options = MongoClientSettings.builder()
+                .codecRegistry(pojoCodecRegistry);
         configurators.forEach(configurator -> configurator.configure(options));
         MongoClient client = MongoClients.create(options.build());
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -18,7 +18,6 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.mongodb.ConnectionString;
-import com.mongodb.DBRefCodecProvider;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -26,10 +25,6 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.mongodb.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
-import org.bson.codecs.configuration.CodecRegistries;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.codecs.pojo.Conventions;
-import org.bson.codecs.pojo.PojoCodecProvider;
 
 import javax.inject.Singleton;
 
@@ -43,15 +38,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class MongoClientModule
         extends AbstractConfigurationAwareModule
 {
-    private final CodecRegistry codecRegistry = CodecRegistries.fromRegistries(
-            MongoClientSettings.getDefaultCodecRegistry(),
-            CodecRegistries.fromProviders(
-                    PojoCodecProvider.builder()
-                            .conventions(Conventions.DEFAULT_CONVENTIONS)
-                            .automatic(true)
-                            .build(),
-                    new DBRefCodecProvider()));
-
     @Override
     public void setup(Binder binder)
     {
@@ -105,7 +91,6 @@ public class MongoClientModule
                 options.applyToClusterSettings(builder -> builder.requiredReplicaSetName(config.getRequiredReplicaSetName()));
             }
             options.applyConnectionString(new ConnectionString(config.getConnectionUrl()));
-            options.codecRegistry(codecRegistry);
         };
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.ProvidesIntoSet;
 import com.mongodb.ConnectionString;
+import com.mongodb.DBRefCodecProvider;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -25,6 +26,10 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.mongodb.ptf.Query;
 import io.trino.spi.ptf.ConnectorTableFunction;
 import io.trino.spi.type.TypeManager;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.Conventions;
+import org.bson.codecs.pojo.PojoCodecProvider;
 
 import javax.inject.Singleton;
 
@@ -38,6 +43,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class MongoClientModule
         extends AbstractConfigurationAwareModule
 {
+    private final CodecRegistry codecRegistry = CodecRegistries.fromRegistries(
+            MongoClientSettings.getDefaultCodecRegistry(),
+            CodecRegistries.fromProviders(
+                    PojoCodecProvider.builder()
+                            .conventions(Conventions.DEFAULT_CONVENTIONS)
+                            .automatic(true)
+                            .build(),
+                    new DBRefCodecProvider()));
+
     @Override
     public void setup(Binder binder)
     {
@@ -91,6 +105,7 @@ public class MongoClientModule
                 options.applyToClusterSettings(builder -> builder.requiredReplicaSetName(config.getRequiredReplicaSetName()));
             }
             options.applyConnectionString(new ConnectionString(config.getConnectionUrl()));
+            options.codecRegistry(codecRegistry);
         };
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -44,6 +44,7 @@ import org.joda.time.chrono.ISOChronology;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -94,6 +95,7 @@ public class MongoPageSource
     private final List<Type> columnTypes;
     private Document currentDoc;
     private boolean finished;
+    private long totalBytes;
 
     private final PageBuilder pageBuilder;
 
@@ -113,7 +115,7 @@ public class MongoPageSource
     @Override
     public long getCompletedBytes()
     {
-        return 0;
+        return totalBytes;
     }
 
     @Override
@@ -144,6 +146,7 @@ public class MongoPageSource
                 break;
             }
             currentDoc = cursor.next();
+            totalBytes += currentDoc.toJson().getBytes(StandardCharsets.UTF_8).length;
 
             pageBuilder.declarePosition();
             for (int column = 0; column < columnTypes.size(); column++) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -44,7 +44,6 @@ import org.joda.time.chrono.ISOChronology;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -82,6 +81,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Math.multiplyExact;
 import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 
 public class MongoPageSource
@@ -146,7 +146,7 @@ public class MongoPageSource
                 break;
             }
             currentDoc = cursor.next();
-            totalBytes += currentDoc.toJson().getBytes(StandardCharsets.UTF_8).length;
+            totalBytes += currentDoc.toBsonDocument().toJson().getBytes(UTF_8).length;
 
             pageBuilder.declarePosition();
             for (int column = 0; column < columnTypes.size(); column++) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes #17713
Currently the MongoDB Connector returns 0 for the getCompletedBytes() in the PageSource implementation.
The suggested approach is to capture the total bytes by take the JSON String representation of the Mongo Document and converting it into a bytes array and simply taking it's length.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
N/A


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
