### PR TITLE
Add OperatorContext to WorkProcessorSourceOperatorFactory.create

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -491,33 +491,33 @@ public class ScanFilterAndProjectOperator
 
         @Override
         public WorkProcessorSourceOperator create(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits)
         {
-            return create(session, memoryTrackingContext, yieldSignal, splits, true);
+            return create(operatorContext, memoryTrackingContext, yieldSignal, splits, true);
         }
 
         @Override
         public WorkProcessorSourceOperator createAdapterOperator(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits)
         {
-            return create(session, memoryTrackingContext, yieldSignal, splits, false);
+            return create(operatorContext, memoryTrackingContext, yieldSignal, splits, false);
         }
 
         private ScanFilterAndProjectOperator create(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits,
                 boolean avoidPageMaterialization)
         {
             return new ScanFilterAndProjectOperator(
-                    session,
+                    operatorContext.getSession(),
                     memoryTrackingContext,
                     yieldSignal,
                     splits,

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import io.trino.Session;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
@@ -114,13 +113,13 @@ public class TableScanOperator
 
         @Override
         public WorkProcessorSourceOperator create(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits)
         {
             return new TableScanWorkProcessorOperator(
-                    session,
+                    operatorContext.getSession(),
                     memoryTrackingContext,
                     splits,
                     pageSourceProvider,

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -146,7 +146,7 @@ public class WorkProcessorPipelineSourceOperator
         WorkProcessor<Split> splits = WorkProcessor.create(new Splits());
 
         sourceOperator = sourceOperatorFactory.create(
-                operatorContext.getSession(),
+                operatorContext,
                 sourceOperatorMemoryTrackingContext,
                 operatorContext.getDriverContext().getYieldSignal(),
                 splits);

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -16,7 +16,6 @@ package io.trino.operator;
 import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import io.trino.Session;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
 import io.trino.spi.Page;
@@ -56,12 +55,12 @@ public class WorkProcessorSourceOperatorAdapter
             extends WorkProcessorSourceOperatorFactory
     {
         default WorkProcessorSourceOperator createAdapterOperator(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits)
         {
-            return create(session, memoryTrackingContext, yieldSignal, splits);
+            return create(operatorContext, memoryTrackingContext, yieldSignal, splits);
         }
     }
 
@@ -72,7 +71,7 @@ public class WorkProcessorSourceOperatorAdapter
         this.splitBuffer = new SplitBuffer();
         this.sourceOperator = sourceOperatorFactory
                 .createAdapterOperator(
-                        operatorContext.getSession(),
+                        operatorContext,
                         new MemoryTrackingContext(
                                 operatorContext.aggregateUserMemoryContext(),
                                 operatorContext.aggregateRevocableMemoryContext()),

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator;
 
-import io.trino.Session;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -29,7 +28,7 @@ public interface WorkProcessorSourceOperatorFactory
     String getOperatorType();
 
     WorkProcessorSourceOperator create(
-            Session session,
+            OperatorContext operatorContext,
             MemoryTrackingContext memoryTrackingContext,
             DriverYieldSignal yieldSignal,
             WorkProcessor<Split> splits);

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -19,7 +19,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.Session;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
 import io.trino.operator.WorkProcessor.Transformation;
@@ -342,7 +341,7 @@ public class TestWorkProcessorPipelineSourceOperator
         }
 
         @Override
-        public WorkProcessorSourceOperator create(Session session, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Split> splits)
+        public WorkProcessorSourceOperator create(OperatorContext operatorContext, MemoryTrackingContext memoryTrackingContext, DriverYieldSignal yieldSignal, WorkProcessor<Split> splits)
         {
             assertNull(sourceOperator, "source operator already created");
             sourceOperator = new TestWorkProcessorSourceOperator(

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
@@ -16,7 +16,6 @@ package io.trino.operator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.airlift.units.Duration;
-import io.trino.Session;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
 import io.trino.operator.WorkProcessorSourceOperatorAdapter.AdapterWorkProcessorSourceOperatorFactory;
@@ -93,7 +92,7 @@ public class TestWorkProcessorSourceOperatorAdapter
     {
         @Override
         public WorkProcessorSourceOperator create(
-                Session session,
+                OperatorContext operatorContext,
                 MemoryTrackingContext memoryTrackingContext,
                 DriverYieldSignal yieldSignal,
                 WorkProcessor<Split> splits)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Since `WorkProcessorSourceOperator` is only used in the context of an operator, it seems feasible to pass `OperatorContext` to its factory.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
