### PR TITLE
Increase S3 connection pool size for Delta Lake tests

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMinioAndHmsConnectorSmokeTest.java
@@ -71,7 +71,7 @@ public class TestDeltaLakeMinioAndHmsConnectorSmokeTest
                 .put("s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress())
                 .put("s3.path-style-access", "true")
                 .put("s3.streaming.part-size", "5MB") // minimize memory usage
-                .put("s3.max-connections", "2") // verify no leaks
+                .put("s3.max-connections", "4") // verify no leaks
                 .put("delta.enable-non-concurrent-writes", "true")
                 .buildOrThrow();
     }


### PR DESCRIPTION
The tests sporadically fail in the CI with the smaller value.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
