### PR TITLE
Create external table location for Hive

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTable.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTable.java
@@ -21,17 +21,20 @@ import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 
 public class TestHiveCreateExternalTable
         extends AbstractTestQueryFramework
@@ -86,5 +89,59 @@ public class TestHiveCreateExternalTable
                 tempDir.toUri().toASCIIString());
 
         assertQueryFails(createTableSql, "Target directory for table '.*' already exists:.*");
+    }
+
+    @Test
+    public void testCreateExternalTableOnNonExistingPath()
+            throws Exception
+    {
+        java.nio.file.Path tempDir = createTempDirectory(null);
+        // delete dir, trino should recreate it
+        deleteRecursively(tempDir, ALLOW_INSECURE);
+        String tableName = "test_create_external_non_exists_" + randomNameSuffix();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE %s.%s.%s (\n" +
+                        "   col1 varchar,\n" +
+                        "   col2 varchar\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   external_location = '%s',\n" +
+                        "   format = 'TEXTFILE'\n" +
+                        ")",
+                getSession().getCatalog().get(),
+                getSession().getSchema().get(),
+                tableName,
+                tempDir.toUri().toASCIIString());
+
+        assertUpdate(createTableSql);
+        String actual = (String) computeScalar("SHOW CREATE TABLE " + tableName);
+        assertEquals(actual, createTableSql);
+        assertUpdate("DROP TABLE " + tableName);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTableOnExistingPathToFile()
+            throws Exception
+    {
+        File tempFile = File.createTempFile("temp", ".tmp");
+        tempFile.deleteOnExit();
+        String tableName = "test_create_external_on_file_" + randomNameSuffix();
+
+        @Language("SQL") String createTableSql = format("""
+                        CREATE TABLE %s.%s.%s (
+                            col1 varchar,
+                            col2 varchar
+                        )WITH (
+                            external_location = '%s',
+                            format = 'TEXTFILE')
+                        """,
+                getSession().getCatalog().get(),
+                getSession().getSchema().get(),
+                tableName,
+                tempFile.toPath().toUri().toASCIIString());
+
+        assertQueryFails(createTableSql, ".*Destination exists and is not a directory.*");
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite2.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite2.java
@@ -36,6 +36,7 @@ public class Suite2
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinode.class)
                         .withGroups("configured_features", "hdfs_no_impersonation")
+                        .withExcludedTests("io.trino.tests.product.TestImpersonation.testExternalLocationTableCreationSuccess")
                         .build(),
                 testOnEnvironment(EnvSinglenodeKerberosHdfsNoImpersonation.class)
                         .withGroups("configured_features", "storage_formats", "hdfs_no_impersonation", "hive_kerberos")

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
@@ -14,3 +14,4 @@ hive.hdfs.impersonation.enabled=true
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
@@ -16,3 +16,4 @@ hive.fs.new-directory-permissions=0700
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
@@ -29,3 +29,4 @@ hive.hdfs.trino.keytab=/etc/hadoop/conf/hdfs-other.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
@@ -20,3 +20,4 @@ hive.security=sql-standard
 hive.hive-views.enabled=true
 
 hive.hdfs.wire-encryption.enabled=true
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -20,3 +20,4 @@ hive.max-partitions-for-eager-load=100
 hive.security=sql-standard
 #required for testAccessControlSetHiveViewAuthorization() product test
 hive.hive-views.enabled=true
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -21,3 +21,4 @@ hive.hdfs.trino.keytab=/etc/hadoop/conf/hdfs.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation-with-credential-cache/hive.properties
@@ -24,3 +24,4 @@ hive.max-partitions-for-eager-load=100
 hive.security=sql-standard
 #required for testAccessControlSetHiveViewAuthorization() product test
 hive.hive-views.enabled=true
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
@@ -24,3 +24,4 @@ hive.max-partitions-for-eager-load=100
 hive.security=sql-standard
 #required for testAccessControlSetHiveViewAuthorization() product test
 hive.hive-views.enabled=true
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-no-impersonation-with-credential-cache/hive.properties
@@ -21,3 +21,4 @@ hive.hdfs.trino.credential-cache.location=/etc/trino/conf/hdfs-krbcc
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.max-partitions-for-eager-load=100
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestImpersonation.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestImpersonation.java
@@ -26,6 +26,8 @@ import org.testng.annotations.Test;
 import java.net.URI;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.tests.product.TestGroups.HDFS_IMPERSONATION;
 import static io.trino.tests.product.TestGroups.HDFS_NO_IMPERSONATION;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -33,12 +35,14 @@ import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_IS
 import static io.trino.tests.product.utils.HadoopTestUtils.RETRYABLE_FAILURES_MATCH;
 import static io.trino.tests.product.utils.QueryExecutors.connectToTrino;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestImpersonation
         extends ProductTest
 {
     private QueryExecutor aliceExecutor;
+    private QueryExecutor bobExecutor;
 
     @Inject
     private HdfsClient hdfsClient;
@@ -47,6 +51,10 @@ public class TestImpersonation
     @Named("databases.alice@presto.jdbc_user")
     private String aliceJdbcUser;
 
+    @Inject
+    @Named("databases.bob@presto.jdbc_user")
+    private String bobJdbcUser;
+
     // The value for configuredHdfsUser is profile dependent
     // For non-Kerberos environments this variable will be equal to -DHADOOP_USER_NAME as set in jvm.config
     // For Kerberized environments this variable will be equal to the hive.hdfs.trino.principal property as set in hive.properties
@@ -54,10 +62,15 @@ public class TestImpersonation
     @Named("databases.presto.configured_hdfs_user")
     private String configuredHdfsUser;
 
+    @Inject
+    @Named("databases.hive.warehouse_directory_path")
+    private String warehouseLocation;
+
     @BeforeMethodWithContext
     public void setup()
     {
         aliceExecutor = connectToTrino("alice@presto");
+        bobExecutor = connectToTrino("bob@presto");
     }
 
     @AfterMethodWithContext
@@ -65,6 +78,49 @@ public class TestImpersonation
     {
         // should not be closed, this would close a shared, global QueryExecutor
         aliceExecutor = null;
+        bobExecutor = null;
+    }
+
+    @Test(groups = {HDFS_IMPERSONATION, PROFILE_SPECIFIC_TESTS})
+    public void testExternalLocationTableCreationFailure()
+    {
+        String commonExternalLocationPath = warehouseLocation + "/nested_" + randomNameSuffix();
+
+        String tableNameBob = "bob_external_table" + randomNameSuffix();
+        String tableLocationBob = commonExternalLocationPath + "/bob_table";
+        bobExecutor.executeQuery(format("CREATE TABLE %s (a bigint) WITH (external_location = '%s')", tableNameBob, tableLocationBob));
+        String owner = hdfsClient.getOwner(commonExternalLocationPath);
+        assertEquals(owner, bobJdbcUser);
+
+        String tableNameAlice = "alice_external_table" + randomNameSuffix();
+        String tableLocationAlice = commonExternalLocationPath + "/alice_table";
+        assertQueryFailure(() -> aliceExecutor.executeQuery(format("CREATE TABLE %s (a bigint) WITH (external_location = '%s')", tableNameAlice, tableLocationAlice)))
+                .hasStackTraceContaining("Permission denied");
+
+        bobExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableNameBob));
+        aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableNameAlice));
+    }
+
+    @Test(groups = {HDFS_NO_IMPERSONATION, PROFILE_SPECIFIC_TESTS})
+    public void testExternalLocationTableCreationSuccess()
+    {
+        String commonExternalLocationPath = warehouseLocation + "/nested_" + randomNameSuffix();
+
+        String tableNameBob = "bob_external_table" + randomNameSuffix();
+        String tableLocationBob = commonExternalLocationPath + "/bob_table";
+        bobExecutor.executeQuery(format("CREATE TABLE %s (a bigint) WITH (external_location = '%s')", tableNameBob, tableLocationBob));
+        String owner = hdfsClient.getOwner(tableLocationBob);
+        assertEquals(owner, configuredHdfsUser);
+
+        String tableNameAlice = "alice_external_table" + randomNameSuffix();
+        String tableLocationAlice = commonExternalLocationPath + "/alice_table";
+        aliceExecutor.executeQuery(format("CREATE TABLE %s (a bigint) WITH (external_location = '%s')", tableNameAlice, tableLocationAlice));
+        assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableNameAlice))).hasRowsCount(0);
+        owner = hdfsClient.getOwner(tableLocationAlice);
+        assertEquals(owner, configuredHdfsUser);
+
+        bobExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableNameBob));
+        aliceExecutor.executeQuery(format("DROP TABLE IF EXISTS %s", tableNameAlice));
     }
 
     @Test(groups = {HDFS_NO_IMPERSONATION, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Create directory structure if it's not exists.
external location will be created if `writesToNonManagedTablesEnabled` flag is set

The same behaviour is on pure Hive as mentioned in  https://github.com/trinodb/trino/pull/17920#issuecomment-1597014375




<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

With current change - external location will be created for Hive tables if flag hive.non-managed-table-writes-enabled is set,
otherwise exception will raised as it was before.

```markdown
# Hive
* Create an empty directory if the external location doesn't exist
```
