### PR TITLE
Skip unsupported tests in BaseBigQueryFailureRecoveryTest

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -43,7 +43,10 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorAnalyzeMetadata;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorMergeTableHandle;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
@@ -81,6 +84,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -664,6 +668,41 @@ public class BigQueryMetadata
     {
         BigQueryInsertTableHandle handle = (BigQueryInsertTableHandle) insertHandle;
         return finishInsert(session, handle.getRemoteTableName(), handle.getTemporaryRemoteTableName(), handle.getPageSinkIdColumnName(), handle.getColumnNames(), fragments);
+    }
+
+    @Override
+    public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
+    {
+        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        return ConnectorMetadata.super.applyDelete(session, handle);
+    }
+
+    @Override
+    public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle handle)
+    {
+        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        return ConnectorMetadata.super.executeDelete(session, handle);
+    }
+
+    @Override
+    public ConnectorMergeTableHandle beginMerge(ConnectorSession session, ConnectorTableHandle tableHandle, RetryMode retryMode)
+    {
+        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        return ConnectorMetadata.super.beginMerge(session, tableHandle, retryMode);
+    }
+
+    @Override
+    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    {
+        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        ConnectorMetadata.super.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+    }
+
+    @Override
+    public ConnectorAnalyzeMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Object> analyzeProperties)
+    {
+        // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
+        return ConnectorMetadata.super.getStatisticsCollectionMetadata(session, tableHandle, analyzeProperties);
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryFailureRecoveryTest.java
@@ -24,8 +24,6 @@ import org.testng.SkipException;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 public class BaseBigQueryFailureRecoveryTest
         extends BaseFailureRecoveryTest
 {
@@ -63,50 +61,49 @@ public class BaseBigQueryFailureRecoveryTest
     @Override
     protected void testAnalyzeTable()
     {
-        assertThatThrownBy(super::testAnalyzeTable).hasMessageMatching("This connector does not support analyze");
+        // This connector does not support analyze
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testDelete()
     {
-        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        // This connector does not support modifying table rows
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testDeleteWithSubquery()
     {
-        assertThatThrownBy(super::testDeleteWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        // This connector does not support modifying table rows
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testMerge()
     {
-        assertThatThrownBy(super::testMerge).hasMessageContaining("This connector does not support modifying table rows");
+        // This connector does not support modifying table rows
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testRefreshMaterializedView()
     {
-        assertThatThrownBy(super::testRefreshMaterializedView)
-                .hasMessageContaining("This connector does not support creating materialized views");
+        // This connector does not support creating materialized views
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testUpdate()
     {
-        assertThatThrownBy(super::testUpdate).hasMessageContaining("This connector does not support modifying table rows");
+        // This connector does not support modifying table rows
         throw new SkipException("skipped");
     }
 
     @Override
     protected void testUpdateWithSubquery()
     {
-        assertThatThrownBy(super::testUpdateWithSubquery).hasMessageContaining("This connector does not support modifying table rows");
+        // This connector does not support modifying table rows
         throw new SkipException("skipped");
     }
 }


### PR DESCRIPTION
## Description

These tests sometimes face transient issue of BigQuery during CTAS setup.
We could reuse `TestingConnectorBehavior`, but choosing simple approach in this PR. 
Fixes #16803

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
