### PR TITLE
Reduce query lock contention

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -23,7 +23,6 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.client.ProtocolHeaders;
-import io.trino.client.QueryResults;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.QueryManager;
 import io.trino.operator.DirectExchangeClientSupplier;
@@ -220,52 +219,52 @@ public class ExecutingStatementResource
         else {
             targetResultSize = Ordering.natural().min(targetResultSize, MAX_TARGET_RESULT_SIZE);
         }
-        ListenableFuture<QueryResults> queryResultsFuture = query.waitForResults(token, uriInfo, wait, targetResultSize);
+        ListenableFuture<QueryResultsResponse> queryResultsFuture = query.waitForResults(token, uriInfo, wait, targetResultSize);
 
-        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, queryResults -> toResponse(query, queryResults), directExecutor());
+        ListenableFuture<Response> response = Futures.transform(queryResultsFuture, this::toResponse, directExecutor());
 
         bindAsyncResponse(asyncResponse, response, responseExecutor);
     }
 
-    private Response toResponse(Query query, QueryResults queryResults)
+    private Response toResponse(QueryResultsResponse resultsResponse)
     {
-        ResponseBuilder response = Response.ok(queryResults);
+        ResponseBuilder response = Response.ok(resultsResponse.queryResults());
 
-        ProtocolHeaders protocolHeaders = query.getProtocolHeaders();
-        query.getSetCatalog().ifPresent(catalog -> response.header(protocolHeaders.responseSetCatalog(), catalog));
-        query.getSetSchema().ifPresent(schema -> response.header(protocolHeaders.responseSetSchema(), schema));
-        query.getSetPath().ifPresent(path -> response.header(protocolHeaders.responseSetPath(), path));
+        ProtocolHeaders protocolHeaders = resultsResponse.protocolHeaders();
+        resultsResponse.setCatalog().ifPresent(catalog -> response.header(protocolHeaders.responseSetCatalog(), catalog));
+        resultsResponse.setSchema().ifPresent(schema -> response.header(protocolHeaders.responseSetSchema(), schema));
+        resultsResponse.setPath().ifPresent(path -> response.header(protocolHeaders.responseSetPath(), path));
 
         // add set session properties
-        query.getSetSessionProperties()
+        resultsResponse.setSessionProperties()
                 .forEach((key, value) -> response.header(protocolHeaders.responseSetSession(), key + '=' + urlEncode(value)));
 
         // add clear session properties
-        query.getResetSessionProperties()
+        resultsResponse.resetSessionProperties()
                 .forEach(name -> response.header(protocolHeaders.responseClearSession(), name));
 
         // add set roles
-        query.getSetRoles()
+        resultsResponse.setRoles()
                 .forEach((key, value) -> response.header(protocolHeaders.responseSetRole(), key + '=' + urlEncode(value.toString())));
 
         // add added prepare statements
-        for (Entry<String, String> entry : query.getAddedPreparedStatements().entrySet()) {
+        for (Entry<String, String> entry : resultsResponse.addedPreparedStatements().entrySet()) {
             String encodedKey = urlEncode(entry.getKey());
             String encodedValue = urlEncode(preparedStatementEncoder.encodePreparedStatementForHeader(entry.getValue()));
             response.header(protocolHeaders.responseAddedPrepare(), encodedKey + '=' + encodedValue);
         }
 
         // add deallocated prepare statements
-        for (String name : query.getDeallocatedPreparedStatements()) {
+        for (String name : resultsResponse.deallocatedPreparedStatements()) {
             response.header(protocolHeaders.responseDeallocatedPrepare(), urlEncode(name));
         }
 
         // add new transaction ID
-        query.getStartedTransactionId()
+        resultsResponse.startedTransactionId()
                 .ifPresent(transactionId -> response.header(protocolHeaders.responseStartedTransactionId(), transactionId));
 
         // add clear transaction ID directive
-        if (query.isClearTransactionId()) {
+        if (resultsResponse.clearTransactionId()) {
             response.header(protocolHeaders.responseClearTransactionId(), true);
         }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultsResponse.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultsResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol;
+
+import io.trino.client.ProtocolHeaders;
+import io.trino.client.QueryResults;
+import io.trino.spi.security.SelectedRole;
+import io.trino.transaction.TransactionId;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+record QueryResultsResponse(
+        Optional<String> setCatalog,
+        Optional<String> setSchema,
+        Optional<String> setPath,
+        Map<String, String> setSessionProperties,
+        Set<String> resetSessionProperties,
+        Map<String, SelectedRole> setRoles,
+        Map<String, String> addedPreparedStatements,
+        Set<String> deallocatedPreparedStatements,
+        Optional<TransactionId> startedTransactionId,
+        boolean clearTransactionId,
+        ProtocolHeaders protocolHeaders,
+        QueryResults queryResults)
+{
+    QueryResultsResponse {
+        requireNonNull(setCatalog, "setCatalog is null");
+        requireNonNull(setSchema, "setSchema is null");
+        requireNonNull(setPath, "setPath is null");
+        requireNonNull(setSessionProperties, "setSessionProperties is null");
+        requireNonNull(resetSessionProperties, "resetSessionProperties is null");
+        requireNonNull(setRoles, "setRoles is null");
+        requireNonNull(addedPreparedStatements, "addedPreparedStatements is null");
+        requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
+        requireNonNull(startedTransactionId, "startedTransactionId is null");
+        requireNonNull(protocolHeaders, "protocolHeaders is null");
+        requireNonNull(queryResults, "queryResults is null");
+    }
+}


### PR DESCRIPTION
## Description
Reduces sources of lock contention associated with `Query#waitForResults` and it's usage by `ExecutingStatementResource`, largely by passing the additional protocol header fields along with the `QueryResults` payload in a single record class.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
