### PR TITLE
Do not run ok-to-test workflow on forks

### DIFF
--- a/.github/workflows/ok-to-test.yml
+++ b/.github/workflows/ok-to-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test-with-secrets:
+    if: github.repository_owner == 'trinodb'
     runs-on: ubuntu-latest
     # Only run for PRs, not issue comments
     if: ${{ github.event.issue.pull_request }}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Forks don't need this since they can just configure their own secrets. Also running this requires the app_id for the GitHub app we are using and sharing that with other repos is not safe anyway.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.