### PR TITLE
Fix file location in case of '/' root

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -207,18 +207,23 @@ public final class Location
      * Creates a new location by appending the given path element to the current path.
      * A slash will be added between the current path and the new path element if needed.
      *
-     * @throws IllegalArgumentException if the new path element is empty or starts with a slash
+     * @throws IllegalArgumentException if the new path element is empty
      */
     public Location appendPath(String newPathElement)
     {
         checkArgument(!newPathElement.isEmpty(), "newPathElement is empty");
-        checkArgument(!newPathElement.startsWith("/"), "newPathElement starts with a slash: %s", newPathElement);
 
         if (path.isEmpty()) {
+            if (newPathElement.startsWith("/")) {
+                newPathElement = newPathElement.substring(1);
+            }
             return appendToEmptyPath(newPathElement);
         }
 
-        if (!path.endsWith("/")) {
+        if (path.endsWith("/") && newPathElement.startsWith("/")) {
+            newPathElement = newPathElement.substring(1);
+        }
+        else if (!path.endsWith("/") && !newPathElement.startsWith("/")) {
             newPathElement = "/" + newPathElement;
         }
         return withPath(location + newPathElement, path + newPathElement);

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -281,7 +281,11 @@ class TestLocation
         assertAppendPath("scheme:///path/", "name", Location.of("scheme:///path/name"));
 
         assertAppendPath("/", "name", Location.of("/name"));
+        assertAppendPath("/", "/name", Location.of("/name"));
         assertAppendPath("/path", "name", Location.of("/path/name"));
+        assertAppendPath("/path", "/name", Location.of("/path/name"));
+        assertAppendPath("/path/", "/name", Location.of("/path/name"));
+        assertAppendPath("/path/", "name", Location.of("/path/name"));
     }
 
     private static void assertAppendPath(String locationString, String newPathElement, Location expected)

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
@@ -72,7 +72,8 @@ class HdfsFileIterator
 
         verify(path.startsWith(root), "iterator path [%s] not a child of listing path [%s] for location [%s]", path, root, listingLocation);
 
-        Location location = listingLocation.appendPath(path.substring(root.length() + 1));
+        int index = root.endsWith("/") ? root.length() : root.length() + 1;
+        Location location = listingLocation.appendPath(path.substring(index));
 
         List<Block> blocks = Stream.of(status.getBlockLocations())
                 .map(HdfsFileIterator::toTrinoBlock)

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
@@ -72,8 +72,7 @@ class HdfsFileIterator
 
         verify(path.startsWith(root), "iterator path [%s] not a child of listing path [%s] for location [%s]", path, root, listingLocation);
 
-        int index = root.endsWith("/") ? root.length() : root.length() + 1;
-        Location location = listingLocation.appendPath(path.substring(index));
+        Location location = listingLocation.appendPath(path.substring(root.length()));
 
         List<Block> blocks = Stream.of(status.getBlockLocations())
                 .map(HdfsFileIterator::toTrinoBlock)


### PR DESCRIPTION
## Description

Before this fix, when `root` was `/`, the first file name's character was trimmed.
For example when `listingLocation="s3a://bucket/"`, `root = "/"`, `path = "/file.parquet"` then location turned out to be `s3a://bucket/ile.parquet`.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( X ) Release notes are required, with the following suggested text:

```markdown
# Section TBD
* Fix TBD. ({issue}`TBD`)
```
