### PR TITLE
Update redlinerpm-maven-plugin to 2.1.8

### DIFF
--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -141,7 +141,7 @@
             <plugin>
                 <groupId>io.airlift.maven.plugins</groupId>
                 <artifactId>redlinerpm-maven-plugin</artifactId>
-                <version>2.1.7</version>
+                <version>2.1.8</version>
                 <extensions>true</extensions>
 
                 <configuration>


### PR DESCRIPTION
## Description

This version removes usage of the deprecated maven-compat dependency.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
