### PR TITLE
Fix reading from Hive table with location being S3 bucket itself

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -224,6 +224,17 @@ public final class Location
         return withPath(location + newPathElement, path + newPathElement);
     }
 
+    Location removeOneTrailingSlash()
+    {
+        if (path.endsWith("/")) {
+            return withPath(location.substring(0, location.length() - 1), path.substring(0, path.length() - 1));
+        }
+        if (path.equals("") && location.endsWith("/")) {
+            return withPath(location.substring(0, location.length() - 1), "");
+        }
+        return this;
+    }
+
     /**
      * Creates a new location by appending the given suffix to the current path.
      * Typical usage for this method is to append a file extension to a file name,

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
@@ -67,4 +67,13 @@ public final class Locations
         checkArgument(location.indexOf('?') < 0, "location contains a query string: %s", location);
         checkArgument(location.indexOf('#') < 0, "location contains a fragment: %s", location);
     }
+
+    /**
+     * Verifies whether the two provided directory location parameters point to the same actual location.
+     */
+    public static boolean areDirectoryLocationsEquivalent(Location leftLocation, Location rightLocation)
+    {
+        return leftLocation.equals(rightLocation) ||
+                leftLocation.removeOneTrailingSlash().equals(rightLocation.removeOneTrailingSlash());
+    }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
@@ -15,14 +15,14 @@ package io.trino.filesystem;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-/**
- * @deprecated use {@link Location} instead
- */
-@Deprecated
 public final class Locations
 {
     private Locations() {}
 
+    /**
+     * @deprecated use {@link Location#appendPath(String)} instead
+     */
+    @Deprecated
     public static String appendPath(String location, String path)
     {
         validateLocation(location);
@@ -33,6 +33,10 @@ public final class Locations
         return location + path;
     }
 
+    /**
+     * @deprecated use {@link Location#parentDirectory()} instead
+     */
+    @Deprecated
     public static String getParent(String location)
     {
         validateLocation(location);
@@ -47,6 +51,10 @@ public final class Locations
         throw new IllegalArgumentException("Location does not have parent: " + location);
     }
 
+    /**
+     * @deprecated use {@link Location#fileName()} instead
+     */
+    @Deprecated
     public static String getFileName(String location)
     {
         validateLocation(location);

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileIterator.java
@@ -72,7 +72,8 @@ class HdfsFileIterator
 
         verify(path.startsWith(root), "iterator path [%s] not a child of listing path [%s] for location [%s]", path, root, listingLocation);
 
-        Location location = listingLocation.appendPath(path.substring(root.length() + 1));
+        int index = root.endsWith("/") ? root.length() : root.length() + 1;
+        Location location = listingLocation.appendPath(path.substring(index));
 
         List<Block> blocks = Stream.of(status.getBlockLocations())
                 .map(HdfsFileIterator::toTrinoBlock)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/VacuumProcedure.java
@@ -175,7 +175,7 @@ public class VacuumProcedure
         String tableLocation = tableSnapshot.getTableLocation();
         String transactionLogDir = getTransactionLogDir(tableLocation);
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        String commonPathPrefix = tableLocation + "/";
+        String commonPathPrefix = tableLocation.endsWith("/") ? tableLocation : tableLocation + "/";
         String queryId = session.getQueryId();
 
         // Retain all active files and every file removed by a "recent" transaction (except for the oldest "recent").

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -1627,6 +1627,52 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     }
 
     @Test
+    public void testVacuumWithTrailingSlash()
+            throws Exception
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+        String tableName = "test_vacuum" + randomNameSuffix();
+        String tableLocation = getLocationForTable(bucketName, tableName) + "/";
+        Session sessionWithShortRetentionUnlocked = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, "vacuum_min_retention", "0s")
+                .build();
+        assertUpdate(
+                format("CREATE TABLE %s WITH (location = '%s', partitioned_by = ARRAY['regionkey']) AS SELECT * FROM tpch.tiny.nation", tableName, tableLocation),
+                25);
+        try {
+            Set<String> initialFiles = getActiveFiles(tableName);
+            assertThat(initialFiles).hasSize(5);
+
+            computeActual("UPDATE " + tableName + " SET nationkey = nationkey + 100");
+            Stopwatch timeSinceUpdate = Stopwatch.createStarted();
+            Set<String> updatedFiles = getActiveFiles(tableName);
+            assertThat(updatedFiles).hasSize(5).doesNotContainAnyElementsOf(initialFiles);
+            assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
+
+            // vacuum with high retention period, nothing should change
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '10m')");
+            assertThat(query("SELECT * FROM " + tableName))
+                    .matches("SELECT nationkey + 100, CAST(name AS varchar), regionkey, CAST(comment AS varchar) FROM tpch.tiny.nation");
+            assertThat(getActiveFiles(tableName)).isEqualTo(updatedFiles);
+            assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(union(initialFiles, updatedFiles));
+
+            // vacuum with low retention period
+            MILLISECONDS.sleep(1_000 - timeSinceUpdate.elapsed(MILLISECONDS) + 1);
+            assertUpdate(sessionWithShortRetentionUnlocked, "CALL system.vacuum(schema_name => CURRENT_SCHEMA, table_name => '" + tableName + "', retention => '1s')");
+            // table data shouldn't change
+            assertThat(query("SELECT * FROM " + tableName))
+                    .matches("SELECT nationkey + 100, CAST(name AS varchar), regionkey, CAST(comment AS varchar) FROM tpch.tiny.nation");
+            // active files shouldn't change
+            assertThat(getActiveFiles(tableName)).isEqualTo(updatedFiles);
+            // old files should be cleaned up
+            assertThat(getAllDataFilesFromTableDirectory(tableName)).isEqualTo(updatedFiles);
+        }
+        finally {
+            assertUpdate("DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testVacuumParameterValidation()
     {
         String catalog = getSession().getCatalog().orElseThrow();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryListingFilter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/DirectoryListingFilter.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 
+import static io.trino.filesystem.Locations.areDirectoryLocationsEquivalent;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -69,7 +70,7 @@ public class DirectoryListingFilter
         while (delegateIterator.hasNext()) {
             TrinoFileStatus candidate = delegateIterator.next();
             Location parent = Location.of(candidate.getPath()).parentDirectory();
-            boolean directChild = parent.equals(prefix);
+            boolean directChild = areDirectoryLocationsEquivalent(parent, prefix);
 
             if (!directChild && failOnUnexpectedFiles && !parentIsHidden(parent, prefix)) {
                 throw new HiveFileIterator.NestedDirectoryNotAllowedException(candidate.getPath());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case that a user decides to dedicate an S3 bucket for a Hive table, this PR adds the required handling to support reading from such a table.

```
CREATE TABLE myhivetable (c integer) WITH (external_location='s3://myhivetable/');
```

The hadoop  `Path` corresponding to 's3://myhivetable/' has the string representation `'s3://myhivetable/'`.
The hadoop `Path` corresponding to `'s3://myhivetable/somedir/' has the string representation `'s3://myhivetable/somedir' (note that in this case the `/` at the end of the string representation is not present).

Specific handling has to be done in such a case to find the data files at the top level of the bucket.

Not present in the tests provided with this PR, but still a valid scenario is the usage of `hive.recursive-directories=true` hive setting. Tested manually so far.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix reading from Hive table with location being S3 bucket itself. ({issue}`issuenumber`)
```
