### PR TITLE
Support iceberg `register_table` procedure to register hadoop tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -172,6 +172,11 @@ public final class IcebergUtil
     //  - 00001-409702ba-4735-4645-8f14-09537cc0b2c8.gz.metadata.json (https://github.com/apache/iceberg/blob/ab398a0d5ff195f763f8c7a4358ac98fa38a8de7/core/src/main/java/org/apache/iceberg/TableMetadataParser.java#L141)
     //  - 00001-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json.gz (https://github.com/apache/iceberg/blob/ab398a0d5ff195f763f8c7a4358ac98fa38a8de7/core/src/main/java/org/apache/iceberg/TableMetadataParser.java#L146)
     private static final Pattern METADATA_FILE_NAME_PATTERN = Pattern.compile("(?<version>\\d+)-(?<uuid>[-a-fA-F0-9]*)(?<compression>\\.[a-zA-Z0-9]+)?" + Pattern.quote(METADATA_FILE_EXTENSION) + "(?<compression2>\\.[a-zA-Z0-9]+)?");
+    // Hadoop Generated Metadata file name examples
+    //  - v0.metadata.json
+    //  - v0.gz.metadata.json
+    //  - v0.metadata.json.gz
+    private static final Pattern HADOOP_GENERATED_METADATA_FILE_NAME_PATTERN = Pattern.compile("v(?<version>\\d+)(?<compression>\\.[a-zA-Z0-9]+)?" + Pattern.quote(METADATA_FILE_EXTENSION) + "(?<compression2>\\.[a-zA-Z0-9]+)?");
 
     private IcebergUtil() {}
 
@@ -713,6 +718,10 @@ public final class IcebergUtil
     {
         checkArgument(!metadataFileName.contains("/"), "Not a file name: %s", metadataFileName);
         Matcher matcher = METADATA_FILE_NAME_PATTERN.matcher(metadataFileName);
+        if (matcher.matches()) {
+            return parseInt(matcher.group("version"));
+        }
+        matcher = HADOOP_GENERATED_METADATA_FILE_NAME_PATTERN.matcher(metadataFileName);
         if (matcher.matches()) {
             return parseInt(matcher.group("version"));
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
@@ -28,6 +28,11 @@ public class TestIcebergUtil
         assertEquals(parseVersion("99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 99999);
         assertEquals(parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 10);
         assertEquals(parseVersion("00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 11);
+        assertEquals(parseVersion("v0.metadata.json"), 0);
+        assertEquals(parseVersion("v10.metadata.json"), 10);
+        assertEquals(parseVersion("v99999.metadata.json"), 99999);
+        assertEquals(parseVersion("v0.gz.metadata.json"), 0);
+        assertEquals(parseVersion("v0.metadata.json.gz"), 0);
 
         assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
                 .hasMessageMatching("Not a file name: .*");
@@ -37,10 +42,18 @@ public class TestIcebergUtil
                 .hasMessageMatching("Invalid metadata file name:.*");
         assertThatThrownBy(() -> parseVersion("00010_409702ba_4735_4645_8f14_09537cc0b2c8.metadata.json"))
                 .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("v10_metadata_json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("v1..gz.metadata.json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("v1.metadata.json.gz."))
+                .hasMessageMatching("Invalid metadata file name:.*");
 
         assertThatThrownBy(() -> parseVersion("00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
                 .hasMessageMatching("Invalid metadata file name:.*");
         assertThatThrownBy(() -> parseVersion("-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("v-10.metadata.json"))
                 .hasMessageMatching("Invalid metadata file name:.*");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes #16363

There are a couple of points to note:

- After hadoop table is registered with any catalog in Trino, `version-hint.text` won't be used or updated on any commit.
- Data should not be inserted using Iceberg's `HadoopTable` API after registering the table in Trino. Those data won't be visible to Trino.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

After creating the Iceberg HadoopTable and commiting a `COMMENT` on it, before `register_table`:

```
[root@hadoop-master /]# hdfs dfs -ls -R /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/
drwxrwxrwx   - marius supergroup          0 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata
-rw-r--r--   3 marius supergroup       1254 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/v1.metadata.json
-rw-r--r--   3 marius supergroup       1492 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/v2.metadata.json
-rw-r--r--   3 marius supergroup          1 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/version-hint.text
```

After `register_table` and doing `2` `INSERT` operations on the table:

```
[root@hadoop-master /]# hdfs dfs -ls -R /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/
drwxrwxrwx   - hive   supergroup          0 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/data
-rw-r--r--   3 hive   supergroup        647 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/data/00000-14-ca909e4a-e2b3-4c15-a80a-2c123fcd8b30-00001.parquet
-rw-r--r--   3 hive   supergroup        344 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/data/20230629_171133_00061_wkmst-a15471d4-68cd-44a4-be84-f4fd94bd77eb.parquet
drwxrwxrwx   - marius supergroup          0 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata
-rw-r--r--   3 hive   supergroup       2639 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/00003-974593c7-1620-4ebe-bd9c-59c06e069d30.metadata.json
-rw-r--r--   3 hive   supergroup       3638 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/00004-236a94af-4c63-4da9-aa8a-753e1e720d35.metadata.json
-rw-r--r--   3 hive   supergroup       4758 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/00005-37b725de-8718-46b9-b014-cf1ebee3bdac.metadata.json
-rw-r--r--   3 hive   supergroup        514 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/20230629_171133_00061_wkmst-58b6b1bd-59ed-41a2-959d-102eea057acb.stats
-rw-r--r--   3 hive   supergroup       5838 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/2869b9a1-9be7-410d-af6f-98eb71d51249-m0.avro
-rw-r--r--   3 hive   supergroup       5825 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/964dd472-0369-4ae3-9678-2db2c7583d56-m0.avro
-rw-r--r--   3 hive   supergroup       3797 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/snap-8030402491578120063-1-2869b9a1-9be7-410d-af6f-98eb71d51249.avro
-rw-r--r--   3 hive   supergroup       3873 2023-06-29 22:56 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/snap-8902239220190026805-1-964dd472-0369-4ae3-9678-2db2c7583d56.avro
-rw-r--r--   3 marius supergroup       1254 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/v1.metadata.json
-rw-r--r--   3 marius supergroup       1492 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/v2.metadata.json
-rw-r--r--   3 marius supergroup          1 2023-06-29 22:54 /user/hive/warehouse/test_register_hadoop_table_hadoop_table_parquet_0x4hdoexi6/metadata/version-hint.text
```

NOTE in the former state of the table:

- `v1.metadata.json`
- `v2.metadata.json`

NOTE in the latter form:

- `v1.metadata.json`
- `v2.metadata.json`
- `00003-974593c7-1620-4ebe-bd9c-59c06e069d30.metadata.json`
- `00004-236a94af-4c63-4da9-aa8a-753e1e720d35.metadata.json`
- `00005-37b725de-8718-46b9-b014-cf1ebee3bdac.metadata.json`

There is an inconsistency on the iceberg lib in handling hadoop iceberg tables and the table created by catalogs.

[BaseMetastoreTableOperations.java](https://github.com/apache/iceberg/blob/1d88e80bacbcb689e7f97932b25bf11b3633b190/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java#L378-L379)
[HadoopTableOperations.java](https://github.com/apache/iceberg/blob/1d88e80bacbcb689e7f97932b25bf11b3633b190/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java#L62)

Author: @findinpath 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
() Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Support iceberg register_table procedure to register hadoop tables. ({issue}`16363`)
```
