### PR TITLE
Add support for exchange hdfs kerberos authentication

### DIFF
--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -24,7 +24,7 @@
 
         <dependency>
             <groupId>io.trino</groupId>
-            <artifactId>trino-hadoop-toolkit</artifactId>
+            <artifactId>trino-hdfs</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsConfig.java
@@ -13,27 +13,22 @@
  */
 package io.trino.plugin.exchange.hdfs;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
-import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.DataSize;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 
 import javax.validation.constraints.NotNull;
 
-import java.io.File;
-import java.util.List;
+import java.util.Optional;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class ExchangeHdfsConfig
 {
     private DataSize hdfsStorageBlockSize = DataSize.of(4, MEGABYTE);
-    private List<File> resourceConfigFiles = ImmutableList.of();
+    private Optional<String> hdfsProxyUser = Optional.empty();
 
     @NotNull
     @MinDataSize("4MB")
@@ -51,18 +46,16 @@ public class ExchangeHdfsConfig
         return this;
     }
 
-    @NotNull
-    public List<@FileExists File> getResourceConfigFiles()
+    public Optional<String> getHdfsProxyUser()
     {
-        return resourceConfigFiles;
+        return hdfsProxyUser;
     }
 
-    @Config("hdfs.config.resources")
-    public ExchangeHdfsConfig setResourceConfigFiles(String files)
+    @Config("exchange.hdfs.proxy-user")
+    @ConfigDescription("Proxy user for HDFS storage")
+    public ExchangeHdfsConfig setHdfsProxyUser(String hdfsProxyUser)
     {
-        this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files).stream()
-                .map(File::new)
-                .collect(toImmutableList());
+        this.hdfsProxyUser = Optional.ofNullable(hdfsProxyUser);
         return this;
     }
 }

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsEnvironment.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/ExchangeHdfsEnvironment.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.exchange.hdfs;
+
+import com.google.inject.Inject;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExchangeHdfsEnvironment
+{
+    private final HdfsEnvironment hdfsEnvironment;
+    private final ExchangeHdfsConfig exchangeHdfsConfig;
+
+    @Inject
+    public ExchangeHdfsEnvironment(ExchangeHdfsConfig exchangeHdfsConfig, HdfsEnvironment hdfsEnvironment)
+    {
+        this.exchangeHdfsConfig = requireNonNull(exchangeHdfsConfig, "exchangeHdfsConfig is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    public FileSystem getFileSystem(Path path)
+            throws IOException
+    {
+        ClassLoader classLoader = ExchangeHdfsEnvironment.class.getClassLoader();
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            HdfsContext hdfsContext = new HdfsContext(ConnectorIdentity.forUser(exchangeHdfsConfig.getHdfsProxyUser().orElse("")).build());
+            return hdfsEnvironment.getFileSystem(hdfsContext, path);
+        }
+    }
+}

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeManagerFactory.java
@@ -15,6 +15,8 @@ package io.trino.plugin.exchange.hdfs;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
+import io.trino.hdfs.HdfsModule;
+import io.trino.hdfs.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.base.jmx.MBeanServerModule;
 import io.trino.plugin.base.jmx.PrefixObjectNameGeneratorModule;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeManager;
@@ -46,6 +48,8 @@ public class HdfsExchangeManagerFactory
                 new MBeanModule(),
                 new MBeanServerModule(),
                 new PrefixObjectNameGeneratorModule("io.trino.plugin.exchange.hdfs", "trino.plugin.exchange.hdfs"),
+                new HdfsModule(),
+                new HdfsAuthenticationModule(),
                 new HdfsExchangeModule());
 
         Injector injector = app

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HdfsExchangeModule.java
@@ -51,6 +51,7 @@ public class HdfsExchangeModule
         if (scheme.equalsIgnoreCase("hdfs")) {
             binder.bind(FileSystemExchangeStorage.class).to(HadoopFileSystemExchangeStorage.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(ExchangeHdfsConfig.class);
+            binder.bind(ExchangeHdfsEnvironment.class).in(Scopes.SINGLETON);
         }
         else {
             binder.addError(new TrinoException(NOT_SUPPORTED,

--- a/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
+++ b/plugin/trino-exchange-hdfs/src/test/java/io/trino/plugin/exchange/hdfs/TestExchangeHdfsConfig.java
@@ -17,9 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -33,24 +30,20 @@ public class TestExchangeHdfsConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(ExchangeHdfsConfig.class)
-                .setResourceConfigFiles("")
+                .setHdfsProxyUser(null)
                 .setHdfsStorageBlockSize(DataSize.of(4, MEGABYTE)));
     }
 
     @Test
     public void testExplicitPropertyMappings()
-            throws IOException
     {
-        Path resource1 = Files.createTempFile(null, null);
-        Path resource2 = Files.createTempFile(null, null);
-
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("hdfs.config.resources", resource1 + "," + resource2)
+                .put("exchange.hdfs.proxy-user", "work")
                 .put("exchange.hdfs.block-size", "8MB")
                 .buildOrThrow();
 
         ExchangeHdfsConfig expected = new ExchangeHdfsConfig()
-                .setResourceConfigFiles(resource1 + "," + resource2)
+                .setHdfsProxyUser("work")
                 .setHdfsStorageBlockSize(DataSize.of(8, MEGABYTE));
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
add support for exchange hdfs plugin with kerberos authentication


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Exchange hdfs plugin not support kerberos authentication when the hdfs environment using kerberos auth，
so the plugin need to resolve it through integration of trino-hdfs lib


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Fault-tolerant execution
* Support kerberos authentication for exchange hdfs
```
