### PR TITLE
Enable Error Prone check: UnnecessaryStringBuilder

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -177,10 +177,9 @@ public final class ExpressionFormatter
         @Override
         protected String visitAtTimeZone(AtTimeZone node, Void context)
         {
-            return new StringBuilder()
-                    .append(process(node.getValue(), context))
-                    .append(" AT TIME ZONE ")
-                    .append(process(node.getTimeZone(), context)).toString();
+            return process(node.getValue(), context) +
+                    " AT TIME ZONE " +
+                    process(node.getTimeZone(), context);
         }
 
         @Override
@@ -716,17 +715,11 @@ public final class ExpressionFormatter
         @Override
         protected String visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
         {
-            return new StringBuilder()
-                    .append("(")
-                    .append(process(node.getValue(), context))
-                    .append(' ')
-                    .append(node.getOperator().getValue())
-                    .append(' ')
-                    .append(node.getQuantifier().toString())
-                    .append(' ')
-                    .append(process(node.getSubquery(), context))
-                    .append(")")
-                    .toString();
+            return "(%s %s %s %s)".formatted(
+                    process(node.getValue(), context),
+                    node.getOperator().getValue(),
+                    node.getQuantifier(),
+                    process(node.getSubquery(), context));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -119,7 +119,6 @@ import static io.trino.sql.ReservedIdentifiers.reserved;
 import static io.trino.sql.RowPatternFormatter.formatPattern;
 import static io.trino.sql.SqlFormatter.formatName;
 import static io.trino.sql.SqlFormatter.formatSql;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -172,7 +171,7 @@ public final class ExpressionFormatter
         @Override
         protected String visitExpression(Expression node, Void context)
         {
-            throw new UnsupportedOperationException(format("not yet implemented: %s.visit%s", getClass().getName(), node.getClass().getSimpleName()));
+            throw new UnsupportedOperationException("not yet implemented: %s.visit%s".formatted(getClass().getName(), node.getClass().getSimpleName()));
         }
 
         @Override
@@ -212,10 +211,10 @@ public final class ExpressionFormatter
         protected String visitTrim(Trim node, Void context)
         {
             if (!node.getTrimCharacter().isPresent()) {
-                return format("trim(%s FROM %s)", node.getSpecification(), process(node.getTrimSource(), context));
+                return "trim(%s FROM %s)".formatted(node.getSpecification(), process(node.getTrimSource(), context));
             }
 
-            return format("trim(%s %s FROM %s)", node.getSpecification(), process(node.getTrimCharacter().get(), context), process(node.getTrimSource(), context));
+            return "trim(%s %s FROM %s)".formatted(node.getSpecification(), process(node.getTrimCharacter().get(), context), process(node.getTrimSource(), context));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ReservedIdentifiers.java
@@ -30,7 +30,6 @@ import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.grammar.sql.SqlKeywords.sqlKeywords;
-import static java.lang.String.format;
 
 public final class ReservedIdentifiers
 {
@@ -106,7 +105,7 @@ public final class ReservedIdentifiers
             }
         }
 
-        System.out.println(format("Validated %s reserved identifiers", reserved.size()));
+        System.out.println("Validated %s reserved identifiers".formatted(reserved.size()));
     }
 
     public static Set<String> reservedIdentifiers()

--- a/core/trino-parser/src/main/java/io/trino/sql/RowPatternFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/RowPatternFormatter.java
@@ -29,7 +29,6 @@ import io.trino.sql.tree.RowPattern;
 import io.trino.sql.tree.ZeroOrMoreQuantifier;
 import io.trino.sql.tree.ZeroOrOneQuantifier;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 
 public final class RowPatternFormatter
@@ -53,7 +52,7 @@ public final class RowPatternFormatter
         @Override
         protected String visitRowPattern(RowPattern node, Void context)
         {
-            throw new UnsupportedOperationException(format("not yet implemented: %s.visit%s", getClass().getName(), node.getClass().getSimpleName()));
+            throw new UnsupportedOperationException("not yet implemented: %s.visit%s".formatted(getClass().getName(), node.getClass().getSimpleName()));
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/jsonpath/PathNodeRef.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/jsonpath/PathNodeRef.java
@@ -15,7 +15,6 @@ package io.trino.sql.jsonpath;
 
 import io.trino.sql.jsonpath.tree.PathNode;
 
-import static java.lang.String.format;
 import static java.lang.System.identityHashCode;
 import static java.util.Objects.requireNonNull;
 
@@ -60,8 +59,7 @@ public final class PathNodeRef<T extends PathNode>
     @Override
     public String toString()
     {
-        return format(
-                "@%s: %s",
+        return "@%s: %s".formatted(
                 Integer.toHexString(identityHashCode(pathNode)),
                 pathNode);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -360,7 +360,6 @@ import static io.trino.sql.tree.SkipTo.skipToLast;
 import static io.trino.sql.tree.SkipTo.skipToNextRow;
 import static io.trino.sql.tree.TableFunctionDescriptorArgument.descriptorArgument;
 import static io.trino.sql.tree.TableFunctionDescriptorArgument.nullDescriptorArgument;
-import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -4019,7 +4018,7 @@ class AstBuilder
                         else {
                             char currentCodePoint = (char) codePoint;
                             if (Character.isSurrogate(currentCodePoint)) {
-                                throw parseError(format("Invalid escaped character: %s. Escaped character is a surrogate. Use '\\+123456' instead.", currentEscapedCode), context);
+                                throw parseError("Invalid escaped character: %s. Escaped character is a surrogate. Use '\\+123456' instead.".formatted(currentEscapedCode), context);
                             }
                             unicodeStringBuilder.append(currentCodePoint);
                         }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/ErrorHandler.java
@@ -45,7 +45,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static java.lang.String.format;
 import static java.util.logging.Level.SEVERE;
 import static org.antlr.v4.runtime.atn.ATNState.RULE_START;
 
@@ -100,7 +99,7 @@ class ErrorHandler
                     .sorted()
                     .collect(Collectors.joining(", "));
 
-            message = format("mismatched input '%s'. Expecting: %s", parser.getTokenStream().get(result.getErrorTokenIndex()).getText(), expected);
+            message = "mismatched input '%s'. Expecting: %s".formatted(parser.getTokenStream().get(result.getErrorTokenIndex()).getText(), expected);
         }
         catch (Exception exception) {
             LOG.log(SEVERE, "Unexpected failure when handling parsing error. This is likely a bug in the implementation", exception);
@@ -157,8 +156,7 @@ class ErrorHandler
                 text = text.replace("\t", "\\t");
             }
 
-            return format(
-                    "%s%s:%s @ %s:<%s>:%s",
+            return "%s%s:%s @ %s:<%s>:%s".formatted(
                     suppressed ? "-" : "+",
                     parser.getRuleNames()[state.ruleIndex],
                     state.stateNumber,

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/ParsingException.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/ParsingException.java
@@ -17,7 +17,6 @@ import io.trino.sql.tree.NodeLocation;
 import org.antlr.v4.runtime.RecognitionException;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.String.format;
 
 public class ParsingException
         extends RuntimeException
@@ -68,6 +67,6 @@ public class ParsingException
     @Override
     public String getMessage()
     {
-        return format("line %s:%s: %s", getLineNumber(), getColumnNumber(), getErrorMessage());
+        return "line %s:%s: %s".formatted(getLineNumber(), getColumnNumber(), getErrorMessage());
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/testing/TreeAssertions.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/testing/TreeAssertions.java
@@ -25,7 +25,6 @@ import jakarta.annotation.Nullable;
 import java.util.List;
 
 import static io.trino.sql.SqlFormatter.formatSql;
-import static java.lang.String.format;
 
 public final class TreeAssertions
 {
@@ -53,7 +52,7 @@ public final class TreeAssertions
             return sqlParser.createStatement(sql);
         }
         catch (ParsingException e) {
-            String message = format("failed to parse formatted SQL: %s\nerror: %s\ntree: %s", sql, e.getMessage(), tree);
+            String message = "failed to parse formatted SQL: %s\nerror: %s\ntree: %s".formatted(sql, e.getMessage(), tree);
             throw new AssertionError(message, e);
         }
     }
@@ -77,10 +76,10 @@ public final class TreeAssertions
     private static <T> void assertListEquals(List<T> actual, List<T> expected)
     {
         if (actual.size() != expected.size()) {
-            throw new AssertionError(format("Lists not equal in size%n%s", formatLists(actual, expected)));
+            throw new AssertionError("Lists not equal in size%n%s".formatted(formatLists(actual, expected)));
         }
         if (!actual.equals(expected)) {
-            throw new AssertionError(format("Lists not equal at index %s%n%s",
+            throw new AssertionError("Lists not equal at index %s%n%s".formatted(
                     differingIndex(actual, expected), formatLists(actual, expected)));
         }
     }
@@ -88,7 +87,7 @@ public final class TreeAssertions
     private static <T> String formatLists(List<T> actual, List<T> expected)
     {
         Joiner joiner = Joiner.on("\n    ");
-        return format("Actual [%s]:%n    %s%nExpected [%s]:%n    %s%n",
+        return "Actual [%s]:%n    %s%nExpected [%s]:%n    %s%n".formatted(
                 actual.size(), joiner.join(actual),
                 expected.size(), joiner.join(expected));
     }
@@ -106,7 +105,7 @@ public final class TreeAssertions
     private static <T> void assertEquals(T actual, T expected)
     {
         if (!actual.equals(expected)) {
-            throw new AssertionError(format("expected [%s] but found [%s]", expected, actual));
+            throw new AssertionError("expected [%s] but found [%s]".formatted(expected, actual));
         }
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/NodeRef.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/NodeRef.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.tree;
 
-import static java.lang.String.format;
 import static java.lang.System.identityHashCode;
 import static java.util.Objects.requireNonNull;
 
@@ -58,8 +57,7 @@ public final class NodeRef<T extends Node>
     @Override
     public String toString()
     {
-        return format(
-                "@%s: %s",
+        return "@%s: %s".formatted(
                 Integer.toHexString(identityHashCode(node)),
                 node);
     }

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -232,9 +232,9 @@ public class TestSqlFormatter
         String createTableSql = "CREATE TABLE %s (\n   %s VARCHAR\n)";
 
         assertThat(formatSql(createTable.apply("table_name", "column_name")))
-                .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
+                .isEqualTo(createTableSql.formatted("table_name", "column_name"));
         assertThat(formatSql(createTable.apply("exists", "exists")))
-                .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+                .isEqualTo(createTableSql.formatted("\"exists\"", "\"exists\""));
 
         // Create a table with table comment
         assertThat(formatSql(
@@ -289,9 +289,9 @@ public class TestSqlFormatter
         String createTableSql = "CREATE TABLE %s( %s ) AS SELECT *\nFROM\n  t\n";
 
         assertThat(formatSql(createTableAsSelect.apply("table_name", "column_name")))
-                .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
+                .isEqualTo(createTableSql.formatted("table_name", "column_name"));
         assertThat(formatSql(createTableAsSelect.apply("exists", "exists")))
-                .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+                .isEqualTo(createTableSql.formatted("\"exists\"", "\"exists\""));
 
         assertThat(formatSql(
                 new CreateTableAsSelect(

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -294,7 +294,6 @@ import static io.trino.sql.tree.Trim.Specification.BOTH;
 import static io.trino.sql.tree.Trim.Specification.LEADING;
 import static io.trino.sql.tree.Trim.Specification.TRAILING;
 import static io.trino.sql.tree.WindowFrame.Type.ROWS;
-import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -1441,11 +1440,11 @@ public class TestSqlParser
     public void testSubstringBuiltInFunction()
     {
         String givenString = "ABCDEF";
-        assertStatement(format("SELECT substring('%s' FROM 2)", givenString),
+        assertStatement("SELECT substring('%s' FROM 2)".formatted(givenString),
                 simpleQuery(selectList(
                         new FunctionCall(QualifiedName.of("substr"), Lists.newArrayList(new StringLiteral(givenString), new LongLiteral("2"))))));
 
-        assertStatement(format("SELECT substring('%s' FROM 2 FOR 3)", givenString),
+        assertStatement("SELECT substring('%s' FROM 2 FOR 3)".formatted(givenString),
                 simpleQuery(selectList(
                         new FunctionCall(QualifiedName.of("substr"), Lists.newArrayList(new StringLiteral(givenString), new LongLiteral("2"), new LongLiteral("3"))))));
     }
@@ -1454,11 +1453,11 @@ public class TestSqlParser
     public void testSubstringRegisteredFunction()
     {
         String givenString = "ABCDEF";
-        assertStatement(format("SELECT substring('%s', 2)", givenString),
+        assertStatement("SELECT substring('%s', 2)".formatted(givenString),
                 simpleQuery(selectList(
                         new FunctionCall(QualifiedName.of("substring"), Lists.newArrayList(new StringLiteral(givenString), new LongLiteral("2"))))));
 
-        assertStatement(format("SELECT substring('%s', 2, 3)", givenString),
+        assertStatement("SELECT substring('%s', 2, 3)".formatted(givenString),
                 simpleQuery(selectList(
                         new FunctionCall(QualifiedName.of("substring"), Lists.newArrayList(new StringLiteral(givenString), new LongLiteral("2"), new LongLiteral("3"))))));
     }
@@ -4092,7 +4091,7 @@ public class TestSqlParser
 
         for (String fullName : tableNames) {
             QualifiedName qualifiedName = makeQualifiedName(fullName);
-            assertStatement(format("SHOW STATS FOR %s", qualifiedName), new ShowStats(new Table(qualifiedName)));
+            assertStatement("SHOW STATS FOR %s".formatted(qualifiedName), new ShowStats(new Table(qualifiedName)));
         }
     }
 
@@ -4105,11 +4104,11 @@ public class TestSqlParser
             QualifiedName qualifiedName = makeQualifiedName(fullName);
 
             // Simple SELECT
-            assertStatement(format("SHOW STATS FOR (SELECT * FROM %s)", qualifiedName),
+            assertStatement("SHOW STATS FOR (SELECT * FROM %s)".formatted(qualifiedName),
                     createShowStats(qualifiedName, ImmutableList.of(new AllColumns()), Optional.empty()));
 
             // SELECT with predicate
-            assertStatement(format("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0)", qualifiedName),
+            assertStatement("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0)".formatted(qualifiedName),
                     createShowStats(qualifiedName,
                             ImmutableList.of(new AllColumns()),
                             Optional.of(
@@ -4118,7 +4117,7 @@ public class TestSqlParser
                                             new LongLiteral("0")))));
 
             // SELECT with more complex predicate
-            assertStatement(format("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0 or field < 0)", qualifiedName),
+            assertStatement("SHOW STATS FOR (SELECT * FROM %s WHERE field > 0 or field < 0)".formatted(qualifiedName),
                     createShowStats(qualifiedName,
                             ImmutableList.of(new AllColumns()),
                             Optional.of(
@@ -6081,7 +6080,7 @@ public class TestSqlParser
     private static void assertParsed(String input, Node expected, Node parsed)
     {
         if (!parsed.equals(expected)) {
-            fail(format("expected\n\n%s\n\nto parse as\n\n%s\n\nbut was\n\n%s\n",
+            fail("expected\n\n%s\n\nto parse as\n\n%s\n\nbut was\n\n%s\n".formatted(
                     indent(input),
                     indent(formatSql(expected)),
                     indent(formatSql(parsed))));

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
@@ -24,7 +24,6 @@ import java.io.UncheckedIOException;
 
 import static com.google.common.base.Strings.repeat;
 import static io.trino.sql.testing.TreeAssertions.assertFormattedSql;
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -419,7 +418,7 @@ public class TestStatementBuilder
         String sql = getTpchQuery(query);
 
         for (int i = values.length - 1; i >= 0; i--) {
-            sql = sql.replaceAll(format(":%s", i + 1), String.valueOf(values[i]));
+            sql = sql.replaceAll(":%s".formatted(i + 1), String.valueOf(values[i]));
         }
 
         assertFalse(sql.matches("(?s).*:[0-9].*"), "Not all bind parameters were replaced: " + sql);

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnSchema.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnSchema.java
@@ -16,6 +16,7 @@ package io.trino.spi.connector;
 import io.trino.spi.type.Type;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static io.trino.spi.connector.SchemaUtil.checkNotEmpty;
 import static java.util.Locale.ENGLISH;
@@ -76,11 +77,10 @@ public final class ColumnSchema
     @Override
     public String toString()
     {
-        return new StringBuilder("ColumnSchema{")
-                .append("name='").append(name).append('\'')
-                .append(", type=").append(type)
-                .append(", hidden=").append(hidden)
-                .append('}')
+        return new StringJoiner(", ", ColumnSchema.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("type=" + type)
+                .add("hidden=" + hidden)
                 .toString();
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableSchema.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableSchema.java
@@ -16,6 +16,7 @@ package io.trino.spi.connector;
 import io.trino.spi.Experimental;
 
 import java.util.List;
+import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,11 +69,10 @@ public class ConnectorTableSchema
     @Override
     public String toString()
     {
-        return new StringBuilder("ConnectorTableSchema{")
-                .append("table=").append(table)
-                .append(", columns=").append(columns)
-                .append(", checkConstraints=").append(checkConstraints)
-                .append('}')
+        return new StringJoiner(", ", ConnectorTableSchema.class.getSimpleName() + "[", "]")
+                .add("table=" + table)
+                .add("columns=" + columns)
+                .add("checkConstraints=" + checkConstraints)
                 .toString();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableVersion.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableVersion.java
@@ -16,6 +16,8 @@ package io.trino.spi.connector;
 
 import io.trino.spi.type.Type;
 
+import java.util.StringJoiner;
+
 import static java.util.Objects.requireNonNull;
 
 public class ConnectorTableVersion
@@ -52,11 +54,10 @@ public class ConnectorTableVersion
     @Override
     public String toString()
     {
-        return new StringBuilder("ConnectorTableVersion{")
-                .append("pointerType=").append(pointerType)
-                .append(", versionType=").append(versionType)
-                .append(", version=").append(version)
-                .append('}')
+        return new StringJoiner(", ", ConnectorTableVersion.class.getSimpleName() + "[", "]")
+                .add("pointerType=" + pointerType)
+                .add("versionType=" + versionType)
+                .add("version=" + version)
                 .toString();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
@@ -66,12 +67,9 @@ public class SortItem
     @Override
     public String toString()
     {
-        return new StringBuilder("SortItem{")
-                .append("name=")
-                .append(name)
-                .append(", sortOrder=")
-                .append(sortOrder)
-                .append("}")
+        return new StringJoiner(", ", SortItem.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("sortOrder=" + sortOrder)
                 .toString();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/procedure/Procedure.java
@@ -99,14 +99,12 @@ public class Procedure
     @Override
     public String toString()
     {
-        return new StringBuilder()
-                .append(schema).append('.').append(name)
-                .append('(')
-                .append(arguments.stream()
+        return schema + '.' + name +
+                '(' +
+                arguments.stream()
                         .map(Object::toString)
-                        .collect(joining(", ")))
-                .append(')')
-                .toString();
+                        .collect(joining(", ")) +
+                ')';
     }
 
     public static class Argument

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSortItem.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSortItem.java
@@ -70,10 +70,6 @@ public final class JdbcSortItem
     @Override
     public String toString()
     {
-        return new StringBuilder()
-                .append(column)
-                .append(" ")
-                .append(sortOrder)
-                .toString();
+        return column + " " + sortOrder;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableExecuteHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/IcebergTableExecuteHandle.java
@@ -77,10 +77,7 @@ public class IcebergTableExecuteHandle
     @Override
     public String toString()
     {
-        return new StringBuilder()
-                .append("schemaTableName").append(":").append(schemaTableName)
-                .append(", procedureId").append(":").append(procedureId)
-                .append(", procedureHandle").append(":{").append(procedureHandle).append("}")
-                .toString();
+        return "schemaTableName:%s, procedureId:%s, procedureHandle:{%s}".formatted(
+                schemaTableName, procedureId, procedureHandle);
     }
 }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
@@ -80,14 +80,11 @@ public class KinesisShardCheckpointer
 
     private String createCheckpointKey(int iterationNo)
     {
-        return new StringBuilder(this.logicalProcessName)
-                .append("_")
-                .append(this.kinesisSplit.getStreamName())
-                .append("_")
-                .append(this.kinesisSplit.getShardId())
-                .append("_")
-                .append(String.valueOf(iterationNo))
-                .toString();
+        return "%s_%s_%s_%d".formatted(
+                this.logicalProcessName,
+                this.kinesisSplit.getStreamName(),
+                this.kinesisSplit.getShardId(),
+                iterationNo);
     }
 
     // storing last read sequence no. in dynamodb table

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
@@ -87,7 +87,7 @@ public final class PinotQueryBuilder
     private static String getTableName(PinotTableHandle tableHandle, Optional<String> tableNameSuffix)
     {
         return tableNameSuffix
-                .map(suffix -> new StringBuilder(tableHandle.getTableName()).append(suffix).toString())
+                .map(suffix -> tableHandle.getTableName() + suffix)
                 .orElseGet(tableHandle::getTableName);
     }
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
@@ -86,21 +86,15 @@ public final class PinotQueryBuilder
 
     private static String getTableName(PinotTableHandle tableHandle, Optional<String> tableNameSuffix)
     {
-        if (tableNameSuffix.isPresent()) {
-            return new StringBuilder(tableHandle.getTableName())
-                    .append(tableNameSuffix.get())
-                    .toString();
-        }
-        return tableHandle.getTableName();
+        return tableNameSuffix
+                .map(suffix -> new StringBuilder(tableHandle.getTableName()).append(suffix).toString())
+                .orElseGet(tableHandle::getTableName);
     }
 
     private static void generateFilterPql(StringBuilder pqlBuilder, PinotTableHandle tableHandle, Optional<String> timePredicate)
     {
-        Optional<String> filterClause = getFilterClause(tableHandle.getConstraint(), timePredicate, false);
-        if (filterClause.isPresent()) {
-            pqlBuilder.append(" WHERE ")
-                    .append(filterClause.get());
-        }
+        getFilterClause(tableHandle.getConstraint(), timePredicate, false)
+                .ifPresent(filterClause -> pqlBuilder.append(" WHERE ").append(filterClause));
     }
 
     public static Optional<String> getFilterClause(TupleDomain<ColumnHandle> tupleDomain, Optional<String> timePredicate, boolean forHavingClause)

--- a/pom.xml
+++ b/pom.xml
@@ -2673,6 +2673,7 @@
                                     -Xep:UnnecessaryMethodReference:ERROR \
                                     -Xep:UnnecessaryOptionalGet:ERROR \
                                     -Xep:UnnecessaryParentheses:ERROR \
+                                    -Xep:UnnecessaryStringBuilder:ERROR \
                                     <!-- Enable when https://github.com/google/error-prone/pull/3837 is fixed -->
                                     <!-- -Xep:UnusedVariable:ERROR \ -->
                                     -Xep:UseEnumSwitch:ERROR \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a new check in Error Prone 2.20.0. Per description: Prefer string concatenation over explicitly using `StringBuilder#append`, since `+` reads better and has equivalent or better performance.

Ever since Java 9 there are specialized optimizations for String concatenation and it no longer desugars to `StringBuilder` usage. This commit fixes mostly some very old-fashioned code where `StringBuilder` never really made sense anyway.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
