### PR TITLE
Various precision for Oracle timestamp

### DIFF
--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -203,7 +203,7 @@ Trino data type mapping:
     - ``TIMESTAMP(0)``
     - See :ref:`datetime mapping`
   * - ``TIMESTAMP(p)``
-    - ``TIMESTAMP``
+    - ``TIMESTAMP(p)``
     - See :ref:`datetime mapping`
   * - ``TIMESTAMP(p) WITH TIME ZONE``
     - ``TIMESTAMP WITH TIME ZONE``
@@ -300,8 +300,8 @@ For Oracle ``NUMBER`` (without precision and scale), you can change
 Mapping datetime types
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Selecting a timestamp with fractional second precision (``p``) greater than 3
-truncates the fractional seconds to three digits instead of rounding it.
+Writing a timestamp with fractional second precision (``p``) greater than 9
+rounds the fractional seconds to nine digits.
 
 Oracle ``DATE`` type stores hours, minutes, and seconds, so it is mapped
 to Trino ``TIMESTAMP(0)``.

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -34,6 +34,8 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.ObjectReadFunction;
+import io.trino.plugin.jdbc.ObjectWriteFunction;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
@@ -63,6 +65,8 @@ import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import oracle.jdbc.OraclePreparedStatement;
@@ -80,6 +84,8 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,6 +103,8 @@ import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.charReadFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.fromLongTrinoTimestamp;
+import static io.trino.plugin.jdbc.StandardColumnMappings.fromTrinoTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalReadFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
@@ -104,6 +112,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalReadFuncti
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.toLongTrinoTimestamp;
+import static io.trino.plugin.jdbc.StandardColumnMappings.toTrinoTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
@@ -123,12 +133,11 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
-import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
-import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
@@ -150,6 +159,7 @@ public class OracleClient
 {
     public static final int ORACLE_MAX_LIST_EXPRESSIONS = 1000;
 
+    private static final int MAX_ORACLE_TIMESTAMP_PRECISION = 9;
     private static final int MAX_BYTES_PER_CHAR = 4;
 
     private static final int ORACLE_VARCHAR2_MAX_BYTES = 4000;
@@ -164,7 +174,13 @@ public class OracleClient
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd");
     private static final DateTimeFormatter TIMESTAMP_SECONDS_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
-    private static final DateTimeFormatter TIMESTAMP_MILLIS_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS");
+
+    private static final DateTimeFormatter TIMESTAMP_NANO_OPTIONAL_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("uuuu-MM-dd HH:mm:ss")
+            .optionalStart()
+            .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+            .optionalEnd()
+            .toFormatter();
 
     private static final Set<String> INTERNAL_SCHEMAS = ImmutableSet.<String>builder()
             .add("ctxsys")
@@ -385,7 +401,7 @@ public class OracleClient
         if (jdbcTypeName.equalsIgnoreCase("date")) {
             return Optional.of(ColumnMapping.longMapping(
                     TIMESTAMP_SECONDS,
-                    oracleTimestampReadFunction(),
+                    oracleTimestampReadFunction(TIMESTAMP_SECONDS),
                     trinoTimestampToOracleDateWriteFunction(),
                     FULL_PUSHDOWN));
         }
@@ -482,11 +498,8 @@ public class OracleClient
                         DISABLE_PUSHDOWN));
 
             case OracleTypes.TIMESTAMP:
-                return Optional.of(ColumnMapping.longMapping(
-                        TIMESTAMP_MILLIS,
-                        oracleTimestampReadFunction(),
-                        trinoTimestampToOracleTimestampWriteFunction(),
-                        FULL_PUSHDOWN));
+                int timestampPrecision = typeHandle.getRequiredDecimalDigits();
+                return Optional.of(oracleTimestampColumnMapping(createTimestampType(timestampPrecision)));
             case OracleTypes.TIMESTAMPTZ:
                 return Optional.of(oracleTimestampWithTimeZoneColumnMapping());
         }
@@ -494,6 +507,22 @@ public class OracleClient
             return mapToUnboundedVarchar(typeHandle);
         }
         return Optional.empty();
+    }
+
+    private static ColumnMapping oracleTimestampColumnMapping(TimestampType timestampType)
+    {
+        if (timestampType.isShort()) {
+            return ColumnMapping.longMapping(
+                    timestampType,
+                    oracleTimestampReadFunction(timestampType),
+                    oracleTimestampWriteFunction(timestampType),
+                    FULL_PUSHDOWN);
+        }
+        return ColumnMapping.objectMapping(
+                timestampType,
+                oracleLongTimestampReadFunction(timestampType),
+                oracleLongTimestampWriteFunction(timestampType),
+                FULL_PUSHDOWN);
     }
 
     @Override
@@ -584,24 +613,30 @@ public class OracleClient
         };
     }
 
-    public static LongWriteFunction trinoTimestampToOracleTimestampWriteFunction()
+    private static ObjectWriteFunction oracleLongTimestampWriteFunction(TimestampType timestampType)
     {
-        return new LongWriteFunction()
-        {
+        int precision = timestampType.getPrecision();
+        verifyLongTimestampPrecision(timestampType);
+
+        return new ObjectWriteFunction() {
             @Override
-            public String getBindExpression()
+            public Class<?> getJavaType()
             {
-                return "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF')";
+                return LongTimestamp.class;
             }
 
             @Override
-            public void set(PreparedStatement statement, int index, long utcMillis)
+            public void set(PreparedStatement statement, int index, Object value)
                     throws SQLException
             {
-                long epochSecond = floorDiv(utcMillis, MICROSECONDS_PER_SECOND);
-                int nanoFraction = floorMod(utcMillis, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
-                LocalDateTime localDateTime = LocalDateTime.ofEpochSecond(epochSecond, nanoFraction, ZoneOffset.UTC);
-                statement.setString(index, TIMESTAMP_MILLIS_FORMATTER.format(localDateTime));
+                LocalDateTime timestamp = fromLongTrinoTimestamp((LongTimestamp) value, precision);
+                statement.setString(index, TIMESTAMP_NANO_OPTIONAL_FORMATTER.format(timestamp));
+            }
+
+            @Override
+            public String getBindExpression()
+            {
+                return getOracleBindExpression(precision);
             }
 
             @Override
@@ -613,7 +648,46 @@ public class OracleClient
         };
     }
 
-    private static LongReadFunction oracleTimestampReadFunction()
+    private static LongWriteFunction oracleTimestampWriteFunction(TimestampType timestampType)
+    {
+        return new LongWriteFunction()
+        {
+            @Override
+            public String getBindExpression()
+            {
+                return getOracleBindExpression(timestampType.getPrecision());
+            }
+
+            @Override
+            public void set(PreparedStatement statement, int index, long epochMicros)
+                    throws SQLException
+            {
+                LocalDateTime timestamp = fromTrinoTimestamp(epochMicros);
+                statement.setString(index, TIMESTAMP_NANO_OPTIONAL_FORMATTER.format(timestamp));
+            }
+
+            @Override
+            public void setNull(PreparedStatement statement, int index)
+                    throws SQLException
+            {
+                statement.setNull(index, Types.VARCHAR);
+            }
+        };
+    }
+
+    private static String getOracleBindExpression(int precision)
+    {
+        if (precision == 0) {
+            return "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS')";
+        }
+        if (precision <= 2) {
+            return "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF')";
+        }
+
+        return format("TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF%d')", precision);
+    }
+
+    private static LongReadFunction oracleTimestampReadFunction(TimestampType timestampType)
     {
         return (resultSet, columnIndex) -> {
             LocalDateTime timestamp = resultSet.getObject(columnIndex, LocalDateTime.class);
@@ -621,8 +695,30 @@ public class OracleClient
             if (timestamp.getYear() <= 0) {
                 timestamp = timestamp.minusYears(1);
             }
-            return timestamp.toInstant(ZoneOffset.UTC).toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
+            return toTrinoTimestamp(timestampType, timestamp);
         };
+    }
+
+    private static ObjectReadFunction oracleLongTimestampReadFunction(TimestampType timestampType)
+    {
+        verifyLongTimestampPrecision(timestampType);
+        return ObjectReadFunction.of(
+                LongTimestamp.class,
+                (resultSet, columnIndex) -> {
+                    LocalDateTime timestamp = resultSet.getObject(columnIndex, LocalDateTime.class);
+                    // Adjust years when the value is B.C. dates because Oracle returns +1 year unless converting to string in their server side
+                    if (timestamp.getYear() <= 0) {
+                        timestamp = timestamp.minusYears(1);
+                    }
+                    return toLongTrinoTimestamp(timestampType, timestamp);
+                });
+    }
+
+    private static void verifyLongTimestampPrecision(TimestampType timestampType)
+    {
+        int precision = timestampType.getPrecision();
+        checkArgument(precision > MAX_SHORT_PRECISION && precision <= MAX_ORACLE_TIMESTAMP_PRECISION,
+                "Precision is out of range: %s", precision);
     }
 
     public static ColumnMapping oracleTimestampWithTimeZoneColumnMapping()
@@ -705,13 +801,18 @@ public class OracleClient
             }
             return WriteMapping.objectMapping(dataType, longDecimalWriteFunction(decimalType));
         }
-        if (type.equals(TIMESTAMP_SECONDS)) {
-            // Specify 'date' instead of 'timestamp(0)' to propagate the type in case of CTAS from date columns
-            // Oracle date stores year, month, day, hour, minute, seconds, but not second fraction
-            return WriteMapping.longMapping("date", trinoTimestampToOracleDateWriteFunction());
-        }
-        if (type.equals(TIMESTAMP_MILLIS)) {
-            return WriteMapping.longMapping("timestamp(3)", trinoTimestampToOracleTimestampWriteFunction());
+        if (type instanceof TimestampType timestampType) {
+            if (type.equals(TIMESTAMP_SECONDS)) {
+                // Specify 'date' instead of 'timestamp(0)' to propagate the type in case of CTAS from date columns
+                // Oracle date stores year, month, day, hour, minute, seconds, but not second fraction
+                return WriteMapping.longMapping("date", trinoTimestampToOracleDateWriteFunction());
+            }
+            int precision = min(timestampType.getPrecision(), MAX_ORACLE_TIMESTAMP_PRECISION);
+            String dataType = format("timestamp(%d)", precision);
+            if (timestampType.isShort()) {
+                return WriteMapping.longMapping(dataType, oracleTimestampWriteFunction(timestampType));
+            }
+            return WriteMapping.objectMapping(dataType, oracleLongTimestampWriteFunction(createTimestampType(precision)));
         }
         WriteMapping writeMapping = WRITE_MAPPINGS.get(type);
         if (writeMapping != null) {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -33,10 +33,12 @@ import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static io.trino.spi.connector.ConnectorMetadata.MODIFYING_ROWS_MESSAGE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 public abstract class BaseOracleConnectorTest
@@ -97,7 +99,6 @@ public abstract class BaseOracleConnectorTest
         }
         if (typeName.equals("time") ||
                 typeName.equals("time(6)") ||
-                typeName.equals("timestamp(6)") ||
                 typeName.equals("timestamp(6) with time zone")) {
             return Optional.of(dataMappingTestSetup.asUnsupported());
         }
@@ -192,6 +193,18 @@ public abstract class BaseOracleConnectorTest
                         "   shippriority decimal(10, 0),\n" +
                         "   comment varchar(79)\n" +
                         ")");
+    }
+
+    @Test
+    public void testTimestampOutOfPrecisionRounded()
+    {
+        String tableName = "test_timestamp_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + " (t timestamp(12))");
+
+        assertEquals(getColumnType(tableName, "t"), "timestamp(9)");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleClient.java
@@ -41,7 +41,9 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_SECONDS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -112,7 +114,9 @@ public class TestOracleClient
                 {createUnboundedVarcharType(), "?", Types.VARCHAR},
                 {createVarcharType(123), "?", Types.VARCHAR},
                 {TIMESTAMP_SECONDS, "TO_DATE(?, 'SYYYY-MM-DD HH24:MI:SS')", Types.VARCHAR},
-                {TIMESTAMP_MILLIS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF')", Types.VARCHAR},
+                {TIMESTAMP_MILLIS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF3')", Types.VARCHAR},
+                {TIMESTAMP_MICROS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF6')", Types.VARCHAR},
+                {TIMESTAMP_NANOS, "TO_TIMESTAMP(?, 'SYYYY-MM-DD HH24:MI:SS.FF9')", Types.VARCHAR},
                 {TIMESTAMP_TZ_MILLIS, "?", OracleTypes.TIMESTAMPTZ},
                 {DATE, "TO_DATE(?, 'SYYYY-MM-DD')", Types.VARCHAR},
         };


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Now we can use any presicion for oracle timestamp(p),
p could be in range from 0 to 9.

```markdown
# Oracle
* Add support for Oracle timestamp with non-milliseconds precision
```
