### PR TITLE
Remove redundant configuration in HiveQueryRunner: setSecurity

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -287,7 +287,7 @@ public final class HiveQueryRunner
         {
             if (metastore.getDatabase(TPCH_SCHEMA).isEmpty()) {
                 metastore.createDatabase(createDatabaseMetastoreObject(TPCH_SCHEMA, initialSchemasLocationBase));
-                Session session = initialTablesSessionMutator.apply(createSession(Optional.empty()));
+                Session session = initialTablesSessionMutator.apply(queryRunner.getDefaultSession());
                 copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, initialTables);
             }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.inject.Module;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -122,12 +123,14 @@ public final class HiveQueryRunner
             super(defaultSession);
         }
 
+        @CanIgnoreReturnValue
         public SELF setSkipTimezoneSetup(boolean skipTimezoneSetup)
         {
             this.skipTimezoneSetup = skipTimezoneSetup;
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setHiveProperties(Map<String, String> hiveProperties)
         {
             this.hiveProperties = ImmutableMap.<String, String>builder()
@@ -135,72 +138,84 @@ public final class HiveQueryRunner
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF addHiveProperty(String key, String value)
         {
             this.hiveProperties.put(key, value);
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setInitialTables(Iterable<TpchTable<?>> initialTables)
         {
             this.initialTables = ImmutableList.copyOf(requireNonNull(initialTables, "initialTables is null"));
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setInitialSchemasLocationBase(String initialSchemasLocationBase)
         {
             this.initialSchemasLocationBase = Optional.of(initialSchemasLocationBase);
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setInitialTablesSessionMutator(Function<Session, Session> initialTablesSessionMutator)
         {
             this.initialTablesSessionMutator = requireNonNull(initialTablesSessionMutator, "initialTablesSessionMutator is null");
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setMetastore(Function<DistributedQueryRunner, HiveMetastore> metastore)
         {
             this.metastore = requireNonNull(metastore, "metastore is null");
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setModule(Module module)
         {
             this.module = requireNonNull(module, "module is null");
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setDirectoryLister(DirectoryLister directoryLister)
         {
             this.directoryLister = Optional.ofNullable(directoryLister);
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setTpcdsCatalogEnabled(boolean tpcdsCatalogEnabled)
         {
             this.tpcdsCatalogEnabled = tpcdsCatalogEnabled;
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setTpchBucketedCatalogEnabled(boolean tpchBucketedCatalogEnabled)
         {
             this.tpchBucketedCatalogEnabled = tpchBucketedCatalogEnabled;
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setCreateTpchSchemas(boolean createTpchSchemas)
         {
             this.createTpchSchemas = createTpchSchemas;
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setTpchColumnNaming(ColumnNaming tpchColumnNaming)
         {
             this.tpchColumnNaming = requireNonNull(tpchColumnNaming, "tpchColumnNaming is null");
             return self();
         }
 
+        @CanIgnoreReturnValue
         public SELF setTpchDecimalTypeMapping(DecimalTypeMapping tpchDecimalTypeMapping)
         {
             this.tpchDecimalTypeMapping = requireNonNull(tpchDecimalTypeMapping, "tpchDecimalTypeMapping is null");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -108,7 +108,6 @@ public final class HiveQueryRunner
         private Optional<DirectoryLister> directoryLister = Optional.empty();
         private boolean tpcdsCatalogEnabled;
         private boolean tpchBucketedCatalogEnabled;
-        private String security = SQL_STANDARD;
         private boolean createTpchSchemas = true;
         private ColumnNaming tpchColumnNaming = SIMPLIFIED;
         private DecimalTypeMapping tpchDecimalTypeMapping = DOUBLE;
@@ -190,12 +189,6 @@ public final class HiveQueryRunner
             return self();
         }
 
-        public SELF setSecurity(String security)
-        {
-            this.security = requireNonNull(security, "security is null");
-            return self();
-        }
-
         public SELF setCreateTpchSchemas(boolean createTpchSchemas)
         {
             this.createTpchSchemas = createTpchSchemas;
@@ -246,7 +239,7 @@ public final class HiveQueryRunner
                 }
                 hiveProperties.put("hive.max-partitions-per-scan", "1000");
                 hiveProperties.put("hive.max-partitions-for-eager-load", "1000");
-                hiveProperties.put("hive.security", security);
+                hiveProperties.put("hive.security", SQL_STANDARD);
                 hiveProperties.putAll(this.hiveProperties.buildOrThrow());
 
                 if (tpchBucketedCatalogEnabled) {
@@ -401,12 +394,12 @@ public final class HiveQueryRunner
 
         DistributedQueryRunner queryRunner = HiveQueryRunner.builder()
                 .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                .setHiveProperties(ImmutableMap.of("hive.security", ALLOW_ALL))
                 .setSkipTimezoneSetup(true)
                 .setHiveProperties(ImmutableMap.of())
                 .setInitialTables(TpchTable.getTables())
                 .setBaseDataDir(baseDataDir)
                 .setTpcdsCatalogEnabled(true)
-                .setSecurity(ALLOW_ALL)
                 // Uncomment to enable standard column naming (column names to be prefixed with the first letter of the table name, e.g.: o_orderkey vs orderkey)
                 // and standard column types (decimals vs double for some columns). This will allow running unmodified tpch queries on the cluster.
                 //.setTpchColumnNaming(ColumnNaming.STANDARD)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileBasedSecurity.java
@@ -40,6 +40,7 @@ public class TestHiveFileBasedSecurity
     {
         String path = new File(Resources.getResource(getClass(), "security.json").toURI()).getPath();
         queryRunner = HiveQueryRunner.builder()
+                .amendSession(session -> session.setIdentity(Identity.ofUser("hive")))
                 .setHiveProperties(ImmutableMap.of(
                         "hive.security", "file",
                         "security.config-file", path))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.s3;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveQueryRunner;
@@ -94,42 +95,49 @@ public final class S3HiveQueryRunner
         private String s3SecretKey;
         private String bucketName;
 
+        @CanIgnoreReturnValue
         public Builder setHiveMetastoreEndpoint(HostAndPort hiveMetastoreEndpoint)
         {
             this.hiveMetastoreEndpoint = requireNonNull(hiveMetastoreEndpoint, "hiveMetastoreEndpoint is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setThriftMetastoreTimeout(Duration thriftMetastoreTimeout)
         {
             this.thriftMetastoreTimeout = requireNonNull(thriftMetastoreTimeout, "thriftMetastoreTimeout is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setThriftMetastoreConfig(ThriftMetastoreConfig thriftMetastoreConfig)
         {
             this.thriftMetastoreConfig = requireNonNull(thriftMetastoreConfig, "thriftMetastoreConfig is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setS3Endpoint(String s3Endpoint)
         {
             this.s3Endpoint = requireNonNull(s3Endpoint, "s3Endpoint is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setS3AccessKey(String s3AccessKey)
         {
             this.s3AccessKey = requireNonNull(s3AccessKey, "s3AccessKey is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setS3SecretKey(String s3SecretKey)
         {
             this.s3SecretKey = requireNonNull(s3SecretKey, "s3SecretKey is null");
             return this;
         }
 
+        @CanIgnoreReturnValue
         public Builder setBucketName(String bucketName)
         {
             this.bucketName = requireNonNull(bucketName, "bucketName is null");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -170,9 +170,9 @@ public final class S3HiveQueryRunner
 
         DistributedQueryRunner queryRunner = S3HiveQueryRunner.builder(hiveMinioDataLake)
                 .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
+                .setHiveProperties(ImmutableMap.of("hive.security", ALLOW_ALL))
                 .setSkipTimezoneSetup(true)
                 .setInitialTables(TpchTable.getTables())
-                .setSecurity(ALLOW_ALL)
                 .build();
         Logger log = Logger.get(S3HiveQueryRunner.class);
         log.info("======== SERVER STARTED ========");


### PR DESCRIPTION
`hive.security` can be configured just as any other properties.
