### PR TITLE
Fix broken release process

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -14,7 +14,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.presto-jdbc-under-test>${project.version}</dep.presto-jdbc-under-test>
+        <!-- Version needs to be hardcoded for the release plugin to work. It will be updated by the release plugin. -->
+        <dep.presto-jdbc-under-test>420-SNAPSHOT</dep.presto-jdbc-under-test>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The release fails with:

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5:prepare (default-cli) on project trino-root: The artifact (io.trino:trino-jdbc) requires a different version (420) than what is found (${project.version}) for the expression (dep.presto-jdbc-under-test) in the project (io.trino:trino-test-jdbc-compatibility-old-driver). -> [Help 1]

This reverts commit 56083aac50bacc2775b8512e00bd477b2d22f1ea.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
