### PR TITLE
Support RLE DictionaryBlock.dictionary in UnnestingPositionsAppender

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -54,7 +54,7 @@ public class RleAwarePositionsAppender
     {
         // RleAwarePositionsAppender should be used with UnnestingPositionsAppender that makes sure
         // append is called only with flat block
-        checkArgument(!(source instanceof RunLengthEncodedBlock), "Append should be called with flat block but got %s", source);
+        checkArgument(!(source instanceof RunLengthEncodedBlock), "Append should be called with non-RLE block but got %s", source);
         switchToFlat();
         delegate.append(positions, source);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -54,7 +54,7 @@ public class RleAwarePositionsAppender
     {
         // RleAwarePositionsAppender should be used with UnnestingPositionsAppender that makes sure
         // append is called only with flat block
-        checkArgument(!(source instanceof RunLengthEncodedBlock));
+        checkArgument(!(source instanceof RunLengthEncodedBlock), "Append should be called with flat block but got %s", source);
         switchToFlat();
         delegate.append(positions, source);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RleAwarePositionsAppender.java
@@ -52,7 +52,7 @@ public class RleAwarePositionsAppender
     @Override
     public void append(IntArrayList positions, Block source)
     {
-        // RleAwarePositionsAppender should be used with FlatteningPositionsAppender that makes sure
+        // RleAwarePositionsAppender should be used with UnnestingPositionsAppender that makes sure
         // append is called only with flat block
         checkArgument(!(source instanceof RunLengthEncodedBlock));
         switchToFlat();

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -117,6 +117,11 @@ public class UnnestingPositionsAppender
     private void appendDictionary(IntArrayList positions, DictionaryBlock source)
     {
         Block dictionary = source.getDictionary();
+        if (dictionary instanceof RunLengthEncodedBlock rleDictionary) {
+            appendRle(rleDictionary.getValue(), positions.size());
+            return;
+        }
+
         IntArrayList dictionaryPositions = getDictionaryPositions(positions, source);
         if (dictionaryBlockBuilder.canAppend(dictionary)) {
             dictionaryBlockBuilder.append(dictionaryPositions, dictionary);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`DictionaryBlock.dictionary` will not be RLE in normal circumstances,
but since there is no precondition in the constructor, we cannot
rely on this to be always the case


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/17861


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix query failure due to an exception from PartitionedOutputOperator. ({issue}`17861`)
```
