### PR TITLE
Add Avro to "File formats" in Iceberg documentation

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -1558,6 +1558,7 @@ The following file types and formats are supported for the Iceberg connector:
 
 * ORC
 * Parquet
+* Avro
 
 ORC format configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Add Avro to "File formats" in Iceberg documentation

## Release notes

(x) This is not user-visible or docs only and no release notes are required.