### PR TITLE
Support writing timestamp with timezone in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -94,7 +94,7 @@ public final class BigQueryType
             1, // 9 digits after the dot
     };
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("''HH:mm:ss.SSSSSS''");
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("''yyyy-MM-dd HH:mm:ss.SSSSSS''");
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSSSSS").withZone(UTC);
 
     private static RowType.Field toRawTypeField(String name, Field field)
     {
@@ -158,7 +158,6 @@ public final class BigQueryType
         return TIME_FORMATTER.format(toZonedDateTime(epochSeconds, nanoAdjustment, UTC));
     }
 
-    @VisibleForTesting
     public static String timestampToStringConverter(Object value)
     {
         LongTimestampWithTimeZone timestamp = (LongTimestampWithTimeZone) value;
@@ -289,7 +288,7 @@ public final class BigQueryType
             case DATE:
                 return Optional.of(dateToStringConverter(value));
             case DATETIME:
-                return Optional.of(datetimeToStringConverter(value));
+                return Optional.of(datetimeToStringConverter(value)).map("'%s'"::formatted);
             case FLOAT64:
                 return Optional.of(floatToStringConverter(value));
             case INT64:
@@ -312,7 +311,7 @@ public final class BigQueryType
             case TIME:
                 return Optional.of(timeToStringConverter(value));
             case TIMESTAMP:
-                return Optional.of(timestampToStringConverter(value));
+                return Optional.of(timestampToStringConverter(value)).map("'%s'"::formatted);
             default:
                 throw new IllegalArgumentException("Unsupported type: " + bigqueryType);
         }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTypeUtils.java
@@ -18,6 +18,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.plugin.bigquery.BigQueryType.timestampToStringConverter;
 import static io.trino.plugin.bigquery.BigQueryType.toZonedDateTime;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -42,6 +44,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -65,7 +68,7 @@ public final class BigQueryTypeUtils
             return null;
         }
 
-        // TODO https://github.com/trinodb/trino/issues/13741 Add support for time, timestamp with time zone, geography, map type
+        // TODO https://github.com/trinodb/trino/issues/13741 Add support for time, geography, map type
         if (type.equals(BOOLEAN)) {
             return BOOLEAN.getBoolean(block, position);
         }
@@ -102,6 +105,10 @@ public final class BigQueryTypeUtils
             long epochSeconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
             int nanoAdjustment = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
             return DATETIME_FORMATTER.format(toZonedDateTime(epochSeconds, nanoAdjustment, UTC));
+        }
+        if (type.equals(TIMESTAMP_TZ_MICROS)) {
+            LongTimestampWithTimeZone timestamp = (LongTimestampWithTimeZone) TIMESTAMP_TZ_MICROS.getObject(block, position);
+            return timestampToStringConverter(timestamp);
         }
         if (type instanceof ArrayType arrayType) {
             Block arrayBlock = block.getObject(position, Block.class);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -265,7 +265,6 @@ public abstract class BaseBigQueryConnectorTest
             case "timestamp":
             case "timestamp(3)":
             case "timestamp(3) with time zone":
-            case "timestamp(6) with time zone":
                 return Optional.of(dataMappingTestSetup.asUnsupported());
         }
         return Optional.of(dataMappingTestSetup);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import io.trino.spi.type.TimeZoneKey;
 import org.testng.annotations.Test;
 
 import static io.airlift.slice.Slices.utf8Slice;
@@ -42,7 +43,10 @@ public class TestBigQueryType
     {
         assertThat(BigQueryType.timestampToStringConverter(
                 fromEpochSecondsAndFraction(1585658096, 123_456_000_000L, UTC_KEY)))
-                .isEqualTo("'2020-03-31 12:34:56.123456'");
+                .isEqualTo("2020-03-31 12:34:56.123456");
+        assertThat(BigQueryType.timestampToStringConverter(
+                fromEpochSecondsAndFraction(1585658096, 123_456_000_000L, TimeZoneKey.getTimeZoneKey("Asia/Kathmandu"))))
+                .isEqualTo("2020-03-31 12:34:56.123456");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Relates to https://github.com/trinodb/trino/issues/13741

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Add support for writing `timestamp with time zone` type. ({issue}`17793`)
```
