### PR TITLE
Round targetPartitionSizeInBytes to a multiple of minTargetPartitionSizeInBytes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ArbitraryDistributionSplitAssigner.java
@@ -60,6 +60,7 @@ class ArbitraryDistributionSplitAssigner
     private int nextPartitionId;
     private int adaptiveCounter;
     private long targetPartitionSizeInBytes;
+    private long roundedTargetPartitionSizeInBytes;
     private final List<PartitionAssignment> allAssignments = new ArrayList<>();
     private final Map<Optional<HostAddress>, PartitionAssignment> openAssignments = new HashMap<>();
 
@@ -94,6 +95,7 @@ class ArbitraryDistributionSplitAssigner
         this.maxTaskSplitCount = maxTaskSplitCount;
 
         this.targetPartitionSizeInBytes = minTargetPartitionSizeInBytes;
+        this.roundedTargetPartitionSizeInBytes = minTargetPartitionSizeInBytes;
     }
 
     @Override
@@ -200,7 +202,7 @@ class ArbitraryDistributionSplitAssigner
             Optional<HostAddress> hostRequirement = getHostRequirement(split);
             PartitionAssignment partitionAssignment = openAssignments.get(hostRequirement);
             long splitSizeInBytes = getSplitSizeInBytes(split);
-            if (partitionAssignment != null && ((partitionAssignment.getAssignedDataSizeInBytes() + splitSizeInBytes > targetPartitionSizeInBytes)
+            if (partitionAssignment != null && ((partitionAssignment.getAssignedDataSizeInBytes() + splitSizeInBytes > roundedTargetPartitionSizeInBytes)
                     || (partitionAssignment.getAssignedSplitCount() + 1 > maxTaskSplitCount))) {
                 partitionAssignment.setFull(true);
                 for (PlanNodeId partitionedSourceNodeId : partitionedSources) {
@@ -221,7 +223,8 @@ class ArbitraryDistributionSplitAssigner
                 if (adaptiveCounter >= adaptiveGrowthPeriod) {
                     targetPartitionSizeInBytes = (long) min(maxTargetPartitionSizeInBytes, ceil(targetPartitionSizeInBytes * adaptiveGrowthFactor));
                     // round to a multiple of minTargetPartitionSizeInBytes so work will be evenly distributed among drivers of a task
-                    targetPartitionSizeInBytes = (targetPartitionSizeInBytes + minTargetPartitionSizeInBytes - 1) / minTargetPartitionSizeInBytes * minTargetPartitionSizeInBytes;
+                    roundedTargetPartitionSizeInBytes = round(targetPartitionSizeInBytes * 1.0 / minTargetPartitionSizeInBytes) * minTargetPartitionSizeInBytes;
+                    verify(roundedTargetPartitionSizeInBytes > 0, "roundedTargetPartitionSizeInBytes %s not positive", roundedTargetPartitionSizeInBytes);
                     adaptiveCounter = 0;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

With growth factor 1.2:
sequence: 512MB, 614.4MB, 737.28MB, 884.736MB, 1061.6832MB
Previous: 512MB, 1024MB, 1536MB, 2048MB, 2560MB
With the change: 512MB, 512MB, 512MB, 1024MB, 1024MB

With some adjustments, sf1000 stays mostly unchanged, sf100 improved wall time around 3.6%

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/16719/commits/4561f0cc8d76e614ddf75f8d7f21bc4946d90775

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
