### PR TITLE
Fixes data duplication when Hudi Table contains a replace commit

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.hudi.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
@@ -21,20 +23,30 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HudiReplaceCommitMetadata
 {
-    private Map<String, List<String>> partitionToReplaceFileIds;
-    private Boolean compacted;
+    private final Map<String, List<String>> partitionToReplaceFileIds;
+    private final Boolean compacted;
 
     // for ser/deser
     public HudiReplaceCommitMetadata()
     {
         partitionToReplaceFileIds = ImmutableMap.of();
         compacted = false;
+    }
+
+    @JsonCreator
+    public HudiReplaceCommitMetadata(
+            @JsonProperty("partitionToReplaceFileIds") Map<String, List<String>> partitionToReplaceFileIds,
+            @JsonProperty("compacted") Boolean compacted)
+    {
+        this.partitionToReplaceFileIds = ImmutableMap.copyOf(partitionToReplaceFileIds);
+        this.compacted = compacted;
     }
 
     public Map<String, List<String>> getPartitionToReplaceFileIds()
@@ -53,14 +65,14 @@ public class HudiReplaceCommitMetadata
         }
 
         HudiReplaceCommitMetadata that = (HudiReplaceCommitMetadata) o;
-
-        return compacted.equals(that.compacted);
+        return Objects.equals(partitionToReplaceFileIds, (that)) &&
+                compacted.equals(that.compacted);
     }
 
     @Override
     public int hashCode()
     {
-        return compacted.hashCode();
+        return Objects.hash(partitionToReplaceFileIds, compacted);
     }
 
     public static <T> T fromBytes(byte[] bytes, ObjectMapper objectMapper, Class<T> clazz)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
@@ -135,7 +135,7 @@ public class HudiTableMetaClient
 
     public String getSchemaFolderName()
     {
-        return metaPath.appendPath(SCHEMA_FOLDER_NAME).path();
+        return metaPath.appendPath(SCHEMA_FOLDER_NAME).toString();
     }
 
     private static HudiTableMetaClient newMetaClient(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
@@ -85,7 +85,7 @@ public class HudiActiveTimeline
 
     private Location getInstantFileNamePath(String fileName)
     {
-        return Location.of(fileName.contains(SCHEMA_COMMIT_ACTION) ? metaClient.getSchemaFolderName() : metaClient.getMetaPath().path()).appendPath(fileName);
+        return Location.of(fileName.contains(SCHEMA_COMMIT_ACTION) ? metaClient.getSchemaFolderName() : metaClient.getMetaPath().toString()).appendPath(fileName);
     }
 
     private Optional<byte[]> readDataFromPath(Location detailPath)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If the Hudi table contains a replace commit generated by the clustering service, duplicate data is returned.
The exclude logic does not work when there is a REPLACE COMMIT.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This logic not works

https://github.com/trinodb/trino/blob/ca9b4a9c56d3f8c46ad30df361eb2faabb3e2505/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java#L214-L217


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```