### PR TITLE
Add missing return in BigQueryQueryPageSource

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -250,6 +250,7 @@ public class BigQueryQueryPageSource
                     appendTo(type.getTypeParameters().get(index), record.get(index), fieldBuilders.get(index));
                 }
             });
+            return;
         }
         throw new TrinoException(GENERIC_INTERNAL_ERROR, "Unhandled type for Block: " + type.getTypeSignature());
     }


### PR DESCRIPTION
(x) This is not user-visible or docs only and no release notes are required.
