### PR TITLE
Update speculative flag for running tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1827,6 +1827,12 @@ public class EventDrivenFaultTolerantQueryScheduler
             // a task may finish before task descriptor is sealed
             if (!finished) {
                 taskDescriptorStorage.put(stageId, taskDescriptor);
+
+                // update speculative flag for running tasks
+                for (TaskId runningTaskId : runningTasks) {
+                    RemoteTask runningTask = tasks.get(runningTaskId);
+                    runningTask.setSpeculative(false);
+                }
             }
         }
 


### PR DESCRIPTION
If speculative flag for task partition changes while task is already running we need to propagate the information to RemoteTask


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
