### PR TITLE
Fix error message in SqlTimestampWithTimeZone

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimestampWithTimeZone.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlTimestampWithTimeZone.java
@@ -55,7 +55,7 @@ public final class SqlTimestampWithTimeZone
                 throw new IllegalArgumentException(format("Expected picosOfMilli to be 0 for precision %s: %s", precision, picosOfMilli));
             }
             if (round(epochMillis, 3 - precision) != epochMillis) {
-                throw new IllegalArgumentException(format("Expected 0s for digits beyond precision %s: epochMicros = %s", precision, epochMillis));
+                throw new IllegalArgumentException(format("Expected 0s for digits beyond precision %s: epochMillis = %s", precision, epochMillis));
             }
         }
         else {


### PR DESCRIPTION
## Description
Fix an error message in `SqlTimestampWithTimeZone`


## Release notes

(x) This is not user-visible or docs only and no release notes are required.