### PR TITLE
Escape object name on the Data Lake connectors

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -240,6 +240,7 @@ import static io.trino.plugin.hive.metastore.StorageFormat.create;
 import static io.trino.plugin.hive.util.HiveClassNames.HIVE_SEQUENCEFILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.plugin.hive.util.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
 import static io.trino.plugin.hive.util.HiveClassNames.SEQUENCEFILE_INPUT_FORMAT_CLASS;
+import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
 import static io.trino.plugin.hive.util.HiveUtil.isHiveSystemSchema;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -962,7 +963,7 @@ public class DeltaLakeMetadata
     {
         String schemaLocation = getSchemaLocation(schema)
                 .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
-        String tableNameForLocation = tableName;
+        String tableNameForLocation = escapeTableName(tableName);
         if (useUniqueTableLocation) {
             tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -777,13 +777,7 @@ public class DeltaLakeMetadata
         boolean external = true;
         String location = getLocation(tableMetadata.getProperties());
         if (location == null) {
-            String schemaLocation = getSchemaLocation(schema)
-                    .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
-            String tableNameForLocation = tableName;
-            if (useUniqueTableLocation) {
-                tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
-            }
-            location = appendPath(schemaLocation, tableNameForLocation);
+            location = getTableLocation(schema, tableName);
             checkPathContainsNoFiles(session, Location.of(location));
             external = false;
         }
@@ -912,13 +906,7 @@ public class DeltaLakeMetadata
         boolean external = true;
         String location = getLocation(tableMetadata.getProperties());
         if (location == null) {
-            String schemaLocation = getSchemaLocation(schema)
-                    .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
-            String tableNameForLocation = tableName;
-            if (useUniqueTableLocation) {
-                tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
-            }
-            location = appendPath(schemaLocation, tableNameForLocation);
+            location = getTableLocation(schema, tableName);
             external = false;
         }
 
@@ -968,6 +956,17 @@ public class DeltaLakeMetadata
         }
 
         return schemaLocation;
+    }
+
+    private String getTableLocation(Database schema, String tableName)
+    {
+        String schemaLocation = getSchemaLocation(schema)
+                .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "The 'location' property must be specified either for the table or the schema"));
+        String tableNameForLocation = tableName;
+        if (useUniqueTableLocation) {
+            tableNameForLocation += "-" + randomUUID().toString().replace("-", "");
+        }
+        return appendPath(schemaLocation, tableNameForLocation);
     }
 
     private void checkPathContainsNoFiles(ConnectorSession session, Location targetPath)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -112,6 +112,7 @@ import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getHiveB
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateStatisticsParameters;
 import static io.trino.plugin.hive.util.HiveUtil.DELTA_LAKE_PROVIDER;
 import static io.trino.plugin.hive.util.HiveUtil.SPARK_TABLE_PROVIDER_KEY;
+import static io.trino.plugin.hive.util.HiveUtil.escapeSchemaName;
 import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.hive.util.HiveUtil.toPartitionValues;
@@ -1413,7 +1414,7 @@ public class FileHiveMetastore
 
     private Path getDatabaseMetadataDirectory(String databaseName)
     {
-        return new Path(catalogDirectory, databaseName);
+        return new Path(catalogDirectory, escapeSchemaName(databaseName));
     }
 
     private Path getTableMetadataDirectory(Table table)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -112,6 +112,7 @@ import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getHiveB
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateStatisticsParameters;
 import static io.trino.plugin.hive.util.HiveUtil.DELTA_LAKE_PROVIDER;
 import static io.trino.plugin.hive.util.HiveUtil.SPARK_TABLE_PROVIDER_KEY;
+import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.hive.util.HiveUtil.toPartitionValues;
 import static io.trino.plugin.hive.util.HiveUtil.unescapePathName;
@@ -1422,7 +1423,7 @@ public class FileHiveMetastore
 
     private Path getTableMetadataDirectory(String databaseName, String tableName)
     {
-        return new Path(getDatabaseMetadataDirectory(databaseName), tableName);
+        return new Path(getDatabaseMetadataDirectory(databaseName), escapeTableName(tableName));
     }
 
     private Path getPartitionMetadataDirectory(Table table, List<String> values)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -153,6 +153,7 @@ import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.mappedCopy;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getHiveBasicStatistics;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateStatisticsParameters;
+import static io.trino.plugin.hive.util.HiveUtil.escapeSchemaName;
 import static io.trino.plugin.hive.util.HiveUtil.toPartitionValues;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -493,7 +494,7 @@ public class GlueHiveMetastore
     public void createDatabase(Database database)
     {
         if (database.getLocation().isEmpty() && defaultDir.isPresent()) {
-            String databaseLocation = new Path(defaultDir.get(), database.getDatabaseName()).toString();
+            String databaseLocation = new Path(defaultDir.get(), escapeSchemaName(database.getDatabaseName())).toString();
             database = Database.builder(database)
                     .setLocation(Optional.of(databaseLocation))
                     .build();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -1225,6 +1225,17 @@ public final class HiveUtil
         return sb.toString();
     }
 
+    public static String escapeSchemaName(String schemaName)
+    {
+        if (isNullOrEmpty(schemaName)) {
+            throw new IllegalArgumentException("The provided schemaName cannot be null or empty");
+        }
+        if (DOT_MATCHER.matchesAllOf(schemaName)) {
+            throw new TrinoException(GENERIC_USER_ERROR, "Invalid schema name");
+        }
+        return escapePathName(schemaName);
+    }
+
     public static String escapeTableName(String tableName)
     {
         if (isNullOrEmpty(tableName)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -107,6 +107,7 @@ import static io.trino.plugin.hive.util.HiveClassNames.HIVE_IGNORE_KEY_OUTPUT_FO
 import static io.trino.plugin.hive.util.HiveClassNames.HIVE_SEQUENCEFILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.plugin.hive.util.HiveClassNames.MAPRED_PARQUET_OUTPUT_FORMAT_CLASS;
 import static io.trino.plugin.hive.util.HiveUtil.checkCondition;
+import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -452,7 +453,7 @@ public final class HiveWriteUtils
             }
         }
 
-        return Location.of(location).appendPath(tableName);
+        return Location.of(location).appendPath(escapeTableName(tableName));
     }
 
     public static boolean pathExists(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
@@ -39,6 +39,7 @@ import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE;
+import static io.trino.plugin.hive.util.HiveUtil.escapeSchemaName;
 import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializer;
 import static io.trino.plugin.hive.util.HiveUtil.getInputFormat;
@@ -148,6 +149,18 @@ public class TestHiveUtil
     {
         assertThat(FileUtils.unescapePathName(value)).isEqualTo(expected);
         assertThat(HiveUtil.unescapePathName(value)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testEscapeDatabaseName()
+    {
+        assertThat(escapeSchemaName("schema1")).isEqualTo("schema1");
+        assertThatThrownBy(() -> escapeSchemaName(null))
+                .hasMessage("The provided schemaName cannot be null or empty");
+        assertThatThrownBy(() -> escapeSchemaName(""))
+                .hasMessage("The provided schemaName cannot be null or empty");
+        assertThat(escapeSchemaName("../schema1")).isEqualTo("..%2Fschema1");
+        assertThat(escapeSchemaName("../../schema1")).isEqualTo("..%2F..%2Fschema1");
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveUtil.java
@@ -39,6 +39,7 @@ import static io.trino.hadoop.ConfigurationInstantiator.newEmptyConfiguration;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.PARQUET;
 import static io.trino.plugin.hive.HiveStorageFormat.SEQUENCEFILE;
+import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.hive.util.HiveUtil.getDeserializer;
 import static io.trino.plugin.hive.util.HiveUtil.getInputFormat;
 import static io.trino.plugin.hive.util.HiveUtil.parseHiveTimestamp;
@@ -49,6 +50,7 @@ import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_CLASS;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_FORMAT;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveUtil
@@ -146,6 +148,18 @@ public class TestHiveUtil
     {
         assertThat(FileUtils.unescapePathName(value)).isEqualTo(expected);
         assertThat(HiveUtil.unescapePathName(value)).isEqualTo(expected);
+    }
+
+    @Test
+    public void testEscapeTableName()
+    {
+        assertThat(escapeTableName("table1")).isEqualTo("table1");
+        assertThatThrownBy(() -> escapeTableName(null))
+                .hasMessage("The provided tableName cannot be null or empty");
+        assertThatThrownBy(() -> escapeTableName(""))
+                .hasMessage("The provided tableName cannot be null or empty");
+        assertThat(escapeTableName("../table1")).isEqualTo("..%2Ftable1");
+        assertThat(escapeTableName("../../table1")).isEqualTo("..%2F..%2Ftable1");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -70,6 +70,7 @@ import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.mappedCopy;
+import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.getStorageSchema;
@@ -203,7 +204,7 @@ public abstract class AbstractTrinoCatalog
 
     protected String createNewTableName(String baseTableName)
     {
-        String tableName = baseTableName;
+        String tableName = escapeTableName(baseTableName);
         if (useUniqueTableLocation) {
             tableName += "-" + randomUUID().toString().replace("-", "");
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case of dealing with table names containing only
dots, the creation of the table is disallowed because
it can lead to unwanted side effects in ABFS.
When dealing with the table name "..", the path to
the files of the table would contain a relative sub-path
component which would cause the engine to look for
active files in the parent directory of the table.


In case of dealing with schema names containing only
dots, the creation of the table is disallowed because
it can lead (same as for tables) to unwanted side effects
in ABFS.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
