### PR TITLE
Add returnsZeroOnEmptyInput to AggregationFunctionMetadata

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2416,6 +2416,10 @@ public final class MetadataManager
             builder.orderSensitive();
         }
 
+        if (aggregationFunctionMetadata.returnsZeroOnEmptyInput()) {
+            builder.returnsZeroOnEmptyInput();
+        }
+
         if (!aggregationFunctionMetadata.getIntermediateTypes().isEmpty()) {
             FunctionBinding functionBinding = toFunctionBinding(resolvedFunction.getFunctionId(), resolvedFunction.getSignature(), functionSignature);
             aggregationFunctionMetadata.getIntermediateTypes().stream()

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationFromAnnotationsParser.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationFromAnnotationsParser.java
@@ -187,6 +187,7 @@ public final class AggregationFromAnnotationsParser
                 parseDescription(aggregationDefinition, outputFunction),
                 aggregationAnnotation.decomposable(),
                 aggregationAnnotation.isOrderSensitive(),
+                aggregationAnnotation.returnsZeroOnEmptyInput(),
                 aggregationAnnotation.hidden(),
                 aggregationDefinition.getAnnotationsByType(Deprecated.class).length > 0);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationHeader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationHeader.java
@@ -24,15 +24,17 @@ public class AggregationHeader
     private final Optional<String> description;
     private final boolean decomposable;
     private final boolean orderSensitive;
+    private final boolean returnsZeroOnEmptyInput;
     private final boolean hidden;
     private final boolean deprecated;
 
-    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive, boolean hidden, boolean deprecated)
+    public AggregationHeader(String name, Optional<String> description, boolean decomposable, boolean orderSensitive, boolean returnsZeroOnEmptyInput, boolean hidden, boolean deprecated)
     {
         this.name = requireNonNull(name, "name cannot be null");
         this.description = requireNonNull(description, "description cannot be null");
         this.decomposable = decomposable;
         this.orderSensitive = orderSensitive;
+        this.returnsZeroOnEmptyInput = returnsZeroOnEmptyInput;
         this.hidden = hidden;
         this.deprecated = deprecated;
     }
@@ -57,6 +59,11 @@ public class AggregationHeader
         return orderSensitive;
     }
 
+    public boolean returnsZeroOnEmptyInput()
+    {
+        return returnsZeroOnEmptyInput;
+    }
+
     public boolean isHidden()
     {
         return hidden;
@@ -75,6 +82,7 @@ public class AggregationHeader
                 .add("description", description)
                 .add("decomposable", decomposable)
                 .add("orderSensitive", orderSensitive)
+                .add("returnsZeroOnEmptyInput", returnsZeroOnEmptyInput)
                 .add("hidden", hidden)
                 .toString();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateCountDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ApproximateCountDistinctAggregation.java
@@ -41,7 +41,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.util.Failures.checkCondition;
 import static io.trino.util.Failures.internalError;
 
-@AggregationFunction("approx_distinct")
+@AggregationFunction(value = "approx_distinct", returnsZeroOnEmptyInput = true)
 public final class ApproximateCountDistinctAggregation
 {
     private static final double LOWEST_MAX_STANDARD_ERROR = 0.0040625;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BooleanApproximateCountDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BooleanApproximateCountDistinctAggregation.java
@@ -24,7 +24,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@AggregationFunction("approx_distinct")
+@AggregationFunction(value = "approx_distinct", returnsZeroOnEmptyInput = true)
 public final class BooleanApproximateCountDistinctAggregation
 {
     private BooleanApproximateCountDistinctAggregation() {}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BooleanDefaultApproximateCountDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BooleanDefaultApproximateCountDistinctAggregation.java
@@ -22,7 +22,7 @@ import io.trino.spi.function.OutputFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
 
-@AggregationFunction("approx_distinct")
+@AggregationFunction(value = "approx_distinct", returnsZeroOnEmptyInput = true)
 public final class BooleanDefaultApproximateCountDistinctAggregation
 {
     // this value is ignored for boolean, but this is left here for completeness

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
@@ -25,7 +25,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@AggregationFunction("count")
+@AggregationFunction(value = "count", returnsZeroOnEmptyInput = true)
 public final class CountAggregation
 {
     private CountAggregation() {}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
@@ -30,7 +30,7 @@ import io.trino.spi.function.TypeParameter;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@AggregationFunction("count")
+@AggregationFunction(value = "count", returnsZeroOnEmptyInput = true)
 @Description("Counts the non-null values")
 public final class CountColumn
 {

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
@@ -26,7 +26,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.trino.spi.type.BigintType.BIGINT;
 
-@AggregationFunction("count_if")
+@AggregationFunction(value = "count_if", returnsZeroOnEmptyInput = true)
 public final class CountIfAggregation
 {
     private CountIfAggregation() {}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -35,7 +35,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 
-@AggregationFunction("approx_distinct")
+@AggregationFunction(value = "approx_distinct", returnsZeroOnEmptyInput = true)
 public final class DefaultApproximateCountDistinctAggregation
 {
     private static final double DEFAULT_STANDARD_ERROR = 0.023;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ParametricAggregation.java
@@ -103,6 +103,9 @@ public class ParametricAggregation
         if (details.isOrderSensitive()) {
             builder.orderSensitive();
         }
+        if (details.returnsZeroOnEmptyInput()) {
+            builder.returnsZeroOnEmptyInput();
+        }
         if (details.isDecomposable()) {
             for (AccumulatorStateDetails<?> stateDetail : stateDetails) {
                 builder.intermediateType(stateDetail.getSerializedType());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/OptimizeMixedDistinctAggregations.java
@@ -22,6 +22,7 @@ import io.trino.cost.TableStatsProvider;
 import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
+import io.trino.spi.function.AggregationFunctionMetadata;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.Symbol;
@@ -189,8 +190,9 @@ public class OptimizeMixedDistinctAggregations
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty());
-                    String signatureName = aggregation.getResolvedFunction().getSignature().getName();
-                    if (signatureName.equals("count") || signatureName.equals("count_if") || signatureName.equals("approx_distinct")) {
+
+                    AggregationFunctionMetadata aggregationFunctionMetadata = metadata.getAggregationFunctionMetadata(session, aggregation.getResolvedFunction());
+                    if (aggregationFunctionMetadata.returnsZeroOnEmptyInput()) {
                         Symbol newSymbol = symbolAllocator.newSymbol("expr", symbolAllocator.getTypes().get(entry.getKey()));
                         aggregations.put(newSymbol, newAggregation);
                         coalesceSymbolsBuilder.put(newSymbol, entry.getKey());

--- a/core/trino-spi/src/main/java/io/trino/spi/function/AggregationFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/AggregationFunction.java
@@ -34,6 +34,13 @@ public @interface AggregationFunction
      */
     boolean isOrderSensitive() default false;
 
+    /**
+     * Indicates whether the function returns value BIGINT 0 when no input is provided.
+     * The SQL specification demands it for COUNT function.
+     * In trino, COUNT_IF and APPROX_DISTINCT also have this characteristic.
+     */
+    boolean returnsZeroOnEmptyInput() default false;
+
     boolean hidden() default false;
 
     String[] alias() default {};

--- a/core/trino-spi/src/main/java/io/trino/spi/function/AggregationFunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/AggregationFunctionMetadata.java
@@ -27,17 +27,25 @@ import static java.util.Objects.requireNonNull;
 public class AggregationFunctionMetadata
 {
     private final boolean orderSensitive;
+
+    private final boolean returnsZeroOnEmptyInput;
     private final List<TypeSignature> intermediateTypes;
 
-    private AggregationFunctionMetadata(boolean orderSensitive, List<TypeSignature> intermediateTypes)
+    private AggregationFunctionMetadata(boolean orderSensitive, boolean returnsZeroOnEmptyInput, List<TypeSignature> intermediateTypes)
     {
         this.orderSensitive = orderSensitive;
+        this.returnsZeroOnEmptyInput = returnsZeroOnEmptyInput;
         this.intermediateTypes = List.copyOf(requireNonNull(intermediateTypes, "intermediateTypes is null"));
     }
 
     public boolean isOrderSensitive()
     {
         return orderSensitive;
+    }
+
+    public boolean returnsZeroOnEmptyInput()
+    {
+        return returnsZeroOnEmptyInput;
     }
 
     public boolean isDecomposable()
@@ -55,6 +63,7 @@ public class AggregationFunctionMetadata
     {
         return new StringJoiner(", ", AggregationFunctionMetadata.class.getSimpleName() + "[", "]")
                 .add("orderSensitive=" + orderSensitive)
+                .add("returnsZeroOnEmptyInput=" + returnsZeroOnEmptyInput)
                 .add("intermediateTypes=" + intermediateTypes)
                 .toString();
     }
@@ -68,12 +77,19 @@ public class AggregationFunctionMetadata
     {
         private boolean orderSensitive;
         private final List<TypeSignature> intermediateTypes = new ArrayList<>();
+        private boolean returnsZeroOnEmptyInput;
 
         private AggregationFunctionMetadataBuilder() {}
 
         public AggregationFunctionMetadataBuilder orderSensitive()
         {
             this.orderSensitive = true;
+            return this;
+        }
+
+        public AggregationFunctionMetadataBuilder returnsZeroOnEmptyInput()
+        {
+            this.returnsZeroOnEmptyInput = true;
             return this;
         }
 
@@ -91,7 +107,7 @@ public class AggregationFunctionMetadata
 
         public AggregationFunctionMetadata build()
         {
-            return new AggregationFunctionMetadata(orderSensitive, intermediateTypes);
+            return new AggregationFunctionMetadata(orderSensitive, returnsZeroOnEmptyInput, intermediateTypes);
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
`COUNT`, `COUNT_IF`, and `APPROX_DISTINCT` do have not standard
behavior when no input was supplied to the function.
They return the value 0, as opposed to standard `NULL`.
Before this change, `OptimizeMixedDistinctAggregations` relied on
matching string function name to handle this case, but
this is brittle and may cause silent correctness issues
if a new function with this characteristic is added.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
