### PR TITLE
Fix concat_ws with array type don't support length exceed 254

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatFunction.java
@@ -25,7 +25,6 @@ import io.trino.spi.type.TypeSignature;
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
@@ -43,7 +42,6 @@ public final class ConcatFunction
 
     public static final ConcatFunction VARBINARY_CONCAT = new ConcatFunction(VARBINARY.getTypeSignature(), "concatenates given varbinary values");
 
-    private static final int MAX_INPUT_VALUES = 254;
     private static final int MAX_OUTPUT_LENGTH = DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 
     private ConcatFunction(TypeSignature type, String description)
@@ -66,10 +64,6 @@ public final class ConcatFunction
 
         if (arity < 2) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "There must be two or more concatenation arguments");
-        }
-
-        if (arity > MAX_INPUT_VALUES) {
-            throw new TrinoException(NOT_SUPPORTED, "Too many arguments for string concatenation");
         }
 
         MethodHandle arrayMethodHandle = methodHandle(ConcatFunction.class, "concat", Slice[].class);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatWsFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ConcatWsFunction.java
@@ -31,7 +31,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.Collections;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -55,7 +54,6 @@ public final class ConcatWsFunction
         extends SqlScalarFunction
 {
     public static final ConcatWsFunction CONCAT_WS = new ConcatWsFunction();
-    private static final int MAX_INPUT_VALUES = 254;
     private static final int MAX_OUTPUT_LENGTH = DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 
     @ScalarFunction("concat_ws")
@@ -146,10 +144,6 @@ public final class ConcatWsFunction
 
     private static Slice concatWs(Slice separator, SliceArray values)
     {
-        if (values.getCount() > MAX_INPUT_VALUES) {
-            throw new TrinoException(NOT_SUPPORTED, "Too many arguments for string concatenation");
-        }
-
         // Validate size of output
         int length = 0;
         boolean requiresSeparator = false;

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestConcatWsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestConcatWsFunction.java
@@ -14,6 +14,7 @@
 package io.trino.operator.scalar;
 
 import io.trino.sql.query.QueryAssertions;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,8 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestConcatWsFunction
 {
+    private static final int MAX_INPUT_VALUES = 254;
+    private static final int MAX_CONCAT_VALUES = MAX_INPUT_VALUES - 1;
     private QueryAssertions assertions;
 
     @BeforeAll
@@ -159,6 +162,16 @@ public class TestConcatWsFunction
         assertThat(assertions.function("concat_ws", "','", "ARRAY['abc', '', '', 'xyz','abcdefghi']"))
                 .hasType(VARCHAR)
                 .isEqualTo("abc,,,xyz,abcdefghi");
+
+        // array may exceed the limit
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < MAX_CONCAT_VALUES; i++) {
+            builder.append(i).append(',');
+        }
+        builder.append(MAX_CONCAT_VALUES);
+        assertThat(assertions.function("concat_ws", "','", "transform(sequence(0, " + MAX_CONCAT_VALUES + "), x -> cast(x as varchar))"))
+                .hasType(VARCHAR)
+                .isEqualTo(builder.toString());
     }
 
     @Test
@@ -173,6 +186,20 @@ public class TestConcatWsFunction
     {
         assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", "','", "1", "15").evaluate())
                 .hasMessageContaining("Unexpected parameters");
+    }
+
+    @Test
+    public void testTooManyArguments()
+    {
+        // all function arguments limit to 127 in io.trino.sql.analyzer.ExpressionAnalyzer.Visitor.visitFunctionCall
+        int argumentsLimit = 127;
+        @Language("SQL") String[] inputValues = new String[argumentsLimit + 1];
+        inputValues[0] = "','";
+        for (int i = 1; i <= argumentsLimit; i++) {
+            inputValues[i] = ("'" + i + "'");
+        }
+        assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", inputValues).evaluate())
+                .hasMessage("line 1:8: Too many arguments for function call concat_ws()");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
concat_ws function support argument with string concatenation and array type. They use the public method `Slice concatWs(Slice separator, SliceArray values)` for processing. This method limit string concatenation to 254. But the array type should not limit the length of the parameter.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix failures for queries involving ``concat_ws`` function on large arrays. ({issue}`17816`)
```
