### PR TITLE
Add hostnameInCertificate JDBC property

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
+++ b/client/trino-client/src/main/java/io/trino/client/OkHttpUtil.java
@@ -328,4 +328,9 @@ public final class OkHttpUtil
         clientBuilder.addInterceptor(handler);
         clientBuilder.authenticator(handler);
     }
+
+    public static void setupAlternateHostnameVerification(OkHttpClient.Builder clientBuilder, String alternativeHostname)
+    {
+        clientBuilder.hostnameVerifier((hostname, session) -> LegacyHostnameVerifier.INSTANCE.verify(alternativeHostname, session));
+    }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -90,6 +90,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> SOURCE = new Source();
     public static final ConnectionProperty<Class<? extends DnsResolver>> DNS_RESOLVER = new Resolver();
     public static final ConnectionProperty<String> DNS_RESOLVER_CONTEXT = new ResolverContext();
+    public static final ConnectionProperty<String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -132,6 +133,7 @@ final class ConnectionProperties
             .add(EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS)
             .add(DNS_RESOLVER)
             .add(DNS_RESOLVER_CONTEXT)
+            .add(HOSTNAME_IN_CERTIFICATE)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -346,6 +348,9 @@ final class ConnectionProperties
 
         static final Predicate<Properties> IF_SSL_VERIFICATION_ENABLED =
                 IF_SSL_ENABLED.and(checkedPredicate(properties -> !SSL_VERIFICATION.getValue(properties).orElse(SslVerificationMode.FULL).equals(SslVerificationMode.NONE)));
+
+        static final Predicate<Properties> IF_FULL_SSL_VERIFICATION_ENABLED =
+                IF_SSL_VERIFICATION_ENABLED.and(checkedPredicate(properties -> !SSL_VERIFICATION.getValue(properties).orElse(SslVerificationMode.FULL).equals(SslVerificationMode.CA)));
 
         public SslVerification()
         {
@@ -642,6 +647,15 @@ final class ConnectionProperties
         public ResolverContext()
         {
             super("dnsResolverContext", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class HostnameInCertificate
+            extends AbstractConnectionProperty<String>
+    {
+        public HostnameInCertificate()
+        {
+            super("hostnameInCertificate", NOT_REQUIRED, SslVerification.IF_FULL_SSL_VERIFICATION_ENABLED, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -44,6 +44,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
 import static io.trino.client.OkHttpUtil.basicAuth;
+import static io.trino.client.OkHttpUtil.setupAlternateHostnameVerification;
 import static io.trino.client.OkHttpUtil.setupCookieJar;
 import static io.trino.client.OkHttpUtil.setupHttpProxy;
 import static io.trino.client.OkHttpUtil.setupInsecureSsl;
@@ -65,6 +66,7 @@ import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_REDIREC
 import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_TIMEOUT;
 import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_TOKEN_CACHE;
 import static io.trino.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
+import static io.trino.jdbc.ConnectionProperties.HOSTNAME_IN_CERTIFICATE;
 import static io.trino.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_CREDENTIAL_CACHE_PATH;
@@ -289,6 +291,11 @@ public final class TrinoDriverUri
                             SSL_TRUST_STORE_PASSWORD.getValue(properties),
                             SSL_TRUST_STORE_TYPE.getValue(properties),
                             SSL_USE_SYSTEM_TRUST_STORE.getValue(properties).orElse(false));
+                }
+
+                if (sslVerificationMode.equals(FULL)) {
+                    HOSTNAME_IN_CERTIFICATE.getValue(properties).ifPresent(certHostname ->
+                            setupAlternateHostnameVerification(builder, certHostname));
                 }
 
                 if (sslVerificationMode.equals(CA)) {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverAuth.java
@@ -105,14 +105,13 @@ public class TestTrinoDriverAuth
                 .signWith(defaultKey)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                assertTrue(statement.execute("SELECT 123"));
-                ResultSet rs = statement.getResultSet();
-                assertTrue(rs.next());
-                assertEquals(rs.getLong(1), 123);
-                assertFalse(rs.next());
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            assertTrue(statement.execute("SELECT 123"));
+            ResultSet rs = statement.getResultSet();
+            assertTrue(rs.next());
+            assertEquals(rs.getLong(1), 123);
+            assertFalse(rs.next());
         }
     }
 
@@ -126,14 +125,13 @@ public class TestTrinoDriverAuth
                 .signWith(hmac222)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                assertTrue(statement.execute("SELECT 123"));
-                ResultSet rs = statement.getResultSet();
-                assertTrue(rs.next());
-                assertEquals(rs.getLong(1), 123);
-                assertFalse(rs.next());
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            assertTrue(statement.execute("SELECT 123"));
+            ResultSet rs = statement.getResultSet();
+            assertTrue(rs.next());
+            assertEquals(rs.getLong(1), 123);
+            assertFalse(rs.next());
         }
     }
 
@@ -147,14 +145,13 @@ public class TestTrinoDriverAuth
                 .signWith(privateKey33)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                assertTrue(statement.execute("SELECT 123"));
-                ResultSet rs = statement.getResultSet();
-                assertTrue(rs.next());
-                assertEquals(rs.getLong(1), 123);
-                assertFalse(rs.next());
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            assertTrue(statement.execute("SELECT 123"));
+            ResultSet rs = statement.getResultSet();
+            assertTrue(rs.next());
+            assertEquals(rs.getLong(1), 123);
+            assertFalse(rs.next());
         }
     }
 
@@ -162,10 +159,9 @@ public class TestTrinoDriverAuth
     public void testFailedNoToken()
             throws Exception
     {
-        try (Connection connection = createConnection(ImmutableMap.of())) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute("SELECT 123");
-            }
+        try (Connection connection = createConnection(ImmutableMap.of());
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
         }
     }
 
@@ -177,10 +173,9 @@ public class TestTrinoDriverAuth
                 .setSubject("test")
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute("SELECT 123");
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
         }
     }
 
@@ -194,10 +189,9 @@ public class TestTrinoDriverAuth
                 .signWith(badKey)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute("SELECT 123");
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
         }
     }
 
@@ -211,10 +205,9 @@ public class TestTrinoDriverAuth
                 .signWith(privateKey33)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute("SELECT 123");
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
         }
     }
 
@@ -228,10 +221,9 @@ public class TestTrinoDriverAuth
                 .signWith(privateKey33)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken))) {
-            try (Statement statement = connection.createStatement()) {
-                statement.execute("SELECT 123");
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken));
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
         }
     }
 
@@ -245,14 +237,13 @@ public class TestTrinoDriverAuth
                 .signWith(privateKey33)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken, "SSLVerification", "FULL"))) {
-            try (Statement statement = connection.createStatement()) {
-                assertTrue(statement.execute("SELECT 123"));
-                ResultSet rs = statement.getResultSet();
-                assertTrue(rs.next());
-                assertEquals(rs.getLong(1), 123);
-                assertFalse(rs.next());
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken, "SSLVerification", "FULL"));
+                Statement statement = connection.createStatement()) {
+            assertTrue(statement.execute("SELECT 123"));
+            ResultSet rs = statement.getResultSet();
+            assertTrue(rs.next());
+            assertEquals(rs.getLong(1), 123);
+            assertFalse(rs.next());
         }
     }
 
@@ -266,14 +257,13 @@ public class TestTrinoDriverAuth
                 .signWith(privateKey33)
                 .compact();
 
-        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken, "SSLVerification", "CA"))) {
-            try (Statement statement = connection.createStatement()) {
-                assertTrue(statement.execute("SELECT 123"));
-                ResultSet rs = statement.getResultSet();
-                assertTrue(rs.next());
-                assertEquals(rs.getLong(1), 123);
-                assertFalse(rs.next());
-            }
+        try (Connection connection = createConnection(ImmutableMap.of("accessToken", accessToken, "SSLVerification", "CA"));
+                Statement statement = connection.createStatement()) {
+            assertTrue(statement.execute("SELECT 123"));
+            ResultSet rs = statement.getResultSet();
+            assertTrue(rs.next());
+            assertEquals(rs.getLong(1), 123);
+            assertFalse(rs.next());
         }
     }
 
@@ -317,11 +307,12 @@ public class TestTrinoDriverAuth
     public void testFailedNoneSslVerificationWithSSLUnsigned()
             throws Exception
     {
-        Connection connection = createBasicConnection(ImmutableMap.of("SSL", "true", "SSLVerification", "NONE"));
-        Statement statement = connection.createStatement();
-        assertThatThrownBy(() -> statement.execute("SELECT 123"))
-                .isInstanceOf(SQLException.class)
-                .hasMessage("Authentication failed: Unauthorized");
+        try (Connection connection = createBasicConnection(ImmutableMap.of("SSL", "true", "SSLVerification", "NONE"));
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("Authentication failed: Unauthorized");
+        }
     }
 
     private Connection createConnection(Map<String, String> additionalProperties)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
adds hostnameInCertificate connection property for JDBC driver.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Our system requires calling one of multiple separate servers with a different hostname than the final Trino host. For maximum security we still want the benefits of full SSL verification with hostname validation and do not want to use CA validation only.

This property is available in other JDBC drivers such as SqlServer and SAP HANA - documentation linked below.

* [SqlServer JDBC Documentation with hostNameInCertificate](https://learn.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?view=sql-server-ver16)
* [SAP HANA JDBC Documentation with hostNameInCertificate](https://help.sap.com/docs/SAP_HANA_CLIENT/f1b440ded6144a54ada97ff95dac7adf/109397c2206a4ab2a5386d494f4cf75e.html)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
JDBC
 - Allow verification of alternative hostname for Full SSL Verification of JDBC Driver by using `hostnameInCertificate` property.