### PR TITLE
Pin jvmkill version for more reproducible build

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM ghcr.io/airlift/jvmkill:latest AS jvmkill
+FROM ghcr.io/airlift/jvmkill@sha256:7297eb25c9011daee5f577784c82622e25d6c4ca16bbbb12079b56a186e8aebf AS jvmkill
 
 # Use Eclipse Temurin as they have base Docker images for more architectures.
 FROM eclipse-temurin:17-jdk


### PR DESCRIPTION
`ghcr.io/airlift/jvmkill` image publishes only one tag (`latest`) and it is currently considered unlikely that it will be updated in the future. In case, however, it gets updated, pin the version used in the docker so that the build is reproducible.
