### PR TITLE
Do not require Confluent libraries for Kafka connector if Protobuf features are not being used

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
@@ -57,7 +57,7 @@ public class KafkaConnectorFactory
                 new CatalogNameModule(catalogName),
                 new JsonModule(),
                 new TypeDeserializerModule(context.getTypeManager()),
-                new KafkaConnectorModule(),
+                new KafkaConnectorModule(context.getTypeManager()),
                 extension,
                 binder -> {
                     binder.bind(ClassLoader.class).toInstance(KafkaConnectorFactory.class.getClassLoader());

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
@@ -31,15 +31,24 @@ import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.type.TypeManager;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static java.util.Objects.requireNonNull;
 
 public class KafkaConnectorModule
         extends AbstractConfigurationAwareModule
 {
+    private final TypeManager typeManager;
+
+    public KafkaConnectorModule(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
     @Override
     public void setup(Binder binder)
     {
@@ -58,7 +67,7 @@ public class KafkaConnectorModule
 
         configBinder(binder).bindConfig(KafkaConfig.class);
         bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule());
-        bindTopicSchemaProviderModule(ConfluentSchemaRegistryTableDescriptionSupplier.NAME, new ConfluentModule());
+        bindTopicSchemaProviderModule(ConfluentSchemaRegistryTableDescriptionSupplier.NAME, new ConfluentModule(typeManager));
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(KafkaSessionProperties.class).in(Scopes.SINGLETON);
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);
     }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/protobuf/ProtobufSchemaParser.java
@@ -75,7 +75,7 @@ public class ProtobufSchemaParser
                 Optional.empty(),
                 Optional.of(subject),
                 Streams.concat(getFields(protobufSchema.toDescriptor()),
-                                getOneofs(protobufSchema))
+                                getOneofs(protobufSchema.toDescriptor()))
                         .collect(toImmutableList()));
     }
 
@@ -101,9 +101,9 @@ public class ProtobufSchemaParser
                         false));
     }
 
-    private Stream<KafkaTopicFieldDescription> getOneofs(ProtobufSchema protobufSchema)
+    private Stream<KafkaTopicFieldDescription> getOneofs(Descriptor descriptor)
     {
-        return protobufSchema.toDescriptor()
+        return descriptor
                 .getOneofs()
                 .stream()
                 .map(oneofDescriptor ->

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentModule.java
@@ -168,7 +168,7 @@ public class ConfluentModule
             implements SchemaProvider
     {
         // Make JVM to load lazily ProtobufSchemaProvider, so Kafka connector can be used
-        // with protobuf dependency for non protobuf based topics
+        // without protobuf dependency for non protobuf based topics
         private final Supplier<SchemaProvider> delegate = Suppliers.memoize(this::create);
         private final AtomicReference<Map<String, ?>> configuration = new AtomicReference<>();
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ForwardingSchemaParser.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ForwardingSchemaParser.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.trino.plugin.kafka.KafkaTopicFieldGroup;
+import io.trino.spi.connector.ConnectorSession;
+
+public abstract class ForwardingSchemaParser
+        implements SchemaParser
+{
+    protected abstract SchemaParser delegate();
+
+    @Override
+    public KafkaTopicFieldGroup parse(ConnectorSession session, String subject, ParsedSchema parsedSchema)
+    {
+        return delegate().parse(session, subject, parsedSchema);
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestForwardingSchemaParser.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestForwardingSchemaParser.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka.schema.confluent;
+
+import org.testng.annotations.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestForwardingSchemaParser
+{
+    @Test
+    public void testAllMethodsOverridden()
+    {
+        assertAllMethodsOverridden(SchemaParser.class, ForwardingSchemaParser.class);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Kafka.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Kafka.java
@@ -23,16 +23,13 @@ import io.trino.tests.product.launcher.testcontainers.PortBinder;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.utility.MountableFile;
 
-import java.io.File;
 import java.time.Duration;
 
-import static io.trino.testing.TestingProperties.getConfluentVersion;
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
-import static org.testcontainers.utility.MountableFile.forClasspathResource;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public class Kafka
@@ -40,8 +37,6 @@ public class Kafka
 {
     private static final String CONFLUENT_VERSION = "7.3.1";
     private static final int SCHEMA_REGISTRY_PORT = 8081;
-    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider-" + getConfluentVersion() + ".jar");
-    private static final File KAFKA_PROTOBUF_TYPES = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-types-" + getConfluentVersion() + ".jar");
     static final String KAFKA = "kafka";
     static final String SCHEMA_REGISTRY = "schema-registry";
     static final String ZOOKEEPER = "zookeeper";
@@ -69,10 +64,7 @@ public class Kafka
             if (isTrinoContainer(container.getLogicalName())) {
                 MountableFile logConfigFile = forHostPath(configDir.getPath("log.properties"));
                 container
-                        .withCopyFileToContainer(logConfigFile, CONTAINER_TRINO_ETC + "/log.properties")
-                        .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_PROVIDER.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-provider.jar")
-                        .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_TYPES.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-types.jar")
-                        .withCopyFileToContainer(forClasspathResource("install-kafka-protobuf-provider.sh", 0755), "/docker/presto-init.d/install-kafka-protobuf-provider.sh");
+                        .withCopyFileToContainer(logConfigFile, CONTAINER_TRINO_ETC + "/log.properties");
             }
         });
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeConfluentKafka.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeConfluentKafka.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.docker.DockerFiles.ResourceProvider;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentProvider;
+import io.trino.tests.product.launcher.env.common.Kafka;
+import io.trino.tests.product.launcher.env.common.StandardMultinode;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import java.io.File;
+
+import static io.trino.testing.TestingProperties.getConfluentVersion;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.configureTempto;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
+import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+/**
+ * {@link EnvMultinodeConfluentKafka} is intended to be the only Kafka product test environment which copies the non-free Confluent License libraries to the Kafka connector
+ * classpath to test functionality which requires those classes.
+ * The other {@link Kafka} environments MUST NOT copy these jars otherwise it's not possible to verify the out of box Trino setup which doesn't ship with the Confluent licensed
+ * libraries.
+ */
+@TestsEnvironment
+public final class EnvMultinodeConfluentKafka
+        extends EnvironmentProvider
+{
+    private static final File KAFKA_PROTOBUF_PROVIDER = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-provider-" + getConfluentVersion() + ".jar");
+    private static final File KAFKA_PROTOBUF_TYPES = new File("testing/trino-product-tests-launcher/target/kafka-protobuf-types-" + getConfluentVersion() + ".jar");
+
+    private final ResourceProvider configDir;
+
+    @Inject
+    public EnvMultinodeConfluentKafka(Kafka kafka, StandardMultinode standardMultinode, DockerFiles dockerFiles)
+    {
+        super(ImmutableList.of(standardMultinode, kafka));
+        requireNonNull(dockerFiles, "dockerFiles is null");
+        configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment/multinode-kafka-confluent-license/");
+    }
+
+    @Override
+    public void extendEnvironment(Environment.Builder builder)
+    {
+        builder.configureContainers(container -> {
+            if (isTrinoContainer(container.getLogicalName())) {
+                builder.addConnector("kafka", forHostPath(configDir.getPath("kafka.properties")), CONTAINER_TRINO_ETC + "/catalog/kafka.properties");
+                builder.addConnector("kafka", forHostPath(configDir.getPath("kafka_schema_registry.properties")), CONTAINER_TRINO_ETC + "/catalog/kafka_schema_registry.properties");
+                container
+                        .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_PROVIDER.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-provider.jar")
+                        .withCopyFileToContainer(forHostPath(KAFKA_PROTOBUF_TYPES.getAbsolutePath()), "/docker/kafka-protobuf-provider/kafka-protobuf-types.jar")
+                        .withCopyFileToContainer(forClasspathResource("install-kafka-protobuf-provider.sh", 0755), "/docker/presto-init.d/install-kafka-protobuf-provider.sh");
+            }
+        });
+
+        configureTempto(builder, configDir);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteKafka.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteKafka.java
@@ -15,6 +15,7 @@ package io.trino.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeConfluentKafka;
 import io.trino.tests.product.launcher.env.environment.EnvMultinodeKafka;
 import io.trino.tests.product.launcher.env.environment.EnvMultinodeKafkaSaslPlaintext;
 import io.trino.tests.product.launcher.env.environment.EnvMultinodeKafkaSsl;
@@ -34,6 +35,10 @@ public class SuiteKafka
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinodeKafka.class)
                         .withGroups("configured_features", "kafka")
+                        .build(),
+                testOnEnvironment(EnvMultinodeConfluentKafka.class)
+                        // testing kafka group with this env is slightly redundant but helps verify that copying confluent libraries doesn't break non-confluent functionality
+                        .withGroups("configured_features", "kafka", "kafka_confluent_license")
                         .build(),
                 testOnEnvironment(EnvMultinodeKafkaSsl.class)
                         .withGroups("configured_features", "kafka")

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/kafka.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/kafka.properties
@@ -1,0 +1,23 @@
+connector.name=kafka
+kafka.table-names=product_tests.read_simple_key_and_value,\
+                    product_tests.read_all_datatypes_raw,\
+                    product_tests.read_all_datatypes_csv,\
+                    product_tests.read_all_datatypes_json,\
+                    product_tests.read_all_datatypes_avro,\
+                    product_tests.read_all_null_avro,\
+                    product_tests.read_structural_datatype_avro,\
+                    product_tests.write_simple_key_and_value,\
+                    product_tests.write_all_datatypes_raw,\
+                    product_tests.write_all_datatypes_csv,\
+                    product_tests.write_all_datatypes_json,\
+                    product_tests.write_all_datatypes_avro,\
+                    product_tests.write_structural_datatype_avro,\
+                    product_tests.pushdown_partition,\
+                    product_tests.pushdown_offset,\
+                    product_tests.pushdown_create_time,\
+                    product_tests.all_datatypes_protobuf,\
+                    product_tests.structural_datatype_protobuf,\
+                    product_tests.read_basic_datatypes_protobuf,\
+                    product_tests.read_basic_structural_datatypes_protobuf
+kafka.nodes=kafka:9092
+kafka.table-description-dir=/docker/presto-product-tests/conf/presto/etc/catalog/kafka

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/kafka_schema_registry.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/kafka_schema_registry.properties
@@ -1,0 +1,5 @@
+connector.name=kafka
+kafka.nodes=kafka:9092
+kafka.table-description-supplier=confluent
+kafka.confluent-schema-registry-url=http://schema-registry:8081
+kafka.default-schema=product_tests

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-kafka-confluent-license/tempto-configuration.yaml
@@ -1,0 +1,2 @@
+schema-registry:
+  url: http://schema-registry:8081

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -69,6 +69,7 @@ public final class TestGroups
     public static final String CANCEL_QUERY = "cancel_query";
     public static final String LARGE_QUERY = "large_query";
     public static final String KAFKA = "kafka";
+    public static final String KAFKA_CONFLUENT_LICENSE = "kafka_confluent_license";
     public static final String TWO_HIVES = "two_hives";
     public static final String ICEBERG = "iceberg";
     public static final String ICEBERG_FORMAT_VERSION_COMPATIBILITY = "iceberg_format_version_compatibility";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaProtobufReadsSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaProtobufReadsSmokeTest.java
@@ -57,7 +57,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Test(singleThreaded = true)
-public class TestKafkaProtobufReads
+public class TestKafkaProtobufReadsSmokeTest
         extends ProductTest
 {
     private static final String KAFKA_SCHEMA = "product_tests";
@@ -179,7 +179,7 @@ public class TestKafkaProtobufReads
         String timestampTopic = "timestamp";
         String timestampProtoFile = "google/protobuf/timestamp.proto";
         ProtobufSchema baseSchema = new ProtobufSchema(
-                Resources.toString(Resources.getResource(TestKafkaProtobufReads.class, "/" + timestampProtoFile), UTF_8),
+                Resources.toString(Resources.getResource(TestKafkaProtobufReadsSmokeTest.class, "/" + timestampProtoFile), UTF_8),
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 null,

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaProtobufWritesSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaProtobufWritesSmokeTest.java
@@ -34,7 +34,7 @@ import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
-public class TestKafkaProtobuf
+public class TestKafkaProtobufWritesSmokeTest
         extends ProductTest
 {
     private static final String KAFKA_CATALOG = "kafka";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes https://github.com/trinodb/trino/issues/17299

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Add product tests for Kafka connector with Confluent licensed libraries

The older approach was to copy the Confluent licensed libraries to the
Kafka connector classpath for all product environments extending from
`Kafka`. This meant that it was not possible to detect changes which
introduce a hard-dependency on the Confluent licensed libraries for
Kafka connector startup.

02cc332319a00e8fec5096921f96cb9e0aceacc1 inadvertently made it so that
the Confluent libraries became required for the Kafka connector to start
up and was not caught by tests because all the product test environments
already had the Confluent libraries present on the Kafka connector
classpath.

This commit instead introduces a new product test environment
`EnvMultinodeKafkaConfluentLicense` which is the only product test
environment that copies the Confluent licensed libraries onto the Kafka
connector classpath. There is also a new test group
`kafka_confluent_license` which now includes all the tests for the
functionality which requires the Confluent licensed libraries.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Kafka
* Fix failure of server startup when a Kafka catalog is present. ({issue}`17299`)
```
