### PR TITLE
Sync Catalogs which created by dynamic catalog with worker nodes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/CatalogSyncTask.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CatalogSyncTask.java
@@ -13,21 +13,12 @@
  */
 package io.trino.connector;
 
-import io.trino.Session;
-import io.trino.spi.connector.CatalogHandle;
+import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
-import java.util.Set;
 
-public interface ConnectorServicesProvider
+@ThreadSafe
+public interface CatalogSyncTask
 {
-    void loadInitialCatalogs();
-
-    void ensureCatalogsLoaded(Session session, List<CatalogProperties> catalogs);
-
-    void pruneCatalogs(Set<CatalogHandle> catalogsInUse);
-
     void syncCatalogs(List<CatalogProperties> catalogsInCoordinator);
-
-    ConnectorServices getConnectorServices(CatalogHandle catalogHandle);
 }

--- a/core/trino-main/src/main/java/io/trino/connector/CoordinatorDynamicCatalogManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/CoordinatorDynamicCatalogManager.java
@@ -67,6 +67,7 @@ public class CoordinatorDynamicCatalogManager
 
     private final CatalogStore catalogStore;
     private final CatalogFactory catalogFactory;
+    private final CatalogSyncTask catalogSyncTask;
     private final Executor executor;
 
     private final Lock catalogsUpdateLock = new ReentrantLock();
@@ -85,10 +86,11 @@ public class CoordinatorDynamicCatalogManager
     private State state = State.CREATED;
 
     @Inject
-    public CoordinatorDynamicCatalogManager(CatalogStore catalogStore, CatalogFactory catalogFactory, @ForStartup Executor executor)
+    public CoordinatorDynamicCatalogManager(CatalogStore catalogStore, CatalogFactory catalogFactory, CatalogSyncTask catalogSyncTask, @ForStartup Executor executor)
     {
         this.catalogStore = requireNonNull(catalogStore, "catalogStore is null");
         this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
+        this.catalogSyncTask = requireNonNull(catalogSyncTask, "catalogSyncTask is null");
         this.executor = requireNonNull(executor, "executor is null");
     }
 
@@ -272,6 +274,7 @@ public class CoordinatorDynamicCatalogManager
                     handle -> catalogFactory.createCatalog(catalogProperties));
             activeCatalogs.put(catalogName, catalog.getCatalog());
             catalogStore.addOrReplaceCatalog(catalogProperties);
+            catalogSyncTask.syncCatalogs(ImmutableList.of(catalogProperties));
 
             log.info("Added catalog: %s", catalog.getCatalogHandle());
         }
@@ -323,5 +326,31 @@ public class CoordinatorDynamicCatalogManager
         }
         // Do not shut down the catalog, because there may still be running queries using this catalog.
         // Catalog shutdown logic will be added later.
+    }
+
+    @Override
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        catalogsUpdateLock.lock();
+        try {
+            if (state == State.STOPPED) {
+                return;
+            }
+
+            List<CatalogProperties> missingCatalogs = getMissingCatalogs(catalogsInCoordinator);
+            if (!missingCatalogs.isEmpty()) {
+                log.error("Missing Catalogs: %s", missingCatalogs);
+            }
+        }
+        finally {
+            catalogsUpdateLock.unlock();
+        }
+    }
+
+    private List<CatalogProperties> getMissingCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        return catalogsInCoordinator.stream()
+                .filter(catalog -> !activeCatalogs.containsKey(catalog.getCatalogHandle().getCatalogName()))
+                .collect(toImmutableList());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogSyncTask.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogSyncTask.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.airlift.discovery.client.ServiceDescriptor;
+import io.airlift.discovery.client.ServiceSelector;
+import io.airlift.discovery.client.ServiceType;
+import io.airlift.http.client.HttpClient;
+import io.airlift.http.client.Request;
+import io.airlift.http.client.Response;
+import io.airlift.http.client.ResponseHandler;
+import io.airlift.json.JsonCodec;
+import io.airlift.log.Logger;
+import io.airlift.node.NodeInfo;
+import io.trino.metadata.ForNodeManager;
+import io.trino.server.InternalCommunicationConfig;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static io.airlift.http.client.Request.Builder.preparePost;
+import static io.airlift.json.JsonCodec.listJsonCodec;
+import static java.util.Objects.requireNonNull;
+
+public class DefaultCatalogSyncTask
+        implements CatalogSyncTask
+{
+    private static final Logger log = Logger.get(DefaultCatalogSyncTask.class);
+    private static final JsonCodec<List<CatalogProperties>> CATALOG_PROPERTIES_CODEC = listJsonCodec(CatalogProperties.class);
+
+    private final NodeInfo nodeInfo;
+    private final ServiceSelector selector;
+    private final HttpClient httpClient;
+
+    private final boolean httpsRequired;
+
+    @Inject
+    public DefaultCatalogSyncTask(
+            NodeInfo nodeInfo,
+            @ServiceType("trino") ServiceSelector selector,
+            @ForNodeManager HttpClient httpClient,
+            InternalCommunicationConfig internalCommunicationConfig)
+    {
+        this.nodeInfo = requireNonNull(nodeInfo, "nodeInfo is null");
+        this.selector = requireNonNull(selector, "selector is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+
+        this.httpsRequired = internalCommunicationConfig.isHttpsRequired();
+    }
+
+    @Override
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        syncWorkerCatalogs(catalogsInCoordinator);
+    }
+
+    @VisibleForTesting
+    void syncWorkerCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        Set<ServiceDescriptor> online = selector.selectAllServices().stream()
+                .filter(descriptor -> !nodeInfo.getNodeId().equals(descriptor.getNodeId()))
+                .collect(toImmutableSet());
+        log.info("syncWorkerCatalogs online: " + online);
+
+        // send message to workers to trigger sync
+        for (ServiceDescriptor service : online) {
+            URI uri = getHttpUri(service);
+            if (uri == null) {
+                continue;
+            }
+            uri = uriBuilderFrom(uri).appendPath("/v1/task/syncCatalogs").build();
+            Request request = preparePost()
+                    .setUri(uri)
+                    .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                    .setBodyGenerator(jsonBodyGenerator(CATALOG_PROPERTIES_CODEC, catalogsInCoordinator))
+                    .build();
+            httpClient.executeAsync(request, new ResponseHandler<>()
+            {
+                @Override
+                public Exception handleException(Request request, Exception exception)
+                {
+                    log.error(exception, "Error syncing catalogs with request: %s", request);
+                    return exception;
+                }
+
+                @Override
+                public Object handle(Request request, Response response)
+                {
+                    log.debug("Synced catalogs on server: %s", request.getUri());
+                    return null;
+                }
+            });
+        }
+    }
+
+    private URI getHttpUri(ServiceDescriptor descriptor)
+    {
+        String url = descriptor.getProperties().get(httpsRequired ? "https" : "http");
+        if (url != null) {
+            try {
+                return new URI(url);
+            }
+            catch (URISyntaxException ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DynamicCatalogManagerModule.java
@@ -60,10 +60,13 @@ public class DynamicCatalogManagerModule
         public CoordinatorLazyRegister(
                 DefaultCatalogFactory defaultCatalogFactory,
                 LazyCatalogFactory lazyCatalogFactory,
+                DefaultCatalogSyncTask defaultCatalogSyncTask,
+                LazyCatalogSyncTask lazyCatalogSyncTask,
                 CoordinatorDynamicCatalogManager catalogManager,
                 GlobalSystemConnector globalSystemConnector)
         {
             lazyCatalogFactory.setCatalogFactory(defaultCatalogFactory);
+            lazyCatalogSyncTask.setCatalogSyncTask(defaultCatalogSyncTask);
             catalogManager.registerGlobalSystemConnector(globalSystemConnector);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/connector/LazyCatalogSyncTask.java
+++ b/core/trino-main/src/main/java/io/trino/connector/LazyCatalogSyncTask.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class LazyCatalogSyncTask
+        implements CatalogSyncTask
+{
+    private final AtomicReference<DefaultCatalogSyncTask> delegate = new AtomicReference<>();
+
+    public void setCatalogSyncTask(DefaultCatalogSyncTask defaultCatalogSyncTask)
+    {
+        checkState(delegate.compareAndSet(null, defaultCatalogSyncTask), "catalogSyncTask already set");
+    }
+
+    @Override
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        getDelegate().syncCatalogs(catalogsInCoordinator);
+    }
+
+    private DefaultCatalogSyncTask getDelegate()
+    {
+        DefaultCatalogSyncTask defaultCatalogSyncTask = delegate.get();
+        checkState(defaultCatalogSyncTask != null, "Catalog factory is not set");
+        return defaultCatalogSyncTask;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/connector/StaticCatalogManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/StaticCatalogManager.java
@@ -230,4 +230,10 @@ public class StaticCatalogManager
     {
         throw new TrinoException(NOT_SUPPORTED, "DROP CATALOG is not supported by the static catalog store");
     }
+
+    @Override
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "SYNC CATALOG is not supported by the static catalog store");
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -458,6 +458,17 @@ public class SqlTaskManager
         }
     }
 
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        catalogsLock.lock();
+        try {
+            connectorServicesProvider.syncCatalogs(catalogsInCoordinator);
+        }
+        finally {
+            catalogsLock.unlock();
+        }
+    }
+
     /**
      * Updates the task plan, splitAssignments and output buffers.  If the task does not
      * already exist, it is created and then updated.

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -25,6 +25,7 @@ import io.airlift.stats.TimeStat;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
+import io.trino.connector.CatalogProperties;
 import io.trino.execution.FailureInjector;
 import io.trino.execution.FailureInjector.InjectedFailure;
 import io.trino.execution.SqlTaskManager;
@@ -399,6 +400,15 @@ public class TaskResource
     public void pruneCatalogs(Set<CatalogHandle> catalogHandles)
     {
         taskManager.pruneCatalogs(catalogHandles);
+    }
+
+    @ResourceSecurity(INTERNAL_ONLY)
+    @POST
+    @Path("syncCatalogs")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+    {
+        taskManager.syncCatalogs(catalogsInCoordinator);
     }
 
     private boolean injectFailure(

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -30,12 +30,14 @@ import io.trino.SystemSessionPropertiesProvider;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogFactory;
 import io.trino.connector.CatalogServiceProviderModule;
+import io.trino.connector.CatalogSyncTask;
 import io.trino.connector.ConnectorName;
 import io.trino.connector.ConnectorServicesProvider;
 import io.trino.connector.CoordinatorDynamicCatalogManager;
 import io.trino.connector.DefaultCatalogFactory;
 import io.trino.connector.InMemoryCatalogStore;
 import io.trino.connector.LazyCatalogFactory;
+import io.trino.connector.LazyCatalogSyncTask;
 import io.trino.connector.system.AnalyzePropertiesSystemTable;
 import io.trino.connector.system.CatalogSystemTable;
 import io.trino.connector.system.ColumnPropertiesSystemTable;
@@ -307,6 +309,7 @@ public class LocalQueryRunner
     private final JoinFilterFunctionCompiler joinFilterFunctionCompiler;
     private final JoinCompiler joinCompiler;
     private final CatalogFactory catalogFactory;
+    private final CatalogSyncTask catalogSyncTask;
     private final CoordinatorDynamicCatalogManager catalogManager;
     private final PluginManager pluginManager;
     private final ExchangeManagerRegistry exchangeManagerRegistry;
@@ -371,7 +374,9 @@ public class LocalQueryRunner
         this.optimizerConfig = new OptimizerConfig();
         LazyCatalogFactory catalogFactory = new LazyCatalogFactory();
         this.catalogFactory = catalogFactory;
-        this.catalogManager = new CoordinatorDynamicCatalogManager(new InMemoryCatalogStore(), catalogFactory, directExecutor());
+        LazyCatalogSyncTask lazyCatalogSyncTask = new LazyCatalogSyncTask();
+        this.catalogSyncTask = lazyCatalogSyncTask;
+        this.catalogManager = new CoordinatorDynamicCatalogManager(new InMemoryCatalogStore(), catalogFactory, catalogSyncTask, directExecutor());
         this.transactionManager = InMemoryTransactionManager.create(
                 new TransactionManagerConfig().setIdleTimeout(new Duration(1, TimeUnit.DAYS)),
                 yieldExecutor,

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -173,6 +173,12 @@ public class TestLocalDispatchQuery
         }
 
         @Override
+        public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public ConnectorServices getConnectorServices(CatalogHandle catalogHandle)
         {
             throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -605,6 +605,12 @@ public class TestSqlTaskManager
         }
 
         @Override
+        public void syncCatalogs(List<CatalogProperties> catalogsInCoordinator)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public ConnectorServices getConnectorServices(CatalogHandle catalogHandle)
         {
             throw new UnsupportedOperationException();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

 - Sync Catalog Properties which created by dynamic catalog feature to Worker Nodes

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

 - Unable to select data when trino is cluster mode
   - looks like worker do not know the catalogs created by dynamic catalog feature, so sync coordinator with worker node when create dynamic catalog
 - https://github.com/trinodb/trino/issues/18053
 - https://github.com/trinodb/trino/issues/18040

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(o) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```