### PR TITLE
Add support for varchar to timestamp coercion in hive tables

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -16,6 +16,8 @@ package io.trino.plugin.hive.coercions;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
 import io.trino.plugin.hive.type.Category;
 import io.trino.plugin.hive.type.ListTypeInfo;
 import io.trino.plugin.hive.type.MapTypeInfo;
@@ -90,6 +92,12 @@ public final class CoercionUtils
         }
         if (fromType instanceof VarcharType fromVarcharType && (toHiveType.equals(HIVE_BYTE) || toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG))) {
             return Optional.of(new VarcharToIntegerNumberCoercer<>(fromVarcharType, toType));
+        }
+        if (fromType instanceof VarcharType varcharType && toType instanceof TimestampType timestampType) {
+            if (timestampType.isShort()) {
+                return Optional.of(new VarcharToShortTimestampCoercer(varcharType, timestampType));
+            }
+            return Optional.of(new VarcharToLongTimestampCoercer(varcharType, timestampType));
         }
         if (fromType instanceof VarcharType fromVarcharType && toType instanceof VarcharType toVarcharType) {
             if (narrowerThan(toVarcharType, fromVarcharType)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/TimestampCoercer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.coercions;
 
+import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -25,19 +26,27 @@ import java.time.LocalDateTime;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_TIMESTAMP_COERCION;
+import static io.trino.spi.type.TimestampType.MAX_PRECISION;
+import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.Timestamps.SECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.round;
+import static io.trino.spi.type.Timestamps.roundDiv;
 import static io.trino.spi.type.Varchars.truncateToLength;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+import static java.time.format.ResolverStyle.STRICT;
 
 public final class TimestampCoercer
 {
@@ -47,6 +56,7 @@ public final class TimestampCoercer
             .appendLiteral(' ')
             .append(ISO_LOCAL_TIME)
             .toFormatter()
+            .withResolverStyle(STRICT)
             .withChronology(IsoChronology.INSTANCE);
 
     // Before 1900, Java Time and Joda Time are not consistent with java.sql.Date and java.util.Calendar
@@ -81,6 +91,68 @@ public final class TimestampCoercer
                             Slices.utf8Slice(
                                     LOCAL_DATE_TIME.format(LocalDateTime.ofEpochSecond(epochSecond, toIntExact(nanosFraction), UTC))),
                             toType));
+        }
+    }
+
+    public static class VarcharToShortTimestampCoercer
+            extends TypeCoercer<VarcharType, TimestampType>
+    {
+        public VarcharToShortTimestampCoercer(VarcharType fromType, TimestampType toType)
+        {
+            super(fromType, toType);
+            checkArgument(toType.isShort(), format("TIMESTAMP precision must be in range [0, %s]: %s", MAX_PRECISION, toType.getPrecision()));
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            try {
+                Slice value = fromType.getSlice(block, position);
+                LocalDateTime dateTime = LOCAL_DATE_TIME.parse(value.toStringUtf8(), LocalDateTime::from);
+                long epochSecond = dateTime.toEpochSecond(UTC);
+                if (epochSecond < START_OF_MODERN_ERA_SECONDS) {
+                    throw new TrinoException(HIVE_INVALID_TIMESTAMP_COERCION, "Coercion on historical dates is not supported");
+                }
+                long roundedNanos = round(dateTime.getNano(), 9 - toType.getPrecision());
+                long epochMicros = epochSecond * MICROSECONDS_PER_SECOND + roundDiv(roundedNanos, NANOSECONDS_PER_MICROSECOND);
+                toType.writeLong(blockBuilder, epochMicros);
+            }
+            catch (DateTimeParseException ignored) {
+                // Hive treats invalid String as null instead of propagating exception
+                // In case of bigger tables with all values being invalid, log output will be huge so avoiding log here.
+                blockBuilder.appendNull();
+            }
+        }
+    }
+
+    public static class VarcharToLongTimestampCoercer
+            extends TypeCoercer<VarcharType, TimestampType>
+    {
+        public VarcharToLongTimestampCoercer(VarcharType fromType, TimestampType toType)
+        {
+            super(fromType, toType);
+            checkArgument(!toType.isShort(), format("Precision must be in the range [%s, %s]", MAX_SHORT_PRECISION + 1, MAX_PRECISION));
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            try {
+                Slice value = fromType.getSlice(block, position);
+                LocalDateTime dateTime = LOCAL_DATE_TIME.parse(value.toStringUtf8(), LocalDateTime::from);
+                long epochSecond = dateTime.toEpochSecond(UTC);
+                if (epochSecond < START_OF_MODERN_ERA_SECONDS) {
+                    throw new TrinoException(HIVE_INVALID_TIMESTAMP_COERCION, "Coercion on historical dates is not supported");
+                }
+                long epochMicros = epochSecond * MICROSECONDS_PER_SECOND + dateTime.getNano() / NANOSECONDS_PER_MICROSECOND;
+                int picosOfMicro = (dateTime.getNano() % NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND;
+                toType.writeObject(blockBuilder, new LongTimestamp(epochMicros, picosOfMicro));
+            }
+            catch (DateTimeParseException ignored) {
+                // Hive treats invalid String as null instead of propagating exception
+                // In case of bigger tables with all values being invalid, log output will be huge so avoiding log here.
+                blockBuilder.appendNull();
+            }
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -15,14 +15,20 @@ package io.trino.plugin.hive.orc;
 
 import io.trino.orc.metadata.OrcType.OrcTypeKind;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
 import io.trino.plugin.hive.coercions.TypeCoercer;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
 import java.util.Optional;
 
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.STRING;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.TIMESTAMP;
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.VARCHAR;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 
 public final class OrcTypeTranslator
 {
@@ -33,6 +39,17 @@ public final class OrcTypeTranslator
         if (fromOrcType == TIMESTAMP && toTrinoType instanceof VarcharType varcharType) {
             return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
         }
+        if (isVarcharType(fromOrcType) && toTrinoType instanceof TimestampType timestampType) {
+            if (timestampType.isShort()) {
+                return Optional.of(new VarcharToShortTimestampCoercer(createUnboundedVarcharType(), timestampType));
+            }
+            return Optional.of(new VarcharToLongTimestampCoercer(createUnboundedVarcharType(), timestampType));
+        }
         return Optional.empty();
+    }
+
+    private static boolean isVarcharType(OrcTypeKind orcTypeKind)
+    {
+        return orcTypeKind == STRING || orcTypeKind == VARCHAR;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -63,7 +63,8 @@ public final class HiveCoercionPolicy
                     toHiveType.equals(HIVE_BYTE) ||
                     toHiveType.equals(HIVE_SHORT) ||
                     toHiveType.equals(HIVE_INT) ||
-                    toHiveType.equals(HIVE_LONG);
+                    toHiveType.equals(HIVE_LONG) ||
+                    toHiveType.equals(HIVE_TIMESTAMP);
         }
         if (fromType instanceof CharType) {
             return toType instanceof CharType;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive.coercions;
 
-import io.airlift.slice.Slices;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -27,6 +26,7 @@ import org.testng.annotations.Test;
 
 import java.time.LocalDateTime;
 
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
@@ -131,7 +131,7 @@ public class TestTimestampCoercer
 
     public static void assertLongTimestampToVarcharCoercions(TimestampType fromType, LongTimestamp valueToBeCoerced, VarcharType toType, String expectedValue)
     {
-        assertCoercions(fromType, valueToBeCoerced, toType, Slices.utf8Slice(expectedValue), NANOSECONDS);
+        assertCoercions(fromType, valueToBeCoerced, toType, utf8Slice(expectedValue), NANOSECONDS);
     }
 
     public static void assertCoercions(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue, HiveTimestampPrecision timestampPrecision)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -122,7 +122,9 @@ public class TestHiveCoercionOnPartitionedTable
                         "    char_to_smaller_char               CHAR(3)," +
                         "    timestamp_to_string                TIMESTAMP," +
                         "    timestamp_to_bounded_varchar       TIMESTAMP," +
-                        "    timestamp_to_smaller_varchar       TIMESTAMP" +
+                        "    timestamp_to_smaller_varchar       TIMESTAMP," +
+                        "    smaller_varchar_to_timestamp       VARCHAR(4)," +
+                        "    varchar_to_timestamp               STRING" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +
@@ -135,10 +137,11 @@ public class TestHiveCoercionOnPartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("" +
                         "CREATE TABLE %NAME%(" +
-                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>, " +
-                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>, " +
-                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>," +
-                        "    timestamp_to_string                  TIMESTAMP" +
+                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>, " +
+                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>, " +
+                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>," +
+                        "    timestamp_to_string                  TIMESTAMP," +
+                        "    string_to_timestamp                  STRING" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -80,6 +80,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                             timestamp_to_string                TIMESTAMP,
                             timestamp_to_bounded_varchar       TIMESTAMP,
                             timestamp_to_smaller_varchar       TIMESTAMP,
+                            smaller_varchar_to_timestamp       VARCHAR(4),
+                            varchar_to_timestamp               STRING,
                             id                                 BIGINT)
                        STORED AS\s""" + fileFormat);
     }
@@ -90,10 +92,11 @@ public class TestHiveCoercionOnUnpartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("""
                          CREATE TABLE %NAME%(
-                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>,
-                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>,
-                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP>>,
+                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>,
+                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>,
+                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>,
                              timestamp_to_string        TIMESTAMP,
+                             string_to_timestamp        STRING,
                              id                         BIGINT)
                         STORED AS\s""" + fileFormat);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allows coerce a varchar type to timestamp in hive tables. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Depends on https://github.com/trinodb/trino/pull/18004

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add support for varchar to timestamp coercion in hive tables 
```
