### PR TITLE
Add reusable implementations of comparable and ordering operator for variable width types.

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/JsonType.java
+++ b/core/trino-main/src/main/java/io/trino/type/JsonType.java
@@ -15,24 +15,15 @@ package io.trino.type;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.function.BlockIndex;
-import io.trino.spi.function.BlockPosition;
-import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractVariableWidthType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TypeOperatorDeclaration;
 import io.trino.spi.type.TypeOperators;
 import io.trino.spi.type.TypeSignature;
-
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.XX_HASH_64;
-import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
-import static java.lang.invoke.MethodHandles.lookup;
 
 /**
  * The stack representation for JSON objects must have the keys in natural sorted order.
@@ -40,8 +31,6 @@ import static java.lang.invoke.MethodHandles.lookup;
 public class JsonType
         extends AbstractVariableWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(JsonType.class, lookup(), Slice.class);
-
     public static final JsonType JSON = new JsonType();
 
     private JsonType()
@@ -58,7 +47,7 @@ public class JsonType
     @Override
     public TypeOperatorDeclaration getTypeOperatorDeclaration(TypeOperators typeOperators)
     {
-        return TYPE_OPERATOR_DECLARATION;
+        return DEFAULT_COMPARABLE_OPERATORS;
     }
 
     @Override
@@ -103,34 +92,5 @@ public class JsonType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         ((VariableWidthBlockBuilder) blockBuilder).writeEntry(value, offset, length);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(Slice left, Slice right)
-    {
-        return left.equals(right);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(Slice value)
-    {
-        return XxHash64.hash(value);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -451,6 +451,14 @@
                                     <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.BlockBuilder io.trino.spi.block.VariableWidthBlockBuilder::writeLong(long)</old>
                                 </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.type.TypeOperatorDeclaration.Builder::&lt;init&gt;(java.lang.Class&lt;?&gt;)</old>
+                                    <new>method void io.trino.spi.type.TypeOperatorDeclaration.Builder::&lt;init&gt;(java.lang.Class&lt;?&gt;)</new>
+                                    <oldVisibility>public</oldVisibility>
+                                    <newVisibility>private</newVisibility>
+                                    <justification>Constructor should have never been public as there is a static factory method</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
@@ -87,6 +87,23 @@ public abstract class AbstractVariableWidthType
             return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
         }
 
+        @ScalarOperator(EQUAL)
+        private static boolean equalOperator(Slice left, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+        {
+            return equalOperator(rightBlock, rightPosition, left);
+        }
+
+        @ScalarOperator(EQUAL)
+        private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, Slice right)
+        {
+            int leftLength = leftBlock.getSliceLength(leftPosition);
+            int rightLength = right.length();
+            if (leftLength != rightLength) {
+                return false;
+            }
+            return leftBlock.bytesEqual(leftPosition, 0, right, 0, leftLength);
+        }
+
         @ScalarOperator(XX_HASH_64)
         private static long xxHash64Operator(Slice value)
         {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/AbstractVariableWidthType.java
@@ -13,17 +13,30 @@
  */
 package io.trino.spi.type;
 
+import io.airlift.slice.Slice;
+import io.airlift.slice.XxHash64;
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.block.VariableWidthBlockBuilder;
+import io.trino.spi.function.BlockIndex;
+import io.trino.spi.function.BlockPosition;
+import io.trino.spi.function.ScalarOperator;
 
+import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.OperatorType.EQUAL;
+import static io.trino.spi.function.OperatorType.XX_HASH_64;
+import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Math.min;
+import static java.lang.invoke.MethodHandles.lookup;
 
 public abstract class AbstractVariableWidthType
         extends AbstractType
         implements VariableWidthType
 {
     protected static final int EXPECTED_BYTES_PER_ENTRY = 32;
+    protected static final TypeOperatorDeclaration DEFAULT_COMPARABLE_OPERATORS = extractOperatorDeclaration(DefaultComparableOperators.class, lookup(), Slice.class);
+    protected static final TypeOperatorDeclaration DEFAULT_ORDERING_OPERATORS = extractOperatorDeclaration(DefaultOrderingOperators.class, lookup(), Slice.class);
 
     protected AbstractVariableWidthType(TypeSignature signature, Class<?> javaType)
     {
@@ -53,5 +66,68 @@ public abstract class AbstractVariableWidthType
     public VariableWidthBlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         return createBlockBuilder(blockBuilderStatus, expectedEntries, EXPECTED_BYTES_PER_ENTRY);
+    }
+
+    private static class DefaultComparableOperators
+    {
+        @ScalarOperator(EQUAL)
+        private static boolean equalOperator(Slice left, Slice right)
+        {
+            return left.equals(right);
+        }
+
+        @ScalarOperator(EQUAL)
+        private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+        {
+            int leftLength = leftBlock.getSliceLength(leftPosition);
+            int rightLength = rightBlock.getSliceLength(rightPosition);
+            if (leftLength != rightLength) {
+                return false;
+            }
+            return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
+        }
+
+        @ScalarOperator(XX_HASH_64)
+        private static long xxHash64Operator(Slice value)
+        {
+            return XxHash64.hash(value);
+        }
+
+        @ScalarOperator(XX_HASH_64)
+        private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
+        {
+            return block.hash(position, 0, block.getSliceLength(position));
+        }
+    }
+
+    private static class DefaultOrderingOperators
+    {
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
+        private static long comparisonOperator(Slice left, Slice right)
+        {
+            return left.compareTo(right);
+        }
+
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
+        private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+        {
+            int leftLength = leftBlock.getSliceLength(leftPosition);
+            int rightLength = rightBlock.getSliceLength(rightPosition);
+            return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
+        }
+
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
+        private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, Slice right)
+        {
+            int leftLength = leftBlock.getSliceLength(leftPosition);
+            return leftBlock.bytesCompare(leftPosition, 0, leftLength, right, 0, right.length());
+        }
+
+        @ScalarOperator(COMPARISON_UNORDERED_LAST)
+        private static long comparisonOperator(Slice left, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+        {
+            int rightLength = rightBlock.getSliceLength(rightPosition);
+            return -rightBlock.bytesCompare(rightPosition, 0, rightLength, left, 0, left.length());
+        }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
@@ -16,14 +16,11 @@ package io.trino.spi.type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceUtf8;
 import io.airlift.slice.Slices;
-import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.function.BlockIndex;
-import io.trino.spi.function.BlockPosition;
 import io.trino.spi.function.ScalarOperator;
 
 import java.util.Objects;
@@ -31,12 +28,9 @@ import java.util.Optional;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Chars.compareChars;
 import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.Slices.sliceRepresentation;
-import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.MIN_CODE_POINT;
 import static java.lang.Math.toIntExact;
@@ -47,7 +41,10 @@ import static java.util.Collections.singletonList;
 public final class CharType
         extends AbstractVariableWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(CharType.class, lookup(), Slice.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(Slice.class)
+            .addOperators(DEFAULT_COMPARABLE_OPERATORS)
+            .addOperators(CharType.class, lookup())
+            .build();
 
     public static final int MAX_LENGTH = 65_536;
     private static final CharType[] CACHED_INSTANCES = new CharType[128];
@@ -237,35 +234,6 @@ public final class CharType
     public int hashCode()
     {
         return Objects.hash(length);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(Slice left, Slice right)
-    {
-        return left.equals(right);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(Slice value)
-    {
-        return XxHash64.hash(value);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_LAST)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -164,10 +164,24 @@ public final class TypeOperatorDeclaration
         private final Collection<OperatorMethodHandle> lessThanOperators = new ArrayList<>();
         private final Collection<OperatorMethodHandle> lessThanOrEqualOperators = new ArrayList<>();
 
-        public Builder(Class<?> typeJavaType)
+        private Builder(Class<?> typeJavaType)
         {
             this.typeJavaType = requireNonNull(typeJavaType, "typeJavaType is null");
             checkArgument(!typeJavaType.equals(void.class), "void type is not supported");
+        }
+
+        public Builder addOperators(TypeOperatorDeclaration operatorDeclaration)
+        {
+            operatorDeclaration.getEqualOperators().forEach(this::addEqualOperator);
+            operatorDeclaration.getHashCodeOperators().forEach(this::addHashCodeOperator);
+            operatorDeclaration.getXxHash64Operators().forEach(this::addXxHash64Operator);
+            operatorDeclaration.getDistinctFromOperators().forEach(this::addDistinctFromOperator);
+            operatorDeclaration.getIndeterminateOperators().forEach(this::addIndeterminateOperator);
+            operatorDeclaration.getComparisonUnorderedLastOperators().forEach(this::addComparisonUnorderedLastOperator);
+            operatorDeclaration.getComparisonUnorderedFirstOperators().forEach(this::addComparisonUnorderedFirstOperator);
+            operatorDeclaration.getLessThanOperators().forEach(this::addLessThanOperator);
+            operatorDeclaration.getLessThanOrEqualOperators().forEach(this::addLessThanOrEqualOperator);
+            return this;
         }
 
         public Builder addEqualOperator(OperatorMethodHandle equalOperator)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
@@ -14,26 +14,18 @@
 package io.trino.spi.type;
 
 import io.airlift.slice.Slice;
-import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.function.BlockIndex;
-import io.trino.spi.function.BlockPosition;
-import io.trino.spi.function.ScalarOperator;
-import io.trino.spi.function.SqlNullable;
-
-import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.XX_HASH_64;
-import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
-import static java.lang.invoke.MethodHandles.lookup;
 
 public final class VarbinaryType
         extends AbstractVariableWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(VarbinaryType.class, lookup(), Slice.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(Slice.class)
+            .addOperators(DEFAULT_COMPARABLE_OPERATORS)
+            .addOperators(DEFAULT_ORDERING_OPERATORS)
+            .build();
 
     public static final VarbinaryType VARBINARY = new VarbinaryType();
 
@@ -118,49 +110,5 @@ public final class VarbinaryType
     public int hashCode()
     {
         return getClass().hashCode();
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(Slice left, Slice right)
-    {
-        return left.equals(right);
-    }
-
-    @ScalarOperator(EQUAL)
-    @SqlNullable
-    private static Boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(Slice value)
-    {
-        return XxHash64.hash(value);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(Slice left, Slice right)
-    {
-        return left.compareTo(right);
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarcharType.java
@@ -16,34 +16,28 @@ package io.trino.spi.type;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceUtf8;
 import io.airlift.slice.Slices;
-import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.function.BlockIndex;
-import io.trino.spi.function.BlockPosition;
-import io.trino.spi.function.ScalarOperator;
 
 import java.util.Objects;
 import java.util.Optional;
 
 import static io.airlift.slice.SliceUtf8.countCodePoints;
-import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.spi.type.Slices.sliceRepresentation;
-import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.String.format;
-import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Collections.singletonList;
 
 public final class VarcharType
         extends AbstractVariableWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(VarcharType.class, lookup(), Slice.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(Slice.class)
+            .addOperators(DEFAULT_COMPARABLE_OPERATORS)
+            .addOperators(DEFAULT_ORDERING_OPERATORS)
+            .build();
 
     public static final int UNBOUNDED_LENGTH = Integer.MAX_VALUE;
     public static final int MAX_LENGTH = Integer.MAX_VALUE - 1;
@@ -239,62 +233,5 @@ public final class VarcharType
     public int hashCode()
     {
         return Objects.hash(length);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(Slice left, Slice right)
-    {
-        return left.equals(right);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(Slice value)
-    {
-        return XxHash64.hash(value);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(Slice left, Slice right)
-    {
-        return left.compareTo(right);
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, Slice right)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        return leftBlock.bytesCompare(leftPosition, 0, leftLength, right, 0, right.length());
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(Slice left, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        return -rightBlock.bytesCompare(rightPosition, 0, rightLength, left, 0, left.length());
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ObjectIdType.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ObjectIdType.java
@@ -18,14 +18,10 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.airlift.slice.Slice;
-import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.VariableWidthBlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.function.BlockIndex;
-import io.trino.spi.function.BlockPosition;
-import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.type.AbstractVariableWidthType;
 import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.TypeOperatorDeclaration;
@@ -35,16 +31,13 @@ import org.bson.types.ObjectId;
 
 import java.io.IOException;
 
-import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
-import static io.trino.spi.function.OperatorType.EQUAL;
-import static io.trino.spi.function.OperatorType.XX_HASH_64;
-import static io.trino.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
-import static java.lang.invoke.MethodHandles.lookup;
-
 public class ObjectIdType
         extends AbstractVariableWidthType
 {
-    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(ObjectIdType.class, lookup(), Slice.class);
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = TypeOperatorDeclaration.builder(Slice.class)
+            .addOperators(DEFAULT_COMPARABLE_OPERATORS)
+            .addOperators(DEFAULT_ORDERING_OPERATORS)
+            .build();
 
     public static final ObjectIdType OBJECT_ID = new ObjectIdType();
 
@@ -110,49 +103,6 @@ public class ObjectIdType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         ((VariableWidthBlockBuilder) blockBuilder).writeEntry(value, offset, length);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(Slice left, Slice right)
-    {
-        return left.equals(right);
-    }
-
-    @ScalarOperator(EQUAL)
-    private static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        if (leftLength != rightLength) {
-            return false;
-        }
-        return leftBlock.equals(leftPosition, 0, rightBlock, rightPosition, 0, leftLength);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(Slice value)
-    {
-        return XxHash64.hash(value);
-    }
-
-    @ScalarOperator(XX_HASH_64)
-    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
-    {
-        return block.hash(position, 0, block.getSliceLength(position));
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(Slice left, Slice right)
-    {
-        return left.compareTo(right);
-    }
-
-    @ScalarOperator(COMPARISON_UNORDERED_LAST)
-    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition, @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
-    {
-        int leftLength = leftBlock.getSliceLength(leftPosition);
-        int rightLength = rightBlock.getSliceLength(rightPosition);
-        return leftBlock.compareTo(leftPosition, 0, leftLength, rightBlock, rightPosition, 0, rightLength);
     }
 
     public static class ObjectIdSerializer


### PR DESCRIPTION
## Description
Add reusable implementations of comparable and ordering operator for variable width types.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
