### PR TITLE
Reduce string concatenation in ProtocolHeaders

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -25,7 +25,33 @@ public final class ProtocolHeaders
     public static final ProtocolHeaders TRINO_HEADERS = new ProtocolHeaders("Trino");
 
     private final String name;
-    private final String prefix;
+    private final String requestUser;
+    private final String requestSource;
+    private final String requestCatalog;
+    private final String requestSchema;
+    private final String requestPath;
+    private final String requestTimeZone;
+    private final String requestLanguage;
+    private final String requestTraceToken;
+    private final String requestSession;
+    private final String requestRole;
+    private final String requestPreparedStatement;
+    private final String requestTransactionId;
+    private final String requestClientInfo;
+    private final String requestClientTags;
+    private final String requestClientCapabilities;
+    private final String requestResourceEstimate;
+    private final String requestExtraCredential;
+    private final String responseSetCatalog;
+    private final String responseSetSchema;
+    private final String responseSetPath;
+    private final String responseSetSession;
+    private final String responseClearSession;
+    private final String responseSetRole;
+    private final String responseAddedPrepare;
+    private final String responseDeallocatedPrepare;
+    private final String responseStartedTransactionId;
+    private final String responseClearTransactionId;
 
     public static ProtocolHeaders createProtocolHeaders(String name)
     {
@@ -41,7 +67,34 @@ public final class ProtocolHeaders
         requireNonNull(name, "name is null");
         checkArgument(!name.isEmpty(), "name is empty");
         this.name = name;
-        this.prefix = "X-" + name + "-";
+        String prefix = "X-" + name + "-";
+        requestUser = prefix + "User";
+        requestSource = prefix + "Source";
+        requestCatalog = prefix + "Catalog";
+        requestSchema = prefix + "Schema";
+        requestPath = prefix + "Path";
+        requestTimeZone = prefix + "Time-Zone";
+        requestLanguage = prefix + "Language";
+        requestTraceToken = prefix + "Trace-Token";
+        requestSession = prefix + "Session";
+        requestRole = prefix + "Role";
+        requestPreparedStatement = prefix + "Prepared-Statement";
+        requestTransactionId = prefix + "Transaction-Id";
+        requestClientInfo = prefix + "Client-Info";
+        requestClientTags = prefix + "Client-Tags";
+        requestClientCapabilities = prefix + "Client-Capabilities";
+        requestResourceEstimate = prefix + "Resource-Estimate";
+        requestExtraCredential = prefix + "Extra-Credential";
+        responseSetCatalog = prefix + "Set-Catalog";
+        responseSetSchema = prefix + "Set-Schema";
+        responseSetPath = prefix + "Set-Path";
+        responseSetSession = prefix + "Set-Session";
+        responseClearSession = prefix + "Clear-Session";
+        responseSetRole = prefix + "Set-Role";
+        responseAddedPrepare = prefix + "Added-Prepare";
+        responseDeallocatedPrepare = prefix + "Deallocated-Prepare";
+        responseStartedTransactionId = prefix + "Started-Transaction-Id";
+        responseClearTransactionId = prefix + "Clear-Transaction-Id";
     }
 
     public String getProtocolName()
@@ -51,137 +104,137 @@ public final class ProtocolHeaders
 
     public String requestUser()
     {
-        return prefix + "User";
+        return requestUser;
     }
 
     public String requestSource()
     {
-        return prefix + "Source";
+        return requestSource;
     }
 
     public String requestCatalog()
     {
-        return prefix + "Catalog";
+        return requestCatalog;
     }
 
     public String requestSchema()
     {
-        return prefix + "Schema";
+        return requestSchema;
     }
 
     public String requestPath()
     {
-        return prefix + "Path";
+        return requestPath;
     }
 
     public String requestTimeZone()
     {
-        return prefix + "Time-Zone";
+        return requestTimeZone;
     }
 
     public String requestLanguage()
     {
-        return prefix + "Language";
+        return requestLanguage;
     }
 
     public String requestTraceToken()
     {
-        return prefix + "Trace-Token";
+        return requestTraceToken;
     }
 
     public String requestSession()
     {
-        return prefix + "Session";
+        return requestSession;
     }
 
     public String requestRole()
     {
-        return prefix + "Role";
+        return requestRole;
     }
 
     public String requestPreparedStatement()
     {
-        return prefix + "Prepared-Statement";
+        return requestPreparedStatement;
     }
 
     public String requestTransactionId()
     {
-        return prefix + "Transaction-Id";
+        return requestTransactionId;
     }
 
     public String requestClientInfo()
     {
-        return prefix + "Client-Info";
+        return requestClientInfo;
     }
 
     public String requestClientTags()
     {
-        return prefix + "Client-Tags";
+        return requestClientTags;
     }
 
     public String requestClientCapabilities()
     {
-        return prefix + "Client-Capabilities";
+        return requestClientCapabilities;
     }
 
     public String requestResourceEstimate()
     {
-        return prefix + "Resource-Estimate";
+        return requestResourceEstimate;
     }
 
     public String requestExtraCredential()
     {
-        return prefix + "Extra-Credential";
+        return requestExtraCredential;
     }
 
     public String responseSetCatalog()
     {
-        return prefix + "Set-Catalog";
+        return responseSetCatalog;
     }
 
     public String responseSetSchema()
     {
-        return prefix + "Set-Schema";
+        return responseSetSchema;
     }
 
     public String responseSetPath()
     {
-        return prefix + "Set-Path";
+        return responseSetPath;
     }
 
     public String responseSetSession()
     {
-        return prefix + "Set-Session";
+        return responseSetSession;
     }
 
     public String responseClearSession()
     {
-        return prefix + "Clear-Session";
+        return responseClearSession;
     }
 
     public String responseSetRole()
     {
-        return prefix + "Set-Role";
+        return responseSetRole;
     }
 
     public String responseAddedPrepare()
     {
-        return prefix + "Added-Prepare";
+        return responseAddedPrepare;
     }
 
     public String responseDeallocatedPrepare()
     {
-        return prefix + "Deallocated-Prepare";
+        return responseDeallocatedPrepare;
     }
 
     public String responseStartedTransactionId()
     {
-        return prefix + "Started-Transaction-Id";
+        return responseStartedTransactionId;
     }
 
     public String responseClearTransactionId()
     {
-        return prefix + "Clear-Transaction-Id";
+        return responseClearTransactionId;
     }
 
     public static ProtocolHeaders detectProtocol(Optional<String> alternateHeaderName, Set<String> headerNames)


### PR DESCRIPTION
## Description
Avoids unnecessary repeated string concatenation for HTTP header names in `ProtocolHeaders` which also enables `String#hashCode()` caching to work instead of having to re-compute it when constructing HTTP request/response headers multimaps.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
