### PR TITLE
add support of kerberos authentication for exchange hdfs

### DIFF
--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -24,12 +24,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-hadoop-toolkit</artifactId>
+            <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-plugin-toolkit</artifactId>
+            <artifactId>trino-hdfs</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
@@ -13,27 +13,21 @@
  */
 package io.trino.plugin.exchange.hdfs;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
-import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
-import java.io.File;
-import java.util.List;
-
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class ExchangeHdfsConfig
 {
     private DataSize hdfsStorageBlockSize = DataSize.of(4, MEGABYTE);
-    private List<File> resourceConfigFiles = ImmutableList.of();
+    private Optional<String> hdfsProxyUser = Optional.empty();
 
     @NotNull
     @MinDataSize("4MB")
@@ -51,18 +45,15 @@ public class ExchangeHdfsConfig
         return this;
     }
 
-    @NotNull
-    public List<@FileExists File> getResourceConfigFiles()
+    public Optional<String> getHdfsProxyUser()
     {
-        return resourceConfigFiles;
+        return hdfsProxyUser;
     }
 
-    @Config("hdfs.config.resources")
-    public ExchangeHdfsConfig setResourceConfigFiles(String files)
+    @Config("hdfs.proxy-user")
+    public ExchangeHdfsConfig setHdfsProxyUser(String hdfsProxyUser)
     {
-        this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files).stream()
-                .map(File::new)
-                .collect(toImmutableList());
+        this.hdfsProxyUser = Optional.ofNullable(hdfsProxyUser);
         return this;
     }
 }

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsEnvironment.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsEnvironment.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.hdfs;
+
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExchangeHdfsEnvironment {
+
+    private final HdfsEnvironment hdfsEnvironment;
+    private final ExchangeHdfsConfig exchangeHdfsConfig;
+
+    @Inject
+    public ExchangeHdfsEnvironment(ExchangeHdfsConfig exchangeHdfsConfig, HdfsEnvironment hdfsEnvironment)
+    {
+        this.exchangeHdfsConfig = requireNonNull(exchangeHdfsConfig, "exchangeHdfsConfig is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    public FileSystem getFileSystem(Path path)
+            throws IOException
+    {
+        ClassLoader classLoader = ExchangeHdfsEnvironment.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            HdfsContext hdfsContext = new HdfsContext(ConnectorIdentity.forUser(exchangeHdfsConfig.getHdfsProxyUser().orElse("")).build());
+            return hdfsEnvironment.getFileSystem(hdfsContext, path);
+        }
+    }
+}

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
@@ -23,7 +23,6 @@ import io.trino.plugin.exchange.filesystem.ExchangeStorageReader;
 import io.trino.plugin.exchange.filesystem.ExchangeStorageWriter;
 import io.trino.plugin.exchange.filesystem.FileStatus;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeStorage;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
@@ -33,7 +32,6 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -42,12 +40,10 @@ import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Queue;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.slice.SizeOf.instanceSize;
-import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -55,18 +51,12 @@ public class HadoopFileSystemExchangeStorage
         implements FileSystemExchangeStorage
 {
     private final int blockSize;
-    private final FileSystem fileSystem;
+    private final ExchangeHdfsEnvironment exchangeHdfsEnvironment;
 
     @Inject
-    public HadoopFileSystemExchangeStorage(ExchangeHdfsConfig config)
-            throws IOException
+    public HadoopFileSystemExchangeStorage(ExchangeHdfsConfig config, ExchangeHdfsEnvironment exchangeHdfsEnvironment)
     {
-        Configuration hdfsConfig = newEmptyConfiguration();
-        for (File resourcePath : config.getResourceConfigFiles()) {
-            checkArgument(resourcePath.exists(), "File does not exist: %s", resourcePath);
-            hdfsConfig.addResource(new Path(resourcePath.getPath()));
-        }
-        fileSystem = FileSystem.get(hdfsConfig);
+        this.exchangeHdfsEnvironment = requireNonNull(exchangeHdfsEnvironment, "exchangeHdfsEnvironment is null");
         blockSize = toIntExact(config.getHdfsStorageBlockSize().toBytes());
     }
 
@@ -74,26 +64,30 @@ public class HadoopFileSystemExchangeStorage
     public void createDirectories(URI dir)
             throws IOException
     {
-        fileSystem.mkdirs(new Path(dir));
+        Path path = new Path(dir);
+        FileSystem fileSystem = exchangeHdfsEnvironment.getFileSystem(path);
+        fileSystem.mkdirs(path);
     }
 
     @Override
     public ExchangeStorageReader createExchangeStorageReader(List<ExchangeSourceFile> sourceFiles, int maxPageStorageSize)
     {
-        return new HadoopExchangeStorageReader(fileSystem, sourceFiles, blockSize);
+        return new HadoopExchangeStorageReader(exchangeHdfsEnvironment, sourceFiles, blockSize);
     }
 
     @Override
     public ExchangeStorageWriter createExchangeStorageWriter(URI file)
     {
-        return new HadoopExchangeStorageWriter(fileSystem, file);
+        return new HadoopExchangeStorageWriter(exchangeHdfsEnvironment, file);
     }
 
     @Override
     public ListenableFuture<Void> createEmptyFile(URI file)
     {
         try {
-            fileSystem.createNewFile(new Path(file));
+            Path path = new Path(file);
+            FileSystem fileSystem = exchangeHdfsEnvironment.getFileSystem(path);
+            fileSystem.createNewFile(path);
         }
         catch (IOException e) {
             return immediateFailedFuture(e);
@@ -106,7 +100,9 @@ public class HadoopFileSystemExchangeStorage
     {
         for (URI dir : directories) {
             try {
-                fileSystem.delete(new Path(dir), true);
+                Path path = new Path(dir);
+                FileSystem fileSystem = exchangeHdfsEnvironment.getFileSystem(path);
+                fileSystem.delete(path, true);
             }
             catch (IOException | RuntimeException e) {
                 return immediateFailedFuture(e);
@@ -120,6 +116,8 @@ public class HadoopFileSystemExchangeStorage
     {
         ImmutableList.Builder<FileStatus> builder = ImmutableList.builder();
         try {
+            Path path = new Path(dir);
+            FileSystem fileSystem = exchangeHdfsEnvironment.getFileSystem(path);
             RemoteIterator<LocatedFileStatus> fileStatusListIterator = fileSystem.listFiles(
                     new Path(dir), true);
             while (fileStatusListIterator.hasNext()) {
@@ -150,7 +148,7 @@ public class HadoopFileSystemExchangeStorage
     {
         private static final int INSTANCE_SIZE = instanceSize(HadoopExchangeStorageReader.class);
 
-        private final FileSystem fileSystem;
+        private final ExchangeHdfsEnvironment exchangeHdfsEnvironment;
         @GuardedBy("this")
         private final Queue<ExchangeSourceFile> sourceFiles;
         private final int blockSize;
@@ -160,9 +158,9 @@ public class HadoopFileSystemExchangeStorage
         @GuardedBy("this")
         private boolean closed;
 
-        public HadoopExchangeStorageReader(FileSystem fileSystem, List<ExchangeSourceFile> sourceFiles, int blockSize)
+        public HadoopExchangeStorageReader(ExchangeHdfsEnvironment exchangeHdfsEnvironment, List<ExchangeSourceFile> sourceFiles, int blockSize)
         {
-            this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
+            this.exchangeHdfsEnvironment = requireNonNull(exchangeHdfsEnvironment, "exchangeHdfsEnvironment is null");
             this.sourceFiles = new ArrayDeque<>(requireNonNull(sourceFiles, "sourceFiles is null"));
             this.blockSize = blockSize;
         }
@@ -224,7 +222,7 @@ public class HadoopFileSystemExchangeStorage
                 throws IOException
         {
             Path fileURL = new Path(sourceFile.getFileUri());
-            return new InputStreamSliceInput(fileSystem.open(fileURL), blockSize);
+            return new InputStreamSliceInput(exchangeHdfsEnvironment.getFileSystem(fileURL).open(fileURL), blockSize);
         }
     }
 
@@ -235,10 +233,11 @@ public class HadoopFileSystemExchangeStorage
         private static final int INSTANCE_SIZE = instanceSize(HadoopExchangeStorageReader.class);
         private final OutputStream outputStream;
 
-        public HadoopExchangeStorageWriter(FileSystem fileSystem, URI file)
+        public HadoopExchangeStorageWriter(ExchangeHdfsEnvironment exchangeHdfsEnvironment, URI file)
         {
             try {
-                this.outputStream = fileSystem.create(new Path(file), true);
+                Path path = new Path(file);
+                this.outputStream = exchangeHdfsEnvironment.getFileSystem(path).create(path, true);
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
@@ -15,6 +15,8 @@ package io.trino.plugin.exchange.hdfs;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
+import io.trino.hdfs.HdfsModule;
+import io.trino.hdfs.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeManager;
@@ -46,6 +48,8 @@ public class HdfsExchangeManagerFactory
                 new MBeanModule(),
                 new MBeanServerModule(),
                 new PrefixObjectNameGeneratorModule("io.trino.plugin.exchange.hdfs", "trino.plugin.exchange.hdfs"),
+                new HdfsModule(),
+                new HdfsAuthenticationModule(),
                 new HdfsExchangeModule());
 
         Injector injector = app

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
@@ -51,6 +51,7 @@ public class HdfsExchangeModule
         if (scheme.equalsIgnoreCase("hdfs")) {
             binder.bind(FileSystemExchangeStorage.class).to(HadoopFileSystemExchangeStorage.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(ExchangeHdfsConfig.class);
+            binder.bind(ExchangeHdfsEnvironment.class).in(Scopes.SINGLETON);
         }
         else {
             binder.addError(new TrinoException(NOT_SUPPORTED,

--- a/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
@@ -18,8 +18,6 @@ import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -33,7 +31,6 @@ public class TestExchangeHdfsConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ExchangeHdfsConfig.class)
-                .setResourceConfigFiles("")
                 .setHdfsStorageBlockSize(DataSize.of(4, MEGABYTE)));
     }
 
@@ -41,16 +38,12 @@ public class TestExchangeHdfsConfig
     public void testExplicitPropertyMappings()
             throws IOException
     {
-        Path resource1 = Files.createTempFile(null, null);
-        Path resource2 = Files.createTempFile(null, null);
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("hdfs.config.resources", resource1 + "," + resource2)
                 .put("exchange.hdfs.block-size", "8MB")
                 .buildOrThrow();
 
         ExchangeHdfsConfig expected = new ExchangeHdfsConfig()
-                .setResourceConfigFiles(resource1 + "," + resource2)
                 .setHdfsStorageBlockSize(DataSize.of(8, MEGABYTE));
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
add support of kerberos authentication for exchange hdfs plugin


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Exchange hdfs plugin not support kerberos authentication when the hdfs environment using kerberos auth，
so the plugin need to resolve it through  integration of trino-hdfs lib


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Support kerberos authentication for exchange hdfs
```
