### PR TITLE
Prevent accidental image pulls in getDockerArchitectureInfo

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/ConditionalPullPolicy.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/ConditionalPullPolicy.java
@@ -22,7 +22,7 @@ import static java.lang.System.getenv;
 public class ConditionalPullPolicy
         implements ImagePullPolicy
 {
-    private static final boolean TESTCONTAINERS_NEVER_PULL = "true".equalsIgnoreCase(getenv("TESTCONTAINERS_NEVER_PULL"));
+    public static final boolean TESTCONTAINERS_NEVER_PULL = "true".equalsIgnoreCase(getenv("TESTCONTAINERS_NEVER_PULL"));
     private static final ImagePullPolicy defaultPolicy = PullPolicy.defaultPolicy();
 
     @Override

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/TestContainers.java
@@ -31,6 +31,7 @@ import static com.github.dockerjava.api.model.Ports.Binding.bindPort;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.padEnd;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.testing.containers.ConditionalPullPolicy.TESTCONTAINERS_NEVER_PULL;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.System.getenv;
 import static java.util.Locale.ENGLISH;
@@ -85,6 +86,7 @@ public final class TestContainers
 
     public static DockerArchitectureInfo getDockerArchitectureInfo(DockerImageName imageName)
     {
+        checkState(!TESTCONTAINERS_NEVER_PULL, "Cannot get arch for image %s without pulling it, and pulling is forbidden", imageName);
         DockerClient client = DockerClientFactory.lazyClient();
         if (!imageExists(client, imageName)) {
             pullImage(client, imageName);


### PR DESCRIPTION
Prevents unwanted image pulls like one fixed by f0b8a4b13cdc58e04ebad35d584895610d7a8241 (https://github.com/trinodb/trino/pull/17936).
