### PR TITLE
Fix the invalid path when getting the instant detail from hudi meta client

### DIFF
--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
@@ -25,6 +25,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class TestS3HadoopPaths
 {
     @Test
+    public void testHdfsPath()
+    {
+        assertThat(hadoopPath(Location.of("hdfs://test/abc/xyz")))
+                .isEqualTo(new Path("hdfs://test/abc/xyz"));
+    }
+
+    @Test
     public void testNonS3Path()
     {
         assertThat(hadoopPath(Location.of("gcs://test/abc//xyz")))

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
@@ -25,17 +25,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class TestS3HadoopPaths
 {
     @Test
-    public void testHdfsPath()
-    {
-        assertThat(hadoopPath(Location.of("hdfs://test/abc/xyz")))
-                .isEqualTo(new Path("hdfs://test/abc/xyz"));
-    }
-
-    @Test
     public void testNonS3Path()
     {
         assertThat(hadoopPath(Location.of("gcs://test/abc//xyz")))
                 .isEqualTo(new Path("gcs://test/abc/xyz"));
+        assertThat(hadoopPath(Location.of("hdfs://test/abc/xyz")))
+                .isEqualTo(new Path("hdfs://test/abc/xyz"));
     }
 
     @Test

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.hudi.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
@@ -35,6 +37,15 @@ public class HudiReplaceCommitMetadata
     {
         partitionToReplaceFileIds = ImmutableMap.of();
         compacted = false;
+    }
+
+    @JsonCreator
+    public HudiReplaceCommitMetadata(
+            @JsonProperty("partitionToReplaceFileIds") Map<String, List<String>> partitionToReplaceFileIds,
+            @JsonProperty("compacted") Boolean compacted)
+    {
+        this.partitionToReplaceFileIds = partitionToReplaceFileIds;
+        this.compacted = compacted;
     }
 
     public Map<String, List<String>> getPartitionToReplaceFileIds()

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
@@ -138,7 +138,7 @@ public class HudiTableMetaClient
 
     public String getSchemaFolderName()
     {
-        return metaPath.appendPath(SCHEMA_FOLDER_NAME).path();
+        return metaPath.appendPath(SCHEMA_FOLDER_NAME).toString();
     }
 
     private static HudiTableMetaClient newMetaClient(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
@@ -85,7 +85,7 @@ public class HudiActiveTimeline
 
     private Location getInstantFileNamePath(String fileName)
     {
-        return Location.of(fileName.contains(SCHEMA_COMMIT_ACTION) ? metaClient.getSchemaFolderName() : metaClient.getMetaPath().path()).appendPath(fileName);
+        return Location.of(fileName.contains(SCHEMA_COMMIT_ACTION) ? metaClient.getSchemaFolderName() : metaClient.getMetaPath().toString()).appendPath(fileName);
     }
 
     private Optional<byte[]> readDataFromPath(Location detailPath)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix the `IllegalArgumentException: No scheme for file system location: xyz/hudi/path/.hoodie`.

`HdfsFileSystem` and `HdfsInputFile` cannot read the hudi files from HDFS by the relative path without the scheme and the namenode like `hdfs://namenode/`.
So changes the path of hudi file to the absolute path contains the scheme and the namenode for reading the hudi files from HDFS.

The error stack trace is 

```
java.lang.IllegalArgumentException: No scheme for file system location: abc/xyz/table_a/.hoodie
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:220)
	at io.trino.filesystem.Location.of(Location.java:74)
	at io.trino.plugin.hudi.timeline.HudiActiveTimeline.getInstantFileNamePath(HudiActiveTimeline.java:91)
	at io.trino.plugin.hudi.timeline.HudiActiveTimeline.getInstantDetails(HudiActiveTimeline.java:73)
	at io.trino.plugin.hudi.table.HudiTableFileSystemView.lambda$resetFileGroupsReplaced$10(HudiTableFileSystemView.java:215)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:273)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:992)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at io.trino.plugin.hudi.table.HudiTableFileSystemView.resetFileGroupsReplaced(HudiTableFileSystemView.java:228)
	at io.trino.plugin.hudi.table.HudiTableFileSystemView.<init>(HudiTableFileSystemView.java:94)
	at io.trino.plugin.hudi.query.HudiReadOptimizedDirectoryLister.<init>(HudiReadOptimizedDirectoryLister.java:66)
	at io.trino.plugin.hudi.HudiSplitSource.<init>(HudiSplitSource.java:71)
	at io.trino.plugin.hudi.HudiSplitManager.getSplits(HudiSplitManager.java:96)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager.getSplits(ClassLoaderSafeConnectorSplitManager.java:51)
	at io.trino.split.SplitManager.getSplits(SplitManager.java:67)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitScanAndFilter(SplitSourceFactory.java:183)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitTableScan(SplitSourceFactory.java:157)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitTableScan(SplitSourceFactory.java:128)
	at io.trino.sql.planner.plan.TableScanNode.accept(TableScanNode.java:222)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitLimit(SplitSourceFactory.java:378)
	at io.trino.sql.planner.SplitSourceFactory$Visitor.visitLimit(SplitSourceFactory.java:128)
	at io.trino.sql.planner.plan.LimitNode.accept(LimitNode.java:124)
	at io.trino.sql.planner.SplitSourceFactory.createSplitSources(SplitSourceFactory.java:108)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.createStageScheduler(PipelinedQueryScheduler.java:1036)
	at io.trino.execution.scheduler.PipelinedQueryScheduler$DistributedStagesScheduler.create(PipelinedQueryScheduler.java:912)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.createDistributedStagesScheduler(PipelinedQueryScheduler.java:313)
	at io.trino.execution.scheduler.PipelinedQueryScheduler.start(PipelinedQueryScheduler.java:294)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:427)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:257)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:145)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:129)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:569)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:544)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1138)
	at io.trino.$gen.Trino_419____20230607_110128_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
A Hudi tables in `hdfs`. The full path of hudi table like `hdfs://test/abc/xyz`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
