### PR TITLE
Enable MixedMutabilityReturnType error-prone check

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/ThreadEquivalence.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/ThreadEquivalence.java
@@ -325,7 +325,7 @@ public class ThreadEquivalence
     private static List<LogicalIndexNavigation> allPositionsToCompare(LogicalIndexNavigation navigation)
     {
         if (navigation.isLast()) {
-            List<LogicalIndexNavigation> result = new ArrayList<>();
+            ImmutableList.Builder<LogicalIndexNavigation> result = ImmutableList.builder();
             for (int offset = 0; offset <= navigation.getLogicalOffset(); offset++) {
                 result.add(navigation.withLogicalOffset(offset));
             }
@@ -336,7 +336,7 @@ public class ThreadEquivalence
             for (int tail = navigation.getPhysicalOffset() + 1; tail < 0; tail++) {
                 result.add(navigation.withoutLogicalOffset().withPhysicalOffset(tail));
             }
-            return result;
+            return result.build();
         }
 
         return ImmutableList.of(navigation);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1323,7 +1323,7 @@ class QueryPlanner
             }
         }
 
-        return allSets;
+        return ImmutableList.copyOf(allSets);
     }
 
     private PlanBuilder planGroupingOperations(PlanBuilder subPlan, QuerySpecification node, Optional<Symbol> groupIdSymbol, List<Set<FieldId>> groupingSets)

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -381,7 +381,7 @@ public final class OrcWriter
 
         columnWriters.forEach(ColumnWriter::close);
 
-        List<OrcDataOutput> outputData = new ArrayList<>();
+        ImmutableList.Builder<OrcDataOutput> outputData = ImmutableList.builder();
         List<Stream> allStreams = new ArrayList<>(columnWriters.size() * 3);
 
         // get index streams
@@ -444,7 +444,7 @@ public final class OrcWriter
         recordValidation(validation -> validation.addStripe(stripeInformation.getNumberOfRows()));
         stats.recordStripeWritten(flushReason, stripeInformation.getTotalLength(), stripeInformation.getNumberOfRows(), dictionaryCompressionOptimizer.getDictionaryMemoryBytes());
 
-        return outputData;
+        return outputData.build();
     }
 
     @Override

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/index/ColumnCardinalityCache.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/index/ColumnCardinalityCache.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.io.Text;
 import javax.annotation.PreDestroy;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -389,14 +388,14 @@ public class ColumnCardinalityCache
 
                 // Create a new map to hold our cardinalities for each range, returning a default of
                 // Zero for each non-existent Key
-                Map<CacheKey, Long> rangeValues = new HashMap<>();
+                ImmutableMap.Builder<CacheKey, Long> rangeValues = ImmutableMap.builder();
                 stream(keys).forEach(key -> rangeValues.put(key, 0L));
 
                 for (Entry<Key, Value> entry : scanner) {
                     rangeValues.put(rangeToKey.get(Range.exact(entry.getKey().getRow())), parseLong(entry.getValue().toString()));
                 }
 
-                return rangeValues;
+                return rangeValues.buildKeepingLast();
             }
             finally {
                 if (scanner != null) {

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -130,6 +130,7 @@ import static java.lang.Math.toIntExact;
 import static java.lang.Math.toRadians;
 import static java.lang.String.format;
 import static java.util.Arrays.setAll;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 import static org.locationtech.jts.simplify.TopologyPreservingSimplifier.simplify;
 
@@ -731,7 +732,7 @@ public final class GeoFunctions
             interpolatedPoints.add(path.getPoint(path.getPointCount() - 1));
         }
 
-        return interpolatedPoints;
+        return unmodifiableList(interpolatedPoints);
     }
 
     @SqlNullable

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -68,7 +68,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -1090,7 +1089,7 @@ public class FileHiveMetastore
         try {
             String directoryPrefix = partitionColumns.get(0).getName() + '=';
 
-            List<ArrayDeque<String>> partitionValues = new ArrayList<>();
+            ImmutableList.Builder<ArrayDeque<String>> partitionValues = ImmutableList.builder();
             for (FileStatus fileStatus : metadataFileSystem.listStatus(director)) {
                 if (!fileStatus.isDirectory()) {
                     continue;
@@ -1113,7 +1112,7 @@ public class FileHiveMetastore
                     partitionValues.add(childPartition);
                 }
             }
-            return partitionValues;
+            return partitionValues.build();
         }
         catch (IOException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, "Error listing partition directories", e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/AsyncQueue.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/AsyncQueue.java
@@ -22,7 +22,6 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Executor;
@@ -142,7 +141,7 @@ public class AsyncQueue<T>
         if (reduceBy == 0) {
             return ImmutableList.of();
         }
-        List<T> result = new ArrayList<>(reduceBy);
+        ImmutableList.Builder<T> result = ImmutableList.builderWithExpectedSize(reduceBy);
         for (int i = 0; i < reduceBy; i++) {
             result.add(elements.remove());
         }
@@ -151,7 +150,7 @@ public class AsyncQueue<T>
             completeAsync(executor, notFullSignal);
             notFullSignal = SettableFuture.create();
         }
-        return result;
+        return result.build();
     }
 
     public synchronized ListenableFuture<List<T>> getBatchAsync(int maxSize)

--- a/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/SessionMatchSpec.java
+++ b/plugin/trino-session-property-managers/src/main/java/io/trino/plugin/session/SessionMatchSpec.java
@@ -25,7 +25,6 @@ import org.jdbi.v3.core.statement.StatementContext;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,12 +159,12 @@ public class SessionMatchSpec
             checkArgument(sessionPropertyNames.size() == sessionPropertyValues.size(),
                     "The number of property names and values should be the same");
 
-            Map<String, String> sessionProperties = new HashMap<>();
+            ImmutableMap.Builder<String, String> sessionProperties = ImmutableMap.builder();
             for (int i = 0; i < sessionPropertyNames.size(); i++) {
                 sessionProperties.put(sessionPropertyNames.get(i), sessionPropertyValues.get(i));
             }
 
-            return sessionProperties;
+            return sessionProperties.buildOrThrow();
         }
     }
 }

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ThriftIndexedTpchService.java
@@ -125,11 +125,11 @@ public class ThriftIndexedTpchService
             return ImmutableList.of();
         }
         List<TrinoThriftBlock> blocks = page.getColumnBlocks();
-        List<List<String>> result = new ArrayList<>(blocks.size());
+        ImmutableList.Builder<List<String>> result = ImmutableList.builderWithExpectedSize(blocks.size());
         for (TrinoThriftBlock block : blocks) {
             result.add(blockAsList(block, begin, end));
         }
-        return result;
+        return result.build();
     }
 
     private static List<String> blockAsList(TrinoThriftBlock block, int begin, int end)

--- a/pom.xml
+++ b/pom.xml
@@ -2339,6 +2339,7 @@
                                     -Xep:MissingCasesInEnumSwitch:ERROR \
                                     -Xep:MissingOverride:ERROR \
                                     -Xep:MissingSummary:OFF <!-- Sometimes our javadoc contains just a @see directive --> \
+                                    -Xep:MixedMutabilityReturnType:ERROR \
                                     -Xep:MutablePublicArray:ERROR \
                                     -Xep:NullOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \


### PR DESCRIPTION
From the check message:

> This method returns both mutable and immutable collections or maps from different paths. This may be confusing for users of the method.
