### PR TITLE
Respect AWS_REGION environment variable

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/TrinoS3FileSystem.java
@@ -1084,6 +1084,9 @@ public class TrinoS3FileSystem
 
         String endpoint = hadoopConfig.get(S3_ENDPOINT);
         String region = hadoopConfig.get(S3_REGION);
+        if (region == null) {
+            region = System.getenv("AWS_REGION");
+        }
         if (endpoint != null) {
             clientBuilder.setEndpointConfiguration(new EndpointConfiguration(endpoint, region));
             regionOrEndpointSet = true;


### PR DESCRIPTION
When region is not explicitly configured, TrinoS3FileSystem defaulted to us-east-1.
