### PR TITLE
Support CASCADE option for DROP SCHEMA statement in engine and BigQuery connector

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -20,7 +20,6 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.security.AccessControl;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.sql.tree.DropSchema;
 import io.trino.sql.tree.Expression;
@@ -30,7 +29,6 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -62,10 +60,6 @@ public class DropSchemaTask
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
-        if (statement.isCascade()) {
-            throw new TrinoException(NOT_SUPPORTED, "CASCADE is not yet supported for DROP SCHEMA");
-        }
-
         Session session = stateMachine.getSession();
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
 
@@ -76,13 +70,13 @@ public class DropSchemaTask
             return immediateVoidFuture();
         }
 
-        if (!isSchemaEmpty(session, schema, metadata)) {
+        if (!statement.isCascade() && !isSchemaEmpty(session, schema, metadata)) {
             throw semanticException(SCHEMA_NOT_EMPTY, statement, "Cannot drop non-empty schema '%s'", schema.getSchemaName());
         }
 
         accessControl.checkCanDropSchema(session.toSecurityContext(), schema);
 
-        metadata.dropSchema(session, schema);
+        metadata.dropSchema(session, schema, statement.isCascade());
 
         return immediateVoidFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -183,7 +183,7 @@ public interface Metadata
     /**
      * Drops the specified schema.
      */
-    void dropSchema(Session session, CatalogSchemaName schema);
+    void dropSchema(Session session, CatalogSchemaName schema, boolean cascade);
 
     /**
      * Renames the specified schema.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -638,12 +638,12 @@ public final class MetadataManager
     }
 
     @Override
-    public void dropSchema(Session session, CatalogSchemaName schema)
+    public void dropSchema(Session session, CatalogSchemaName schema, boolean cascade)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, schema.getCatalogName());
         CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle();
         ConnectorMetadata metadata = catalogMetadata.getMetadata(session);
-        metadata.dropSchema(session.toConnectorSession(catalogHandle), schema.getSchemaName());
+        metadata.dropSchema(session.toConnectorSession(catalogHandle), schema.getSchemaName(), cascade);
         if (catalogMetadata.getSecurityManagement() == SYSTEM) {
             systemSecurityMetadata.schemaDropped(session, schema);
         }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -327,6 +327,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
+    {
+        Span span = startSpan("dropSchema", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            delegate.dropSchema(session, schemaName, cascade);
+        }
+    }
+
+    @Override
     public void dropSchema(ConnectorSession session, String schemaName)
     {
         Span span = startSpan("dropSchema", schemaName);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -342,11 +342,11 @@ public class TracingMetadata
     }
 
     @Override
-    public void dropSchema(Session session, CatalogSchemaName schema)
+    public void dropSchema(Session session, CatalogSchemaName schema, boolean cascade)
     {
         Span span = startSpan("dropSchema", schema);
         try (var ignored = scopedSpan(span)) {
-            delegate.dropSchema(session, schema);
+            delegate.dropSchema(session, schema, cascade);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -26,6 +26,7 @@ import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.metadata.TableHandle;
 import io.trino.metadata.TableMetadata;
@@ -283,6 +284,34 @@ public abstract class BaseDataDefinitionTaskTest
                 throw new TrinoException(ALREADY_EXISTS, "Schema already exists");
             }
             schemas.add(schema);
+        }
+
+        @Override
+        public void dropSchema(Session session, CatalogSchemaName schema, boolean cascade)
+        {
+            if (cascade) {
+                tables.keySet().stream()
+                        .filter(table -> schema.getSchemaName().equals(table.getSchemaName()))
+                        .forEach(tables::remove);
+                views.keySet().stream()
+                        .filter(view -> schema.getSchemaName().equals(view.getSchemaName()))
+                        .forEach(tables::remove);
+                materializedViews.keySet().stream()
+                        .filter(materializedView -> schema.getSchemaName().equals(materializedView.getSchemaName()))
+                        .forEach(tables::remove);
+            }
+            schemas.remove(schema);
+        }
+
+        @Override
+        public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+        {
+            List<QualifiedObjectName> tables = ImmutableList.<QualifiedObjectName>builder()
+                    .addAll(this.tables.keySet().stream().map(table -> new QualifiedObjectName(catalogName, table.getSchemaName(), table.getTableName())).collect(toImmutableList()))
+                    .addAll(this.views.keySet().stream().map(view -> new QualifiedObjectName(catalogName, view.getSchemaName(), view.getTableName())).collect(toImmutableList()))
+                    .addAll(this.materializedViews.keySet().stream().map(mv -> new QualifiedObjectName(catalogName, mv.getSchemaName(), mv.getTableName())).collect(toImmutableList()))
+                    .build();
+            return tables.stream().filter(prefix::matches).collect(toImmutableList());
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropSchemaTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropSchemaTask.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.connector.CatalogServiceProvider;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.SchemaPropertyManager;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.sql.tree.CreateSchema;
+import io.trino.sql.tree.DropSchema;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestDropSchemaTask
+        extends BaseDataDefinitionTaskTest
+{
+    private static final CatalogSchemaName CATALOG_SCHEMA_NAME = new CatalogSchemaName(TEST_CATALOG_NAME, "test_db");
+
+    @Test
+    public void testDropSchemaRestrict()
+    {
+        CreateSchemaTask createSchemaTask = getCreateSchemaTask();
+        CreateSchema createSchema = new CreateSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, ImmutableList.of());
+        getFutureValue(createSchemaTask.execute(createSchema, queryStateMachine, emptyList(), NOOP));
+        assertTrue(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+        DropSchema dropSchema = new DropSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, false);
+        getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP));
+        assertFalse(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+
+        assertThatExceptionOfType(TrinoException.class)
+                .isThrownBy(() -> getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP)))
+                .withMessage("Schema 'test-catalog.test_db' does not exist");
+    }
+
+    @Test
+    public void testDropNonEmptySchemaRestrict()
+    {
+        CreateSchemaTask createSchemaTask = getCreateSchemaTask();
+        CreateSchema createSchema = new CreateSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, ImmutableList.of());
+        getFutureValue(createSchemaTask.execute(createSchema, queryStateMachine, emptyList(), NOOP));
+
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+        DropSchema dropSchema = new DropSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, false);
+
+        QualifiedObjectName tableName = new QualifiedObjectName(CATALOG_SCHEMA_NAME.getCatalogName(), CATALOG_SCHEMA_NAME.getSchemaName(), "test_table");
+        metadata.createTable(testSession, CATALOG_SCHEMA_NAME.getCatalogName(), someTable(tableName), false);
+
+        assertThatExceptionOfType(TrinoException.class)
+                .isThrownBy(() -> getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP)))
+                .withMessage("Cannot drop non-empty schema 'test_db'");
+        assertTrue(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+    }
+
+    @Test
+    public void testDropSchemaIfExistsRestrict()
+    {
+        CatalogSchemaName schema = new CatalogSchemaName(CATALOG_SCHEMA_NAME.getCatalogName(), "test_if_exists_restrict");
+
+        assertFalse(metadata.schemaExists(testSession, schema));
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+
+        DropSchema dropSchema = new DropSchema(QualifiedName.of("test_if_exists_restrict"), true, false);
+        getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP));
+    }
+
+    @Test
+    public void testDropSchemaCascade()
+    {
+        CreateSchemaTask createSchemaTask = getCreateSchemaTask();
+        CreateSchema createSchema = new CreateSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, ImmutableList.of());
+        getFutureValue(createSchemaTask.execute(createSchema, queryStateMachine, emptyList(), NOOP));
+        assertTrue(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+        DropSchema dropSchema = new DropSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, true);
+
+        getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP));
+        assertFalse(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+    }
+
+    @Test
+    public void testDropNonEmptySchemaCascade()
+    {
+        CreateSchemaTask createSchemaTask = getCreateSchemaTask();
+        CreateSchema createSchema = new CreateSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, ImmutableList.of());
+        getFutureValue(createSchemaTask.execute(createSchema, queryStateMachine, emptyList(), NOOP));
+
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+        DropSchema dropSchema = new DropSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), false, true);
+
+        QualifiedObjectName tableName = new QualifiedObjectName(CATALOG_SCHEMA_NAME.getCatalogName(), CATALOG_SCHEMA_NAME.getSchemaName(), "test_table");
+        metadata.createTable(testSession, CATALOG_SCHEMA_NAME.getCatalogName(), someTable(tableName), false);
+
+        getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP));
+        assertFalse(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
+    }
+
+    @Test
+    public void testDropSchemaIfExistsCascade()
+    {
+        CatalogSchemaName schema = new CatalogSchemaName(CATALOG_SCHEMA_NAME.getCatalogName(), "test_if_exists_cascade");
+
+        assertFalse(metadata.schemaExists(testSession, schema));
+        DropSchemaTask dropSchemaTask = getDropSchemaTask();
+
+        DropSchema dropSchema = new DropSchema(QualifiedName.of("test_if_exists_cascade"), true, false);
+        getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP));
+    }
+
+    private CreateSchemaTask getCreateSchemaTask()
+    {
+        SchemaPropertyManager schemaPropertyManager = new SchemaPropertyManager(CatalogServiceProvider.singleton(TEST_CATALOG_HANDLE, ImmutableMap.of()));
+        return new CreateSchemaTask(plannerContext, new AllowAllAccessControl(), schemaPropertyManager);
+    }
+
+    private DropSchemaTask getDropSchemaTask()
+    {
+        return new DropSchemaTask(metadata, new AllowAllAccessControl());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -241,7 +241,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void dropSchema(Session session, CatalogSchemaName schema)
+    public void dropSchema(Session session, CatalogSchemaName schema, boolean cascade)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
@@ -245,9 +245,9 @@ public class CountingAccessMetadata
     }
 
     @Override
-    public void dropSchema(Session session, CatalogSchemaName schema)
+    public void dropSchema(Session session, CatalogSchemaName schema, boolean cascade)
     {
-        delegate.dropSchema(session, schema);
+        delegate.dropSchema(session, schema, cascade);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -339,8 +339,23 @@ public interface ConnectorMetadata
     /**
      * Drops the specified schema.
      *
-     * @throws TrinoException with {@code SCHEMA_NOT_EMPTY} if the schema is not empty
+     * @throws TrinoException with {@code SCHEMA_NOT_EMPTY} if {@code cascade} is false and the schema is not empty
      */
+    default void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
+    {
+        if (!cascade) {
+            dropSchema(session, schemaName);
+            return;
+        }
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas with CASCADE option");
+    }
+
+    /**
+     * Drops the specified schema.
+     *
+     * @deprecated use {@link #dropSchema(ConnectorSession, String, boolean)}
+     */
+    @Deprecated
     default void dropSchema(ConnectorSession session, String schemaName)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas");

--- a/docs/src/main/sphinx/sql/drop-schema.rst
+++ b/docs/src/main/sphinx/sql/drop-schema.rst
@@ -7,7 +7,7 @@ Synopsis
 
 .. code-block:: text
 
-    DROP SCHEMA [ IF EXISTS ] schema_name
+    DROP SCHEMA [ IF EXISTS ] schema_name [ CASCADE | RESTRICT ]
 
 Description
 -----------
@@ -27,6 +27,10 @@ Drop the schema ``web``::
 Drop the schema ``sales`` if it exists::
 
     DROP SCHEMA IF EXISTS sales
+
+Drop the schema ``archive``, along with everything it contains::
+
+    DROP SCHEMA archive CASCADE
 
 See also
 --------

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -361,6 +361,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.dropSchema(session, schemaName, cascade);
+        }
+    }
+
+    @Override
     public void dropSchema(ConnectorSession session, String schemaName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -66,6 +66,7 @@ public class TestAccumuloConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -129,6 +129,9 @@ public abstract class BaseJdbcConnectorTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         switch (connectorBehavior) {
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
+                return false;
+
             case SUPPORTS_UPDATE: // not supported by any JDBC connector
             case SUPPORTS_MERGE: // not supported by any JDBC connector
                 return false;

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQuery.DatasetDeleteOption;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
 import com.google.cloud.bigquery.DatasetId;
@@ -251,9 +252,14 @@ public class BigQueryClient
         bigQuery.create(datasetInfo);
     }
 
-    public void dropSchema(DatasetId datasetId)
+    public void dropSchema(DatasetId datasetId, boolean cascade)
     {
-        bigQuery.delete(datasetId);
+        if (cascade) {
+            bigQuery.delete(datasetId, DatasetDeleteOption.deleteContents());
+        }
+        else {
+            bigQuery.delete(datasetId);
+        }
     }
 
     public void createTable(TableInfo tableInfo)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -422,12 +422,12 @@ public class BigQueryMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
         String projectId = client.getProjectId();
         String remoteSchemaName = getRemoteSchemaName(client, projectId, schemaName);
-        client.dropSchema(DatasetId.of(projectId, remoteSchemaName));
+        client.dropSchema(DatasetId.of(projectId, remoteSchemaName), cascade);
     }
 
     private void setRollback(Runnable action)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -144,6 +144,7 @@ public class TestDeltaLakeConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_DROP_COLUMN:

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -240,6 +240,9 @@ public abstract class BaseHiveConnectorTest
             case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
 
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
+                return false;
+
             case SUPPORTS_DROP_FIELD:
             case SUPPORTS_SET_COLUMN_TYPE:
                 return false;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -220,6 +220,9 @@ public abstract class BaseIcebergConnectorTest
             case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
 
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
+                return false;
+
             case SUPPORTS_RENAME_MATERIALIZED_VIEW_ACROSS_SCHEMAS:
                 return false;
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -72,6 +72,7 @@ public class TestKuduConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_CREATE_TABLE_WITH_TABLE_COMMENT:
@@ -147,6 +148,13 @@ public class TestKuduConnectorTest
     public void testDropNonEmptySchemaWithTable()
     {
         assertThatThrownBy(super::testDropNonEmptySchemaWithTable)
+                .hasMessage("Creating schema in Kudu connector not allowed if schema emulation is disabled.");
+    }
+
+    @Override
+    public void testDropSchemaCascade()
+    {
+        assertThatThrownBy(super::testDropSchemaCascade)
                 .hasMessage("Creating schema in Kudu connector not allowed if schema emulation is disabled.");
     }
 

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -99,6 +99,7 @@ public class TestMemoryConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_ADD_COLUMN:

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -104,6 +104,7 @@ public class TestMongoConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
+            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_DROP_FIELD:

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -71,6 +71,7 @@ public enum TestingConnectorBehavior
     SUPPORTS_CREATE_SCHEMA,
     // Expect rename to be supported when create schema is supported, to help make connector implementations coherent.
     SUPPORTS_RENAME_SCHEMA(SUPPORTS_CREATE_SCHEMA),
+    SUPPORTS_DROP_SCHEMA_CASCADE(SUPPORTS_CREATE_SCHEMA),
 
     SUPPORTS_CREATE_TABLE,
     SUPPORTS_CREATE_TABLE_WITH_DATA(SUPPORTS_CREATE_TABLE),


### PR DESCRIPTION
## Description

Pushing cascading option to connectors for avoiding failure on the way during deleting child objects under the schema (e.g. access denied in specific table). Also, the remote database may contain objects that Trino engine isn't aware of. 
I didn't touch access control because I couldn't find the difference between cascade and restrict option in SQL standard. 

Relates to #17649

## Release notes

```markdown
# General, BigQuery
* Support `CASCADE` option for `DROP SCHEMA` statement. ({issue}`17855`)
```
