### PR TITLE
Increase max possible value for write.batch-size

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcWriteConfig.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.Min;
 
 public class JdbcWriteConfig
 {
-    static final int MAX_ALLOWED_WRITE_BATCH_SIZE = 1_000_000;
+    public static final int MAX_ALLOWED_WRITE_BATCH_SIZE = 10_000_000;
 
     private int writeBatchSize = 1000;
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcWriteConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcWriteConfig.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.jdbc.JdbcWriteConfig.MAX_ALLOWED_WRITE_BATCH_SIZE;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -58,6 +59,9 @@ public class TestJdbcWriteConfig
 
         assertThatThrownBy(() -> makeConfig(ImmutableMap.of("write.batch-size", "0")))
                 .hasMessageContaining("write.batch-size: must be greater than or equal to 1");
+
+        assertThatThrownBy(() -> makeConfig(ImmutableMap.of("write.batch-size", String.valueOf(MAX_ALLOWED_WRITE_BATCH_SIZE + 1))))
+                .hasMessageContaining("write.batch-size: must be less than or equal to");
 
         assertThatCode(() -> makeConfig(ImmutableMap.of("write.batch-size", "1")))
                 .doesNotThrowAnyException();


### PR DESCRIPTION
Increase max possible value for write.batch-size

In some cases it is desired to have bigger batches.
