### PR TITLE
Fix deprecation warning for license checker plugin

### DIFF
--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -71,9 +71,14 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <configuration>
-                        <excludes combine.children="append">
-                            <exclude>src/main/rpm/**</exclude>
-                        </excludes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>${air.license.header-file}</header>
+                                <excludes combine.children="append">
+                                    <exclude>src/main/rpm/**</exclude>
+                                </excludes>
+                            </licenseSet>
+                        </licenseSets>
                         <mapping>
                             <groovy>SLASHSTAR_STYLE</groovy>
                         </mapping>


### PR DESCRIPTION
The configuration uses a legacy option, which results in the following warning:

    [WARNING]    * Mojo license:check (com.mycila.maven.plugin.license.LicenseCheckMojo)
    [WARNING]      - Parameter 'legacyConfigExcludes' (user property 'license.excludes') is deprecated: use LicenseSet.excludes

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
