### PR TITLE
Fix correctness issue with double slash and add test for S3 and Glue metastore

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeConcurrentModificationGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeConcurrentModificationGlueMetastore.java
@@ -17,6 +17,8 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.amazonaws.services.glue.model.ConcurrentModificationException;
 import io.trino.Session;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.hdfs.TrinoHdfsFileSystemStats;
 import io.trino.plugin.deltalake.TestingDeltaLakePlugin;
 import io.trino.plugin.deltalake.metastore.TestingDeltaLakeMetastoreModule;
 import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
@@ -92,6 +94,7 @@ public class TestDeltaLakeConcurrentModificationGlueMetastore
         });
 
         metastore = new GlueHiveMetastore(
+                new HdfsFileSystemFactory(HDFS_ENVIRONMENT, new TrinoHdfsFileSystemStats()),
                 HDFS_ENVIRONMENT,
                 glueConfig,
                 directExecutor(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.PartitionUpdate.UpdateMode;
 import io.trino.spi.Page;
 
@@ -114,8 +115,8 @@ public class HiveWriter
         return new PartitionUpdate(
                 partitionName.orElse(""),
                 updateMode,
-                writePath,
-                targetPath,
+                Location.of(writePath),
+                Location.of(targetPath),
                 ImmutableList.of(fileName),
                 rowCount,
                 inputSizeInBytes,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionUpdate.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionUpdate.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimaps;
+import io.trino.filesystem.Location;
 import io.trino.spi.TrinoException;
-import org.apache.hadoop.fs.Path;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,8 +33,8 @@ public class PartitionUpdate
 {
     private final String name;
     private final UpdateMode updateMode;
-    private final Path writePath;
-    private final Path targetPath;
+    private final Location writePath;
+    private final Location targetPath;
     private final List<String> fileNames;
     private final long rowCount;
     private final long inMemoryDataSizeInBytes;
@@ -54,8 +54,8 @@ public class PartitionUpdate
         this(
                 name,
                 updateMode,
-                new Path(requireNonNull(writePath, "writePath is null")),
-                new Path(requireNonNull(targetPath, "targetPath is null")),
+                Location.of(requireNonNull(writePath, "writePath is null")),
+                Location.of(requireNonNull(targetPath, "targetPath is null")),
                 fileNames,
                 rowCount,
                 inMemoryDataSizeInBytes,
@@ -65,8 +65,8 @@ public class PartitionUpdate
     public PartitionUpdate(
             String name,
             UpdateMode updateMode,
-            Path writePath,
-            Path targetPath,
+            Location writePath,
+            Location targetPath,
             List<String> fileNames,
             long rowCount,
             long inMemoryDataSizeInBytes,
@@ -101,12 +101,12 @@ public class PartitionUpdate
         return updateMode;
     }
 
-    public Path getWritePath()
+    public Location getWritePath()
     {
         return writePath;
     }
 
-    public Path getTargetPath()
+    public Location getTargetPath()
     {
         return targetPath;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import io.trino.filesystem.Location;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.plugin.hive.PartitionStatistics;
@@ -240,7 +241,7 @@ public class SyncPartitionMetadataProcedure
                     table.getDatabaseName(),
                     table.getTableName(),
                     buildPartitionObject(session, table, name),
-                    new Path(table.getStorage().getLocation(), name),
+                    Location.of(table.getStorage().getLocation()).appendPath(name),
                     Optional.empty(), // no need for failed attempts cleanup
                     PartitionStatistics.empty(),
                     false);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -203,6 +203,7 @@ import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static io.airlift.testing.Assertions.assertInstanceOf;
 import static io.airlift.testing.Assertions.assertLessThanOrEqual;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.trino.filesystem.hdfs.HadoopPaths.hadoopPath;
 import static io.trino.parquet.reader.ParquetReader.PARQUET_CODEC_METRIC_PREFIX;
 import static io.trino.plugin.hive.AbstractTestHive.TransactionDeleteInsertTestTag.COMMIT;
 import static io.trino.plugin.hive.AbstractTestHive.TransactionDeleteInsertTestTag.ROLLBACK_AFTER_APPEND_PAGE;
@@ -6304,8 +6305,8 @@ public abstract class AbstractTestHive
                 throws IOException
         {
             for (PartitionUpdate partitionUpdate : partitionUpdates) {
-                if ("pk2=insert2".equals(partitionUpdate.getTargetPath().getName())) {
-                    path = new Path(partitionUpdate.getTargetPath(), partitionUpdate.getFileNames().get(0));
+                if ("pk2=insert2".equals(partitionUpdate.getTargetPath().fileName())) {
+                    path = new Path(hadoopPath(partitionUpdate.getTargetPath()), partitionUpdate.getFileNames().get(0));
                     break;
                 }
             }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.RecursiveDeleteOption;
 import com.google.common.reflect.ClassPath;
 import io.airlift.log.Logger;
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -33,7 +34,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.PrincipalType;
 import io.trino.testing.MaterializedResult;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
@@ -190,7 +189,7 @@ public abstract class AbstractTestHiveLocal
                             BUCKETING_V1,
                             3,
                             ImmutableList.of(new SortingColumn("name", SortingColumn.Order.ASCENDING)))),
-                    new Path(URI.create("file://" + externalLocation.toString())));
+                    Location.of("file://" + externalLocation.toString()));
 
             assertReadFailsWithMessageMatching(ORC, tableName, "Hive table is corrupt\\. File '.*/.*' is for bucket [0-2], but contains a row for bucket [0-2].");
             markTableAsCreatedBySpark(tableName, "orc");
@@ -227,7 +226,7 @@ public abstract class AbstractTestHiveLocal
         }
     }
 
-    private void createExternalTable(SchemaTableName schemaTableName, HiveStorageFormat hiveStorageFormat, List<Column> columns, List<Column> partitionColumns, Optional<HiveBucketProperty> bucketProperty, Path externalLocation)
+    private void createExternalTable(SchemaTableName schemaTableName, HiveStorageFormat hiveStorageFormat, List<Column> columns, List<Column> partitionColumns, Optional<HiveBucketProperty> bucketProperty, Location externalLocation)
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorSession session = newSession();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTable.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTable.java
@@ -51,13 +51,13 @@ public class TestHiveCreateExternalTable
             throws IOException
     {
         Path tempDir = createTempDirectory(null);
-        Path tableLocation = tempDir.resolve("data");
+        String tableLocation = tempDir.resolve("data").toUri().toASCIIString();
 
         @Language("SQL") String createTableSql = format("" +
                         "CREATE TABLE test_create_external " +
                         "WITH (external_location = '%s') AS " +
                         "SELECT * FROM tpch.tiny.nation",
-                tableLocation.toUri().toASCIIString());
+                tableLocation);
 
         assertUpdate(createTableSql, 25);
 
@@ -67,7 +67,7 @@ public class TestHiveCreateExternalTable
 
         MaterializedResult result = computeActual("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '/') FROM test_create_external");
         String tablePath = (String) result.getOnlyValue();
-        assertThat(tablePath).startsWith(tableLocation.toFile().toURI().toString());
+        assertThat(tablePath).startsWith(tableLocation);
 
         assertUpdate("DROP TABLE test_create_external");
         deleteRecursively(tempDir, ALLOW_INSECURE);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestPartitionUpdate.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestPartitionUpdate.java
@@ -15,8 +15,8 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.PartitionUpdate.UpdateMode;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -43,8 +43,8 @@ public class TestPartitionUpdate
 
         assertEquals(actual.getName(), "test");
         assertEquals(actual.getUpdateMode(), UpdateMode.APPEND);
-        assertEquals(actual.getWritePath(), new Path("/writePath"));
-        assertEquals(actual.getTargetPath(), new Path("/targetPath"));
+        assertEquals(actual.getWritePath(), Location.of("/writePath"));
+        assertEquals(actual.getTargetPath(), Location.of("/targetPath"));
         assertEquals(actual.getFileNames(), ImmutableList.of("file1", "file3"));
         assertEquals(actual.getRowCount(), 123);
         assertEquals(actual.getInMemoryDataSizeInBytes(), 456);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
@@ -15,13 +15,13 @@ package io.trino.plugin.hive.metastore;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.HiveBucketProperty;
 import io.trino.plugin.hive.HiveMetastoreClosure;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
-import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -53,7 +53,7 @@ public class TestSemiTransactionalHiveMetastore
             Optional.of("comment"));
     private static final Storage TABLE_STORAGE = new Storage(
             StorageFormat.create("serde", "input", "output"),
-            Optional.of("location"),
+            Optional.of("file://location/"),
             Optional.of(new HiveBucketProperty(ImmutableList.of("column"), BUCKETING_V1, 10, ImmutableList.of(new SortingColumn("column", SortingColumn.Order.ASCENDING)))),
             true,
             ImmutableMap.of("param", "value2"));
@@ -109,7 +109,7 @@ public class TestSemiTransactionalHiveMetastore
             IntStream.range(0, tablesToUpdate).forEach(i -> semiTransactionalHiveMetastore.finishChangingExistingTable(INSERT, SESSION,
                     "database",
                     "table_" + i,
-                    new Path("location"),
+                    Location.of("file://location/"),
                     ImmutableList.of(),
                     PartitionStatistics.empty(),
                     false));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -30,6 +30,8 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.concurrent.BoundedExecutor;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.hdfs.TrinoHdfsFileSystemStats;
 import io.trino.plugin.hive.AbstractTestHiveLocal;
 import io.trino.plugin.hive.HiveBasicStatistics;
 import io.trino.plugin.hive.HiveMetastoreClosure;
@@ -232,6 +234,7 @@ public class TestHiveGlueMetastore
         Executor executor = new BoundedExecutor(this.executor, 10);
         GlueMetastoreStats stats = new GlueMetastoreStats();
         return new GlueHiveMetastore(
+                new HdfsFileSystemFactory(HDFS_ENVIRONMENT, new TrinoHdfsFileSystemStats()),
                 HDFS_ENVIRONMENT,
                 glueConfig,
                 executor,


### PR DESCRIPTION
## Description

Fixes #17803

- [ ] Add test for Hive Thrift metastore and MinIO

## Release notes

```markdown
# Hive
* Fix correctness issue when location contains double slash. ({issue}`17803`)
```