### PR TITLE
Fix correctness issue due to dbref field order in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -39,7 +39,6 @@ import org.bson.types.ObjectId;
 import org.joda.time.chrono.ISOChronology;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -314,14 +313,10 @@ public class MongoPageSource
             if (value instanceof Map<?, ?> mapValue) {
                 BlockBuilder builder = output.beginBlockEntry();
 
-                List<String> fieldNames = new ArrayList<>();
                 for (int i = 0; i < type.getTypeSignature().getParameters().size(); i++) {
                     TypeSignatureParameter parameter = type.getTypeSignature().getParameters().get(i);
-                    fieldNames.add(parameter.getNamedTypeSignature().getName().orElse("field" + i));
-                }
-                checkState(fieldNames.size() == type.getTypeParameters().size(), "fieldName doesn't match with type size : %s", type);
-                for (int index = 0; index < type.getTypeParameters().size(); index++) {
-                    appendTo(type.getTypeParameters().get(index), mapValue.get(fieldNames.get(index)), builder);
+                    String fieldName = parameter.getNamedTypeSignature().getName().orElse("field" + i);
+                    appendTo(type.getTypeParameters().get(i), mapValue.get(fieldName), builder);
                 }
                 output.closeEntry();
                 return;

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -138,9 +138,9 @@ public class MongoSession
     private static final String LTE_OP = "$lte";
     private static final String IN_OP = "$in";
 
-    private static final String DATABASE_NAME = "databaseName";
-    private static final String COLLECTION_NAME = "collectionName";
-    private static final String ID = "id";
+    public static final String DATABASE_NAME = "databaseName";
+    public static final String COLLECTION_NAME = "collectionName";
+    public static final String ID = "id";
 
     // The 'simple' locale is the default collection in MongoDB. The locale doesn't allow specifying other fields (e.g. numericOrdering)
     // https://www.mongodb.com/docs/manual/reference/collation/

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -478,6 +478,24 @@ public class TestMongoConnectorTest
     }
 
     @Test
+    public void testDbRefFieldOrder()
+    {
+        // DBRef's field order is databaseName, collectionName and id
+        // Create a table with different order and verify the result
+        String tableName = "test_dbref_field_order" + randomNameSuffix();
+        assertUpdate("CREATE TABLE test." + tableName + "(x row(id int, \"collectionName\" varchar, \"databaseName\" varchar))");
+
+        Document document = new Document()
+                .append("x", new DBRef("test_db", "test_collection", 1));
+        client.getDatabase("test").getCollection(tableName).insertOne(document);
+
+        assertThat(query("SELECT * FROM test." + tableName))
+                .matches("SELECT CAST(row(1, 'test_collection', 'test_db') AS row(id int, \"collectionName\" varchar, \"databaseName\" varchar))");
+
+        assertUpdate("DROP TABLE test." + tableName);
+    }
+
+    @Test
     public void testMaps()
     {
         String mapIntegerTable = "test_map_integer" + randomNameSuffix();


### PR DESCRIPTION
## Description

Fix correctness issue due to dbref field order in MongoDB

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Fix correctness issue when the field order of [dbref type](https://www.mongodb.com/docs/manual/reference/database-references/#dbrefs) is different from `databaseName`, `collectionName` and `id`. ({issue}`issuenumber`)
```
