### PR TITLE
Pass and use provided OutputStream in every Launcher command

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/LauncherModule.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/LauncherModule.java
@@ -15,15 +15,38 @@ package io.trino.tests.product.launcher;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.Singleton;
 import io.trino.tests.product.launcher.docker.DockerFiles;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static java.util.Objects.requireNonNull;
 
 public final class LauncherModule
         implements Module
 {
+    private final OutputStream outputStream;
+
+    public LauncherModule(OutputStream outputStream)
+    {
+        this.outputStream = requireNonNull(outputStream, "outputStream is null");
+    }
+
     @Override
     public void configure(Binder binder)
     {
         binder.bind(DockerFiles.class).in(Scopes.SINGLETON);
+        binder.bind(OutputStream.class).toInstance(outputStream);
+    }
+
+    @Provides
+    @Singleton
+    private PrintStream provideOutputStreamPrinter()
+    {
+        return new PrintStream(outputStream, true, StandardCharsets.UTF_8);
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentList.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentList.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import io.trino.tests.product.launcher.Extensions;
-import io.trino.tests.product.launcher.LauncherModule;
 import io.trino.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.trino.tests.product.launcher.env.EnvironmentFactory;
 import io.trino.tests.product.launcher.env.EnvironmentModule;
@@ -28,9 +27,9 @@ import picocli.CommandLine.Option;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.concurrent.Callable;
 
-import static io.trino.tests.product.launcher.cli.Commands.runCommand;
 import static java.util.Objects.requireNonNull;
 import static picocli.CommandLine.Command;
 
@@ -39,27 +38,20 @@ import static picocli.CommandLine.Command;
         description = "List environments",
         usageHelpAutoWidth = true)
 public final class EnvironmentList
-        implements Callable<Integer>
+        extends LauncherCommand
 {
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit")
     public boolean usageHelpRequested;
 
-    private final Module additionalEnvironments;
-
     public EnvironmentList(Extensions extensions)
     {
-        this.additionalEnvironments = extensions.getAdditionalEnvironments();
+        super(EnvironmentList.Execution.class, extensions);
     }
 
     @Override
-    public Integer call()
+    List<Module> getCommandModules()
     {
-        return runCommand(
-                ImmutableList.<Module>builder()
-                        .add(new LauncherModule())
-                        .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
-                        .build(),
-                EnvironmentList.Execution.class);
+        return ImmutableList.of(new EnvironmentModule(EnvironmentOptions.empty(), extensions.getAdditionalEnvironments()));
     }
 
     public static class Execution

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentList.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentList.java
@@ -24,9 +24,8 @@ import io.trino.tests.product.launcher.env.EnvironmentOptions;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
 
+import java.io.OutputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -43,9 +42,9 @@ public final class EnvironmentList
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit")
     public boolean usageHelpRequested;
 
-    public EnvironmentList(Extensions extensions)
+    public EnvironmentList(OutputStream outputStream, Extensions extensions)
     {
-        super(EnvironmentList.Execution.class, extensions);
+        super(EnvironmentList.Execution.class, outputStream, extensions);
     }
 
     @Override
@@ -62,17 +61,11 @@ public final class EnvironmentList
         private final EnvironmentConfigFactory configFactory;
 
         @Inject
-        public Execution(EnvironmentFactory factory, EnvironmentConfigFactory configFactory)
+        public Execution(PrintStream out, EnvironmentFactory factory, EnvironmentConfigFactory configFactory)
         {
             this.factory = requireNonNull(factory, "factory is null");
             this.configFactory = requireNonNull(configFactory, "configFactory is null");
-
-            try {
-                this.out = new PrintStream(System.out, true, Charset.defaultCharset().name());
-            }
-            catch (UnsupportedEncodingException e) {
-                throw new IllegalStateException("Could not create print stream", e);
-            }
+            this.out = requireNonNull(out, "out is null");
         }
 
         @Override

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/LauncherCommand.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/LauncherCommand.java
@@ -20,6 +20,7 @@ import io.airlift.bootstrap.Bootstrap;
 import io.trino.tests.product.launcher.Extensions;
 import io.trino.tests.product.launcher.LauncherModule;
 
+import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -29,11 +30,13 @@ public abstract class LauncherCommand
         implements Callable<Integer>
 {
     private final Class<? extends Callable<Integer>> commandClass;
+    private final OutputStream outputStream;
     protected final Extensions extensions;
 
-    public LauncherCommand(Class<? extends Callable<Integer>> commandClass, Extensions extensions)
+    public LauncherCommand(Class<? extends Callable<Integer>> commandClass, OutputStream outputStream, Extensions extensions)
     {
         this.commandClass = requireNonNull(commandClass, "commandClass is null");
+        this.outputStream = requireNonNull(outputStream, "outputStream is null");
         this.extensions = requireNonNull(extensions, "extensions is null");
     }
 
@@ -45,8 +48,7 @@ public abstract class LauncherCommand
     {
         Bootstrap app = new Bootstrap(
                 ImmutableList.<Module>builder()
-                        .add()
-                        .add(new LauncherModule())
+                        .add(new LauncherModule(outputStream))
                         .addAll(getCommandModules())
                         .add(binder -> binder.bind(commandClass))
                         .build());

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteList.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteList.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import io.trino.tests.product.launcher.Extensions;
-import io.trino.tests.product.launcher.LauncherModule;
 import io.trino.tests.product.launcher.env.EnvironmentConfigFactory;
 import io.trino.tests.product.launcher.env.EnvironmentModule;
 import io.trino.tests.product.launcher.env.EnvironmentOptions;
@@ -31,9 +30,9 @@ import picocli.CommandLine.Option;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.concurrent.Callable;
 
-import static io.trino.tests.product.launcher.cli.Commands.runCommand;
 import static java.util.Objects.requireNonNull;
 
 @Command(
@@ -41,30 +40,22 @@ import static java.util.Objects.requireNonNull;
         description = "List tests suite",
         usageHelpAutoWidth = true)
 public final class SuiteList
-        implements Callable<Integer>
+        extends LauncherCommand
 {
-    private final Module additionalEnvironments;
-    private final Module additionalSuites;
-
     @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit")
     public boolean usageHelpRequested;
 
     public SuiteList(Extensions extensions)
     {
-        this.additionalEnvironments = extensions.getAdditionalEnvironments();
-        this.additionalSuites = extensions.getAdditionalSuites();
+        super(SuiteList.Execution.class, extensions);
     }
 
     @Override
-    public Integer call()
+    List<Module> getCommandModules()
     {
-        return runCommand(
-                ImmutableList.<Module>builder()
-                        .add(new LauncherModule())
-                        .add(new EnvironmentModule(EnvironmentOptions.empty(), additionalEnvironments))
-                        .add(new SuiteModule(additionalSuites))
-                        .build(),
-                SuiteList.Execution.class);
+        return ImmutableList.of(
+                new EnvironmentModule(EnvironmentOptions.empty(), extensions.getAdditionalEnvironments()),
+                new SuiteModule(extensions.getAdditionalSuites()));
     }
 
     public static class Execution

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
@@ -39,6 +39,8 @@ import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
 
 import java.io.File;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -89,9 +91,9 @@ public class SuiteRun
     @Mixin
     public EnvironmentOptions environmentOptions = new EnvironmentOptions();
 
-    public SuiteRun(Extensions extensions)
+    public SuiteRun(OutputStream outputStream, Extensions extensions)
     {
-        super(SuiteRun.Execution.class, extensions);
+        super(SuiteRun.Execution.class, outputStream, extensions);
     }
 
     @Override
@@ -142,6 +144,7 @@ public class SuiteRun
         private final JdkProviderFactory jdkProviderFactory;
         private final EnvironmentFactory environmentFactory;
         private final EnvironmentConfigFactory configFactory;
+        private final PrintStream printStream;
         private final long suiteStartTime;
 
         @Inject
@@ -151,7 +154,8 @@ public class SuiteRun
                 SuiteFactory suiteFactory,
                 JdkProviderFactory jdkProviderFactory,
                 EnvironmentFactory environmentFactory,
-                EnvironmentConfigFactory configFactory)
+                EnvironmentConfigFactory configFactory,
+                PrintStream printStream)
         {
             this.suiteRunOptions = requireNonNull(suiteRunOptions, "suiteRunOptions is null");
             this.environmentOptions = requireNonNull(environmentOptions, "environmentOptions is null");
@@ -159,6 +163,7 @@ public class SuiteRun
             this.jdkProviderFactory = requireNonNull(jdkProviderFactory, "jdkProviderFactory is null");
             this.environmentFactory = requireNonNull(environmentFactory, "environmentFactory is null");
             this.configFactory = requireNonNull(configFactory, "configFactory is null");
+            this.printStream = requireNonNull(printStream, "printStream is null");
             this.suiteStartTime = System.nanoTime();
         }
 
@@ -292,7 +297,7 @@ public class SuiteRun
 
         private int runTest(String runId, EnvironmentConfig environmentConfig, TestRun.TestRunOptions testRunOptions)
         {
-            TestRun.Execution execution = new TestRun.Execution(environmentFactory, jdkProviderFactory, environmentOptions, environmentConfig, testRunOptions);
+            TestRun.Execution execution = new TestRun.Execution(environmentFactory, jdkProviderFactory, environmentOptions, environmentConfig, testRunOptions, printStream);
 
             log.info("Test run %s started", runId);
             int exitCode = execution.call();

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentFactory.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentFactory.java
@@ -16,6 +16,7 @@ package io.trino.tests.product.launcher.env;
 import com.google.common.collect.Ordering;
 import com.google.inject.Inject;
 
+import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 
@@ -33,12 +34,12 @@ public final class EnvironmentFactory
         this.environmentProviders = requireNonNull(environmentProviders, "environmentProviders is null");
     }
 
-    public Environment.Builder get(String environmentName, EnvironmentConfig config, Map<String, String> extraOptions)
+    public Environment.Builder get(String environmentName, PrintStream printStream, EnvironmentConfig config, Map<String, String> extraOptions)
     {
         environmentName = canonicalEnvironmentName(environmentName);
         checkArgument(environmentProviders.containsKey(environmentName), "No environment with name '%s'. Those do exist, however: %s", environmentName, list());
         return environmentProviders.get(environmentName)
-                .createEnvironment(environmentName, config, extraOptions);
+                .createEnvironment(environmentName, printStream, config, extraOptions);
     }
 
     public List<String> list()

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentProvider.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.tests.product.launcher.env.common.EnvironmentExtender;
 
+import java.io.PrintStream;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,11 +43,11 @@ public abstract class EnvironmentProvider
         this.bases = ImmutableList.copyOf(requireNonNull(bases, "bases is null"));
     }
 
-    public final Environment.Builder createEnvironment(String name, EnvironmentConfig environmentConfig, Map<String, String> extraOptions)
+    public final Environment.Builder createEnvironment(String name, PrintStream printStream, EnvironmentConfig environmentConfig, Map<String, String> extraOptions)
     {
         requireNonNull(environmentConfig, "environmentConfig is null");
         requireNonNull(extraOptions, "extraOptions is null");
-        Environment.Builder builder = Environment.builder(name);
+        Environment.Builder builder = Environment.builder(name, printStream);
 
         // Environment is created by applying bases, environment definition and environment config to builder
         ImmutableList<EnvironmentExtender> extenders = ImmutableList.<EnvironmentExtender>builder()


### PR DESCRIPTION
This is required because using `System.out` will result in output being intercepted by the `io.airlift.log.Logging#rewireStdStreams`

