### PR TITLE
Add another failure pattern in SQL Server concurrent modification test

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -171,6 +171,7 @@ public abstract class BaseSqlServerConnectorTest
                     .hasMessageMatching("(?s).*(" +
                             "No task completed before timeout|" +
                             "was deadlocked on lock resources with another process and has been chosen as the deadlock victim|" +
+                            "Lock request time out period exceeded|" +
                             // E.g. system.metadata.table_comments can return empty results, when underlying metadata list tables call fails
                             "Expecting actual not to be empty).*");
             throw new SkipException("to be fixed");


### PR DESCRIPTION
## Description

https://github.com/trinodb/trino/actions/runs/5299189833/jobs/9592021346
```
Error:    TestSqlServerConnectorTest>BaseSqlServerConnectorTest.testReadMetadataWithRelationsConcurrentModifications:171 
Expecting message:
  "io.trino.testing.QueryFailedException: Error listing tables for catalog sqlserver: Lock request time out period exceeded."
to match regex:
  "(?s).*(No task completed before timeout|was deadlocked on lock resources with another process and has been chosen as the deadlock victim|Expecting actual not to be empty).*"
but did not.
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.