### PR TITLE
Support complex type in migrate procedure

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -135,6 +135,116 @@ public class TestIcebergMigrateProcedure
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @ParameterizedTest
+    @MethodSource("fileFormats")
+    public void testMigrateTableWithComplexType(IcebergFileFormat fileFormat)
+    {
+        String tableName = "test_migrate_complex_" + randomNameSuffix();
+        String hiveTableName = "hive.tpch." + tableName;
+        String icebergTableName = "iceberg.tpch." + tableName;
+
+        assertUpdate("CREATE TABLE " + hiveTableName + " WITH (format='" + fileFormat + "') AS " +
+                        "SELECT 1 x, array[2, 3] a, " +
+                        "CAST(map(array['key1'], array['value1']) AS map(varchar, varchar)) b, " +
+                        "CAST(row(1) AS row(d integer)) c",
+                1);
+        assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableName + "')");
+
+        String firstRow = "VALUES (" +
+                "1, " +
+                "ARRAY[2, 3], " +
+                "CAST(map(ARRAY['key1'], ARRAY['value1']) AS map(varchar, varchar)), " +
+                "CAST(row(1) AS row(d integer)))";
+        assertThat(query("SELECT * FROM " + icebergTableName))
+                .matches(firstRow);
+
+        String secondRow = " VALUES (" +
+                "2, " +
+                "ARRAY[4, 5], " +
+                "CAST(map(ARRAY['key2'], ARRAY['value2']) AS map(varchar, varchar)), " +
+                "CAST(row(2) AS row(d integer)))";
+        assertUpdate("INSERT INTO " + icebergTableName + secondRow, 1);
+        assertThat(query("SELECT * FROM " + icebergTableName))
+                .matches(firstRow + " UNION ALL " + secondRow);
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fileFormats")
+    public void testMigrateTableSchemaEvolution(IcebergFileFormat fileFormat)
+            throws Exception
+    {
+        String randomNameSuffix = randomNameSuffix();
+        String tableNameOneColumn = "test_migrate_one_column_" + randomNameSuffix;
+        String tableNameTwoColumns = "test_migrate_two_columns_" + randomNameSuffix;
+        String hiveTableNameOneColumn = "hive.tpch." + tableNameOneColumn;
+        String hiveTableNameTwoColumns = "hive.tpch." + tableNameTwoColumns;
+        String icebergTableNameTwoColumns = "iceberg.tpch." + tableNameTwoColumns;
+
+        assertUpdate("CREATE TABLE " + hiveTableNameOneColumn + " WITH (format='" + fileFormat + "') AS SELECT 1 col1", 1);
+        assertUpdate("CREATE TABLE " + hiveTableNameTwoColumns + " WITH (format='" + fileFormat + "') AS SELECT 2 col1, CAST(row(10, 20) AS row(x integer, y integer)) AS nested", 1);
+
+        // Copy the parquet file containing only one column to the table with two columns
+        Path tableNameOneColumnLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableNameOneColumn));
+        Path tableNameTwoColumnsLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableNameTwoColumns));
+        try (Stream<Path> files = Files.list(tableNameOneColumnLocation)) {
+            Path file = files.filter(path -> !path.getFileName().toString().startsWith(".")).collect(onlyElement());
+            Files.copy(file, tableNameTwoColumnsLocation.resolve(file.getFileName()));
+        }
+
+        assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableNameTwoColumns + "')");
+
+        assertThat(query("SELECT * FROM " + icebergTableNameTwoColumns))
+                .skippingTypesCheck()
+                .matches("VALUES (1, CAST(null AS row(x integer, y integer))), (2, row(10, 20))");
+
+        assertUpdate("INSERT INTO " + icebergTableNameTwoColumns + " VALUES (3, row(100, 200))", 1);
+        assertThat(query("SELECT * FROM " + icebergTableNameTwoColumns))
+                .skippingTypesCheck()
+                .matches("VALUES (1, CAST(null AS row(x integer, y integer))), (2, row(10, 20)), (3, row(100, 200))");
+
+        assertUpdate("DROP TABLE " + icebergTableNameTwoColumns);
+        assertUpdate("DROP TABLE " + hiveTableNameOneColumn);
+    }
+
+    @ParameterizedTest
+    @MethodSource("fileFormats")
+    public void testMigrateTableRowColumnSchemaEvolution(IcebergFileFormat fileFormat)
+            throws Exception
+    {
+        String randomNameSuffix = randomNameSuffix();
+        String tableNameRowOneField = "test_migrate_row_one_field_" + randomNameSuffix;
+        String tableNameRowTwoFields = "test_migrate_row_two_fields_" + randomNameSuffix;
+        String hiveTableNameRowOneField = "hive.tpch." + tableNameRowOneField;
+        String hiveTableNameRowTwoFields = "hive.tpch." + tableNameRowTwoFields;
+        String icebergTableNameRowTwoFields = "iceberg.tpch." + tableNameRowTwoFields;
+
+        assertUpdate("CREATE TABLE " + hiveTableNameRowOneField + " WITH (format='" + fileFormat + "') AS SELECT CAST(row(1) AS row(x integer)) as nested", 1);
+        assertUpdate("CREATE TABLE " + hiveTableNameRowTwoFields + " WITH (format='" + fileFormat + "') AS SELECT CAST(row(10, 20) AS row(x integer, y integer)) AS nested", 1);
+
+        Path tableNameRowOneFieldLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableNameRowOneField));
+        Path tableNameRowTwoFieldsLocation = Path.of("%s/tpch/%s".formatted(dataDirectory, tableNameRowTwoFields));
+        try (Stream<Path> files = Files.list(tableNameRowOneFieldLocation)) {
+            Path file = files.filter(path -> !path.getFileName().toString().startsWith(".")).collect(onlyElement());
+            Files.copy(file, tableNameRowTwoFieldsLocation.resolve(file.getFileName()));
+        }
+
+        assertUpdate("CALL iceberg.system.migrate('tpch', '" + tableNameRowTwoFields + "')");
+
+        assertThat(query("SELECT * FROM " + icebergTableNameRowTwoFields))
+                .skippingTypesCheck()
+                .matches("VALUES row(CAST((1,null) AS row(x integer, y integer))), row(row(10, 20))");
+
+        assertUpdate("INSERT INTO " + icebergTableNameRowTwoFields + " VALUES (row(row(100, 200)))", 1);
+        assertThat(query("SELECT * FROM " + icebergTableNameRowTwoFields))
+                .skippingTypesCheck()
+                .matches("VALUES row(CAST((1, null) AS row(x integer, y integer))), row(row(10, 20)), row(row(100, 200))");
+
+        assertUpdate("DROP TABLE " + icebergTableNameRowTwoFields);
+        assertUpdate("DROP TABLE " + hiveTableNameRowOneField);
+    }
+
     public static Object[][] fileFormats()
     {
         return Stream.of(IcebergFileFormat.values())
@@ -317,26 +427,6 @@ public class TestIcebergMigrateProcedure
         assertQuery("SELECT * FROM " + hiveTableName, "VALUES timestamp '2021-01-01 00:00:00.000'");
         assertQueryFails("SELECT * FROM " + icebergTableName, "Not an Iceberg table: .*");
 
-        assertUpdate("DROP TABLE " + hiveTableName);
-    }
-
-    @Test
-    public void testMigrateUnsupportedComplexColumnType()
-    {
-        // TODO https://github.com/trinodb/trino/issues/17583 Add support for these complex types
-        String tableName = "test_migrate_unsupported_complex_column_type_" + randomNameSuffix();
-        String hiveTableName = "hive.tpch." + tableName;
-
-        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT array[1] x", 1);
-        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating array(integer) type is not supported");
-        assertUpdate("DROP TABLE " + hiveTableName);
-
-        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT map(array['key'], array[2]) x", 1);
-        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating map(varchar(3), integer) type is not supported");
-        assertUpdate("DROP TABLE " + hiveTableName);
-
-        assertUpdate("CREATE TABLE " + hiveTableName + " AS SELECT CAST(row(1) AS row(y integer)) x", 1);
-        assertQueryFails("CALL iceberg.system.migrate('tpch', '" + tableName + "')", "\\QMigrating row(y integer) type is not supported");
         assertUpdate("DROP TABLE " + hiveTableName);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix https://github.com/trinodb/trino/issues/17583


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/TableMetadata.java#L103 Will reassign columnId start from 1, we need to reset `nextFieldId`.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for `array`, `map` and `row` types in migrate procedure. ({issue}`17583`)
```
