### PR TITLE
Do not block hive split loader when dynamic filter columns do not contain partition columns

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -298,8 +298,10 @@ public class BackgroundHiveSplitLoader
                 // Block until one of below conditions is met:
                 // 1. Completion of DynamicFilter
                 // 2. Timeout after waiting for the configured time
+                // 3. Filtered columns do not contain any partition columns
                 long timeLeft = dynamicFilteringWaitTimeoutMillis - stopwatch.elapsed(MILLISECONDS);
-                if (timeLeft > 0 && dynamicFilter.isAwaitable()) {
+                if (timeLeft > 0 && dynamicFilter.isAwaitable() &&
+                        getPartitionKeyColumnHandles(table, typeManager).stream().anyMatch(dynamicFilter.getColumnsCovered()::contains)) {
                     future = asVoid(toListenableFuture(dynamicFilter.isBlocked()
                             // As isBlocked() returns unmodifiableFuture, we need to create new future for correct propagation of the timeout
                             .thenApply(Function.identity())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
It seems that Dynamic Filtering in Hive Connector only uses partition columns, which is shown below:  
![image](https://github.com/trinodb/trino/assets/26461591/4b2113af-13c3-4977-82c3-de4d83a4d6d5)  
![image](https://github.com/trinodb/trino/assets/26461591/4ecf98fd-8e83-447d-962f-10e2a441f10d)  
So we may not need to block hive split loader for collecting predicates if filtered columns do not contain partition columns, and scan hive tables immediately in this condition. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Do not block hive split loader when dynamic filter columns do not contain partition columns. ({issue}`18062`)
```
