### PR TITLE
Retry test on TestAvroSchemaUrl

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
@@ -18,6 +18,7 @@ import io.trino.tempto.AfterMethodWithContext;
 import io.trino.tempto.BeforeMethodWithContext;
 import io.trino.tempto.hadoop.hdfs.HdfsClient;
 import io.trino.tempto.query.QueryExecutionException;
+import io.trino.testng.services.Flaky;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,6 +33,8 @@ import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.AVRO;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
+import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_ISSUES;
+import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_MATCH;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -84,6 +87,7 @@ public class TestAvroSchemaUrl
     }
 
     @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, STORAGE_FORMATS})
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testHiveCreatedTable(String schemaLocation)
     {
         onHive().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_hive");
@@ -104,6 +108,7 @@ public class TestAvroSchemaUrl
     }
 
     @Test(groups = AVRO)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testAvroSchemaUrlInSerdeProperties()
             throws IOException
     {
@@ -146,6 +151,7 @@ public class TestAvroSchemaUrl
     }
 
     @Test(dataProvider = "avroSchemaLocations", groups = {AVRO, STORAGE_FORMATS})
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testPrestoCreatedTable(String schemaLocation)
     {
         onTrino().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_presto");
@@ -159,6 +165,7 @@ public class TestAvroSchemaUrl
     }
 
     @Test(groups = {AVRO, STORAGE_FORMATS})
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testTableWithLongColumnType()
     {
         onTrino().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_long_column");
@@ -188,6 +195,7 @@ public class TestAvroSchemaUrl
     }
 
     @Test(groups = {AVRO, STORAGE_FORMATS})
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testPartitionedTableWithLongColumnType()
     {
         if (isOnHdp() && getHiveVersionMajor() < 3) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The test failed in https://github.com/trinodb/trino/actions/runs/5215544242/jobs/9413753076
```
2023-06-08T23:12:25.6411240Z tests | 2023-06-09 04:57:25 INFO: FAILURE / io.trino.tests.product.hive.TestAvroSchemaUrl.testHiveCreatedTable [/user/hive/warehouse/TestAvroSchemaUrl/schemas/original_schema.avsc] (Groups: storage_formats, avro) took 1.7 seconds
2023-06-08T23:12:25.6425792Z tests | 2023-06-09 04:57:25 SEVERE: Failure cause:
2023-06-08T23:12:25.6427078Z tests | io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask. Error caching map.xml: java.nio.channels.ClosedByInterruptException
2023-06-08T23:12:25.6428750Z tests | at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:119)
2023-06-08T23:12:25.6429755Z tests | at io.trino.tempto.query.JdbcQueryExecutor.executeQuery(JdbcQueryExecutor.java:84)
2023-06-08T23:12:25.6430614Z tests | at io.trino.tests.product.hive.TestAvroSchemaUrl.testHiveCreatedTable(TestAvroSchemaUrl.java:98)
2023-06-08T23:12:25.6431355Z tests | at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-06-08T23:12:25.6432147Z tests | at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2023-06-08T23:12:25.6432947Z tests | at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-06-08T23:12:25.6433692Z tests | at java.base/java.lang.reflect.Method.invoke(Method.java:568)
2023-06-08T23:12:25.6434456Z tests | at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
2023-06-08T23:12:25.6435133Z tests | at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
2023-06-08T23:12:25.6435731Z tests | at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
2023-06-08T23:12:25.6436339Z tests | at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
2023-06-08T23:12:25.6437017Z tests | at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
2023-06-08T23:12:25.6437671Z tests | at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
2023-06-08T23:12:25.6438348Z tests | at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
2023-06-08T23:12:25.6439043Z tests | at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
2023-06-08T23:12:25.6439640Z tests | at java.base/java.lang.Thread.run(Thread.java:833)
2023-06-08T23:12:25.6440613Z tests | Caused by: java.sql.SQLException: Error while processing statement: FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask. Error caching map.xml: java.nio.channels.ClosedByInterruptException
2023-06-08T23:12:25.6441505Z tests | at org.apache.hive.jdbc.HiveStatement.execute(HiveStatement.java:275)
2023-06-08T23:12:25.6442208Z tests | at io.trino.tempto.query.JdbcQueryExecutor.executeQueryNoParams(JdbcQueryExecutor.java:128)
2023-06-08T23:12:25.6442992Z tests | at io.trino.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:112)
2023-06-08T23:12:25.6443496Z tests | ... 15 more
2023-06-08T23:12:25.6444321Z tests | Suppressed: java.lang.Exception: Query: INSERT INTO test_avro_schema_url_hive VALUES ('some text', 123042)
2023-06-08T23:12:25.6445056Z tests | at io.trino.
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.