### PR TITLE
Update airbase to 140

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -147,7 +147,8 @@ public class Console
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             exiting.set(true);
             interruptor.interrupt();
-            awaitUninterruptibly(exited, EXIT_DELAY.toMillis(), MILLISECONDS);
+            @SuppressWarnings("CheckReturnValue")
+            boolean ignored = awaitUninterruptibly(exited, EXIT_DELAY.toMillis(), MILLISECONDS);
             // Terminal closing restores terminal settings and releases underlying system resources
             closeTerminal();
         }));

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/split/HudiBackgroundSplitLoader.java
@@ -74,7 +74,7 @@ public class HudiBackgroundSplitLoader
                             .map(partition -> Futures.submit(() -> loadSplits(partition), executor))
                             .peek(this::hookErrorListener)
                             .collect(Collectors.toList());
-                    Futures.whenAllComplete(futures).run(asyncQueue::finish, directExecutor());
+                    hookErrorListener(Futures.whenAllComplete(futures).run(asyncQueue::finish, directExecutor()));
                     return null;
                 },
                 directExecutor());

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/util/TestPrioritizedFifoExecutor.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/util/TestPrioritizedFifoExecutor.java
@@ -70,7 +70,8 @@ public class TestPrioritizedFifoExecutor
             futures.add(executor.submit(() -> {
                 try {
                     // wait for the go signal
-                    awaitUninterruptibly(startLatch, 1, TimeUnit.MINUTES);
+                    @SuppressWarnings("CheckReturnValue")
+                    boolean ignored = awaitUninterruptibly(startLatch, 1, TimeUnit.MINUTES);
 
                     assertFalse(futures.get(taskNumber).isDone());
 
@@ -90,7 +91,8 @@ public class TestPrioritizedFifoExecutor
 
         // signal go and wait for tasks to complete
         startLatch.countDown();
-        awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES);
+        @SuppressWarnings("CheckReturnValue")
+        boolean ignored = awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES);
 
         assertEquals(counter.get(), totalTasks);
         // since this is a fifo executor with one thread and completeLatch is decremented inside the future,
@@ -142,7 +144,8 @@ public class TestPrioritizedFifoExecutor
 
         // signal go and wait for tasks to complete
         startLatch.countDown();
-        awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES);
+        @SuppressWarnings("CheckReturnValue")
+        boolean ignored = awaitUninterruptibly(completeLatch, 1, TimeUnit.MINUTES);
 
         assertFalse(failed.get());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>139</version>
+        <version>140</version>
     </parent>
 
     <groupId>io.trino</groupId>


### PR DESCRIPTION
This change makes it possible to build project with `project.build.targetJdk` 21.

The only remaining maven infrastructure bit that doesn't work under JDK 21 is error-prone but the current HEAD fixes those problems so it's a matter of updating error-prone when the next version is released.

This also brings Guava to version `32.0.0` (https://github.com/google/guava/releases/tag/v32.0.0)