### PR TITLE
Revert "Remove usages of Hadoop Path for Hive LocationService"

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LocationHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LocationHandle.java
@@ -15,18 +15,21 @@ package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.filesystem.Location;
+import org.apache.hadoop.fs.Path;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class LocationHandle
 {
-    private final Location targetPath;
-    private final Location writePath;
+    private final Path targetPath;
+    private final Path writePath;
     private final WriteMode writeMode;
 
-    public LocationHandle(Location targetPath, Location writePath, WriteMode writeMode)
+    public LocationHandle(
+            Path targetPath,
+            Path writePath,
+            WriteMode writeMode)
     {
         if (writeMode.isWritePathSameAsTargetPath() && !targetPath.equals(writePath)) {
             throw new IllegalArgumentException(format("targetPath is expected to be same as writePath for writeMode %s", writeMode));
@@ -43,19 +46,19 @@ public class LocationHandle
             @JsonProperty("writeMode") WriteMode writeMode)
     {
         this(
-                Location.of(requireNonNull(targetPath, "targetPath is null")),
-                Location.of(requireNonNull(writePath, "writePath is null")),
+                new Path(requireNonNull(targetPath, "targetPath is null")),
+                new Path(requireNonNull(writePath, "writePath is null")),
                 writeMode);
     }
 
     // This method should only be called by LocationService
-    Location getTargetPath()
+    Path getTargetPath()
     {
         return targetPath;
     }
 
     // This method should only be called by LocationService
-    Location getWritePath()
+    Path getWritePath()
     {
         return writePath;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import com.google.errorprone.annotations.FormatMethod;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
-import io.trino.filesystem.Location;
 import io.trino.hdfs.HdfsContext;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.hive.thrift.metastore.DataOperationType;
@@ -766,7 +765,7 @@ public class SemiTransactionalHiveMetastore
             ConnectorSession session,
             String databaseName,
             String tableName,
-            Location currentLocation,
+            Path currentLocation,
             List<PartitionUpdateAndMergeResults> partitionUpdateAndMergeResults,
             List<Partition> partitions)
     {
@@ -792,7 +791,7 @@ public class SemiTransactionalHiveMetastore
                             new TableAndMergeResults(
                                     table,
                                     Optional.of(principalPrivileges),
-                                    Optional.of(new Path(currentLocation.toString())),
+                                    Optional.of(currentLocation),
                                     partitionUpdateAndMergeResults,
                                     partitions),
                             hdfsContext,
@@ -1243,7 +1242,7 @@ public class SemiTransactionalHiveMetastore
         setExclusive((delegate, hdfsEnvironment) -> delegate.revokeTablePrivileges(databaseName, tableName, getRequiredTableOwner(databaseName, tableName), grantee, grantor, privileges, grantOption));
     }
 
-    public synchronized String declareIntentionToWrite(ConnectorSession session, WriteMode writeMode, Location stagingPathRoot, SchemaTableName schemaTableName)
+    public synchronized String declareIntentionToWrite(ConnectorSession session, WriteMode writeMode, Path stagingPathRoot, SchemaTableName schemaTableName)
     {
         setShared();
         if (writeMode == WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY) {
@@ -1256,7 +1255,7 @@ public class SemiTransactionalHiveMetastore
         String queryId = session.getQueryId();
         String declarationId = queryId + "_" + declaredIntentionsToWriteCounter;
         declaredIntentionsToWriteCounter++;
-        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(declarationId, writeMode, hdfsContext, queryId, new Path(stagingPathRoot.toString()), schemaTableName));
+        declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(declarationId, writeMode, hdfsContext, queryId, stagingPathRoot, schemaTableName));
         return declarationId;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -137,8 +137,8 @@ public class CreateEmptyPartitionProcedure
                         new PartitionUpdate(
                                 partitionName,
                                 UpdateMode.NEW,
-                                writeInfo.writePath().toString(),
-                                writeInfo.targetPath().toString(),
+                                writeInfo.getWritePath(),
+                                writeInfo.getTargetPath(),
                                 ImmutableList.of(),
                                 0,
                                 0,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -579,8 +579,10 @@ public abstract class AbstractTestHiveFileSystem
             // table, which fails without explicit configuration for file system.
             // We work around that by using a dummy location when creating the
             // table and update it here to the correct location.
-            Location location = locationService.getTableWriteInfo(((HiveOutputTableHandle) outputHandle).getLocationHandle(), false).targetPath();
-            metastoreClient.updateTableLocation(database, tableName.getTableName(), location.toString());
+            metastoreClient.updateTableLocation(
+                    database,
+                    tableName.getTableName(),
+                    locationService.getTableWriteInfo(((HiveOutputTableHandle) outputHandle).getLocationHandle(), false).getTargetPath().toString());
         }
 
         try (Transaction transaction = newTransaction()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slices;
-import io.trino.filesystem.Location;
 import io.trino.operator.GroupByHashPageIndexerFactory;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
@@ -44,6 +43,7 @@ import io.trino.tpch.LineItemGenerator;
 import io.trino.tpch.TpchColumnType;
 import io.trino.tpch.TpchColumnTypes;
 import io.trino.type.BlockTypeOperators;
+import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -166,7 +166,7 @@ public class TestHivePageSink
     {
         HiveTransactionHandle transaction = new HiveTransactionHandle(false);
         HiveWriterStats stats = new HiveWriterStats();
-        ConnectorPageSink pageSink = createPageSink(transaction, config, sortingFileWriterConfig, metastore, Location.of("file:///" + outputPath), stats);
+        ConnectorPageSink pageSink = createPageSink(transaction, config, sortingFileWriterConfig, metastore, new Path("file:///" + outputPath), stats);
         List<LineItemColumn> columns = getTestColumns();
         List<Type> columnTypes = columns.stream()
                 .map(LineItemColumn::getType)
@@ -278,7 +278,7 @@ public class TestHivePageSink
         return provider.createPageSource(transaction, getHiveSession(config), split, table, ImmutableList.copyOf(getColumnHandles()), DynamicFilter.EMPTY);
     }
 
-    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveConfig config, SortingFileWriterConfig sortingFileWriterConfig, HiveMetastore metastore, Location outputPath, HiveWriterStats stats)
+    private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveConfig config, SortingFileWriterConfig sortingFileWriterConfig, HiveMetastore metastore, Path outputPath, HiveWriterStats stats)
     {
         LocationHandle locationHandle = new LocationHandle(outputPath, outputPath, DIRECT_TO_TARGET_NEW_DIRECTORY);
         HiveOutputTableHandle handle = new HiveOutputTableHandle(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
@@ -129,7 +129,8 @@ public class TestHiveS3AndGlueMetastoreTest
         assertQuery("SELECT * FROM " + tableName, "VALUES ('str1', 1), ('str2', 2), ('str3', 3)");
 
         String actualTableLocation = getTableLocation(tableName);
-        assertThat(actualTableLocation).isEqualTo(location);
+        String expectedLocation = location.endsWith("/") ? location.substring(0, location.length() - 1) : location;
+        assertThat(actualTableLocation).isEqualTo(expectedLocation);
 
         assertUpdate("INSERT INTO " + tableName + " VALUES ('str4', 4)", 1);
         assertQuery("SELECT * FROM " + tableName, "VALUES ('str1', 1), ('str2', 2), ('str3', 3), ('str4', 4)");


### PR DESCRIPTION
## Description

Revert https://github.com/trinodb/trino/commit/8bd9f754fb2aec61ffa353adfb421b460b60d947.
Relates to https://github.com/trinodb/trino/pull/17804#discussion_r1231968909

## Release notes

(x) This is not user-visible or docs only and no release notes are required.