### PR TITLE
Change MinIO bucket names not to look like S3's

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -77,7 +77,7 @@ public class TestDeltaLakeConnectorTest
 {
     protected static final String SCHEMA = "test_schema";
 
-    protected final String bucketName = "trino-ci-test-" + randomNameSuffix();
+    protected final String bucketName = "test-bucket-" + randomNameSuffix();
     protected MinioClient minioClient;
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystemMinio.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystemMinio.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertTrue;
 public class TestTrinoS3FileSystemMinio
         extends BaseTestTrinoS3FileSystemObjectStorage
 {
-    private final String bucketName = "trino-ci-test-" + randomNameSuffix();
+    private final String bucketName = "test-bucket-" + randomNameSuffix();
 
     private Minio minio;
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeOss.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeDeltaLakeOss.java
@@ -114,7 +114,7 @@ public class EnvSinglenodeDeltaLakeOss
         FileAttribute<Set<PosixFilePermission>> posixFilePermissions = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
         Path minioBucketDirectory;
         try {
-            minioBucketDirectory = Files.createTempDirectory("trino-ci-test", posixFilePermissions);
+            minioBucketDirectory = Files.createTempDirectory("test-bucket-contents", posixFilePermissions);
             minioBucketDirectory.toFile().deleteOnExit();
         }
         catch (IOException e) {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeHiveHudiRedirections.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeHiveHudiRedirections.java
@@ -52,7 +52,7 @@ public class EnvSinglenodeHiveHudiRedirections
     private static final int SPARK_THRIFT_PORT = 10213;
 
     private static final String SPARK_CONTAINER_NAME = "spark";
-    private static final String S3_BUCKET_NAME = "trino-ci-test";
+    private static final String S3_BUCKET_NAME = "test-bucket";
 
     private final PortBinder portBinder;
     private final String hadoopImagesVersion;
@@ -91,7 +91,7 @@ public class EnvSinglenodeHiveHudiRedirections
         FileAttribute<Set<PosixFilePermission>> posixFilePermissions = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
         Path minioBucketDirectory;
         try {
-            minioBucketDirectory = Files.createTempDirectory("trino-ci-test", posixFilePermissions);
+            minioBucketDirectory = Files.createTempDirectory("test-bucket-contents", posixFilePermissions);
             minioBucketDirectory.toFile().deleteOnExit();
         }
         catch (IOException e) {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeHudi.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeHudi.java
@@ -56,7 +56,7 @@ public class EnvSinglenodeHudi
     private static final int SPARK_THRIFT_PORT = 10213;
 
     private static final String SPARK_CONTAINER_NAME = "spark";
-    private static final String S3_BUCKET_NAME = "trino-ci-test";
+    private static final String S3_BUCKET_NAME = "test-bucket";
 
     private final PortBinder portBinder;
     private final String hadoopImagesVersion;
@@ -101,7 +101,7 @@ public class EnvSinglenodeHudi
         FileAttribute<Set<PosixFilePermission>> posixFilePermissions = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-r--r--"));
         Path minioBucketDirectory;
         try {
-            minioBucketDirectory = Files.createTempDirectory("trino-ci-test", posixFilePermissions);
+            minioBucketDirectory = Files.createTempDirectory("test-bucket-contents", posixFilePermissions);
             minioBucketDirectory.toFile().deleteOnExit();
         }
         catch (IOException e) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToHudi.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToHudi.java
@@ -41,7 +41,7 @@ public class TestHiveRedirectionToHudi
     @BeforeMethodWithContext
     public void setUp()
     {
-        bucketName = System.getenv().getOrDefault("S3_BUCKET", "trino-ci-test");
+        bucketName = System.getenv().getOrDefault("S3_BUCKET", "test-bucket");
     }
 
     @DataProvider


### PR DESCRIPTION
`trino-ci-test` is the bucket currently used by the CI. For buckets that have nothing to do with this `trino-ci-test` S3 testing bucket, use different names.

