### PR TITLE
Fix Iceberg scheduling failure due to dynamic filters

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -321,6 +321,7 @@ public class IcebergSplitSource
         close();
         this.fileScanIterable = CloseableIterable.empty();
         this.fileScanIterator = CloseableIterator.empty();
+        this.fileTasksIterator = emptyIterator();
     }
 
     @Override


### PR DESCRIPTION
`IcebergSplitSource` could fail with `Split source must be finished before TableExecuteSplitsInfo is read` in the following scenario

- `getNextBatch` called, initializing `fileScanIterator` and `fileTasksIterator`, but not consuming them fully
- dynamic filters completes
- `getNextBatch` called, crossing dynamic filter with table predicate, concluding it's none, calling `finish()` and returning NO_MORE_SPLITS_BATCH (signalling the source is finished)
- `getTableExecuteSplitsInfo` is called by `SourcePartitionedScheduler`. The invocation fails because `isFinished` returns false, as `fileTasksIterator` isn't consumed.
