### PR TITLE
Support LZ4 compression in optimized parquet writer

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -190,11 +190,6 @@ public final class DeltaLakeSessionProperties
                         "Compression codec to use when writing new data files",
                         HiveCompressionCodec.class,
                         deltaLakeConfig.getCompressionCodec(),
-                        value -> {
-                            if (value == HiveCompressionCodec.LZ4) {
-                                throw new TrinoException(INVALID_SESSION_PROPERTY, "Unsupported codec: LZ4");
-                            }
-                        },
                         false),
                 booleanProperty(
                         PROJECTION_PUSHDOWN_ENABLED,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2078,10 +2078,6 @@ public abstract class BaseHiveConnectorTest
                 if ((storageFormat == HiveStorageFormat.AVRO) && (compressionCodec == HiveCompressionCodec.LZ4)) {
                     continue;
                 }
-                if ((storageFormat == HiveStorageFormat.PARQUET) && (compressionCodec == HiveCompressionCodec.LZ4)) {
-                    // TODO (https://github.com/trinodb/trino/issues/9142) Support LZ4 compression with native Parquet writer
-                    continue;
-                }
                 testEmptyBucketedTable(storageFormat, compressionCodec, true);
             }
             testEmptyBucketedTable(storageFormat, HiveCompressionCodec.GZIP, false);
@@ -7723,13 +7719,6 @@ public abstract class BaseHiveConnectorTest
     public void testCreateTableWithCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         testWithAllStorageFormats((session, hiveStorageFormat) -> {
-            if (isNativeParquetWriter(session, hiveStorageFormat) && compressionCodec == HiveCompressionCodec.LZ4) {
-                // TODO (https://github.com/trinodb/trino/issues/9142) Support LZ4 compression with native Parquet writer
-                assertThatThrownBy(() -> testCreateTableWithCompressionCodec(session, hiveStorageFormat, compressionCodec))
-                        .hasMessage("Unsupported codec: LZ4");
-                return;
-            }
-
             if (!isSupportedCodec(hiveStorageFormat, compressionCodec)) {
                 assertThatThrownBy(() -> testCreateTableWithCompressionCodec(session, hiveStorageFormat, compressionCodec))
                         .hasMessage("Compression codec " + compressionCodec + " not supported for " + hiveStorageFormat);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
@@ -102,6 +102,7 @@ public class BenchmarkHiveFileFormat
 
     @Param({
             "NONE",
+            "LZ4",
             "SNAPPY",
             "GZIP"})
     private HiveCompressionCodec compression;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -198,7 +198,7 @@ public class ParquetTester
     {
         return new ParquetTester(
                 ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, LZO, LZ4, ZSTD),
-                ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, ZSTD),
+                ImmutableSet.of(GZIP, UNCOMPRESSED, SNAPPY, LZ4, ZSTD),
                 ImmutableSet.copyOf(WriterVersion.values()),
                 ImmutableSet.of(SESSION, SESSION_USE_NAME, SESSION_OPTIMIZED_READER),
                 StandardFileFormats.TRINO_PARQUET);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -1451,12 +1451,6 @@ public class TestIcebergSparkCompatibility
         onTrino().executeQuery("SET SESSION iceberg.compression_codec = '" + compressionCodec + "'");
 
         String createTable = "CREATE TABLE " + trinoTableName + " WITH (format = '" + storageFormat + "') AS TABLE tpch.tiny.nation";
-        if (storageFormat == StorageFormat.PARQUET && "LZ4".equals(compressionCodec)) {
-            // TODO (https://github.com/trinodb/trino/issues/9142) LZ4 is not supported with native Parquet writer
-            assertQueryFailure(() -> onTrino().executeQuery(createTable))
-                    .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Unsupported codec: LZ4");
-            return;
-        }
         if (storageFormat == StorageFormat.AVRO && (compressionCodec.equals("LZ4"))) {
             assertQueryFailure(() -> onTrino().executeQuery(createTable))
                     .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Unsupported compression codec: " + compressionCodec);


### PR DESCRIPTION
## Description
Support LZ4 compression in optimized parquet writer

```
read    LINEITEM    SNAPPY  TRINO_OPTIMIZED_PARQUET   858.0MB/s ±    24.0MB/s ( 2.80%) (N = 20, α = 99.9%)
read    LINEITEM    LZ4     TRINO_OPTIMIZED_PARQUET  1075.8MB/s ±    23.5MB/s ( 2.18%) (N = 20, α = 99.9%)
write   LINEITEM    SNAPPY  TRINO_OPTIMIZED_PARQUET   137.4MB/s ±  8419.6kB/s ( 5.98%) (N = 20, α = 99.9%)
write   LINEITEM    LZ4     TRINO_OPTIMIZED_PARQUET   136.4MB/s ±  7074.2kB/s ( 5.07%) (N = 20, α = 99.9%)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/9142

Note: LZ4 compression scheme has been deprecated by parquet spec in favor of LZ4_RAW https://github.com/apache/parquet-format/blob/master/Compression.md#lz4
However, LZ4 is the more widely supported encoding in other engines. E.g. https://issues.apache.org/jira/browse/SPARK-43273

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Support LZ4 compression in optimized parquet writer. ({issue}`9142`)

# Hudi, Delta Lake, Iceberg
* Support LZ4 compression in parquet writer. ({issue}`9142`)
```
