### PR TITLE
Add missing return in BigQueryStorageAvroPageSource

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
@@ -271,6 +271,7 @@ public class BigQueryStorageAvroPageSource
                     appendTo(type.getTypeParameters().get(index), record.get(fieldNames.get(index)), fieldBuilders.get(index));
                 }
             });
+            return;
         }
         throw new TrinoException(GENERIC_INTERNAL_ERROR, "Unhandled type for Block: " + type.getTypeSignature());
     }


### PR DESCRIPTION
(x) This is not user-visible or docs only and no release notes are required.
