### PR TITLE
Mark Oracle FailureRecovery tests as flaky

### DIFF
--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleFailureRecoveryTest.java
@@ -18,7 +18,9 @@ import io.trino.operator.RetryPolicy;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
 import io.trino.plugin.jdbc.BaseJdbcFailureRecoveryTest;
 import io.trino.testing.QueryRunner;
+import io.trino.testng.services.Flaky;
 import io.trino.tpch.TpchTable;
+import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -58,5 +60,13 @@ public abstract class BaseOracleFailureRecoveryTest
                     runner.loadExchangeManager("filesystem", ImmutableMap.of(
                             "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
                 });
+    }
+
+    @Override
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/16277", match = "There should be no remaining tmp_trino tables that are queryable")
+    @Test(dataProvider = "parallelTests")
+    public void testParallel(Runnable runnable)
+    {
+        super.testParallel(runnable);
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -209,7 +209,7 @@ public abstract class BaseFailureRecoveryTest
     }
 
     @Test(dataProvider = "parallelTests")
-    public final void testParallel(Runnable runnable)
+    public void testParallel(Runnable runnable)
     {
         try {
             // By default, a test method using a @DataProvider with parallel attribute is run in 10 threads (org.testng.xml.XmlSuite#DEFAULT_DATA_PROVIDER_THREAD_COUNT).


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We have been [fighting](https://github.com/trinodb/trino/issues/16277) with Oracle FailureRecovery tests, so until we identify the solution, we have decided to mark this test as flaky.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
