### PR TITLE
Add support for HTTP transport in thrift metastore client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,6 +957,7 @@ jobs:
             - suite-delta-lake-databricks113
             - suite-delta-lake-databricks122
             - suite-delta-lake-databricks133
+            - suite-databricks-unity-http-hms
             - suite-gcs
             - suite-clients
             - suite-functions
@@ -1001,6 +1002,11 @@ jobs:
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
             - suite: suite-delta-lake-databricks133
+              ignore exclusion if: >-
+                ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
+            - suite: suite-databricks-unity-http-hms
+              config: hdp3
+            - suite: suite-databricks-unity-http-hms
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
 
@@ -1049,6 +1055,10 @@ jobs:
           DATABRICKS_113_JDBC_URL:
           DATABRICKS_122_JDBC_URL:
           DATABRICKS_133_JDBC_URL:
+          DATABRICKS_UNITY_JDBC_URL:
+          DATABRICKS_UNITY_CATALOG_NAME:
+          DATABRICKS_UNITY_EXTERNAL_LOCATION:
+          DATABRICKS_HOST:
           DATABRICKS_LOGIN:
           DATABRICKS_TOKEN:
           GCP_CREDENTIALS_KEY:
@@ -1116,6 +1126,10 @@ jobs:
           DATABRICKS_113_JDBC_URL: ${{ secrets.DATABRICKS_113_JDBC_URL }}
           DATABRICKS_122_JDBC_URL: ${{ secrets.DATABRICKS_122_JDBC_URL }}
           DATABRICKS_133_JDBC_URL: ${{ secrets.DATABRICKS_133_JDBC_URL }}
+          DATABRICKS_UNITY_JDBC_URL: ${{ secrets.DATABRICKS_UNITY_JDBC_URL }}
+          DATABRICKS_UNITY_CATALOG_NAME: ${{ vars.DATABRICKS_UNITY_CATALOG_NAME }}
+          DATABRICKS_UNITY_EXTERNAL_LOCATION: ${{ vars.DATABRICKS_UNITY_EXTERNAL_LOCATION }}
+          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_LOGIN: token
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           GCP_CREDENTIALS_KEY: ${{ secrets.GCP_CREDENTIALS_KEY }}

--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -185,6 +185,26 @@ properties:
 * - `hive.metastore.thrift.txn-lock-max-wait`
   - Maximum time to wait to acquire hive transaction lock.
   - `10m`
+* - ``hive.metastore.http.client.bearer-token``
+  - Bearer token used to authenticate with the metastore service
+    when https transport mode is used. This must not be set when
+    using http url.
+  -
+* - ``hive.metastore.http.client.additional-headers``
+  - Additional headers which can be sent to the metastore service
+    http thrift requests when using the http transport mode. These
+    headers must be comma-separated and delimited using ``:``. E.g
+    header1:value1,header2:value2 sends two headers header1 and
+    header2 with their values as value1 and value2 respectively.
+    If you need to use a comma(``,``) or colon(``:``) in a header name
+    or value, escape it using a backslash (``\``).
+  -
+* - ``hive.metastore.http.client.authentication.type``
+  - The authentication type to be used for the http metastore client.
+    Currently, the only supported type is ``BEARER``. When set to ``BEARER``
+    the token configured in ``hive.metastore.http.client.bearer-token``
+    is used to authenticate the client to the http metastore service.
+  -
 :::
 
 (hive-glue-metastore)=

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -197,7 +197,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                     "hive",
                     "hive",
                     ImmutableMap.<String, String>builder()
-                            .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                            .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                             .put("hive.allow-drop-table", "true")
                             .putAll(hiveStorageConfiguration())
                             .buildOrThrow());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -229,7 +229,7 @@ public final class DeltaLakeQueryRunner
                 .setCoordinatorProperties(coordinatorProperties)
                 .addExtraProperties(extraProperties)
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
-                        .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                         .putAll(connectorProperties)
                         .buildOrThrow())
                 .build();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -67,7 +67,7 @@ public class TestDeltaLakeSharedHiveMetastoreWithViews
                 "hive",
                 "hive",
                 ImmutableMap.<String, String>builder()
-                        .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.allow-drop-table", "true")
                         .putAll(s3Properties)
                         .buildOrThrow());

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -402,6 +402,120 @@ public class TestHivePlugin
         connector.shutdown();
     }
 
+    @Test
+    public void testHttpMetastoreConfigs()
+    {
+        ConnectorFactory connectorFactory = getHiveConnectorFactory();
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .buildOrThrow(),
+                new TestingConnectorContext());
+        connector.shutdown();
+
+        Connector httpConnector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "http://localhost:443")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .buildOrThrow(),
+                new TestingConnectorContext());
+        httpConnector.shutdown();
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "http://localhost:443")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.http.client.bearer-token' must not be set while using http metastore URIs in 'hive.metastore.uri'");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "http://localhost:443, https://localhost:443")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.uri' cannot contain both http and https URI schemes");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "http://localhost:443, thrift://localhost:443")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.uri' cannot contain both http(s) and thrift URI schemes");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.http.client.authentication.type' must be set while using http/https metastore URIs in 'hive.metastore.uri'");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .put("hive.metastore.thrift.impersonation.enabled", "true")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.thrift.impersonation.enabled' is not supported when using http/https metastore URIs in 'hive.metastore.uri'");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.http.client.bearer-token' must be set while using https metastore URIs in 'hive.metastore.uri'");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .put("hive.metastore.username", "test")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.username' is not supported when using http/https metastore URIs in 'hive.metastore.uri'");
+
+        assertThatThrownBy(() -> connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "https://localhost:443")
+                        .put("hive.metastore.http.client.bearer-token", "token")
+                        .put("hive.metastore.http.client.additional-headers", "key:value")
+                        .put("hive.metastore.http.client.authentication.type", "BEARER")
+                        .put("hive.metastore.thrift.client.socks-proxy", "localhost:10000")
+                        .buildOrThrow(),
+                new TestingConnectorContext()))
+                .hasMessageContaining("'hive.metastore.thrift.client.socks-proxy' is not supported when using http/https metastore URIs in 'hive.metastore.uri'");
+    }
+
     private static ConnectorFactory getHiveConnectorFactory()
     {
         Plugin plugin = new HivePlugin();

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -23,6 +23,7 @@
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
         <air.test.parallel>instances</air.test.parallel>
+        <dep.http.version>5.2.1</dep.http.version>
     </properties>
 
     <dependencies>
@@ -209,13 +210,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.2.1</version>
+            <version>${dep.http.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <version>5.2.1</version>
+            <version>${dep.http.version}</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -207,6 +207,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
         </dependency>
@@ -284,6 +296,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-context</artifactId>
             <scope>runtime</scope>
@@ -293,6 +311,19 @@
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.13</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -449,8 +480,20 @@
         </dependency>
 
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-jakarta-servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -13,11 +13,23 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient.TransportSupplier;
 import io.trino.spi.NodeManager;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.thrift.transport.THttpClient;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
@@ -25,12 +37,17 @@ import javax.net.ssl.SSLContext;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.security.GeneralSecurityException;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.base.ssl.SslUtils.createSSLContext;
 import static java.lang.Math.toIntExact;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultThriftMetastoreClientFactory
@@ -42,6 +59,7 @@ public class DefaultThriftMetastoreClientFactory
     private final int readTimeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
     private final String hostname;
+    private final Optional<ThriftHttpContext> thriftHttpContext;
 
     private final MetastoreSupportsDateStatistics metastoreSupportsDateStatistics = new MetastoreSupportsDateStatistics();
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
@@ -58,7 +76,8 @@ public class DefaultThriftMetastoreClientFactory
             Duration connectTimeout,
             Duration readTimeout,
             HiveMetastoreAuthentication metastoreAuthentication,
-            String hostname)
+            String hostname,
+            Optional<ThriftHttpContext> thriftHttpContext)
     {
         this.sslContext = requireNonNull(sslContext, "sslContext is null");
         this.socksProxy = requireNonNull(socksProxy, "socksProxy is null");
@@ -66,11 +85,13 @@ public class DefaultThriftMetastoreClientFactory
         this.readTimeoutMillis = toIntExact(readTimeout.toMillis());
         this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
         this.hostname = requireNonNull(hostname, "hostname is null");
+        this.thriftHttpContext = requireNonNull(thriftHttpContext, "thriftHttpContext is null");
     }
 
     @Inject
     public DefaultThriftMetastoreClientFactory(
             ThriftMetastoreConfig config,
+            ThriftHttpMetastoreConfig httpMetastoreConfig,
             HiveMetastoreAuthentication metastoreAuthentication,
             NodeManager nodeManager)
     {
@@ -85,14 +106,53 @@ public class DefaultThriftMetastoreClientFactory
                 config.getConnectTimeout(),
                 config.getReadTimeout(),
                 metastoreAuthentication,
-                nodeManager.getCurrentNode().getHost());
+                nodeManager.getCurrentNode().getHost(),
+                buildThriftHttpContext(httpMetastoreConfig));
     }
 
     @Override
-    public ThriftMetastoreClient create(HostAndPort address, Optional<String> delegationToken)
+    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
             throws TTransportException
     {
-        return create(() -> createTransport(address, delegationToken), hostname);
+        return create(() -> getTransportSupplier(uri, delegationToken), hostname);
+    }
+
+    private TTransport getTransportSupplier(URI uri, Optional<String> delegationToken)
+            throws TTransportException
+    {
+        switch (uri.getScheme().toLowerCase(ENGLISH)) {
+            case "thrift" -> {
+                return createTransport(HostAndPort.fromParts(uri.getHost(), uri.getPort()), delegationToken);
+            }
+            case "http", "https" -> {
+                return createHttpTransport(uri, thriftHttpContext.orElseThrow(() -> new IllegalArgumentException("Thrift http context is not set")));
+            }
+            default -> throw new IllegalArgumentException("Invalid metastore uri scheme " + uri.getScheme());
+        }
+    }
+
+    private TTransport createHttpTransport(URI uri, ThriftHttpContext httpThriftContext)
+            throws TTransportException
+    {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        if (sslContext.isPresent()) {
+            checkArgument(uri.getScheme().toLowerCase(ENGLISH).equals("https"), "URI must be https when setting SSLContext");
+            checkArgument(httpThriftContext.token.isPresent(), "'hive.metastore.http.client.bearer-token' must be set when using https URI");
+            SSLConnectionSocketFactory socketFactory = new SSLConnectionSocketFactory(sslContext.get(), new DefaultHostnameVerifier(null));
+            Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("https", socketFactory)
+                    .build();
+            httpClientBuilder.setConnectionManager(new BasicHttpClientConnectionManager(registry));
+            httpClientBuilder.addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) -> {
+                httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + httpThriftContext.token.get());
+            });
+        }
+
+        httpClientBuilder.addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) -> {
+            httpThriftContext.additionalHeaders().forEach(httpRequest::addHeader);
+        });
+        httpClientBuilder.setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS).build());
+        return new THttpClient(uri.toString(), httpClientBuilder.build());
     }
 
     protected ThriftMetastoreClient create(TransportSupplier transportSupplier, String hostname)
@@ -134,5 +194,25 @@ public class DefaultThriftMetastoreClientFactory
         catch (GeneralSecurityException | IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private record ThriftHttpContext(Optional<String> token, Map<String, String> additionalHeaders)
+    {
+        private ThriftHttpContext
+        {
+            requireNonNull(additionalHeaders, "additionalHeaders is null");
+            additionalHeaders = ImmutableMap.copyOf(additionalHeaders);
+        }
+    }
+
+    @VisibleForTesting
+    public static Optional<ThriftHttpContext> buildThriftHttpContext(ThriftHttpMetastoreConfig config)
+    {
+        if (config.getAdditionalHeaders().isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new ThriftHttpContext(
+                config.getHttpBearerToken(),
+                config.getAdditionalHeaders()));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -91,7 +91,7 @@ public class DefaultThriftMetastoreClientFactory
     @Inject
     public DefaultThriftMetastoreClientFactory(
             ThriftMetastoreConfig config,
-            ThriftHttpMetastoreConfig httpMetastoreConfig,
+            Optional<ThriftHttpMetastoreConfig> httpMetastoreConfig,
             HiveMetastoreAuthentication metastoreAuthentication,
             NodeManager nodeManager)
     {
@@ -107,7 +107,7 @@ public class DefaultThriftMetastoreClientFactory
                 config.getReadTimeout(),
                 metastoreAuthentication,
                 nodeManager.getCurrentNode().getHost(),
-                buildThriftHttpContext(httpMetastoreConfig));
+                httpMetastoreConfig.map(DefaultThriftMetastoreClientFactory::buildThriftHttpContext));
     }
 
     @Override
@@ -206,13 +206,8 @@ public class DefaultThriftMetastoreClientFactory
     }
 
     @VisibleForTesting
-    public static Optional<ThriftHttpContext> buildThriftHttpContext(ThriftHttpMetastoreConfig config)
+    public static ThriftHttpContext buildThriftHttpContext(ThriftHttpMetastoreConfig config)
     {
-        if (config.getAdditionalHeaders().isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(new ThriftHttpContext(
-                config.getHttpBearerToken(),
-                config.getAdditionalHeaders()));
+        return new ThriftHttpContext(config.getHttpBearerToken(), config.getAdditionalHeaders());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.metastore.thrift;
 import com.google.common.base.Splitter;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -66,5 +67,28 @@ public class StaticMetastoreConfig
     {
         this.metastoreUsername = metastoreUsername;
         return this;
+    }
+
+    @AssertFalse(message = "'hive.metastore.uri' cannot contain both http and https URI schemes")
+    public boolean isMetastoreHttpUrisValid()
+    {
+        boolean hasHttpMetastore = metastoreUris.stream()
+                .anyMatch(uri -> "http".equalsIgnoreCase(uri.getScheme()));
+        boolean hasHttpsMetastore = metastoreUris.stream()
+                .anyMatch(uri -> "https".equalsIgnoreCase(uri.getScheme()));
+        if (hasHttpsMetastore || hasHttpMetastore) {
+            return hasHttpMetastore && hasHttpsMetastore;
+        }
+        return false;
+    }
+
+    @AssertFalse(message = "'hive.metastore.uri' cannot contain both http(s) and thrift URI schemes")
+    public boolean isEitherThriftOrHttpMetastore()
+    {
+        boolean hasHttpMetastore = metastoreUris.stream()
+                .anyMatch(uri -> "http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()));
+        boolean hasThriftMetastore = metastoreUris.stream()
+                .anyMatch(uri -> "thrift".equalsIgnoreCase(uri.getScheme()));
+        return hasHttpMetastore && hasThriftMetastore;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreConfig.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ThriftHttpMetastoreConfig
+{
+    public enum AuthenticationMode
+    {
+        BEARER
+    }
+
+    private AuthenticationMode authenticationMode;
+    private Optional<String> httpBearerToken = Optional.empty();
+    private Map<String, String> additionalHeaders = ImmutableMap.of();
+
+    @NotNull
+    public Optional<AuthenticationMode> getAuthenticationMode()
+    {
+        return Optional.ofNullable(authenticationMode);
+    }
+
+    @Config("hive.metastore.http.client.authentication.type")
+    @ConfigDescription("Authentication mode for thrift http based metastore client")
+    public ThriftHttpMetastoreConfig setAuthenticationMode(AuthenticationMode authenticationMode)
+    {
+        this.authenticationMode = authenticationMode;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getHttpBearerToken()
+    {
+        return httpBearerToken;
+    }
+
+    @Config("hive.metastore.http.client.bearer-token")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Bearer token to authenticate with a HTTP transport based metastore service")
+    public ThriftHttpMetastoreConfig setHttpBearerToken(String httpBearerToken)
+    {
+        this.httpBearerToken = Optional.ofNullable(httpBearerToken);
+        return this;
+    }
+
+    public Map<String, String> getAdditionalHeaders()
+    {
+        return additionalHeaders;
+    }
+
+    @Config("hive.metastore.http.client.additional-headers")
+    @ConfigDescription("Comma separated key:value pairs to be send to metastore as additional headers")
+    public ThriftHttpMetastoreConfig setAdditionalHeaders(String httpHeaders)
+    {
+        try {
+            // we allow escaping the delimiters like , and : using back-slash.
+            // To support that we create a negative lookbehind of , and : which
+            // are not preceded by a back-slash.
+            String headersDelim = "(?<!\\\\),";
+            String kvDelim = "(?<!\\\\):";
+            Map<String, String> temp = new HashMap<>();
+            if (httpHeaders != null) {
+                for (String kv : httpHeaders.split(headersDelim)) {
+                    String key = kv.split(kvDelim, 2)[0].trim();
+                    String val = kv.split(kvDelim, 2)[1].trim();
+                    temp.put(key, val);
+                }
+                this.additionalHeaders = ImmutableMap.copyOf(temp);
+            }
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(String.format("Invalid format for 'hive.metastore.http.client.additional-headers'. " +
+                    "Value provided is %s", httpHeaders), e);
+        }
+        return this;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
@@ -13,13 +13,13 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
-import com.google.common.net.HostAndPort;
 import org.apache.thrift.transport.TTransportException;
 
+import java.net.URI;
 import java.util.Optional;
 
 public interface ThriftMetastoreClientFactory
 {
-    ThriftMetastoreClient create(HostAndPort address, Optional<String> delegationToken)
+    ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
             throws TTransportException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -379,7 +379,9 @@ public final class ThriftMetastoreUtil
 
         return Database.builder()
                 .setDatabaseName(database.getName())
-                .setLocation(Optional.ofNullable(database.getLocationUri()))
+                // Some metastore implementations like Databricks Unity Catalog can return empty strings
+                // for database locations. We treat them as null.
+                .setLocation(Optional.ofNullable(emptyToNull(database.getLocationUri())))
                 .setOwnerName(Optional.of(ownerName))
                 .setOwnerType(Optional.of(ownerType))
                 .setComment(Optional.ofNullable(database.getDescription()))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorFactory.java
@@ -40,7 +40,7 @@ public class TestHiveConnectorFactory
         assertCreateConnectorFails("abc", "metastoreUri scheme is missing: abc");
         assertCreateConnectorFails("thrift://:8090", "metastoreUri host is missing: thrift://:8090");
         assertCreateConnectorFails("thrift://localhost", "metastoreUri port is missing: thrift://localhost");
-        assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift: abc::");
+        assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift, http or https: abc::");
         assertCreateConnectorFails("", "metastoreUris must specify at least one URI");
         assertCreateConnectorFails("thrift://localhost:1234,thrift://test-1", "metastoreUri port is missing: thrift://test-1");
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
@@ -22,6 +22,7 @@ import io.trino.testing.containers.BaseTestContainer;
 import io.trino.testing.containers.PrintingLogConsumer;
 import org.testcontainers.containers.Network;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -93,9 +94,10 @@ public class HiveHadoop
         return executeInContainerFailOnError("mysql", "-D", "metastore", "-uroot", "-proot", "--batch", "--column-names=false", "-e", query).replaceAll("\n$", "");
     }
 
-    public HostAndPort getHiveMetastoreEndpoint()
+    public URI getHiveMetastoreEndpoint()
     {
-        return getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+        HostAndPort address = getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+        return URI.create("thrift://" + address.getHost() + ":" + address.getPort());
     }
 
     public static class Builder

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHttpThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHttpThriftMetastoreConfig.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.hive.metastore.thrift.ThriftHttpMetastoreConfig.AuthenticationMode.BEARER;
+
+public class TestHttpThriftMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ThriftHttpMetastoreConfig.class)
+                .setHttpBearerToken(null)
+                .setAdditionalHeaders(null)
+                .setAuthenticationMode(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        String testToken = "test-token";
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.http.client.bearer-token", testToken)
+                .put("hive.metastore.http.client.additional-headers", "key1:value1, key2:value2")
+                .put("hive.metastore.http.client.authentication.type", "BEARER")
+                .buildOrThrow();
+
+        ThriftHttpMetastoreConfig expected = new ThriftHttpMetastoreConfig()
+                .setHttpBearerToken(testToken)
+                .setAdditionalHeaders("key1:value1, key2:value2")
+                .setAuthenticationMode(BEARER);
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testEscapingInAdditionalProperties()
+    {
+        String testToken = "test-token";
+        String additionalHeaders = "key\\:1:value\\,1, key\\,2:value\\:2";
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.http.client.bearer-token", testToken)
+                .put("hive.metastore.http.client.additional-headers", additionalHeaders)
+                .put("hive.metastore.http.client.authentication.type", "BEARER")
+                .buildOrThrow();
+
+        ThriftHttpMetastoreConfig expected = new ThriftHttpMetastoreConfig()
+                .setHttpBearerToken(testToken)
+                .setAdditionalHeaders("key\\:1:value\\,1, key\\,2:value\\:2")
+                .setAuthenticationMode(BEARER);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreClient.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import io.airlift.testing.Closeables;
+import io.airlift.units.Duration;
+import io.trino.hive.thrift.metastore.Database;
+import io.trino.hive.thrift.metastore.NoSuchObjectException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.http.HttpHeaders;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestThriftHttpMetastoreClient
+{
+    private static final HiveMetastoreAuthentication NO_HIVE_METASTORE_AUTHENTICATION = new NoHiveMetastoreAuthentication();
+    private static final Duration TIMEOUT = new Duration(20, SECONDS);
+    private static InMemoryThriftMetastore delegate;
+    private static TestingThriftHttpMetastoreServer metastoreServer;
+
+    @BeforeClass
+    public static void setup()
+            throws Exception
+    {
+        TestRequestHeaderInterceptor requestHeaderInterceptor = new TestRequestHeaderInterceptor();
+        File tempDir = Files.createTempDirectory(null).toFile();
+        tempDir.deleteOnExit();
+        delegate = new InMemoryThriftMetastore(new File(tempDir, "/metastore"), new ThriftMetastoreConfig());
+        metastoreServer = new TestingThriftHttpMetastoreServer(delegate, requestHeaderInterceptor);
+    }
+
+    @AfterClass
+    public static void tearDown()
+            throws Exception
+    {
+        Closeables.closeAll(metastoreServer);
+        metastoreServer = null;
+    }
+
+    @Test
+    public void testHttpThriftConnection()
+            throws Exception
+    {
+        String testDbName = "testdb";
+        Database db = new Database().setName(testDbName);
+        delegate.createDatabase(db);
+
+        ThriftMetastoreClientFactory factory = new DefaultThriftMetastoreClientFactory(
+                Optional.empty(),
+                Optional.empty(),
+                TIMEOUT,
+                TIMEOUT,
+                NO_HIVE_METASTORE_AUTHENTICATION,
+                "localhost",
+                DefaultThriftMetastoreClientFactory.buildThriftHttpContext(getHttpMetastoreConfig()));
+        URI metastoreUri = URI.create("http://localhost:" + metastoreServer.getPort());
+        ThriftMetastoreClient client = factory.create(
+                metastoreUri, Optional.empty());
+        assertThat(client.getAllDatabases()).containsAll(List.of(testDbName));
+        // negative case
+        assertThatThrownBy(() -> client.getDatabase("does-not-exist"))
+                .isInstanceOf(NoSuchObjectException.class);
+    }
+
+    private static ThriftHttpMetastoreConfig getHttpMetastoreConfig()
+    {
+        ThriftHttpMetastoreConfig config = new ThriftHttpMetastoreConfig();
+        config.setAdditionalHeaders("key1:value1, key2:value2");
+        return config;
+    }
+
+    private static class TestRequestHeaderInterceptor
+            implements Consumer<HttpServletRequest>
+    {
+        @Override
+        public void accept(HttpServletRequest httpServletRequest)
+        {
+            assertThat(Collections.list(httpServletRequest.getHeaderNames())).contains("key1", "key2");
+            assertThat(httpServletRequest.getHeader("key1")).isEqualTo("value1");
+            assertThat(httpServletRequest.getHeader("key2")).isEqualTo("value2");
+            assertThat(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingThriftHttpMetastoreServer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingThriftHttpMetastoreServer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.TheServlet;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.trino.hive.thrift.metastore.Database;
+import io.trino.hive.thrift.metastore.NoSuchObjectException;
+import io.trino.hive.thrift.metastore.ThriftHiveMetastore;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.thrift.TProcessor;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.server.TServlet;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.google.common.reflect.Reflection.newProxy;
+
+public class TestingThriftHttpMetastoreServer
+        implements Closeable
+{
+    private final TestingThriftHttpServlet thriftHttpServlet;
+    private final LifeCycleManager lifeCycleManager;
+    private final URI baseUri;
+
+    public TestingThriftHttpMetastoreServer(ThriftMetastore delegate, Consumer<HttpServletRequest> requestInterceptor)
+    {
+        ThriftHiveMetastore.Iface mockThriftHandler = proxyHandler(delegate, ThriftHiveMetastore.Iface.class);
+        TProcessor processor = new ThriftHiveMetastore.Processor<>(mockThriftHandler);
+        thriftHttpServlet = new TestingThriftHttpServlet(processor, new TBinaryProtocol.Factory(), requestInterceptor);
+        Bootstrap app = new Bootstrap(
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                binder -> {
+                    binder.bind(new TypeLiteral<Map<String, String>>() {}).annotatedWith(TheServlet.class).toInstance(ImmutableMap.of());
+                    binder.bind(Servlet.class).annotatedWith(TheServlet.class).toInstance(thriftHttpServlet);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .initialize();
+
+        lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        HttpServerInfo httpServerInfo = injector.getInstance(HttpServerInfo.class);
+        baseUri = httpServerInfo.getHttpUri();
+    }
+
+    private static <T> T proxyHandler(ThriftMetastore delegate, Class<T> iface)
+    {
+        return newProxy(iface, (proxy, method, args) -> switch (method.getName()) {
+            case "getAllDatabases" -> delegate.getAllDatabases();
+            case "getDatabase" -> {
+                Optional<Database> optionalDatabase = delegate.getDatabase(args[0].toString());
+                yield optionalDatabase.orElseThrow(() -> new NoSuchObjectException(""));
+            }
+            default -> throw new UnsupportedOperationException();
+        });
+    }
+
+    public int getPort()
+    {
+        return baseUri.getPort();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        lifeCycleManager.stop();
+    }
+
+    private static class TestingThriftHttpServlet
+            extends TServlet
+    {
+        private final Consumer<HttpServletRequest> requestInterceptor;
+
+        public TestingThriftHttpServlet(
+                TProcessor processor,
+                TProtocolFactory protocolFactory,
+                Consumer<HttpServletRequest> requestInterceptor)
+        {
+            super(processor, protocolFactory);
+            this.requestInterceptor = requestInterceptor;
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest request,
+                HttpServletResponse response)
+                throws ServletException, IOException
+        {
+            requestInterceptor.accept(request);
+            super.doPost(request, response);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -17,6 +17,7 @@ import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import org.apache.thrift.TException;
 
+import java.net.URI;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -29,16 +30,16 @@ public class TestingTokenAwareMetastoreClientFactory
     public static final Duration TIMEOUT = new Duration(20, SECONDS);
 
     private final DefaultThriftMetastoreClientFactory factory;
-    private final HostAndPort address;
+    private final URI address;
 
-    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI address)
     {
         this(socksProxy, address, TIMEOUT);
     }
 
-    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI address, Duration timeout)
     {
-        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost");
+        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost", Optional.empty());
         this.address = requireNonNull(address, "address is null");
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.s3;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.HostAndPort;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
@@ -26,6 +25,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
 
+import java.net.URI;
 import java.util.Locale;
 import java.util.Map;
 
@@ -70,7 +70,7 @@ public final class S3HiveQueryRunner
     public static class Builder
             extends HiveQueryRunner.Builder<Builder>
     {
-        private HostAndPort hiveMetastoreEndpoint;
+        private URI hiveMetastoreEndpoint;
         private Duration thriftMetastoreTimeout = TestingTokenAwareMetastoreClientFactory.TIMEOUT;
         private ThriftMetastoreConfig thriftMetastoreConfig = new ThriftMetastoreConfig();
         private String s3Region;
@@ -80,7 +80,7 @@ public final class S3HiveQueryRunner
         private String bucketName;
 
         @CanIgnoreReturnValue
-        public Builder setHiveMetastoreEndpoint(HostAndPort hiveMetastoreEndpoint)
+        public Builder setHiveMetastoreEndpoint(URI hiveMetastoreEndpoint)
         {
             this.hiveMetastoreEndpoint = requireNonNull(hiveMetastoreEndpoint, "hiveMetastoreEndpoint is null");
             return this;

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorFactory.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorFactory.java
@@ -41,7 +41,7 @@ public class TestHudiConnectorFactory
         assertCreateConnectorFails("abc", "metastoreUri scheme is missing: abc");
         assertCreateConnectorFails("thrift://:8090", "metastoreUri host is missing: thrift://:8090");
         assertCreateConnectorFails("thrift://localhost", "metastoreUri port is missing: thrift://localhost");
-        assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift: abc::");
+        assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift, http or https: abc::");
         assertCreateConnectorFails("", "metastoreUris must specify at least one URI");
         assertCreateConnectorFails("thrift://localhost:1234,thrift://test-1", "metastoreUri port is missing: thrift://test-1");
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -71,7 +71,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
-                                .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                                .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -233,7 +233,7 @@ public final class IcebergQueryRunner
                             "http-server.http.port", "8080"))
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
-                            "hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint(),
+                            "hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString(),
                             "hive.s3.aws-access-key", MINIO_ACCESS_KEY,
                             "hive.s3.aws-secret-key", MINIO_SECRET_KEY,
                             "hive.s3.endpoint", hiveMinioDataLake.getMinio().getMinioAddress(),
@@ -332,7 +332,7 @@ public final class IcebergQueryRunner
                             "http-server.http.port", "8080"))
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
-                            "hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint(),
+                            "hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString(),
                             "hive.azure.abfs-storage-account", azureAccount,
                             "hive.azure.abfs-access-key", azureAccessKey))
                     .setSchemaInitializer(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
@@ -84,7 +84,7 @@ public class TestIcebergAbfsConnectorSmokeTest
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
-                                .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                                .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("hive.azure.abfs-storage-account", account)
                                 .put("hive.azure.abfs-access-key", accessKey)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -95,7 +95,7 @@ public class TestIcebergGcsConnectorSmokeTest
                 .setIcebergProperties(ImmutableMap.<String, String>builder()
                         .put("iceberg.catalog.type", "hive_metastore")
                         .put("hive.gcs.json-key", gcpCredentials)
-                        .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                         .put("iceberg.file-format", format.name())
                         .put("iceberg.register-table-procedure.enabled", "true")
                         .put("iceberg.writer-sort-buffer-size", "1MB")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.DockerContainer;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentProvider;
+import io.trino.tests.product.launcher.env.common.StandardMultinode;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import java.io.File;
+
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.configureTempto;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+@TestsEnvironment
+public class EnvMultinodeDatabricksHttpHms
+        extends EnvironmentProvider
+{
+    private final DockerFiles.ResourceProvider configDir;
+    private static final File DATABRICKS_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/databricks-jdbc.jar");
+
+    @Inject
+    public EnvMultinodeDatabricksHttpHms(StandardMultinode standardMultinode, DockerFiles dockerFiles)
+    {
+        super(standardMultinode);
+        requireNonNull(dockerFiles, "dockerFiles is null");
+        configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment/multinode-databricks-http-hms");
+    }
+
+    @Override
+    public void extendEnvironment(Environment.Builder builder)
+    {
+        String databricksTestJdbcUrl = requireNonNull(System.getenv("DATABRICKS_UNITY_JDBC_URL"), "Environment DATABRICKS_UNITY_JDBC_URL was not set");
+        String databricksTestLogin = requireNonNull(System.getenv("DATABRICKS_LOGIN"), "Environment DATABRICKS_LOGIN was not set");
+        String databricksTestToken = requireNonNull(System.getenv("DATABRICKS_TOKEN"), "Environment DATABRICKS_TOKEN was not set");
+        String awsRegion = requireNonNull(System.getenv("AWS_REGION"), "Environment AWS_REGION was not set");
+
+        builder.configureContainer(COORDINATOR, dockerContainer -> exportAWSCredentials(dockerContainer)
+                .withEnv("AWS_REGION", awsRegion)
+                .withEnv("DATABRICKS_TOKEN", databricksTestToken)
+                .withEnv("DATABRICKS_HOST", getEnvVariable("DATABRICKS_HOST"))
+                .withEnv("DATABRICKS_UNITY_CATALOG_NAME", getEnvVariable("DATABRICKS_UNITY_CATALOG_NAME")));
+
+        builder.configureContainer(WORKER, dockerContainer -> exportAWSCredentials(dockerContainer)
+                .withEnv("AWS_REGION", awsRegion)
+                .withEnv("DATABRICKS_TOKEN", databricksTestToken)
+                .withEnv("DATABRICKS_HOST", getEnvVariable("DATABRICKS_HOST"))
+                .withEnv("DATABRICKS_UNITY_CATALOG_NAME", getEnvVariable("DATABRICKS_UNITY_CATALOG_NAME")));
+
+        builder.configureContainer(TESTS, container -> exportAWSCredentials(container)
+                .withEnv("DATABRICKS_JDBC_URL", databricksTestJdbcUrl)
+                .withEnv("DATABRICKS_LOGIN", databricksTestLogin)
+                .withEnv("DATABRICKS_TOKEN", databricksTestToken)
+                .withEnv("DATABRICKS_UNITY_CATALOG_NAME", getEnvVariable("DATABRICKS_UNITY_CATALOG_NAME"))
+                .withEnv("DATABRICKS_UNITY_EXTERNAL_LOCATION", getEnvVariable("DATABRICKS_UNITY_EXTERNAL_LOCATION"))
+                .withCopyFileToContainer(
+                        forHostPath(DATABRICKS_JDBC_PROVIDER.getAbsolutePath()),
+                        "/docker/jdbc/databricks-jdbc.jar"));
+
+        builder.addConnector("hive", forHostPath(configDir.getPath("hive.properties")));
+        builder.addConnector(
+                "delta_lake",
+                forHostPath(configDir.getPath("delta.properties")),
+                "/docker/presto-product-tests/conf/presto/etc/catalog/delta.properties");
+        configureTempto(builder, configDir);
+    }
+
+    private DockerContainer exportAWSCredentials(DockerContainer container)
+    {
+        container = exportAWSCredential(container, "TRINO_AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID", true);
+        container = exportAWSCredential(container, "TRINO_AWS_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY", true);
+        return exportAWSCredential(container, "TRINO_AWS_SESSION_TOKEN", "AWS_SESSION_TOKEN", false);
+    }
+
+    private String getEnvVariable(String name)
+    {
+        String credentialValue = System.getenv(name);
+        if (credentialValue == null) {
+            throw new IllegalStateException(format("Environment variable %s not set", name));
+        }
+        return credentialValue;
+    }
+
+    private DockerContainer exportAWSCredential(DockerContainer container, String credentialEnvVariable, String containerEnvVariable, boolean required)
+    {
+        String credentialValue = System.getenv(credentialEnvVariable);
+        if (credentialValue == null) {
+            if (required) {
+                throw new IllegalStateException(format("Environment variable %s not set", credentialEnvVariable));
+            }
+            return container;
+        }
+        return container.withEnv(containerEnvVariable, credentialValue);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
@@ -35,8 +35,9 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class EnvMultinodeDatabricksHttpHms
         extends EnvironmentProvider
 {
-    private final DockerFiles.ResourceProvider configDir;
     private static final File DATABRICKS_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/databricks-jdbc.jar");
+
+    private final DockerFiles.ResourceProvider configDir;
 
     @Inject
     public EnvMultinodeDatabricksHttpHms(StandardMultinode standardMultinode, DockerFiles dockerFiles)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDatabricksUnityHttpHms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDatabricksUnityHttpHms.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeDatabricksHttpHms;
+import io.trino.tests.product.launcher.suite.Suite;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDatabricksUnityHttpHms
+        extends Suite
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvMultinodeDatabricksHttpHms.class)
+                        .withGroups("configured_features", "databricks-unity-http-hms")
+                        .build());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/delta.properties
@@ -1,0 +1,10 @@
+connector.name=delta_lake
+hive.metastore.uri=https://${ENV:DATABRICKS_HOST}:443/api/2.0/unity-hms-proxy/metadata
+hive.metastore.http.client.bearer-token=${ENV:DATABRICKS_TOKEN}
+hive.metastore.http.client.additional-headers=X-Databricks-Catalog-Name:${ENV:DATABRICKS_UNITY_CATALOG_NAME}
+hive.metastore.http.client.authentication.type=BEARER
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
+hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL
+delta.enable-non-concurrent-writes=true
+hive.metastore.thrift.client.ssl.enabled=true
+hive.metastore.thrift.client.ssl.trust-certificate=/etc/pki/java/cacerts

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/hive.properties
@@ -1,0 +1,10 @@
+connector.name=hive
+hive.metastore.uri=https://${ENV:DATABRICKS_HOST}:443/api/2.0/unity-hms-proxy/metadata
+hive.metastore.http.client.bearer-token=${ENV:DATABRICKS_TOKEN}
+hive.metastore.http.client.additional-headers=X-Databricks-Catalog-Name:${ENV:DATABRICKS_UNITY_CATALOG_NAME}
+hive.metastore.http.client.authentication.type=BEARER
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
+hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL
+hive.metastore.thrift.client.ssl.enabled=true
+hive.metastore.thrift.client.ssl.trust-certificate=/etc/pki/java/cacerts
+hive.non-managed-table-writes-enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/tempto-configuration.yaml
@@ -1,0 +1,16 @@
+databases:
+  presto:
+    jdbc_user: root
+  delta:
+    jdbc_driver_class: com.databricks.client.jdbc.Driver
+    jdbc_jar: /docker/jdbc/databricks-jdbc.jar
+    schema: default
+    prepare_statement:
+      - USE ${databases.delta.schema}
+    table_manager_type: jdbc
+    jdbc_url: ${DATABRICKS_JDBC_URL};EnableArrow=0
+    jdbc_user: ${DATABRICKS_LOGIN}
+    jdbc_password: ${DATABRICKS_TOKEN}
+
+s3:
+  server_type: aws

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -90,6 +90,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_DATABRICKS_104 = "delta-lake-databricks-104";
     public static final String DELTA_LAKE_DATABRICKS_113 = "delta-lake-databricks-113";
     public static final String DELTA_LAKE_DATABRICKS_122 = "delta-lake-databricks-122";
+    public static final String DATABRICKS_UNITY_HTTP_HMS = "databricks-unity-http-hms";
     public static final String DELTA_LAKE_EXCLUDE_91 = "delta-lake-exclude-91";
     public static final String DELTA_LAKE_EXCLUDE_133 = "delta-lake-exclude-133";
     public static final String HUDI = "hudi";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUnityCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUnityCompatibility.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tempto.AfterMethodWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.tempto.assertions.QueryAssert;
+import io.trino.testng.services.Flaky;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DATABRICKS_UNITY_HTTP_HMS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeDatabricksUnityCompatibility
+        extends ProductTest
+{
+    private final String schemaName = "test_delta_basic_" + randomNameSuffix();
+    private String unityCatalogName;
+    private String externalLocationPath;
+
+    @BeforeMethodWithContext
+    public void setUp()
+    {
+        unityCatalogName = requireNonNull(System.getenv("DATABRICKS_UNITY_CATALOG_NAME"), "Environment variable not set: DATABRICKS_UNITY_CATALOG_NAME");
+        externalLocationPath = requireNonNull(System.getenv("DATABRICKS_UNITY_EXTERNAL_LOCATION"), "Environment variable not set: DATABRICKS_UNITY_EXTERNAL_LOCATION");
+        onDelta().executeQuery(format("CREATE SCHEMA %s.%s", unityCatalogName, schemaName));
+    }
+
+    @AfterMethodWithContext
+    public void cleanUp()
+    {
+        onDelta().executeQuery(format("DROP SCHEMA IF EXISTS %s.%s CASCADE", unityCatalogName, schemaName));
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testBasicTableReadWrite()
+    {
+        String tableName = "test_read_write_" + randomNameSuffix();
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+        onDelta().executeQuery(
+                format("CREATE TABLE %s.%s.%s (c1 int, c2 string) USING delta LOCATION '%s'",
+                        unityCatalogName, schemaName, tableName, tableLocation));
+        onDelta().executeQuery(
+                format("INSERT INTO %s.%s.%s VALUES (1, 'one')",
+                        unityCatalogName, schemaName, tableName));
+
+        assertThat(onTrino().executeQuery("SHOW SCHEMAS FROM delta"))
+                .contains(ImmutableList.of(
+                        row(schemaName.toLowerCase(ENGLISH))));
+
+        assertThat(onTrino().executeQuery("SHOW TABLES IN delta." + schemaName))
+                .containsOnly(row(tableName.toLowerCase(ENGLISH)));
+
+        // select
+        List<QueryAssert.Row> expectedRowsForSelect = ImmutableList.of(row(1, "one"));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM delta.%s.%s", schemaName, tableName)))
+                .containsOnly(expectedRowsForSelect);
+
+        // insert
+        List<QueryAssert.Row> expectedRowsForInsert = ImmutableList.of(row(1, "one"), row(2, "two"));
+        onTrino().executeQuery(format("INSERT INTO delta.%s.%s VALUES (2, 'two')", schemaName, tableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM delta.%s.%s", schemaName, tableName)))
+                .containsOnly(expectedRowsForInsert);
+        assertThat(onDelta().executeQuery(format("SELECT * FROM %s.%s.%s", unityCatalogName, schemaName, tableName)))
+                .containsOnly(expectedRowsForInsert);
+
+        // update
+        List<QueryAssert.Row> expectedRowsForUpdate = ImmutableList.of(row(1, "one"), row(2, "two hundred"));
+        onTrino().executeQuery(format("UPDATE delta.%s.%s SET c2 = 'two hundred' WHERE c1 = 2", schemaName, tableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM delta.%s.%s", schemaName, tableName)))
+                .containsOnly(expectedRowsForUpdate);
+        assertThat(onDelta().executeQuery(format("SELECT * FROM %s.%s.%s", unityCatalogName, schemaName, tableName)))
+                .containsOnly(expectedRowsForUpdate);
+
+        // delete
+        List<QueryAssert.Row> expectedRowsForDelete = ImmutableList.of(row(2, "two hundred"));
+        onTrino().executeQuery(format("DELETE FROM delta.%s.%s WHERE c2 = 'one'", schemaName, tableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM delta.%s.%s", schemaName, tableName)))
+                .containsOnly(expectedRowsForDelete);
+        assertThat(onDelta().executeQuery(format("SELECT * FROM %s.%s.%s", unityCatalogName, schemaName, tableName)))
+                .containsOnly(expectedRowsForDelete);
+
+        // merge
+        List<QueryAssert.Row> expectedRowsForMerge = ImmutableList.of(row(1, "one"), row(2, "two"), row(3, "three"));
+        String sourceTableName = "test_source_" + randomNameSuffix();
+        String tableLocation2 = format("%s/%s/%s", externalLocationPath, schemaName, sourceTableName);
+        onDelta().executeQuery(
+                format("CREATE TABLE %s.%s.%s (c1 int, c2 string) using delta location '%s'",
+                        unityCatalogName, schemaName, sourceTableName, tableLocation2));
+        onDelta().executeQuery(
+                format("INSERT INTO %s.%s.%s values (1, 'one'), (2, 'two'), (3, 'three')",
+                        unityCatalogName, schemaName, sourceTableName));
+
+        onTrino().executeQuery(format("MERGE INTO delta.%s.%s t USING delta.%s.%s s on t.c1 = s.c1 " +
+                "WHEN MATCHED THEN UPDATE SET c2 = s.c2 " +
+                "WHEN NOT MATCHED THEN INSERT (c1, c2) VALUES (s.c1, s.c2)", schemaName, tableName, schemaName, sourceTableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM delta.%s.%s", schemaName, tableName)))
+                .containsOnly(expectedRowsForMerge);
+        assertThat(onDelta().executeQuery(format("SELECT * FROM %s.%s.%s", unityCatalogName, schemaName, tableName)))
+                .containsOnly(expectedRowsForMerge);
+    }
+
+    /**
+     * The Unity Catalog's HMS API has a limitation where managed tables are not supported. This test
+     * verifies that if a managed table is created using Databricks delta lake, Trino which connects
+     * to Unity Catalog's HMS endpoint doesn't see it.
+     */
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testManagedTables()
+    {
+        String tableName = "test_managed_table_" + randomNameSuffix();
+        onDelta().executeQuery(
+                format("CREATE TABLE %s.%s.%s (c1 int, c2 string)",
+                        unityCatalogName, schemaName, tableName));
+        assertThat(onTrino().executeQuery(format("SHOW CREATE SCHEMA delta.%s", schemaName)))
+                .containsOnly(row(format("CREATE SCHEMA delta.%s", schemaName)));
+        assertThat(onTrino().executeQuery("SHOW TABLES IN delta." + schemaName)).hasNoRows();
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testTableColumns()
+    {
+        String tableName = "test_cols";
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+        onDelta().executeQuery(format("CREATE TABLE %s.%s.%s (" +
+                "int_col INT," +
+                "string_col STRING," +
+                "tinyint_col TINYINT," +
+                "smallint_col SMALLINT," +
+                "bigint_col BIGINT," +
+                "decimal_col DECIMAL," +
+                "float_col FLOAT," +
+                "double_col DOUBLE," +
+                "date_col DATE," +
+                "timestamp_col TIMESTAMP," +
+                "binary_col BINARY," +
+                "bool_col BOOLEAN," +
+                "array_int_col ARRAY<int>," +
+                "map_col MAP<TIMESTAMP,INT>," +
+                "struct_col struct<a: LONG, b: String NOT NULL>" +
+                ") " +
+                "USING DELTA " +
+                "LOCATION '%s'", unityCatalogName, schemaName, tableName, tableLocation));
+        assertThat(
+                onTrino().executeQuery("SHOW TABLES IN delta." + schemaName))
+                .containsOnly(row(tableName));
+        assertThat(
+                onTrino().executeQuery(format("SHOW COLUMNS IN delta.%s.%s", schemaName, tableName)))
+                .containsOnly(
+                    row("int_col", "integer", "", ""),
+                    row("string_col", "varchar", "", ""),
+                    row("tinyint_col", "tinyint", "", ""),
+                    row("smallint_col", "smallint", "", ""),
+                    row("bigint_col", "bigint", "", ""),
+                    row("decimal_col", "decimal(10,0)", "", ""),
+                    row("float_col", "real", "", ""),
+                    row("double_col", "double", "", ""),
+                    row("date_col", "date", "", ""),
+                    row("timestamp_col", "timestamp(3) with time zone", "", ""),
+                    row("binary_col", "varbinary", "", ""),
+                    row("bool_col", "boolean", "", ""),
+                    row("array_int_col", "array(integer)", "", ""),
+                    row("map_col", "map(timestamp(3) with time zone, integer)", "", ""),
+                    row("struct_col", "row(a bigint, b varchar)", "", ""));
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testUnsupportedStatement()
+    {
+        String tableName = "test_unsupported_" + randomNameSuffix();
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+        String trinoLocation = format("%s/%s", externalLocationPath, "trino_test_" + randomNameSuffix());
+        onDelta().executeQuery(format("CREATE TABLE %s.%s.%s (c1 int, c2 string) USING delta LOCATION '%s'", unityCatalogName, schemaName, tableName, tableLocation));
+        assertQueryFailure(() -> onTrino().executeQuery(format("CREATE TABLE delta.%s.new_table (c1 int) WITH (location = '%s')", schemaName, trinoLocation)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("CREATE TABLE delta.%s.new_table (c1) WITH (location = '%s') AS SELECT 1", schemaName, trinoLocation)))
+                .hasRootCauseMessage("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE delta.%s.%s RENAME TO delta.%s.new_t1", schemaName, tableName, schemaName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("DROP TABLE delta.%s.%s", schemaName, tableName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("DROP SCHEMA delta.%s CASCADE", schemaName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDatabricksUnityCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDatabricksUnityCompatibility.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.tempto.AfterMethodWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.testng.services.Flaky;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DATABRICKS_UNITY_HTTP_HMS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHiveDatabricksUnityCompatibility
+        extends ProductTest
+{
+    private String unityCatalogName;
+    private String externalLocationPath;
+    private final String schemaName = "test_basic_hive_" + randomNameSuffix();
+
+    @BeforeMethodWithContext
+    public void setUp()
+    {
+        unityCatalogName = requireNonNull(System.getenv("DATABRICKS_UNITY_CATALOG_NAME"), "Environment variable not set: DATABRICKS_UNITY_CATALOG_NAME");
+        externalLocationPath = requireNonNull(System.getenv("DATABRICKS_UNITY_EXTERNAL_LOCATION"), "Environment variable not set: DATABRICKS_UNITY_EXTERNAL_LOCATION");
+        String schemaLocation = format("%s/%s", externalLocationPath, schemaName);
+        onDelta().executeQuery(format(
+                "CREATE SCHEMA %s.%s MANAGED LOCATION '%s'",
+                unityCatalogName, schemaName, schemaLocation));
+    }
+
+    @AfterMethodWithContext
+    public void cleanUp()
+    {
+        onDelta().executeQuery(format("DROP SCHEMA IF EXISTS %s.%s CASCADE", unityCatalogName, schemaName));
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testBasicHiveOperations()
+    {
+        String tableName = "testTable";
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+        onDelta().executeQuery(format(
+                "CREATE TABLE %s.%s.%s (c1 int, c2 string) " +
+                        "USING PARQUET " +
+                        "LOCATION '%s'", unityCatalogName, schemaName, tableName, tableLocation));
+
+        onDelta().executeQuery(
+                format("INSERT INTO %s.%s.%s VALUES (1, 'one')", unityCatalogName, schemaName, tableName));
+
+        assertThat(onTrino().executeQuery("SHOW SCHEMAS FROM hive"))
+                .contains(row(schemaName));
+
+        assertThat(onTrino().executeQuery("SHOW TABLES IN hive." + schemaName))
+                .containsOnly(row("testtable"));
+
+        assertThat(onTrino().executeQuery(format("SELECT * FROM hive.%s.%s", schemaName, tableName)))
+                .containsOnly(row(1, "one"));
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.tests.product.hive;
 
-import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.airlift.units.Duration;
@@ -36,7 +35,8 @@ public final class TestHiveMetastoreClientFactory
             new Duration(10, SECONDS),
             new Duration(10, SECONDS),
             new NoHiveMetastoreAuthentication(),
-            "localhost");
+            "localhost",
+            Optional.empty());
 
     @Inject
     @Named("databases.hive.metastore.host")
@@ -50,8 +50,7 @@ public final class TestHiveMetastoreClientFactory
             throws TException
     {
         URI metastore = URI.create("thrift://" + metastoreHost + ":" + metastorePort);
-        return thriftMetastoreClientFactory.create(
-                HostAndPort.fromParts(metastore.getHost(), metastore.getPort()),
+        return thriftMetastoreClientFactory.create(metastore,
                 Optional.empty());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR adds support for using HTTP as the transport for the thrift metastore client. In this mode the `hive.metastore.uri` can support a http(s) URL to the metastore service. Since each thrift API is a POST request to the the metastore endpoint, this PR also adds support for adding a HTTP bearer token which must be configured to authenticate the metastore client to the metastore server. The token can be configured using a configuration `hive.metastore.http.client.bearer-token`. To support Databricks Unity Catalog's HMS API interface, the configuration `hive.metastore.http.client.additional-headers` must be set to `X-Databricks-Unity-Catalog-Name=<catalog_name>` where the catalog_name is the name of the catalog object in Databricks Unity Catalog.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Thrift has support HTTP based transport for a long time. Ref https://github.com/apache/thrift/blob/master/lib/javame/src/org/apache/thrift/transport/THttpClient.java. We have used the http mode for thrift on various services in other projects like HiveServer2 in Apache Hive and Apache Spark for a while now.

More recently, Apache Hive also added support for Hive Metastore server to use HTTP mode.
https://issues.apache.org/jira/browse/HIVE-21456

This PR modifies the logic in `DefaultThriftMetastoreClientFactory` to instantiate `THttpClient` for the transport when creating the thrift metastore client.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Add HTTP support for the thrift metastore client.
```markdown
# Section
* Fix some things. ({issue}17865)
```

Fixes https://github.com/trinodb/trino/issues/17865