### PR TITLE
Ban javax.annotation dependency

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -103,6 +103,12 @@
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -127,6 +133,10 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>listenablefuture</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -153,6 +163,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>listenablefuture</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -171,6 +185,10 @@
                 <exclusion>
                     <groupId>com.google.re2j</groupId>
                     <artifactId>re2j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -112,6 +112,10 @@
                     <groupId>org.threeten</groupId>
                     <artifactId>threetenbp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -177,6 +181,10 @@
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -167,6 +167,10 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <dep.aws-sdk-v2.version>2.20.78</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
-        <dep.drift.version>1.19</dep.drift.version>
+        <dep.drift.version>1.20</dep.drift.version>
         <dep.tempto.version>197</dep.tempto.version>
         <dep.gcs.version>2.2.8</dep.gcs.version>
 
@@ -896,7 +896,7 @@
             <dependency>
                 <groupId>io.airlift.discovery</groupId>
                 <artifactId>discovery-server</artifactId>
-                <version>1.34</version>
+                <version>1.35</version>
                 <exclusions>
                     <exclusion>
                         <groupId>io.airlift</groupId>
@@ -2052,6 +2052,8 @@
                                     <exclude>org.yaml:snakeyaml</exclude>
                                     <!-- use Guice version -->
                                     <exclude>javax.inject:javax.inject</exclude>
+                                    <!-- use Jakarta version -->
+                                    <exclude>javax.annotation:javax.annotation-api</exclude>
                                 </excludes>
                                 <includes combine.children="append">
                                     <!-- 2.x versions are not affected by CVE-2022-1471 -->

--- a/pom.xml
+++ b/pom.xml
@@ -2050,7 +2050,8 @@
                                     <exclude>org.apache.logging.log4j:log4j-core</exclude>
                                     <!-- 1.x versions are banned due to https://www.cve.org/CVERecord?id=CVE-2022-1471 -->
                                     <exclude>org.yaml:snakeyaml</exclude>
-                                    <exclude>javax.inject:javax.inject:*</exclude>
+                                    <!-- use Guice version -->
+                                    <exclude>javax.inject:javax.inject</exclude>
                                 </excludes>
                                 <includes combine.children="append">
                                     <!-- 2.x versions are not affected by CVE-2022-1471 -->

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -100,6 +100,8 @@
                             <includes combine.children="append">
                                 <!-- allow vulnerable snakeyaml version until benchto is updated -->
                                 <include>org.yaml:snakeyaml:1.33</include>
+                                <!-- benchto still uses javax.annotation -->
+                                <include>javax.annotation:javax.annotation-api</include>
                             </includes>
                         </bannedDependencies>
                     </rules>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
