### PR TITLE
Treat precision as NANOSECONDS for timestamp to be coerced 

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -17,44 +17,19 @@ import com.google.common.collect.ImmutableList;
 import io.trino.filesystem.Location;
 import io.trino.plugin.hive.HivePageSourceProvider.BucketAdaptation;
 import io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping;
-import io.trino.plugin.hive.coercions.CharCoercer;
-import io.trino.plugin.hive.coercions.DoubleToFloatCoercer;
-import io.trino.plugin.hive.coercions.FloatToDoubleCoercer;
-import io.trino.plugin.hive.coercions.IntegerNumberToVarcharCoercer;
-import io.trino.plugin.hive.coercions.IntegerNumberUpscaleCoercer;
-import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
-import io.trino.plugin.hive.coercions.TimestampCoercer.ShortTimestampToVarcharCoercer;
-import io.trino.plugin.hive.coercions.VarcharCoercer;
-import io.trino.plugin.hive.coercions.VarcharToIntegerNumberCoercer;
-import io.trino.plugin.hive.type.Category;
-import io.trino.plugin.hive.type.ListTypeInfo;
-import io.trino.plugin.hive.type.MapTypeInfo;
 import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
-import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.ColumnarArray;
-import io.trino.spi.block.ColumnarMap;
-import io.trino.spi.block.ColumnarRow;
-import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.LazyBlock;
 import io.trino.spi.block.LazyBlockLoader;
-import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.metrics.Metrics;
-import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.CharType;
-import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.MapType;
-import io.trino.spi.type.RowType;
-import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.VarcharType;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 import javax.annotation.Nullable;
@@ -76,26 +51,8 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMappingKind.EMPTY;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
-import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
-import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
-import static io.trino.plugin.hive.HiveType.HIVE_FLOAT;
-import static io.trino.plugin.hive.HiveType.HIVE_INT;
-import static io.trino.plugin.hive.HiveType.HIVE_LONG;
-import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToRealCoercer;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToVarcharCoercer;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createDoubleToDecimalCoercer;
-import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucket;
-import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static io.trino.spi.block.ColumnarArray.toColumnarArray;
-import static io.trino.spi.block.ColumnarMap.toColumnarMap;
-import static io.trino.spi.block.ColumnarRow.toColumnarRow;
-import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -297,233 +254,6 @@ public class HivePageSource
     public ConnectorPageSource getPageSource()
     {
         return delegate;
-    }
-
-    public static Optional<Function<Block, Block>> createCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
-    {
-        if (fromHiveType.equals(toHiveType)) {
-            return Optional.empty();
-        }
-
-        Type fromType = fromHiveType.getType(typeManager, timestampPrecision);
-        Type toType = toHiveType.getType(typeManager, timestampPrecision);
-
-        if (toType instanceof VarcharType toVarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
-            return Optional.of(new IntegerNumberToVarcharCoercer<>(fromType, toVarcharType));
-        }
-        if (fromType instanceof VarcharType fromVarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
-            return Optional.of(new VarcharToIntegerNumberCoercer<>(fromVarcharType, toType));
-        }
-        if (fromType instanceof VarcharType fromVarcharType && toType instanceof VarcharType toVarcharType) {
-            if (narrowerThan(toVarcharType, fromVarcharType)) {
-                return Optional.of(new VarcharCoercer(fromVarcharType, toVarcharType));
-            }
-            return Optional.empty();
-        }
-        if (fromType instanceof CharType fromCharType && toType instanceof CharType toCharType) {
-            if (narrowerThan(toCharType, fromCharType)) {
-                return Optional.of(new CharCoercer(fromCharType, toCharType));
-            }
-            return Optional.empty();
-        }
-        if (fromHiveType.equals(HIVE_BYTE) && (toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
-            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
-        }
-        if (fromHiveType.equals(HIVE_SHORT) && (toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
-            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
-        }
-        if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {
-            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
-        }
-        if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
-            return Optional.of(new FloatToDoubleCoercer());
-        }
-        if (fromHiveType.equals(HIVE_DOUBLE) && toHiveType.equals(HIVE_FLOAT)) {
-            return Optional.of(new DoubleToFloatCoercer());
-        }
-        if (fromType instanceof DecimalType fromDecimalType && toType instanceof DecimalType toDecimalType) {
-            return Optional.of(createDecimalToDecimalCoercer(fromDecimalType, toDecimalType));
-        }
-        if (fromType instanceof DecimalType fromDecimalType && toType == DOUBLE) {
-            return Optional.of(createDecimalToDoubleCoercer(fromDecimalType));
-        }
-        if (fromType instanceof DecimalType fromDecimalType && toType == REAL) {
-            return Optional.of(createDecimalToRealCoercer(fromDecimalType));
-        }
-        if (fromType instanceof DecimalType fromDecimalType && toType instanceof VarcharType toVarcharType) {
-            return Optional.of(createDecimalToVarcharCoercer(fromDecimalType, toVarcharType));
-        }
-        if (fromType == DOUBLE && toType instanceof DecimalType toDecimalType) {
-            return Optional.of(createDoubleToDecimalCoercer(toDecimalType));
-        }
-        if (fromType == REAL && toType instanceof DecimalType toDecimalType) {
-            return Optional.of(createRealToDecimalCoercer(toDecimalType));
-        }
-        if (fromType instanceof TimestampType timestampType && toType instanceof VarcharType varcharType) {
-            if (timestampType.isShort()) {
-                return Optional.of(new ShortTimestampToVarcharCoercer(timestampType, varcharType));
-            }
-            return Optional.of(new LongTimestampToVarcharCoercer(timestampType, varcharType));
-        }
-        if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
-            return Optional.of(new ListCoercer(typeManager, fromHiveType, toHiveType, timestampPrecision));
-        }
-        if ((fromType instanceof MapType) && (toType instanceof MapType)) {
-            return Optional.of(new MapCoercer(typeManager, fromHiveType, toHiveType, timestampPrecision));
-        }
-        if ((fromType instanceof RowType) && (toType instanceof RowType)) {
-            HiveType fromHiveTypeStruct = (fromHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(fromType) : fromHiveType;
-            HiveType toHiveTypeStruct = (toHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(toType) : toHiveType;
-
-            return Optional.of(new StructCoercer(typeManager, fromHiveTypeStruct, toHiveTypeStruct, timestampPrecision));
-        }
-
-        throw new TrinoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));
-    }
-
-    public static boolean narrowerThan(VarcharType first, VarcharType second)
-    {
-        requireNonNull(first, "first is null");
-        requireNonNull(second, "second is null");
-        if (first.isUnbounded() || second.isUnbounded()) {
-            return !first.isUnbounded();
-        }
-        return first.getBoundedLength() < second.getBoundedLength();
-    }
-
-    public static boolean narrowerThan(CharType first, CharType second)
-    {
-        requireNonNull(first, "first is null");
-        requireNonNull(second, "second is null");
-        return first.getLength() < second.getLength();
-    }
-
-    private static class ListCoercer
-            implements Function<Block, Block>
-    {
-        private final Optional<Function<Block, Block>> elementCoercer;
-
-        public ListCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
-        {
-            requireNonNull(typeManager, "typeManager is null");
-            requireNonNull(fromHiveType, "fromHiveType is null");
-            requireNonNull(toHiveType, "toHiveType is null");
-            requireNonNull(timestampPrecision, "timestampPrecision is null");
-            HiveType fromElementHiveType = HiveType.valueOf(((ListTypeInfo) fromHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
-            HiveType toElementHiveType = HiveType.valueOf(((ListTypeInfo) toHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
-            this.elementCoercer = createCoercer(typeManager, fromElementHiveType, toElementHiveType, timestampPrecision);
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            if (elementCoercer.isEmpty()) {
-                return block;
-            }
-            ColumnarArray arrayBlock = toColumnarArray(block);
-            Block elementsBlock = elementCoercer.get().apply(arrayBlock.getElementsBlock());
-            boolean[] valueIsNull = new boolean[arrayBlock.getPositionCount()];
-            int[] offsets = new int[arrayBlock.getPositionCount() + 1];
-            for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
-                valueIsNull[i] = arrayBlock.isNull(i);
-                offsets[i + 1] = offsets[i] + arrayBlock.getLength(i);
-            }
-            return ArrayBlock.fromElementBlock(arrayBlock.getPositionCount(), Optional.of(valueIsNull), offsets, elementsBlock);
-        }
-    }
-
-    private static class MapCoercer
-            implements Function<Block, Block>
-    {
-        private final Type toType;
-        private final Optional<Function<Block, Block>> keyCoercer;
-        private final Optional<Function<Block, Block>> valueCoercer;
-
-        public MapCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
-        {
-            requireNonNull(typeManager, "typeManager is null");
-            requireNonNull(fromHiveType, "fromHiveType is null");
-            requireNonNull(timestampPrecision, "timestampPrecision is null");
-            this.toType = toHiveType.getType(typeManager);
-            HiveType fromKeyHiveType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
-            HiveType fromValueHiveType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
-            HiveType toKeyHiveType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
-            HiveType toValueHiveType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
-            this.keyCoercer = createCoercer(typeManager, fromKeyHiveType, toKeyHiveType, timestampPrecision);
-            this.valueCoercer = createCoercer(typeManager, fromValueHiveType, toValueHiveType, timestampPrecision);
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            ColumnarMap mapBlock = toColumnarMap(block);
-            Block keysBlock = keyCoercer.isEmpty() ? mapBlock.getKeysBlock() : keyCoercer.get().apply(mapBlock.getKeysBlock());
-            Block valuesBlock = valueCoercer.isEmpty() ? mapBlock.getValuesBlock() : valueCoercer.get().apply(mapBlock.getValuesBlock());
-            boolean[] valueIsNull = new boolean[mapBlock.getPositionCount()];
-            int[] offsets = new int[mapBlock.getPositionCount() + 1];
-            for (int i = 0; i < mapBlock.getPositionCount(); i++) {
-                valueIsNull[i] = mapBlock.isNull(i);
-                offsets[i + 1] = offsets[i] + mapBlock.getEntryCount(i);
-            }
-            return ((MapType) toType).createBlockFromKeyValue(Optional.of(valueIsNull), offsets, keysBlock, valuesBlock);
-        }
-    }
-
-    private static class StructCoercer
-            implements Function<Block, Block>
-    {
-        private final List<Optional<Function<Block, Block>>> coercers;
-        private final Block[] nullBlocks;
-
-        public StructCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
-        {
-            requireNonNull(typeManager, "typeManager is null");
-            requireNonNull(fromHiveType, "fromHiveType is null");
-            requireNonNull(toHiveType, "toHiveType is null");
-            requireNonNull(timestampPrecision, "timestampPrecision is null");
-            List<HiveType> fromFieldTypes = extractStructFieldTypes(fromHiveType);
-            List<HiveType> toFieldTypes = extractStructFieldTypes(toHiveType);
-            ImmutableList.Builder<Optional<Function<Block, Block>>> coercers = ImmutableList.builder();
-            this.nullBlocks = new Block[toFieldTypes.size()];
-            for (int i = 0; i < toFieldTypes.size(); i++) {
-                if (i >= fromFieldTypes.size()) {
-                    nullBlocks[i] = toFieldTypes.get(i).getType(typeManager).createBlockBuilder(null, 1).appendNull().build();
-                    coercers.add(Optional.empty());
-                }
-                else {
-                    coercers.add(createCoercer(typeManager, fromFieldTypes.get(i), toFieldTypes.get(i), timestampPrecision));
-                }
-            }
-            this.coercers = coercers.build();
-        }
-
-        @Override
-        public Block apply(Block block)
-        {
-            ColumnarRow rowBlock = toColumnarRow(block);
-            Block[] fields = new Block[coercers.size()];
-            int[] ids = new int[rowBlock.getField(0).getPositionCount()];
-            for (int i = 0; i < coercers.size(); i++) {
-                Optional<Function<Block, Block>> coercer = coercers.get(i);
-                if (coercer.isPresent()) {
-                    fields[i] = coercer.get().apply(rowBlock.getField(i));
-                }
-                else if (i < rowBlock.getFieldCount()) {
-                    fields[i] = rowBlock.getField(i);
-                }
-                else {
-                    fields[i] = DictionaryBlock.create(ids.length, nullBlocks[i], ids);
-                }
-            }
-            boolean[] valueIsNull = null;
-            if (rowBlock.mayHaveNull()) {
-                valueIsNull = new boolean[rowBlock.getPositionCount()];
-                for (int i = 0; i < rowBlock.getPositionCount(); i++) {
-                    valueIsNull[i] = rowBlock.isNull(i);
-                }
-            }
-            return RowBlock.fromFieldBlocks(rowBlock.getPositionCount(), Optional.ofNullable(valueIsNull), fields);
-        }
     }
 
     private static final class CoercionLazyBlockLoader

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.filesystem.Location;
 import io.trino.plugin.hive.HivePageSourceProvider.BucketAdaptation;
 import io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping;
+import io.trino.plugin.hive.coercions.TypeCoercer;
 import io.trino.plugin.hive.type.TypeInfo;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
 import io.trino.spi.Page;
@@ -68,7 +69,7 @@ public class HivePageSource
     private final Optional<BucketValidator> bucketValidator;
     private final Object[] prefilledValues;
     private final Type[] types;
-    private final List<Optional<Function<Block, Block>>> coercers;
+    private final List<Optional<TypeCoercer<? extends Type, ? extends Type>>> coercers;
     private final Optional<ReaderProjectionsAdapter> projectionsAdapter;
 
     private final ConnectorPageSource delegate;
@@ -97,7 +98,7 @@ public class HivePageSource
 
         prefilledValues = new Object[size];
         types = new Type[size];
-        ImmutableList.Builder<Optional<Function<Block, Block>>> coercers = ImmutableList.builder();
+        ImmutableList.Builder<Optional<TypeCoercer<? extends Type, ? extends Type>>> coercers = ImmutableList.builder();
 
         for (int columnIndex = 0; columnIndex < size; columnIndex++) {
             ColumnMapping columnMapping = columnMappings.get(columnIndex);
@@ -189,7 +190,7 @@ public class HivePageSource
                     case REGULAR:
                     case SYNTHESIZED:
                         Block block = dataPage.getBlock(columnMapping.getIndex());
-                        Optional<Function<Block, Block>> coercer = coercers.get(fieldId);
+                        Optional<TypeCoercer<? extends Type, ? extends Type>> coercer = coercers.get(fieldId);
                         if (coercer.isPresent()) {
                             block = new LazyBlock(batchSize, new CoercionLazyBlockLoader(block, coercer.get()));
                         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -71,6 +71,7 @@ import static io.trino.plugin.hive.HiveColumnHandle.isRowIdColumnHandle;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.toColumnHandles;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMappingKind.PREFILLED;
 import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createTypeFromCoercer;
 import static io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketFilter;
 import static io.trino.plugin.hive.util.HiveUtil.getPrefilledColumnValue;
@@ -564,14 +565,14 @@ public class HivePageSourceProvider
                                     projectedColumn.getDereferenceIndices(),
                                     projectedColumn.getDereferenceNames(),
                                     fromHiveType,
-                                    fromHiveType.getType(typeManager, timestampPrecision));
+                                    createTypeFromCoercer(typeManager, fromHiveType, columnHandle.getHiveType(), timestampPrecision));
                         });
 
                         return new HiveColumnHandle(
                                 columnHandle.getBaseColumnName(),
                                 columnHandle.getBaseHiveColumnIndex(),
                                 fromHiveTypeBase,
-                                fromHiveTypeBase.getType(typeManager, timestampPrecision),
+                                createTypeFromCoercer(typeManager, fromHiveTypeBase, columnHandle.getBaseHiveType(), timestampPrecision),
                                 newColumnProjectionInfo,
                                 columnHandle.getColumnType(),
                                 columnHandle.getComment());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CharCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CharCoercer.java
@@ -19,7 +19,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.CharType;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.plugin.hive.HivePageSource.narrowerThan;
+import static io.trino.plugin.hive.coercions.CoercionUtils.narrowerThan;
 import static io.trino.spi.type.Chars.truncateToLengthAndTrimSpaces;
 
 public class CharCoercer

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.type.Category;
+import io.trino.plugin.hive.type.ListTypeInfo;
+import io.trino.plugin.hive.type.MapTypeInfo;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ColumnarArray;
+import io.trino.spi.block.ColumnarMap;
+import io.trino.spi.block.ColumnarRow;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarcharType;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
+import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
+import static io.trino.plugin.hive.HiveType.HIVE_FLOAT;
+import static io.trino.plugin.hive.HiveType.HIVE_INT;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
+import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToRealCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToVarcharCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDoubleToDecimalCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createRealToDecimalCoercer;
+import static io.trino.plugin.hive.util.HiveUtil.extractStructFieldTypes;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.block.ColumnarArray.toColumnarArray;
+import static io.trino.spi.block.ColumnarMap.toColumnarMap;
+import static io.trino.spi.block.ColumnarRow.toColumnarRow;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.RealType.REAL;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class CoercionUtils
+{
+    private CoercionUtils() {}
+
+    public static Optional<Function<Block, Block>> createCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
+    {
+        if (fromHiveType.equals(toHiveType)) {
+            return Optional.empty();
+        }
+
+        Type fromType = fromHiveType.getType(typeManager, timestampPrecision);
+        Type toType = toHiveType.getType(typeManager, timestampPrecision);
+
+        if (toType instanceof VarcharType toVarcharType && (fromHiveType.equals(HIVE_BYTE) || fromHiveType.equals(HIVE_SHORT) || fromHiveType.equals(HIVE_INT) || fromHiveType.equals(HIVE_LONG))) {
+            return Optional.of(new IntegerNumberToVarcharCoercer<>(fromType, toVarcharType));
+        }
+        if (fromType instanceof VarcharType fromVarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+            return Optional.of(new VarcharToIntegerNumberCoercer<>(fromVarcharType, toType));
+        }
+        if (fromType instanceof VarcharType fromVarcharType && toType instanceof VarcharType toVarcharType) {
+            if (narrowerThan(toVarcharType, fromVarcharType)) {
+                return Optional.of(new VarcharCoercer(fromVarcharType, toVarcharType));
+            }
+            return Optional.empty();
+        }
+        if (fromType instanceof CharType fromCharType && toType instanceof CharType toCharType) {
+            if (narrowerThan(toCharType, fromCharType)) {
+                return Optional.of(new CharCoercer(fromCharType, toCharType));
+            }
+            return Optional.empty();
+        }
+        if (fromHiveType.equals(HIVE_BYTE) && (toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
+        }
+        if (fromHiveType.equals(HIVE_SHORT) && (toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
+            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
+        }
+        if (fromHiveType.equals(HIVE_INT) && toHiveType.equals(HIVE_LONG)) {
+            return Optional.of(new IntegerNumberUpscaleCoercer<>(fromType, toType));
+        }
+        if (fromHiveType.equals(HIVE_FLOAT) && toHiveType.equals(HIVE_DOUBLE)) {
+            return Optional.of(new FloatToDoubleCoercer());
+        }
+        if (fromHiveType.equals(HIVE_DOUBLE) && toHiveType.equals(HIVE_FLOAT)) {
+            return Optional.of(new DoubleToFloatCoercer());
+        }
+        if (fromType instanceof DecimalType fromDecimalType && toType instanceof DecimalType toDecimalType) {
+            return Optional.of(createDecimalToDecimalCoercer(fromDecimalType, toDecimalType));
+        }
+        if (fromType instanceof DecimalType fromDecimalType && toType == DOUBLE) {
+            return Optional.of(createDecimalToDoubleCoercer(fromDecimalType));
+        }
+        if (fromType instanceof DecimalType fromDecimalType && toType == REAL) {
+            return Optional.of(createDecimalToRealCoercer(fromDecimalType));
+        }
+        if (fromType instanceof DecimalType fromDecimalType && toType instanceof VarcharType toVarcharType) {
+            return Optional.of(createDecimalToVarcharCoercer(fromDecimalType, toVarcharType));
+        }
+        if (fromType == DOUBLE && toType instanceof DecimalType toDecimalType) {
+            return Optional.of(createDoubleToDecimalCoercer(toDecimalType));
+        }
+        if (fromType == REAL && toType instanceof DecimalType toDecimalType) {
+            return Optional.of(createRealToDecimalCoercer(toDecimalType));
+        }
+        if (fromType instanceof TimestampType timestampType && toType instanceof VarcharType varcharType) {
+            if (timestampType.isShort()) {
+                return Optional.of(new TimestampCoercer.ShortTimestampToVarcharCoercer(timestampType, varcharType));
+            }
+            return Optional.of(new TimestampCoercer.LongTimestampToVarcharCoercer(timestampType, varcharType));
+        }
+        if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
+            return Optional.of(new ListCoercer(typeManager, fromHiveType, toHiveType, timestampPrecision));
+        }
+        if ((fromType instanceof MapType) && (toType instanceof MapType)) {
+            return Optional.of(new MapCoercer(typeManager, fromHiveType, toHiveType, timestampPrecision));
+        }
+        if ((fromType instanceof RowType) && (toType instanceof RowType)) {
+            HiveType fromHiveTypeStruct = (fromHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(fromType) : fromHiveType;
+            HiveType toHiveTypeStruct = (toHiveType.getCategory() == Category.UNION) ? HiveType.toHiveType(toType) : toHiveType;
+
+            return Optional.of(new StructCoercer(typeManager, fromHiveTypeStruct, toHiveTypeStruct, timestampPrecision));
+        }
+
+        throw new TrinoException(NOT_SUPPORTED, format("Unsupported coercion from %s to %s", fromHiveType, toHiveType));
+    }
+
+    public static boolean narrowerThan(VarcharType first, VarcharType second)
+    {
+        requireNonNull(first, "first is null");
+        requireNonNull(second, "second is null");
+        if (first.isUnbounded() || second.isUnbounded()) {
+            return !first.isUnbounded();
+        }
+        return first.getBoundedLength() < second.getBoundedLength();
+    }
+
+    public static boolean narrowerThan(CharType first, CharType second)
+    {
+        requireNonNull(first, "first is null");
+        requireNonNull(second, "second is null");
+        return first.getLength() < second.getLength();
+    }
+
+    private static class ListCoercer
+            implements Function<Block, Block>
+    {
+        private final Optional<Function<Block, Block>> elementCoercer;
+
+        public ListCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
+        {
+            requireNonNull(typeManager, "typeManager is null");
+            requireNonNull(fromHiveType, "fromHiveType is null");
+            requireNonNull(toHiveType, "toHiveType is null");
+            requireNonNull(timestampPrecision, "timestampPrecision is null");
+            HiveType fromElementHiveType = HiveType.valueOf(((ListTypeInfo) fromHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
+            HiveType toElementHiveType = HiveType.valueOf(((ListTypeInfo) toHiveType.getTypeInfo()).getListElementTypeInfo().getTypeName());
+            this.elementCoercer = createCoercer(typeManager, fromElementHiveType, toElementHiveType, timestampPrecision);
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            if (elementCoercer.isEmpty()) {
+                return block;
+            }
+            ColumnarArray arrayBlock = toColumnarArray(block);
+            Block elementsBlock = elementCoercer.get().apply(arrayBlock.getElementsBlock());
+            boolean[] valueIsNull = new boolean[arrayBlock.getPositionCount()];
+            int[] offsets = new int[arrayBlock.getPositionCount() + 1];
+            for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
+                valueIsNull[i] = arrayBlock.isNull(i);
+                offsets[i + 1] = offsets[i] + arrayBlock.getLength(i);
+            }
+            return ArrayBlock.fromElementBlock(arrayBlock.getPositionCount(), Optional.of(valueIsNull), offsets, elementsBlock);
+        }
+    }
+
+    private static class MapCoercer
+            implements Function<Block, Block>
+    {
+        private final Type toType;
+        private final Optional<Function<Block, Block>> keyCoercer;
+        private final Optional<Function<Block, Block>> valueCoercer;
+
+        public MapCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
+        {
+            requireNonNull(typeManager, "typeManager is null");
+            requireNonNull(fromHiveType, "fromHiveType is null");
+            requireNonNull(timestampPrecision, "timestampPrecision is null");
+            this.toType = toHiveType.getType(typeManager);
+            HiveType fromKeyHiveType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
+            HiveType fromValueHiveType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
+            HiveType toKeyHiveType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
+            HiveType toValueHiveType = HiveType.valueOf(((MapTypeInfo) toHiveType.getTypeInfo()).getMapValueTypeInfo().getTypeName());
+            this.keyCoercer = createCoercer(typeManager, fromKeyHiveType, toKeyHiveType, timestampPrecision);
+            this.valueCoercer = createCoercer(typeManager, fromValueHiveType, toValueHiveType, timestampPrecision);
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            ColumnarMap mapBlock = toColumnarMap(block);
+            Block keysBlock = keyCoercer.isEmpty() ? mapBlock.getKeysBlock() : keyCoercer.get().apply(mapBlock.getKeysBlock());
+            Block valuesBlock = valueCoercer.isEmpty() ? mapBlock.getValuesBlock() : valueCoercer.get().apply(mapBlock.getValuesBlock());
+            boolean[] valueIsNull = new boolean[mapBlock.getPositionCount()];
+            int[] offsets = new int[mapBlock.getPositionCount() + 1];
+            for (int i = 0; i < mapBlock.getPositionCount(); i++) {
+                valueIsNull[i] = mapBlock.isNull(i);
+                offsets[i + 1] = offsets[i] + mapBlock.getEntryCount(i);
+            }
+            return ((MapType) toType).createBlockFromKeyValue(Optional.of(valueIsNull), offsets, keysBlock, valuesBlock);
+        }
+    }
+
+    private static class StructCoercer
+            implements Function<Block, Block>
+    {
+        private final List<Optional<Function<Block, Block>>> coercers;
+        private final Block[] nullBlocks;
+
+        public StructCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
+        {
+            requireNonNull(typeManager, "typeManager is null");
+            requireNonNull(fromHiveType, "fromHiveType is null");
+            requireNonNull(toHiveType, "toHiveType is null");
+            requireNonNull(timestampPrecision, "timestampPrecision is null");
+            List<HiveType> fromFieldTypes = extractStructFieldTypes(fromHiveType);
+            List<HiveType> toFieldTypes = extractStructFieldTypes(toHiveType);
+            ImmutableList.Builder<Optional<Function<Block, Block>>> coercers = ImmutableList.builder();
+            this.nullBlocks = new Block[toFieldTypes.size()];
+            for (int i = 0; i < toFieldTypes.size(); i++) {
+                if (i >= fromFieldTypes.size()) {
+                    nullBlocks[i] = toFieldTypes.get(i).getType(typeManager).createBlockBuilder(null, 1).appendNull().build();
+                    coercers.add(Optional.empty());
+                }
+                else {
+                    coercers.add(createCoercer(typeManager, fromFieldTypes.get(i), toFieldTypes.get(i), timestampPrecision));
+                }
+            }
+            this.coercers = coercers.build();
+        }
+
+        @Override
+        public Block apply(Block block)
+        {
+            ColumnarRow rowBlock = toColumnarRow(block);
+            Block[] fields = new Block[coercers.size()];
+            int[] ids = new int[rowBlock.getField(0).getPositionCount()];
+            for (int i = 0; i < coercers.size(); i++) {
+                Optional<Function<Block, Block>> coercer = coercers.get(i);
+                if (coercer.isPresent()) {
+                    fields[i] = coercer.get().apply(rowBlock.getField(i));
+                }
+                else if (i < rowBlock.getFieldCount()) {
+                    fields[i] = rowBlock.getField(i);
+                }
+                else {
+                    fields[i] = DictionaryBlock.create(ids.length, nullBlocks[i], ids);
+                }
+            }
+            boolean[] valueIsNull = null;
+            if (rowBlock.mayHaveNull()) {
+                valueIsNull = new boolean[rowBlock.getPositionCount()];
+                for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+                    valueIsNull[i] = rowBlock.isNull(i);
+                }
+            }
+            return RowBlock.fromFieldBlocks(rowBlock.getPositionCount(), Optional.ofNullable(valueIsNull), fields);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -61,6 +61,7 @@ import static io.trino.spi.block.ColumnarMap.toColumnarMap;
 import static io.trino.spi.block.ColumnarRow.toColumnarRow;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -135,11 +136,8 @@ public final class CoercionUtils
         if (fromType == REAL && toType instanceof DecimalType toDecimalType) {
             return Optional.of(createRealToDecimalCoercer(toDecimalType));
         }
-        if (fromType instanceof TimestampType timestampType && toType instanceof VarcharType varcharType) {
-            if (timestampType.isShort()) {
-                return Optional.of(new TimestampCoercer.ShortTimestampToVarcharCoercer(timestampType, varcharType));
-            }
-            return Optional.of(new TimestampCoercer.LongTimestampToVarcharCoercer(timestampType, varcharType));
+        if (fromType instanceof TimestampType && toType instanceof VarcharType varcharType) {
+            return Optional.of(new TimestampCoercer.LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
         }
         if ((fromType instanceof ArrayType) && (toType instanceof ArrayType)) {
             return createCoercerForList(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -68,6 +68,13 @@ public final class CoercionUtils
 {
     private CoercionUtils() {}
 
+    public static Type createTypeFromCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
+    {
+        return createCoercer(typeManager, fromHiveType, toHiveType, timestampPrecision)
+                .map(TypeCoercer::getFromType)
+                .orElseGet(() -> fromHiveType.getType(typeManager, timestampPrecision));
+    }
+
     public static Optional<TypeCoercer<? extends Type, ? extends Type>> createCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, HiveTimestampPrecision timestampPrecision)
     {
         if (fromHiveType.equals(toHiveType)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DecimalCoercers.java
@@ -24,8 +24,6 @@ import io.trino.spi.type.Int128;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.VarcharType;
 
-import java.util.function.Function;
-
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.type.DecimalConversions.doubleToLongDecimal;
 import static io.trino.spi.type.DecimalConversions.doubleToShortDecimal;
@@ -49,7 +47,7 @@ public final class DecimalCoercers
 {
     private DecimalCoercers() {}
 
-    public static Function<Block, Block> createDecimalToDecimalCoercer(DecimalType fromType, DecimalType toType)
+    public static TypeCoercer<DecimalType, DecimalType> createDecimalToDecimalCoercer(DecimalType fromType, DecimalType toType)
     {
         if (fromType.isShort()) {
             if (toType.isShort()) {
@@ -148,7 +146,7 @@ public final class DecimalCoercers
         }
     }
 
-    public static Function<Block, Block> createDecimalToDoubleCoercer(DecimalType fromType)
+    public static TypeCoercer<DecimalType, DoubleType> createDecimalToDoubleCoercer(DecimalType fromType)
     {
         if (fromType.isShort()) {
             return new ShortDecimalToDoubleCoercer(fromType);
@@ -191,7 +189,7 @@ public final class DecimalCoercers
         }
     }
 
-    public static Function<Block, Block> createDecimalToRealCoercer(DecimalType fromType)
+    public static TypeCoercer<DecimalType, RealType> createDecimalToRealCoercer(DecimalType fromType)
     {
         if (fromType.isShort()) {
             return new ShortDecimalToRealCoercer(fromType);
@@ -234,7 +232,7 @@ public final class DecimalCoercers
         }
     }
 
-    public static Function<Block, Block> createDecimalToVarcharCoercer(DecimalType fromType, VarcharType toType)
+    public static TypeCoercer<DecimalType, VarcharType> createDecimalToVarcharCoercer(DecimalType fromType, VarcharType toType)
     {
         if (fromType.isShort()) {
             return new ShortDecimalToVarcharCoercer(fromType, toType);
@@ -288,7 +286,7 @@ public final class DecimalCoercers
         }
     }
 
-    public static Function<Block, Block> createDoubleToDecimalCoercer(DecimalType toType)
+    public static TypeCoercer<DoubleType, DecimalType> createDoubleToDecimalCoercer(DecimalType toType)
     {
         if (toType.isShort()) {
             return new DoubleToShortDecimalCoercer(toType);
@@ -328,7 +326,7 @@ public final class DecimalCoercers
         }
     }
 
-    public static Function<Block, Block> createRealToDecimalCoercer(DecimalType toType)
+    public static TypeCoercer<RealType, DecimalType> createRealToDecimalCoercer(DecimalType toType)
     {
         if (toType.isShort()) {
             return new RealToShortDecimalCoercer(toType);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
@@ -48,29 +48,6 @@ public final class TimestampCoercer
 
     private TimestampCoercer() {}
 
-    public static class ShortTimestampToVarcharCoercer
-            extends TypeCoercer<TimestampType, VarcharType>
-    {
-        public ShortTimestampToVarcharCoercer(TimestampType fromType, VarcharType toType)
-        {
-            super(fromType, toType);
-        }
-
-        @Override
-        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
-        {
-            long epochMicros = fromType.getLong(block, position);
-            long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
-            int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
-            toType.writeSlice(
-                    blockBuilder,
-                    truncateToLength(
-                            Slices.utf8Slice(
-                                    LOCAL_DATE_TIME.format(LocalDateTime.ofEpochSecond(epochSecond, nanoFraction, UTC))),
-                            toType));
-        }
-    }
-
     public static class LongTimestampToVarcharCoercer
             extends TypeCoercer<TimestampType, VarcharType>
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarcharCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/VarcharCoercer.java
@@ -19,7 +19,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.VarcharType;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.plugin.hive.HivePageSource.narrowerThan;
+import static io.trino.plugin.hive.coercions.CoercionUtils.narrowerThan;
 import static io.trino.spi.type.Varchars.truncateToLength;
 
 public class VarcharCoercer

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -90,7 +90,6 @@ import static io.trino.plugin.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcMaxReadBlockSize;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static io.trino.plugin.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
-import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isOrcNestedLazy;
 import static io.trino.plugin.hive.HiveSessionProperties.isUseOrcColumnNames;
@@ -366,7 +365,7 @@ public class OrcPageSourceFactory
                 Type readType = column.getType();
                 if (orcColumn != null) {
                     int sourceIndex = fileReadColumns.size();
-                    Optional<TypeCoercer<?, ?>> coercer = createCoercer(orcColumn.getColumnType(), readType, getTimestampPrecision(session));
+                    Optional<TypeCoercer<?, ?>> coercer = createCoercer(orcColumn.getColumnType(), readType);
                     if (coercer.isPresent()) {
                         fileReadTypes.add(coercer.get().getFromType());
                         columnAdaptations.add(ColumnAdaptation.coercedColumn(sourceIndex, coercer.get()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -14,31 +14,24 @@
 package io.trino.plugin.hive.orc;
 
 import io.trino.orc.metadata.OrcType.OrcTypeKind;
-import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
-import io.trino.plugin.hive.coercions.TimestampCoercer.ShortTimestampToVarcharCoercer;
 import io.trino.plugin.hive.coercions.TypeCoercer;
-import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import java.util.Optional;
 
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.TIMESTAMP;
-import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 
 public final class OrcTypeTranslator
 {
     private OrcTypeTranslator() {}
 
-    public static Optional<TypeCoercer<? extends Type, ? extends Type>> createCoercer(OrcTypeKind fromOrcType, Type toTrinoType, HiveTimestampPrecision timestampPrecision)
+    public static Optional<TypeCoercer<? extends Type, ? extends Type>> createCoercer(OrcTypeKind fromOrcType, Type toTrinoType)
     {
         if (fromOrcType == TIMESTAMP && toTrinoType instanceof VarcharType varcharType) {
-            TimestampType timestampType = createTimestampType(timestampPrecision.getPrecision());
-            if (timestampType.isShort()) {
-                return Optional.of(new ShortTimestampToVarcharCoercer(timestampType, varcharType));
-            }
-            return Optional.of(new LongTimestampToVarcharCoercer(timestampType, varcharType));
+            return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
         }
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -26,10 +26,10 @@ import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
 
-import static io.trino.plugin.hive.HivePageSource.createCoercer;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
 import static io.trino.spi.predicate.Utils.blockToNativeValue;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -26,13 +26,11 @@ import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
 
-import static io.trino.plugin.hive.HiveTimestampPrecision.MICROSECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
 import static io.trino.spi.predicate.Utils.blockToNativeValue;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
@@ -44,15 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestTimestampCoercer
 {
     @Test(dataProvider = "timestampValuesProvider")
-    public void testShortTimestampToVarchar(String timestampValue, String hiveTimestampValue)
-    {
-        LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
-        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_MICROS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createUnboundedVarcharType(), hiveTimestampValue);
-    }
-
-    @Test(dataProvider = "timestampValuesProvider")
-    public void testLongTimestampToVarchar(String timestampValue, String hiveTimestampValue)
+    public void testTimestampToVarchar(String timestampValue, String hiveTimestampValue)
     {
         LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
         SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
@@ -60,47 +50,40 @@ public class TestTimestampCoercer
     }
 
     @Test
-    public void testShortTimestampToSmallerVarchar()
-    {
-        LocalDateTime localDateTime = LocalDateTime.parse("2023-04-11T05:16:12.345678");
-        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_MICROS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(1), "2");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(2), "20");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(3), "202");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(4), "2023");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(5), "2023-");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(6), "2023-0");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(7), "2023-04");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(8), "2023-04-");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(9), "2023-04-1");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(10), "2023-04-11");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(11), "2023-04-11 ");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(12), "2023-04-11 0");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(13), "2023-04-11 05");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(14), "2023-04-11 05:");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(15), "2023-04-11 05:1");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(16), "2023-04-11 05:16");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(17), "2023-04-11 05:16:");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(18), "2023-04-11 05:16:1");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(19), "2023-04-11 05:16:12");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(20), "2023-04-11 05:16:12.");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(21), "2023-04-11 05:16:12.3");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(22), "2023-04-11 05:16:12.34");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(23), "2023-04-11 05:16:12.345");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(24), "2023-04-11 05:16:12.3456");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(25), "2023-04-11 05:16:12.34567");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(26), "2023-04-11 05:16:12.345678");
-        assertShortTimestampToVarcharCoercions(TIMESTAMP_MICROS, timestamp.getEpochMicros(), createVarcharType(27), "2023-04-11 05:16:12.345678");
-    }
-
-    @Test
-    public void testLongTimestampToSmallerVarchar()
+    public void testTimestampToSmallerVarchar()
     {
         LocalDateTime localDateTime = LocalDateTime.parse("2023-04-11T05:16:12.345678876");
         SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
-        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(27), "2023-04-11 05:16:12.3456788");
-        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(28), "2023-04-11 05:16:12.34567887");
-        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createVarcharType(29), "2023-04-11 05:16:12.345678876");
+        LongTimestamp longTimestamp = new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros());
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(1), "2");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(2), "20");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(3), "202");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(4), "2023");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(5), "2023-");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(6), "2023-0");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(7), "2023-04");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(8), "2023-04-");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(9), "2023-04-1");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(10), "2023-04-11");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(11), "2023-04-11 ");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(12), "2023-04-11 0");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(13), "2023-04-11 05");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(14), "2023-04-11 05:");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(15), "2023-04-11 05:1");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(16), "2023-04-11 05:16");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(17), "2023-04-11 05:16:");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(18), "2023-04-11 05:16:1");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(19), "2023-04-11 05:16:12");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(20), "2023-04-11 05:16:12.");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(21), "2023-04-11 05:16:12.3");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(22), "2023-04-11 05:16:12.34");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(23), "2023-04-11 05:16:12.345");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(24), "2023-04-11 05:16:12.3456");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(25), "2023-04-11 05:16:12.34567");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(26), "2023-04-11 05:16:12.345678");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(27), "2023-04-11 05:16:12.3456788");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(28), "2023-04-11 05:16:12.34567887");
+        assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, longTimestamp, createVarcharType(29), "2023-04-11 05:16:12.345678876");
     }
 
     @DataProvider
@@ -127,11 +110,6 @@ public class TestTimestampCoercer
                 // before epoch with second fraction
                 {"1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456"}
         };
-    }
-
-    public static void assertShortTimestampToVarcharCoercions(TimestampType fromType, Long valueToBeCoerced, VarcharType toType, String expectedValue)
-    {
-        assertCoercions(fromType, valueToBeCoerced, toType, Slices.utf8Slice(expectedValue), MICROSECONDS);
     }
 
     public static void assertLongTimestampToVarcharCoercions(TimestampType fromType, LongTimestamp valueToBeCoerced, VarcharType toType, String expectedValue)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -135,9 +135,10 @@ public class TestHiveCoercionOnPartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("" +
                         "CREATE TABLE %NAME%(" +
-                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT>, " +
-                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT>>, " +
-                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT>>" +
+                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>, " +
+                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>, " +
+                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>," +
+                        "    timestamp_to_string                  TIMESTAMP" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -90,9 +90,10 @@ public class TestHiveCoercionOnUnpartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("""
                          CREATE TABLE %NAME%(
-                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT>,
-                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT>>,
-                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT>>,
+                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>,
+                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>,
+                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>,
+                             timestamp_to_string        TIMESTAMP,
                              id                         BIGINT)
                         STORED AS\s""" + fileFormat);
     }
@@ -146,6 +147,9 @@ public class TestHiveCoercionOnUnpartitionedTable
                 .put(columnContext("orc", "long_decimal_to_varchar"), "Cannot read SQL type 'varchar' from ORC stream '.long_decimal_to_varchar' of type DECIMAL")
                 .put(columnContext("orc", "short_decimal_to_bounded_varchar"), "Cannot read SQL type 'varchar(30)' from ORC stream '.short_decimal_to_bounded_varchar' of type DECIMAL")
                 .put(columnContext("orc", "long_decimal_to_bounded_varchar"), "Cannot read SQL type 'varchar(30)' from ORC stream '.long_decimal_to_bounded_varchar' of type DECIMAL")
+                .put(columnContext("orc", "timestamp_row_to_row"), "Cannot read SQL type 'varchar' from ORC stream '.timestamp_row_to_row.timestamp2string' of type TIMESTAMP with attributes {}")
+                .put(columnContext("orc", "timestamp_list_to_list"), "Cannot read SQL type 'varchar' from ORC stream '.timestamp_row_to_row.timestamp2string' of type TIMESTAMP with attributes {}")
+                .put(columnContext("orc", "timestamp_map_to_map"), "Cannot read SQL type 'varchar' from ORC stream '.timestamp_row_to_row.timestamp2string' of type TIMESTAMP with attributes {}")
                 .buildOrThrow();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This will be irrespective of the precision configured or specified as
session property.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Depends on https://github.com/trinodb/trino/pull/17900.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Treat precision as NANOSECONDS for timestamp to be coerced.
```
