### PR TITLE
Kerberos delegation support

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -120,7 +120,8 @@ public class QueryRunner
                     kerberosConfigPath.map(File::new),
                     kerberosKeytabPath.map(File::new),
                     kerberosCredentialCachePath.map(File::new),
-                    delegatedKerberos);
+                    delegatedKerberos,
+                    Optional.empty());
         }
 
         this.httpClient = builder.build();

--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -16,10 +16,10 @@ package io.trino.client;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.StandardSystemProperty;
 import com.google.common.net.HostAndPort;
-import io.trino.client.auth.kerberos.ContextBasedSubjectProvider;
-import io.trino.client.auth.kerberos.LoginBasedSubjectProvider;
+import io.trino.client.auth.kerberos.DelegatedUnconstrainedContextProvider;
+import io.trino.client.auth.kerberos.GSSContextProvider;
+import io.trino.client.auth.kerberos.LoginBasedUnconstrainedContextProvider;
 import io.trino.client.auth.kerberos.SpnegoHandler;
-import io.trino.client.auth.kerberos.SubjectProvider;
 import okhttp3.Credentials;
 import okhttp3.Interceptor;
 import okhttp3.JavaNetCookieJar;
@@ -317,14 +317,14 @@ public final class OkHttpUtil
             Optional<File> credentialCache,
             boolean delegatedKerberos)
     {
-        SubjectProvider subjectProvider;
+        GSSContextProvider contextProvider;
         if (delegatedKerberos) {
-            subjectProvider = new ContextBasedSubjectProvider();
+            contextProvider = new DelegatedUnconstrainedContextProvider();
         }
         else {
-            subjectProvider = new LoginBasedSubjectProvider(principal, kerberosConfig, keytab, credentialCache);
+            contextProvider = new LoginBasedUnconstrainedContextProvider(principal, kerberosConfig, keytab, credentialCache);
         }
-        SpnegoHandler handler = new SpnegoHandler(servicePrincipalPattern, remoteServiceName, useCanonicalHostname, subjectProvider);
+        SpnegoHandler handler = new SpnegoHandler(servicePrincipalPattern, remoteServiceName, useCanonicalHostname, contextProvider);
         clientBuilder.addInterceptor(handler);
         clientBuilder.authenticator(handler);
     }

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/AbstractUnconstrainedContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/AbstractUnconstrainedContextProvider.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.kerberos;
+
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+
+import javax.security.auth.Subject;
+
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.ietf.jgss.GSSCredential.DEFAULT_LIFETIME;
+import static org.ietf.jgss.GSSCredential.INITIATE_ONLY;
+import static org.ietf.jgss.GSSName.NT_USER_NAME;
+
+public abstract class AbstractUnconstrainedContextProvider
+        extends BaseGSSContextProvider
+{
+    private GSSCredential clientCredential;
+
+    @Override
+    public GSSContext getContext(String servicePrincipal)
+            throws GSSException
+    {
+        if ((clientCredential == null) || clientCredential.getRemainingLifetime() < MIN_CREDENTIAL_LIFETIME.getValue(SECONDS)) {
+            clientCredential = createGssCredential();
+        }
+
+        return doAs(getSubject(), () -> createContext(servicePrincipal, clientCredential));
+    }
+
+    private GSSCredential createGssCredential()
+            throws GSSException
+    {
+        refresh();
+        Subject subject = getSubject();
+        Principal clientPrincipal = subject.getPrincipals().iterator().next();
+        return doAs(subject, () -> GSS_MANAGER.createCredential(
+                GSS_MANAGER.createName(clientPrincipal.getName(), NT_USER_NAME),
+                DEFAULT_LIFETIME,
+                KERBEROS_OID,
+                INITIATE_ONLY));
+    }
+
+    public abstract void refresh()
+            throws GSSException;
+
+    protected abstract Subject getSubject();
+
+    interface GssSupplier<T>
+    {
+        T get()
+                throws GSSException;
+    }
+
+    static <T> T doAs(Subject subject, GssSupplier<T> action)
+            throws GSSException
+    {
+        try {
+            return Subject.doAs(subject, (PrivilegedExceptionAction<T>) action::get);
+        }
+        catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            throwIfInstanceOf(t, GSSException.class);
+            throwIfUnchecked(t);
+            throw new RuntimeException(t);
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/BaseGSSContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/BaseGSSContextProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.kerberos;
+
+import io.airlift.units.Duration;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.Oid;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.ietf.jgss.GSSContext.INDEFINITE_LIFETIME;
+import static org.ietf.jgss.GSSName.NT_HOSTBASED_SERVICE;
+
+public abstract class BaseGSSContextProvider
+        implements GSSContextProvider
+{
+    protected static final GSSManager GSS_MANAGER = GSSManager.getInstance();
+    protected static final Oid SPNEGO_OID = createOid("1.3.6.1.5.5.2");
+    protected static final Oid KERBEROS_OID = createOid("1.2.840.113554.1.2.2");
+    protected static final Duration MIN_CREDENTIAL_LIFETIME = new Duration(60, SECONDS);
+
+    protected GSSContext createContext(String servicePrincipal, GSSCredential gssCredential)
+            throws GSSException
+    {
+        GSSContext result = GSS_MANAGER.createContext(
+                GSS_MANAGER.createName(servicePrincipal, NT_HOSTBASED_SERVICE),
+                SPNEGO_OID,
+                gssCredential,
+                INDEFINITE_LIFETIME);
+
+        result.requestMutualAuth(true);
+        result.requestConf(true);
+        result.requestInteg(true);
+        result.requestCredDeleg(true);
+        return result;
+    }
+
+    static Oid createOid(String value)
+    {
+        try {
+            return new Oid(value);
+        }
+        catch (GSSException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedConstrainedContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedConstrainedContextProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.kerberos;
+
+import io.trino.client.ClientException;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSException;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class DelegatedConstrainedContextProvider
+        extends BaseGSSContextProvider
+{
+    private final GSSCredential gssCredential;
+
+    public DelegatedConstrainedContextProvider(GSSCredential gssCredential)
+    {
+        this.gssCredential = requireNonNull(gssCredential, "gssCredential is null");
+    }
+
+    @Override
+    public GSSContext getContext(String servicePrincipal)
+            throws GSSException
+    {
+        if (gssCredential.getRemainingLifetime() < MIN_CREDENTIAL_LIFETIME.getValue(SECONDS)) {
+            throw new ClientException(format("Kerberos credential is expired: %s seconds", gssCredential.getRemainingLifetime()));
+        }
+        return createContext(servicePrincipal, gssCredential);
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedUnconstrainedContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/DelegatedUnconstrainedContextProvider.java
@@ -19,27 +19,26 @@ import org.ietf.jgss.GSSException;
 import javax.security.auth.RefreshFailedException;
 import javax.security.auth.Subject;
 import javax.security.auth.kerberos.KerberosTicket;
-import javax.security.auth.login.LoginException;
 
+import java.security.AccessController;
 import java.util.Set;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static java.security.AccessController.getContext;
 
-public class ContextBasedSubjectProvider
-        implements SubjectProvider
+public class DelegatedUnconstrainedContextProvider
+        extends AbstractUnconstrainedContextProvider
 {
-    private final Subject subject = Subject.getSubject(getContext());
+    private final Subject subject = Subject.getSubject(AccessController.getContext());
 
     @Override
-    public Subject getSubject()
+    protected Subject getSubject()
     {
         return subject;
     }
 
     @Override
     public void refresh()
-            throws LoginException, GSSException
+            throws GSSException
     {
         Set<KerberosTicket> credentials = subject.getPrivateCredentials(KerberosTicket.class);
 

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/GSSContextProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/GSSContextProvider.java
@@ -13,15 +13,11 @@
  */
 package io.trino.client.auth.kerberos;
 
+import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 
-import javax.security.auth.Subject;
-import javax.security.auth.login.LoginException;
-
-public interface SubjectProvider
+public interface GSSContextProvider
 {
-    Subject getSubject();
-
-    void refresh()
-            throws LoginException, GSSException;
+    GSSContext getContext(String servicePrincipal)
+            throws GSSException;
 }

--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/SpnegoHandler.java
@@ -14,8 +14,6 @@
 package io.trino.client.auth.kerberos;
 
 import com.google.common.base.Splitter;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
-import io.airlift.units.Duration;
 import io.trino.client.ClientException;
 import okhttp3.Authenticator;
 import okhttp3.Interceptor;
@@ -23,67 +21,42 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.Route;
 import org.ietf.jgss.GSSContext;
-import org.ietf.jgss.GSSCredential;
 import org.ietf.jgss.GSSException;
-import org.ietf.jgss.GSSManager;
-import org.ietf.jgss.Oid;
 
-import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.security.Principal;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Base64;
 import java.util.Locale;
 
 import static com.google.common.base.CharMatcher.whitespace;
-import static com.google.common.base.Throwables.throwIfInstanceOf;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.ietf.jgss.GSSContext.INDEFINITE_LIFETIME;
-import static org.ietf.jgss.GSSCredential.DEFAULT_LIFETIME;
-import static org.ietf.jgss.GSSCredential.INITIATE_ONLY;
-import static org.ietf.jgss.GSSName.NT_HOSTBASED_SERVICE;
-import static org.ietf.jgss.GSSName.NT_USER_NAME;
 
 // TODO: This class is similar to SpnegoAuthentication in Airlift. Consider extracting a library.
 public class SpnegoHandler
         implements Interceptor, Authenticator
 {
     private static final String NEGOTIATE = "Negotiate";
-    private static final Duration MIN_CREDENTIAL_LIFETIME = new Duration(60, SECONDS);
-
-    private static final GSSManager GSS_MANAGER = GSSManager.getInstance();
-
-    private static final Oid SPNEGO_OID = createOid("1.3.6.1.5.5.2");
-    private static final Oid KERBEROS_OID = createOid("1.2.840.113554.1.2.2");
-
     private final String servicePrincipalPattern;
     private final String remoteServiceName;
     private final boolean useCanonicalHostname;
-    private final SubjectProvider subjectProvider;
-
-    @GuardedBy("this")
-    private GSSCredential clientCredential;
+    private final GSSContextProvider contextProvider;
 
     public SpnegoHandler(
             String servicePrincipalPattern,
             String remoteServiceName,
             boolean useCanonicalHostname,
-            SubjectProvider subjectProvider)
+            GSSContextProvider contextProvider)
     {
         this.servicePrincipalPattern = requireNonNull(servicePrincipalPattern, "servicePrincipalPattern is null");
         this.remoteServiceName = requireNonNull(remoteServiceName, "remoteServiceName is null");
         this.useCanonicalHostname = useCanonicalHostname;
-        this.subjectProvider = requireNonNull(subjectProvider, "subjectProvider is null");
+        this.contextProvider = requireNonNull(contextProvider, "subjectProvider is null");
     }
 
     @Override
@@ -132,21 +105,7 @@ public class SpnegoHandler
     {
         GSSContext context = null;
         try {
-            GSSCredential clientCredential = getGssCredential();
-            context = doAs(subjectProvider.getSubject(), () -> {
-                GSSContext result = GSS_MANAGER.createContext(
-                        GSS_MANAGER.createName(servicePrincipal, NT_HOSTBASED_SERVICE),
-                        SPNEGO_OID,
-                        clientCredential,
-                        INDEFINITE_LIFETIME);
-
-                result.requestMutualAuth(true);
-                result.requestConf(true);
-                result.requestInteg(true);
-                result.requestCredDeleg(true);
-                return result;
-            });
-
+            context = contextProvider.getContext(servicePrincipal);
             byte[] token = context.initSecContext(new byte[0], 0, 0);
             if (token == null) {
                 throw new LoginException("No token generated from GSS context");
@@ -165,28 +124,6 @@ public class SpnegoHandler
             catch (GSSException ignored) {
             }
         }
-    }
-
-    private synchronized GSSCredential getGssCredential()
-            throws LoginException, GSSException
-    {
-        if ((clientCredential == null) || clientCredential.getRemainingLifetime() < MIN_CREDENTIAL_LIFETIME.getValue(SECONDS)) {
-            clientCredential = createGssCredential();
-        }
-        return clientCredential;
-    }
-
-    private GSSCredential createGssCredential()
-            throws LoginException, GSSException
-    {
-        subjectProvider.refresh();
-        Subject subject = subjectProvider.getSubject();
-        Principal clientPrincipal = subject.getPrincipals().iterator().next();
-        return doAs(subject, () -> GSS_MANAGER.createCredential(
-                GSS_MANAGER.createName(clientPrincipal.getName(), NT_USER_NAME),
-                DEFAULT_LIFETIME,
-                KERBEROS_OID,
-                INITIATE_ONLY));
     }
 
     private static String makeServicePrincipal(String servicePrincipalPattern, String serviceName, String hostName, boolean useCanonicalHostname)
@@ -216,36 +153,6 @@ public class SpnegoHandler
         }
         catch (UnknownHostException e) {
             throw new ClientException("Failed to resolve host: " + hostName, e);
-        }
-    }
-
-    private interface GssSupplier<T>
-    {
-        T get()
-                throws GSSException;
-    }
-
-    private static <T> T doAs(Subject subject, GssSupplier<T> action)
-            throws GSSException
-    {
-        try {
-            return Subject.doAs(subject, (PrivilegedExceptionAction<T>) action::get);
-        }
-        catch (PrivilegedActionException e) {
-            Throwable t = e.getCause();
-            throwIfInstanceOf(t, GSSException.class);
-            throwIfUnchecked(t);
-            throw new RuntimeException(t);
-        }
-    }
-
-    private static Oid createOid(String value)
-    {
-        try {
-            return new Oid(value);
-        }
-        catch (GSSException e) {
-            throw new AssertionError(e);
         }
     }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -50,49 +50,49 @@ final class ConnectionProperties
         FULL, CA, NONE
     }
 
-    public static final ConnectionProperty<String> USER = new User();
-    public static final ConnectionProperty<String> PASSWORD = new Password();
-    public static final ConnectionProperty<String> SESSION_USER = new SessionUser();
-    public static final ConnectionProperty<Map<String, ClientSelectedRole>> ROLES = new Roles();
-    public static final ConnectionProperty<HostAndPort> SOCKS_PROXY = new SocksProxy();
-    public static final ConnectionProperty<HostAndPort> HTTP_PROXY = new HttpProxy();
-    public static final ConnectionProperty<String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
-    public static final ConnectionProperty<Boolean> DISABLE_COMPRESSION = new DisableCompression();
-    public static final ConnectionProperty<Boolean> ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralNamesInMetadataCallsForNonConformingClients();
-    public static final ConnectionProperty<Boolean> ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
-    public static final ConnectionProperty<Boolean> SSL = new Ssl();
-    public static final ConnectionProperty<SslVerificationMode> SSL_VERIFICATION = new SslVerification();
-    public static final ConnectionProperty<String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
-    public static final ConnectionProperty<String> SSL_KEY_STORE_PASSWORD = new SslKeyStorePassword();
-    public static final ConnectionProperty<String> SSL_KEY_STORE_TYPE = new SslKeyStoreType();
-    public static final ConnectionProperty<String> SSL_TRUST_STORE_PATH = new SslTrustStorePath();
-    public static final ConnectionProperty<String> SSL_TRUST_STORE_PASSWORD = new SslTrustStorePassword();
-    public static final ConnectionProperty<String> SSL_TRUST_STORE_TYPE = new SslTrustStoreType();
-    public static final ConnectionProperty<Boolean> SSL_USE_SYSTEM_TRUST_STORE = new SslUseSystemTrustStore();
-    public static final ConnectionProperty<String> KERBEROS_SERVICE_PRINCIPAL_PATTERN = new KerberosServicePrincipalPattern();
-    public static final ConnectionProperty<String> KERBEROS_REMOTE_SERVICE_NAME = new KerberosRemoteServiceName();
-    public static final ConnectionProperty<Boolean> KERBEROS_USE_CANONICAL_HOSTNAME = new KerberosUseCanonicalHostname();
-    public static final ConnectionProperty<String> KERBEROS_PRINCIPAL = new KerberosPrincipal();
-    public static final ConnectionProperty<File> KERBEROS_CONFIG_PATH = new KerberosConfigPath();
-    public static final ConnectionProperty<File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
-    public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
-    public static final ConnectionProperty<Boolean> KERBEROS_DELEGATION = new KerberosDelegation();
-    public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
-    public static final ConnectionProperty<Boolean> EXTERNAL_AUTHENTICATION = new ExternalAuthentication();
-    public static final ConnectionProperty<Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
-    public static final ConnectionProperty<List<ExternalRedirectStrategy>> EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS = new ExternalAuthenticationRedirectHandlers();
-    public static final ConnectionProperty<KnownTokenCache> EXTERNAL_AUTHENTICATION_TOKEN_CACHE = new ExternalAuthenticationTokenCache();
-    public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
-    public static final ConnectionProperty<String> CLIENT_INFO = new ClientInfo();
-    public static final ConnectionProperty<String> CLIENT_TAGS = new ClientTags();
-    public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
-    public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
-    public static final ConnectionProperty<String> SOURCE = new Source();
-    public static final ConnectionProperty<Class<? extends DnsResolver>> DNS_RESOLVER = new Resolver();
-    public static final ConnectionProperty<String> DNS_RESOLVER_CONTEXT = new ResolverContext();
-    public static final ConnectionProperty<String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
+    public static final ConnectionProperty<String, String> USER = new User();
+    public static final ConnectionProperty<String, String> PASSWORD = new Password();
+    public static final ConnectionProperty<String, String> SESSION_USER = new SessionUser();
+    public static final ConnectionProperty<String, Map<String, ClientSelectedRole>> ROLES = new Roles();
+    public static final ConnectionProperty<String, HostAndPort> SOCKS_PROXY = new SocksProxy();
+    public static final ConnectionProperty<String, HostAndPort> HTTP_PROXY = new HttpProxy();
+    public static final ConnectionProperty<String, String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
+    public static final ConnectionProperty<String, Boolean> DISABLE_COMPRESSION = new DisableCompression();
+    public static final ConnectionProperty<String, Boolean> ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralNamesInMetadataCallsForNonConformingClients();
+    public static final ConnectionProperty<String, Boolean> ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
+    public static final ConnectionProperty<String, Boolean> SSL = new Ssl();
+    public static final ConnectionProperty<String, SslVerificationMode> SSL_VERIFICATION = new SslVerification();
+    public static final ConnectionProperty<String, String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
+    public static final ConnectionProperty<String, String> SSL_KEY_STORE_PASSWORD = new SslKeyStorePassword();
+    public static final ConnectionProperty<String, String> SSL_KEY_STORE_TYPE = new SslKeyStoreType();
+    public static final ConnectionProperty<String, String> SSL_TRUST_STORE_PATH = new SslTrustStorePath();
+    public static final ConnectionProperty<String, String> SSL_TRUST_STORE_PASSWORD = new SslTrustStorePassword();
+    public static final ConnectionProperty<String, String> SSL_TRUST_STORE_TYPE = new SslTrustStoreType();
+    public static final ConnectionProperty<String, Boolean> SSL_USE_SYSTEM_TRUST_STORE = new SslUseSystemTrustStore();
+    public static final ConnectionProperty<String, String> KERBEROS_SERVICE_PRINCIPAL_PATTERN = new KerberosServicePrincipalPattern();
+    public static final ConnectionProperty<String, String> KERBEROS_REMOTE_SERVICE_NAME = new KerberosRemoteServiceName();
+    public static final ConnectionProperty<String, Boolean> KERBEROS_USE_CANONICAL_HOSTNAME = new KerberosUseCanonicalHostname();
+    public static final ConnectionProperty<String, String> KERBEROS_PRINCIPAL = new KerberosPrincipal();
+    public static final ConnectionProperty<String, File> KERBEROS_CONFIG_PATH = new KerberosConfigPath();
+    public static final ConnectionProperty<String, File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
+    public static final ConnectionProperty<String, File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
+    public static final ConnectionProperty<String, Boolean> KERBEROS_DELEGATION = new KerberosDelegation();
+    public static final ConnectionProperty<String, String> ACCESS_TOKEN = new AccessToken();
+    public static final ConnectionProperty<String, Boolean> EXTERNAL_AUTHENTICATION = new ExternalAuthentication();
+    public static final ConnectionProperty<String, Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
+    public static final ConnectionProperty<String, List<ExternalRedirectStrategy>> EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS = new ExternalAuthenticationRedirectHandlers();
+    public static final ConnectionProperty<String, KnownTokenCache> EXTERNAL_AUTHENTICATION_TOKEN_CACHE = new ExternalAuthenticationTokenCache();
+    public static final ConnectionProperty<String, Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
+    public static final ConnectionProperty<String, String> CLIENT_INFO = new ClientInfo();
+    public static final ConnectionProperty<String, String> CLIENT_TAGS = new ClientTags();
+    public static final ConnectionProperty<String, String> TRACE_TOKEN = new TraceToken();
+    public static final ConnectionProperty<String, Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
+    public static final ConnectionProperty<String, String> SOURCE = new Source();
+    public static final ConnectionProperty<String, Class<? extends DnsResolver>> DNS_RESOLVER = new Resolver();
+    public static final ConnectionProperty<String, String> DNS_RESOLVER_CONTEXT = new ResolverContext();
+    public static final ConnectionProperty<String, String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
 
-    private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
+    private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             .add(USER)
             .add(PASSWORD)
             .add(SESSION_USER)
@@ -136,14 +136,14 @@ final class ConnectionProperties
             .add(HOSTNAME_IN_CERTIFICATE)
             .build();
 
-    private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
+    private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
             .collect(toMap(ConnectionProperty::getKey, identity())));
 
-    private static final Map<String, String> DEFAULTS;
+    private static final Map<String, Object> DEFAULTS;
 
     static {
-        ImmutableMap.Builder<String, String> defaults = ImmutableMap.builder();
-        for (ConnectionProperty<?> property : ALL_PROPERTIES) {
+        ImmutableMap.Builder<String, Object> defaults = ImmutableMap.builder();
+        for (ConnectionProperty<?, ?> property : ALL_PROPERTIES) {
             property.getDefault().ifPresent(value -> defaults.put(property.getKey(), value));
         }
         DEFAULTS = defaults.buildOrThrow();
@@ -151,23 +151,23 @@ final class ConnectionProperties
 
     private ConnectionProperties() {}
 
-    public static ConnectionProperty<?> forKey(String propertiesKey)
+    public static ConnectionProperty<?, ?> forKey(String propertiesKey)
     {
         return KEY_LOOKUP.get(propertiesKey);
     }
 
-    public static Set<ConnectionProperty<?>> allProperties()
+    public static Set<ConnectionProperty<?, ?>> allProperties()
     {
         return ALL_PROPERTIES;
     }
 
-    public static Map<String, String> getDefaults()
+    public static Map<String, Object> getDefaults()
     {
         return DEFAULTS;
     }
 
     private static class User
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public User()
         {
@@ -176,7 +176,7 @@ final class ConnectionProperties
     }
 
     private static class Password
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public Password()
         {
@@ -185,7 +185,7 @@ final class ConnectionProperties
     }
 
     private static class SessionUser
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         protected SessionUser()
         {
@@ -194,7 +194,7 @@ final class ConnectionProperties
     }
 
     private static class Roles
-            extends AbstractConnectionProperty<Map<String, ClientSelectedRole>>
+            extends AbstractConnectionProperty<String, Map<String, ClientSelectedRole>>
     {
         public Roles()
         {
@@ -226,7 +226,7 @@ final class ConnectionProperties
     }
 
     private static class SocksProxy
-            extends AbstractConnectionProperty<HostAndPort>
+            extends AbstractConnectionProperty<String, HostAndPort>
     {
         private static final Predicate<Properties> NO_HTTP_PROXY =
                 checkedPredicate(properties -> !HTTP_PROXY.getValue(properties).isPresent());
@@ -238,7 +238,7 @@ final class ConnectionProperties
     }
 
     private static class HttpProxy
-            extends AbstractConnectionProperty<HostAndPort>
+            extends AbstractConnectionProperty<String, HostAndPort>
     {
         private static final Predicate<Properties> NO_SOCKS_PROXY =
                 checkedPredicate(properties -> !SOCKS_PROXY.getValue(properties).isPresent());
@@ -250,7 +250,7 @@ final class ConnectionProperties
     }
 
     private static class ApplicationNamePrefix
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public ApplicationNamePrefix()
         {
@@ -259,7 +259,7 @@ final class ConnectionProperties
     }
 
     private static class ClientInfo
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public ClientInfo()
         {
@@ -268,7 +268,7 @@ final class ConnectionProperties
     }
 
     private static class ClientTags
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public ClientTags()
         {
@@ -277,7 +277,7 @@ final class ConnectionProperties
     }
 
     private static class TraceToken
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public TraceToken()
         {
@@ -286,7 +286,7 @@ final class ConnectionProperties
     }
 
     private static class DisableCompression
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public DisableCompression()
         {
@@ -298,7 +298,7 @@ final class ConnectionProperties
      * @deprecated use {@link AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients}
      */
     private static class AssumeLiteralNamesInMetadataCallsForNonConformingClients
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         private static final Predicate<Properties> IS_ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED =
                 checkedPredicate(properties -> !ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false));
@@ -315,7 +315,7 @@ final class ConnectionProperties
     }
 
     private static class AssumeLiteralUnderscoreInMetadataCallsForNonConformingClients
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         private static final Predicate<Properties> IS_ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS_NOT_ENABLED =
                 checkedPredicate(properties -> !ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false));
@@ -332,7 +332,7 @@ final class ConnectionProperties
     }
 
     private static class Ssl
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public Ssl()
         {
@@ -341,7 +341,7 @@ final class ConnectionProperties
     }
 
     private static class SslVerification
-            extends AbstractConnectionProperty<SslVerificationMode>
+            extends AbstractConnectionProperty<String, SslVerificationMode>
     {
         private static final Predicate<Properties> IF_SSL_ENABLED =
                 checkedPredicate(properties -> SSL.getValue(properties).orElse(false));
@@ -359,7 +359,7 @@ final class ConnectionProperties
     }
 
     private static class SslKeyStorePath
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public SslKeyStorePath()
         {
@@ -368,7 +368,7 @@ final class ConnectionProperties
     }
 
     private static class SslKeyStorePassword
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         private static final Predicate<Properties> IF_KEY_STORE =
                 checkedPredicate(properties -> SSL_KEY_STORE_PATH.getValue(properties).isPresent());
@@ -380,7 +380,7 @@ final class ConnectionProperties
     }
 
     private static class SslKeyStoreType
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         private static final Predicate<Properties> IF_KEY_STORE =
                 checkedPredicate(properties -> SSL_KEY_STORE_PATH.getValue(properties).isPresent());
@@ -392,7 +392,7 @@ final class ConnectionProperties
     }
 
     private static class SslTrustStorePath
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         private static final Predicate<Properties> IF_SYSTEM_TRUST_STORE_NOT_ENABLED =
                 checkedPredicate(properties -> !SSL_USE_SYSTEM_TRUST_STORE.getValue(properties).orElse(false));
@@ -404,7 +404,7 @@ final class ConnectionProperties
     }
 
     private static class SslTrustStorePassword
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         private static final Predicate<Properties> IF_TRUST_STORE =
                 checkedPredicate(properties -> SSL_TRUST_STORE_PATH.getValue(properties).isPresent());
@@ -416,7 +416,7 @@ final class ConnectionProperties
     }
 
     private static class SslTrustStoreType
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         private static final Predicate<Properties> IF_TRUST_STORE =
                 checkedPredicate(properties -> SSL_TRUST_STORE_PATH.getValue(properties).isPresent() || SSL_USE_SYSTEM_TRUST_STORE.getValue(properties).orElse(false));
@@ -428,7 +428,7 @@ final class ConnectionProperties
     }
 
     private static class SslUseSystemTrustStore
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public SslUseSystemTrustStore()
         {
@@ -437,7 +437,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosRemoteServiceName
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public KerberosRemoteServiceName()
         {
@@ -456,7 +456,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosServicePrincipalPattern
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public KerberosServicePrincipalPattern()
         {
@@ -465,7 +465,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosPrincipal
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public KerberosPrincipal()
         {
@@ -474,7 +474,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosUseCanonicalHostname
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public KerberosUseCanonicalHostname()
         {
@@ -483,7 +483,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosConfigPath
-            extends AbstractConnectionProperty<File>
+            extends AbstractConnectionProperty<String, File>
     {
         public KerberosConfigPath()
         {
@@ -492,7 +492,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosKeytabPath
-            extends AbstractConnectionProperty<File>
+            extends AbstractConnectionProperty<String, File>
     {
         public KerberosKeytabPath()
         {
@@ -501,7 +501,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosCredentialCachePath
-            extends AbstractConnectionProperty<File>
+            extends AbstractConnectionProperty<String, File>
     {
         public KerberosCredentialCachePath()
         {
@@ -510,7 +510,7 @@ final class ConnectionProperties
     }
 
     private static class KerberosDelegation
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public KerberosDelegation()
         {
@@ -519,7 +519,7 @@ final class ConnectionProperties
     }
 
     private static class AccessToken
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public AccessToken()
         {
@@ -528,7 +528,7 @@ final class ConnectionProperties
     }
 
     private static class ExternalAuthentication
-            extends AbstractConnectionProperty<Boolean>
+            extends AbstractConnectionProperty<String, Boolean>
     {
         public ExternalAuthentication()
         {
@@ -537,7 +537,7 @@ final class ConnectionProperties
     }
 
     private static class ExternalAuthenticationRedirectHandlers
-            extends AbstractConnectionProperty<List<ExternalRedirectStrategy>>
+            extends AbstractConnectionProperty<String, List<ExternalRedirectStrategy>>
     {
         private static final Splitter ENUM_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
@@ -555,7 +555,7 @@ final class ConnectionProperties
     }
 
     private static class ExternalAuthenticationTimeout
-            extends AbstractConnectionProperty<Duration>
+            extends AbstractConnectionProperty<String, Duration>
     {
         private static final Predicate<Properties> IF_EXTERNAL_AUTHENTICATION_ENABLED =
                 checkedPredicate(properties -> EXTERNAL_AUTHENTICATION.getValue(properties).orElse(false));
@@ -567,7 +567,7 @@ final class ConnectionProperties
     }
 
     private static class ExternalAuthenticationTokenCache
-            extends AbstractConnectionProperty<KnownTokenCache>
+            extends AbstractConnectionProperty<String, KnownTokenCache>
     {
         public ExternalAuthenticationTokenCache()
         {
@@ -576,7 +576,7 @@ final class ConnectionProperties
     }
 
     private static class ExtraCredentials
-            extends AbstractConnectionProperty<Map<String, String>>
+            extends AbstractConnectionProperty<String, Map<String, String>>
     {
         public ExtraCredentials()
         {
@@ -592,7 +592,7 @@ final class ConnectionProperties
     }
 
     private static class SessionProperties
-            extends AbstractConnectionProperty<Map<String, String>>
+            extends AbstractConnectionProperty<String, Map<String, String>>
     {
         private static final Splitter NAME_PARTS_SPLITTER = Splitter.on('.');
 
@@ -614,7 +614,7 @@ final class ConnectionProperties
     }
 
     private static class Source
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public Source()
         {
@@ -623,7 +623,7 @@ final class ConnectionProperties
     }
 
     private static class Resolver
-            extends AbstractConnectionProperty<Class<? extends DnsResolver>>
+            extends AbstractConnectionProperty<String, Class<? extends DnsResolver>>
     {
         public Resolver()
         {
@@ -642,7 +642,7 @@ final class ConnectionProperties
     }
 
     private static class ResolverContext
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public ResolverContext()
         {
@@ -651,7 +651,7 @@ final class ConnectionProperties
     }
 
     private static class HostnameInCertificate
-            extends AbstractConnectionProperty<String>
+            extends AbstractConnectionProperty<String, String>
     {
         public HostnameInCertificate()
         {

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperty.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperty.java
@@ -20,11 +20,11 @@ import java.util.Properties;
 
 import static java.lang.String.format;
 
-interface ConnectionProperty<T>
+interface ConnectionProperty<V, T>
 {
     String getKey();
 
-    Optional<String> getDefault();
+    Optional<V> getDefault();
 
     DriverPropertyInfo getDriverPropertyInfo(Properties properties);
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -69,6 +69,7 @@ import static io.trino.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.trino.jdbc.ConnectionProperties.HOSTNAME_IN_CERTIFICATE;
 import static io.trino.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
+import static io.trino.jdbc.ConnectionProperties.KERBEROS_CONSTRAINED_DELEGATION;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_CREDENTIAL_CACHE_PATH;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_DELEGATION;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_KEYTAB_PATH;
@@ -321,7 +322,8 @@ public final class TrinoDriverUri
                         KERBEROS_KEYTAB_PATH.getValue(properties),
                         Optional.ofNullable(KERBEROS_CREDENTIAL_CACHE_PATH.getValue(properties)
                                 .orElseGet(() -> defaultCredentialCachePath().map(File::new).orElse(null))),
-                        KERBEROS_DELEGATION.getRequiredValue(properties));
+                        KERBEROS_DELEGATION.getRequiredValue(properties),
+                        KERBEROS_CONSTRAINED_DELEGATION.getValue(properties));
             }
 
             if (ACCESS_TOKEN.getValue(properties).isPresent()) {
@@ -486,7 +488,8 @@ public final class TrinoDriverUri
     {
         Map<String, Object> defaults = ConnectionProperties.getDefaults();
         Map<String, Object> urlProperties = parseParameters(uri.getQuery());
-        Map<String, Object> suppliedProperties = driverProperties.entrySet().stream().collect(toImmutableMap(entry -> (String) entry.getKey(), Entry::getValue));
+        Map<String, Object> suppliedProperties = driverProperties.entrySet().stream()
+                .collect(toImmutableMap(entry -> (String) entry.getKey(), Entry::getValue));
 
         for (String key : urlProperties.keySet()) {
             if (suppliedProperties.containsKey(key)) {

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -16,7 +16,6 @@ package io.trino.jdbc;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import io.trino.client.ClientException;
 import io.trino.client.ClientSelectedRole;
@@ -42,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
 import static io.trino.client.OkHttpUtil.basicAuth;
 import static io.trino.client.OkHttpUtil.setupAlternateHostnameVerification;
@@ -379,10 +379,10 @@ public final class TrinoDriverUri
         }
     }
 
-    private static Map<String, String> parseParameters(String query)
+    private static Map<String, Object> parseParameters(String query)
             throws SQLException
     {
-        Map<String, String> result = new HashMap<>();
+        Map<String, Object> result = new HashMap<>();
 
         if (query != null) {
             Iterable<String> queryArgs = QUERY_SPLITTER.split(query);
@@ -484,9 +484,9 @@ public final class TrinoDriverUri
     private static Properties mergeConnectionProperties(URI uri, Properties driverProperties)
             throws SQLException
     {
-        Map<String, String> defaults = ConnectionProperties.getDefaults();
-        Map<String, String> urlProperties = parseParameters(uri.getQuery());
-        Map<String, String> suppliedProperties = Maps.fromProperties(driverProperties);
+        Map<String, Object> defaults = ConnectionProperties.getDefaults();
+        Map<String, Object> urlProperties = parseParameters(uri.getQuery());
+        Map<String, Object> suppliedProperties = driverProperties.entrySet().stream().collect(toImmutableMap(entry -> (String) entry.getKey(), Entry::getValue));
 
         for (String key : urlProperties.keySet()) {
             if (suppliedProperties.containsKey(key)) {
@@ -501,11 +501,9 @@ public final class TrinoDriverUri
         return result;
     }
 
-    private static void setProperties(Properties properties, Map<String, String> values)
+    private static void setProperties(Properties properties, Map<String, Object> values)
     {
-        for (Entry<String, String> entry : values.entrySet()) {
-            properties.setProperty(entry.getKey(), entry.getValue());
-        }
+        properties.putAll(values);
     }
 
     private static void validateConnectionProperties(Properties connectionProperties)
@@ -517,7 +515,7 @@ public final class TrinoDriverUri
             }
         }
 
-        for (ConnectionProperty<?> property : ConnectionProperties.allProperties()) {
+        for (ConnectionProperty<?, ?> property : ConnectionProperties.allProperties()) {
             property.validate(connectionProperties);
         }
     }

--- a/docs/src/main/sphinx/client/jdbc.rst
+++ b/docs/src/main/sphinx/client/jdbc.rst
@@ -185,6 +185,7 @@ Name                                                              Description
 ``KerberosDelegation``                                            Set to ``true`` to use the token from an existing Kerberos context.
                                                                   This allows client to use Kerberos authentication without passing
                                                                   the Keytab or credential cache. Defaults to ``false``.
+``KerberosConstrainedDelegation``                                 Pass GssCredential object as driver property directly to driver.
 ``extraCredentials``                                              Extra credentials for connecting to external services,
                                                                   specified as a list of key-value pairs. For example,
                                                                   ``foo:bar;abc:xyz`` creates the credential named ``abc``

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberos.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberos.java
@@ -76,6 +76,7 @@ public class HadoopKerberos
         });
         builder.configureContainer(TESTS, container -> {
             container.setDockerImageName(dockerImageName);
+            container.withCopyFileToContainer(forHostPath(configDir.getPath("krb5_client.conf")), "/etc/krb5.conf");
         });
         configureTempto(builder, configDir);
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite1.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite1.java
@@ -36,6 +36,7 @@ public class Suite1
                                 "cli",
                                 "jdbc",
                                 "trino_jdbc",
+                                "jdbc_kerberos_constrained_delegation",
                                 "functions",
                                 "hive_compression",
                                 "large_query",

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite3.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite3.java
@@ -49,7 +49,7 @@ public class Suite3
                         .withTests("TestHiveStorageFormats.testOrcTableCreatedInTrino", "TestHiveCreateTable.testCreateTable")
                         .build(),
                 testOnEnvironment(EnvMultinodeTlsKerberosDelegation.class)
-                        .withGroups("configured_features", "jdbc")
+                        .withGroups("configured_features", "jdbc", "jdbc_kerberos_constrained_delegation")
                         .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/krb5_client.conf
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/krb5_client.conf
@@ -1,0 +1,25 @@
+# Copy of hdp2.6-hive-kerberized/etc/krb5.conf with lower ticket_lifetime
+[logging]
+ default = FILE:/var/log/krb5libs.log
+ kdc = FILE:/var/log/krb5kdc.log
+ admin_server = FILE:/var/log/kadmind.log
+
+[libdefaults]
+ default_realm = LABS.TERADATA.COM
+ dns_lookup_realm = false
+ dns_lookup_kdc = false
+ forwardable = true
+ allow_weak_crypto = true
+ # low ticket_lifetime to make sure ticket could expired if needed (on client side - timeout is 60s)
+ ticket_lifetime = 80s
+
+[realms]
+ LABS.TERADATA.COM = {
+  kdc = hadoop-master:88
+  admin_server = hadoop-master
+ }
+ OTHERLABS.TERADATA.COM = {
+  kdc = hadoop-master:89
+  admin_server = hadoop-master
+ }
+

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -28,6 +28,7 @@ public final class TestGroups
     public static final String BLACKHOLE_CONNECTOR = "blackhole";
     public static final String SMOKE = "smoke";
     public static final String JDBC = "jdbc";
+    public static final String JDBC_KERBEROS_CONSTRAINED_DELEGATION = "jdbc_kerberos_constrained_delegation";
     public static final String OAUTH2 = "oauth2";
     public static final String OAUTH2_REFRESH = "oauth2_refresh";
     public static final String MYSQL = "mysql";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestKerberosConstrainedDelegationJdbc.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestKerberosConstrainedDelegationJdbc.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.jdbc;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.tempto.kerberos.KerberosAuthentication;
+import io.trino.tests.product.TpchTableResults;
+import org.assertj.core.api.Assertions;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.Oid;
+import org.testng.annotations.Test;
+
+import javax.security.auth.Subject;
+
+import java.security.Principal;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tempto.query.QueryResult.forResultSet;
+import static io.trino.tests.product.TestGroups.JDBC_KERBEROS_CONSTRAINED_DELEGATION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.ietf.jgss.GSSCredential.DEFAULT_LIFETIME;
+import static org.ietf.jgss.GSSCredential.INITIATE_ONLY;
+import static org.ietf.jgss.GSSName.NT_USER_NAME;
+
+public class TestKerberosConstrainedDelegationJdbc
+        extends ProductTest
+{
+    private static final String KERBEROS_OID = "1.2.840.113554.1.2.2";
+    @Inject
+    @Named("databases.presto.jdbc_url")
+    String jdbcUrl;
+
+    @Inject
+    @Named("databases.presto.kerberos_principal")
+    private String kerberosPrincipal;
+
+    @Inject
+    @Named("databases.presto.kerberos_keytab")
+    private String kerberosKeytab;
+
+    private GSSManager gssManager;
+    private KerberosAuthentication kerberosAuthentication;
+
+    @BeforeMethodWithContext
+    public void setUp()
+    {
+        this.gssManager = GSSManager.getInstance();
+        this.kerberosAuthentication = new KerberosAuthentication(kerberosPrincipal, kerberosKeytab);
+    }
+
+    @Test(groups = JDBC_KERBEROS_CONSTRAINED_DELEGATION)
+    public void testSelectConstrainedDelegationKerberos()
+            throws Exception
+    {
+        Properties driverProperties = new Properties();
+        GSSCredential credential = createGssCredential();
+        driverProperties.put("KerberosConstrainedDelegation", credential);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties);
+                PreparedStatement statement = connection.prepareStatement("SELECT * FROM tpch.tiny.nation");
+                ResultSet results = statement.executeQuery()) {
+            assertThat(forResultSet(results)).matches(TpchTableResults.PRESTO_NATION_RESULT);
+        }
+        finally {
+            credential.dispose();
+        }
+    }
+
+    @Test(groups = JDBC_KERBEROS_CONSTRAINED_DELEGATION)
+    public void testCtasConstrainedDelegationKerberos()
+            throws Exception
+    {
+        Properties driverProperties = new Properties();
+        GSSCredential credential = createGssCredential();
+        driverProperties.put("KerberosConstrainedDelegation", credential);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties);
+                PreparedStatement statement = connection.prepareStatement(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.nation", "test_kerberos_ctas"))) {
+            int results = statement.executeUpdate();
+            Assertions.assertThat(results).isEqualTo(25);
+        }
+        finally {
+            credential.dispose();
+        }
+    }
+
+    @Test(groups = JDBC_KERBEROS_CONSTRAINED_DELEGATION)
+    public void testQueryOnDisposedCredential()
+            throws Exception
+    {
+        Properties driverProperties = new Properties();
+        GSSCredential credential = createGssCredential();
+        credential.dispose();
+        driverProperties.put("KerberosConstrainedDelegation", credential);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties)) {
+            assertThatThrownBy(() -> connection.prepareStatement("SELECT * FROM tpch.tiny.nation"))
+                    .cause()
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("This credential is no longer valid");
+        }
+    }
+
+    @Test(groups = JDBC_KERBEROS_CONSTRAINED_DELEGATION)
+    public void testQueryOnExpiredCredential()
+            throws Exception
+    {
+        Properties driverProperties = new Properties();
+        GSSCredential credential = createGssCredential();
+        // ticket default lifetime is 80s by kerb.conf, sleep to expire ticket
+        Thread.sleep(30000);
+        // check before execution that current lifetime is less than 60s (MIN_LIFETIME on client), to be sure that we already expired
+        Assertions.assertThat(credential.getRemainingLifetime()).isLessThanOrEqualTo(60);
+        driverProperties.put("KerberosConstrainedDelegation", credential);
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, driverProperties)) {
+            assertThatThrownBy(() -> connection.prepareStatement("SELECT * FROM tpch.tiny.nation"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessageContaining("Kerberos credential is expired");
+        }
+        finally {
+            credential.dispose();
+        }
+    }
+
+    private GSSCredential createGssCredential()
+    {
+        Subject authenticatedSubject = this.kerberosAuthentication.authenticate();
+        Principal clientPrincipal = getOnlyElement(authenticatedSubject.getPrincipals());
+
+        try {
+            return Subject.doAs(authenticatedSubject,
+                    (PrivilegedExceptionAction<GSSCredential>) () ->
+                            gssManager.createCredential(
+                                    gssManager.createName(clientPrincipal.getName(), NT_USER_NAME),
+                                    DEFAULT_LIFETIME,
+                                    new Oid(KERBEROS_OID),
+                                    INITIATE_ONLY));
+        }
+        catch (PrivilegedActionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+}


### PR DESCRIPTION
Adding constrained delegation support to trino JDBC driver

Now user can create GSSCredential on its own and just pass it as driver property to JDBC driver, smth like this:

```
Properties driverProperties = new Properties();
GSSCredential userCredential = [userCredential]
driverProperties.put("KerberosConstrainedDelegation", userCredential);
Connection conn = DriverManager.getConnection(CONNECTION_URI, driverProperties)
```


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Adding constrained delegation support to trino JDBC driver

Now user can create GSSCredential on its own and just pass it as driver property to JDBC driver, smth like this:

```
Properties driverProperties = new Properties();
GSSCredential userCredential = [userCredential]
driverProperties.put("KerberosConstrainedDelegation", userCredential);
Connection conn = DriverManager.getConnection(CONNECTION_URI, driverProperties)
```

```markdown
# Section
* Add constrained delegation support to Trino JDBC driver
```
