### PR TITLE
Use Block#bytesCompare for comparisions with strings

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor.java
@@ -166,11 +166,23 @@ public class BenchmarkPageProcessor
 
         private static boolean filter(int position, Block discountBlock, Block shipDateBlock, Block quantityBlock)
         {
-            return !shipDateBlock.isNull(position) && VARCHAR.getSlice(shipDateBlock, position).compareTo(MIN_SHIP_DATE) >= 0 &&
-                    !shipDateBlock.isNull(position) && VARCHAR.getSlice(shipDateBlock, position).compareTo(MAX_SHIP_DATE) < 0 &&
+            return !shipDateBlock.isNull(position) && greaterThanOrEqual(shipDateBlock, position, MIN_SHIP_DATE) &&
+                    !shipDateBlock.isNull(position) && lessThan(shipDateBlock, position, MAX_SHIP_DATE) &&
                     !discountBlock.isNull(position) && DOUBLE.getDouble(discountBlock, position) >= 0.05 &&
                     !discountBlock.isNull(position) && DOUBLE.getDouble(discountBlock, position) <= 0.07 &&
                     !quantityBlock.isNull(position) && DOUBLE.getDouble(quantityBlock, position) < 24;
+        }
+
+        private static boolean lessThan(Block left, int leftPosition, Slice right)
+        {
+            int leftLength = left.getSliceLength(leftPosition);
+            return left.bytesCompare(leftPosition, 0, leftLength, right, 0, right.length()) < 0;
+        }
+
+        private static boolean greaterThanOrEqual(Block left, int leftPosition, Slice right)
+        {
+            int leftLength = left.getSliceLength(leftPosition);
+            return left.bytesCompare(leftPosition, 0, leftLength, right, 0, right.length()) >= 0;
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -315,6 +315,12 @@ public class TypeOperators
             if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, BLOCK_POSITION))) {
                 comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION);
             }
+            else if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(NEVER_NULL, BLOCK_POSITION))) {
+                comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, BLOCK_POSITION);
+            }
+            else if (operatorConvention.callingConvention().getArgumentConventions().equals(List.of(BLOCK_POSITION, NEVER_NULL))) {
+                comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, NEVER_NULL);
+            }
             else {
                 comparisonCallingConvention = simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL);
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
@@ -283,4 +283,18 @@ public final class VarcharType
         int rightLength = rightBlock.getSliceLength(rightPosition);
         return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
     }
+
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
+    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, Slice right)
+    {
+        int leftLength = leftBlock.getSliceLength(leftPosition);
+        return leftBlock.bytesCompare(leftPosition, 0, leftLength, right, 0, right.length());
+    }
+
+    @ScalarOperator(COMPARISON_UNORDERED_LAST)
+    private static long comparisonOperator(Slice left, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+    {
+        int rightLength = rightBlock.getSliceLength(rightPosition);
+        return -rightBlock.bytesCompare(rightPosition, 0, rightLength, left, 0, left.length());
+    }
 }


### PR DESCRIPTION
## Description
Avoids overhead of creating a Slice from VariableWidthBlock for LESS_THAN and LESS_THAN_OR_EQUAL comparisions with constant strings

```
Before
Benchmark                          Mode  Cnt     Score    Error  Units
BenchmarkPageProcessor.compiled   thrpt   50  3956.935 ± 96.529  ops/s
BenchmarkPageProcessor.handCoded  thrpt   50  4515.943 ± 35.327  ops/s

After
Benchmark                          Mode  Cnt     Score     Error  Units
BenchmarkPageProcessor.compiled   thrpt   50  6258.105 ± 172.675  ops/s
BenchmarkPageProcessor.handCoded  thrpt   50  7024.419 ± 116.318  ops/s
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
