### PR TITLE
Revert optimization to reorder columns in parquet writer

### DIFF
--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -35,7 +35,6 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -137,12 +136,8 @@ public class TestParquetWriter
         ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, Optional.empty());
         assertThat(parquetMetadata.getBlocks().size()).isGreaterThanOrEqualTo(10);
         for (BlockMetaData blockMetaData : parquetMetadata.getBlocks()) {
-            // Sort columns by size in file
-            List<ColumnChunkMetaData> columns = blockMetaData.getColumns().stream()
-                    .sorted(Comparator.comparingLong(ColumnChunkMetaData::getTotalUncompressedSize))
-                    .collect(toImmutableList());
-            // Verify that the columns are stored in the same order
-            List<Long> offsets = columns.stream()
+            // Verify that the columns are stored in the same order as the metadata
+            List<Long> offsets = blockMetaData.getColumns().stream()
                     .map(ColumnChunkMetaData::getFirstDataPageOffset)
                     .collect(toImmutableList());
             assertThat(offsets).isSorted();


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Some files produced by this optimization were ignored by Apache Spark.
Related to https://trinodb.slack.com/archives/CGB0QHWSW/p1687254718875619
Some versions of Databricks Runtime produce an exception when reading files with re-ordered columns.
Related to https://trinodb.slack.com/archives/CP1MUNEUX/p1685685945379909

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Original PR https://github.com/trinodb/trino/pull/17404
The files produced after this change were found to be sometimes ignored by Apache Spark
and produce exceptions on DBR 12.2 LTS.
Apache Hive and trino parquet reader did not have problems reading any of the new files. 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Hudi, Iceberg
* Fix parquet writer compatibility with Apache Spark and Databricks Runtime. ({issue}`17978`)
```
