### PR TITLE
Avoid creating Hive tables with double slashed location

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -453,7 +453,10 @@ public final class HiveWriteUtils
             }
         }
 
-        return Location.of(location).appendPath(escapeTableName(tableName));
+        // Note: this results in `databaseLocation` being a "normalized location", e.g. not containing double slashes.
+        // TODO (https://github.com/trinodb/trino/issues/17803): We need to use normalized location until all relevant Hive connector components are migrated off Hadoop Path.
+        Location databaseLocation = Location.of(databasePath.toString());
+        return databaseLocation.appendPath(escapeTableName(tableName));
     }
 
     public static boolean pathExists(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path)


### PR DESCRIPTION
Hive connector does not support table locations containing double slashes. On S3 this leads to correctness issues (e.g. INSERT works, but SELECT does not find any data).

This commit

- restores normalization of implicit table location during CREATE TABLE. There used to be such normalization until 8bd9f754fb2aec61ffa353adfb421b460b60d947.
- rejects explicit table locations containing double slash during `CREATE TABLE .. WITH (external_location = ...)`. Before 8bd9f754fb2aec61ffa353adfb421b460b60d947 there used to be normalization also during this flow, but rejecting such unsupported locations is deemed more correct.

Alternative to https://github.com/trinodb/trino/pull/17947
Stop gap solution until we fix all problems related to double slashes in Hive connector (https://github.com/trinodb/trino/issues/17803).

After merging this, https://github.com/trinodb/trino/issues/17803 is no longer a `release-blocker`.