### PR TITLE
Add support for RENAME COLUMN in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -260,6 +260,12 @@ public class MongoMetadata
     }
 
     @Override
+    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    {
+        mongoSession.renameColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) source).getName(), target);
+    }
+
+    @Override
     public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
     {
         mongoSession.dropColumn(((MongoTableHandle) tableHandle), ((MongoColumnHandle) column).getName());

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -107,7 +107,6 @@ public class TestMongoConnectorTest
                 return false;
 
             case SUPPORTS_DROP_FIELD:
-            case SUPPORTS_RENAME_COLUMN:
                 return false;
 
             case SUPPORTS_CREATE_VIEW:


### PR DESCRIPTION
## Description

Add support for RENAME COLUMN in MongoDB

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Add support for `RENAME COLUMN`. ({issue}`17874`)
```
