### PR TITLE
Fix build inside git worktrees by working around git-commit-id #639

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2105,6 +2105,9 @@
                         <injectAllReactorProjects>true</injectAllReactorProjects>
                         <!-- A workaround to make build work in a Git worktree, see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 -->
                         <useNativeGit>true</useNativeGit>
+                        <!-- git-commit-id 6.0.0 incorrectly detects the .git dir, breaking the native-git workaround; see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/639 -->
+                        <!-- When Maven 4.0 is used, this can be replaced by a native Maven property (see MNG-7038), assuming git-commit-id #639 isn't yet fixed -->
+                        <dotGitDirectory>${air.main.basedir}/.git</dotGitDirectory>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Description
Explicitly configure the `dotGitDirectory` used by the `git-commit-id-maven-plugin` to be the root of the (multi-module) project using the `air.main.basedir` property.

This is needed when using git worktrees, as the plugin incorrectly detects the wrong directory in which to run git commands. If https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/639 _or_ https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/215 are resolved, this will become unnecessary. When Trino upgrades to Maven 4.0.0, assuming the workaround is still needed, we can update to using the new `project.rootDirectory` property (see [MNG-7038](https://issues.apache.org/jira/browse/MNG-7038)) instead of the Airbase one.

## Additional context and related issues
This fixes #18027; see the discussion there for more details.

## Release notes
(X) This is not user-visible or docs only and no release notes are required.