### PR TITLE
Add empty SkewedInfo object to StorageDescriptor in GlueInputConverter

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueInputConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueInputConverter.java
@@ -17,6 +17,7 @@ import com.amazonaws.services.glue.model.DatabaseInput;
 import com.amazonaws.services.glue.model.Order;
 import com.amazonaws.services.glue.model.PartitionInput;
 import com.amazonaws.services.glue.model.SerDeInfo;
+import com.amazonaws.services.glue.model.SkewedInfo;
 import com.amazonaws.services.glue.model.StorageDescriptor;
 import com.amazonaws.services.glue.model.TableInput;
 import com.google.common.collect.ImmutableMap;
@@ -96,6 +97,7 @@ public final class GlueInputConverter
         sd.setInputFormat(storage.getStorageFormat().getInputFormatNullable());
         sd.setOutputFormat(storage.getStorageFormat().getOutputFormatNullable());
         sd.setParameters(ImmutableMap.of());
+        sd.setSkewedInfo(new SkewedInfo());
 
         Optional<HiveBucketProperty> bucketProperty = storage.getBucketProperty();
         if (bucketProperty.isPresent()) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueInputConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueInputConverter.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.metastore.glue;
 
 import com.amazonaws.services.glue.model.DatabaseInput;
 import com.amazonaws.services.glue.model.PartitionInput;
+import com.amazonaws.services.glue.model.SkewedInfo;
 import com.amazonaws.services.glue.model.StorageDescriptor;
 import com.amazonaws.services.glue.model.TableInput;
 import com.google.common.collect.ImmutableList;
@@ -109,5 +110,7 @@ public class TestGlueInputConverter
             assertEquals(actual.getBucketColumns(), bucketProperty.getBucketedBy());
             assertEquals(actual.getNumberOfBuckets().intValue(), bucketProperty.getBucketCount());
         }
+
+        assertEquals(actual.getSkewedInfo(), new SkewedInfo());
     }
 }


### PR DESCRIPTION
## Description
This PR resolves #17948

## Additional context and related issues
When any operation is done using Glue Metastore, while converting representation of Trino Table/Column to Glue Table/Column storage description is also converted to `StorageDescriptor` in Glue. StorageDescriptor has a field `SkewedInfo` that needs to be populated incase table is skewed. Since, Trino doesn't support writing to skewed tables, we don't put any value for this while converting to Glue datatype resulting in null being set for `SkewedInfo` which breaks reading/writing in Hive as it starts throwing NPE.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix bug in writing data to Glue tables. ({issue}`17948`)
```
