### PR TITLE
Fix ptl suite list failing

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests.product.launcher.env;
 
+import com.google.common.io.Files;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -60,7 +61,7 @@ public final class EnvironmentOptions
     public String jdkProvider = BUILT_IN_NAME;
 
     @Option(names = "--jdk-tmp-download-path", paramLabel = "<jdk-tmp-download-path>", defaultValue = "${env:PTL_TMP_DOWNLOAD_PATH:-${sys:java.io.tmpdir}/ptl-tmp-download}", description = "Path to use to download JDK distributions " + DEFAULT_VALUE)
-    public Path jdkDownloadPath;
+    public Path jdkDownloadPath = Files.createTempDir().toPath();
 
     @Option(names = "--bind", description = "Bind exposed container ports to host ports, possible values: " + BIND_ON_HOST + ", " + DO_NOT_BIND + ", [port base number] " + DEFAULT_VALUE, defaultValue = BIND_ON_HOST, arity = "0..1", fallbackValue = BIND_ON_HOST)
     public void setBindOnHost(String value)


### PR DESCRIPTION
It fails with:

```
[Guice/ErrorInjectingConstructor]: NullPointerException: environmentOptions.jdkDownloadPath is null
  at Zulu20JdkProvider.<init>(Zulu20JdkProvider.java:28)
  while locating Zulu20JdkProvider
  at EnvironmentModule.lambda$configure$2(EnvironmentModule.java:97)
  while locating JdkProvider annotated with @Element(setName=,uniqueId=378, type=MAPBINDER, keyType=String)
```

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
