### PR TITLE
Native Avro File Writer

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -765,6 +765,13 @@
                                     <annotation>@javax.annotation.Nullable</annotation>
                                     <justification>Migration to jakarta namespace</justification>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method void io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</old>
+                                    <new>method io.trino.spi.block.VariableWidthBlockBuilder io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</new>
+                                    <justification>Safe to change void return to match other method of same name with different signature</justification>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockBuilder.java
@@ -187,9 +187,9 @@ public class VariableWidthBlockBuilder
         return new VariableWidthBlock(0, length, newSlice.slice(), newOffsets, newValueIsNull);
     }
 
-    public void writeEntry(Slice source)
+    public VariableWidthBlockBuilder writeEntry(Slice source)
     {
-        writeEntry(source, 0, source.length());
+        return writeEntry(source, 0, source.length());
     }
 
     public VariableWidthBlockBuilder writeEntry(Slice source, int sourceIndex, int length)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroCompressionKind.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroCompressionKind.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
+
+import static org.apache.avro.file.CodecFactory.DEFAULT_DEFLATE_LEVEL;
+import static org.apache.avro.file.CodecFactory.DEFAULT_ZSTANDARD_BUFFERPOOL;
+import static org.apache.avro.file.CodecFactory.DEFAULT_ZSTANDARD_LEVEL;
+import static org.apache.avro.file.CodecFactory.deflateCodec;
+import static org.apache.avro.file.CodecFactory.nullCodec;
+import static org.apache.avro.file.CodecFactory.snappyCodec;
+import static org.apache.avro.file.CodecFactory.zstandardCodec;
+
+/**
+ * Inner join between Trino plugin supported codec types and Avro spec supported codec types
+ * Spec list: <a href="https://avro.apache.org/docs/1.11.1/specification/#required-codecs">required</a> and
+ * <a href="https://avro.apache.org/docs/1.11.1/specification/#optional-codecs">optionals</a>
+ */
+public enum AvroCompressionKind
+{
+    // Avro nulls out codec's if it can't find the proper library locally
+    NULL(DataFileConstants.NULL_CODEC, nullCodec() != null),
+    DEFLATE(DataFileConstants.DEFLATE_CODEC, deflateCodec(DEFAULT_DEFLATE_LEVEL) != null),
+    SNAPPY(DataFileConstants.SNAPPY_CODEC, snappyCodec() != null),
+    ZSTANDARD(DataFileConstants.ZSTANDARD_CODEC, zstandardCodec(DEFAULT_ZSTANDARD_LEVEL, DEFAULT_ZSTANDARD_BUFFERPOOL) != null);
+
+    private final String codecString;
+    private final boolean supportedLocally;
+
+    AvroCompressionKind(String codecString, boolean supportedLocally)
+    {
+        this.codecString = codecString;
+        this.supportedLocally = supportedLocally;
+    }
+
+    @Override
+    public String toString()
+    {
+        return codecString;
+    }
+
+    public CodecFactory getCodecFactory()
+    {
+        return CodecFactory.fromString(codecString);
+    }
+
+    public boolean isSupportedLocally()
+    {
+        return supportedLocally;
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileReader.java
@@ -13,6 +13,7 @@
  */
 package io.trino.hive.formats.avro;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.hive.formats.TrinoDataInputStream;
 import io.trino.spi.Page;
@@ -132,7 +133,8 @@ public class AvroFileReader
         fileReader.close();
     }
 
-    private record TrinoDataInputStreamAsAvroSeekableInput(TrinoDataInputStream inputStream, long fileSize)
+    @VisibleForTesting
+    record TrinoDataInputStreamAsAvroSeekableInput(TrinoDataInputStream inputStream, long fileSize)
             implements SeekableInput
     {
         TrinoDataInputStreamAsAvroSeekableInput

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileWriter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import io.trino.spi.Page;
+import io.trino.spi.type.Type;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
+
+public class AvroFileWriter
+        implements Closeable
+{
+    private static final int INSTANCE_SIZE = instanceSize(AvroFileWriter.class);
+
+    private final AvroPagePositionDataWriter pagePositionDataWriter;
+    private final DataFileWriter<Integer> pagePositionFileWriter;
+
+    public AvroFileWriter(
+            OutputStream rawOutput,
+            Schema schema,
+            AvroTypeManager avroTypeManager,
+            AvroCompressionKind compressionKind,
+            Map<String, String> fileMetadata,
+            List<String> names,
+            List<Type> types)
+            throws IOException, AvroTypeException
+    {
+        verify(compressionKind.isSupportedLocally(), "compression kind must be supported locally: %s", compressionKind);
+        pagePositionDataWriter = new AvroPagePositionDataWriter(schema, avroTypeManager, names, types);
+        try {
+            DataFileWriter<Integer> fileWriter = new DataFileWriter<>(pagePositionDataWriter)
+                    .setCodec(compressionKind.getCodecFactory());
+            fileMetadata.forEach(fileWriter::setMeta);
+            pagePositionFileWriter = fileWriter.create(schema, rawOutput);
+        }
+        catch (org.apache.avro.AvroTypeException e) {
+            throw new AvroTypeException(e);
+        }
+        catch (org.apache.avro.AvroRuntimeException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public void write(Page page)
+            throws IOException
+    {
+        pagePositionDataWriter.setPage(page);
+        for (int pos = 0; pos < page.getPositionCount(); pos++) {
+            try {
+                pagePositionFileWriter.append(pos);
+            }
+            catch (RuntimeException e) {
+                throw new IOException("Error writing to avro file", e);
+            }
+        }
+    }
+
+    public long getRetainedSize()
+    {
+        // Avro library delegates to java.io.BufferedOutputStream.BufferedOutputStream(java.io.OutputStream)
+        // which has a default buffer size of 8192
+        return INSTANCE_SIZE + 8192;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        pagePositionFileWriter.close();
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
@@ -1,0 +1,580 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.SingleRowBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+import java.util.function.ToIntBiFunction;
+import java.util.function.ToLongBiFunction;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.hive.formats.avro.AvroTypeUtils.SimpleUnionNullIndex;
+import static io.trino.hive.formats.avro.AvroTypeUtils.getSimpleNullableUnionNullIndex;
+import static io.trino.hive.formats.avro.AvroTypeUtils.isSimpleNullableUnion;
+import static io.trino.hive.formats.avro.AvroTypeUtils.unwrapNullableUnion;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class AvroPagePositionDataWriter
+        implements DatumWriter<Integer>
+{
+    private Page page;
+    private final Schema schema;
+    private final RecordBlockPositionEncoder pageBlockPositionEncoder;
+
+    public AvroPagePositionDataWriter(Schema schema, AvroTypeManager avroTypeManager, List<String> channelNames, List<Type> channelTypes)
+            throws AvroTypeException
+    {
+        this.schema = requireNonNull(schema, "schema is null");
+        pageBlockPositionEncoder = new RecordBlockPositionEncoder(schema, avroTypeManager, channelNames, channelTypes);
+        checkInvariants();
+    }
+
+    @Override
+    public void setSchema(Schema schema)
+    {
+        verify(this.schema == requireNonNull(schema, "schema is null"), "Unable to change schema for this data writer");
+    }
+
+    public void setPage(Page page)
+    {
+        this.page = requireNonNull(page, "page is null");
+        checkInvariants();
+        pageBlockPositionEncoder.setChannelBlocksFromPage(page);
+    }
+
+    private void checkInvariants()
+    {
+        verify(schema.getType() == Schema.Type.RECORD, "Can only write pages to record schema");
+        verify(page == null || page.getChannelCount() == schema.getFields().size(), "Page channel count must equal schema field count");
+    }
+
+    @Override
+    public void write(Integer position, Encoder encoder)
+            throws IOException
+    {
+        checkWritable();
+        if (position >= page.getPositionCount()) {
+            throw new IndexOutOfBoundsException("Position %s not within page with position count %s".formatted(position, page.getPositionCount()));
+        }
+        pageBlockPositionEncoder.encodePositionInEachChannel(position, encoder);
+    }
+
+    private void checkWritable()
+    {
+        checkState(page != null, "page must be set before beginning to write positions");
+    }
+
+    private abstract static class BlockPositionEncoder
+    {
+        protected Block block;
+        private final Optional<SimpleUnionNullIndex> nullIndex;
+
+        public BlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIndex)
+        {
+            this.nullIndex = requireNonNull(nullIndex, "nullIdx is null");
+        }
+
+        abstract void encodeFromBlock(int position, Encoder encoder)
+                throws IOException;
+
+        void encode(int position, Encoder encoder)
+                throws IOException
+        {
+            checkState(block != null, "block must be set before calling encode");
+            boolean isNull = block.isNull(position);
+            if (isNull && nullIndex.isEmpty()) {
+                throw new IOException("Can not write null value for non-nullable schema");
+            }
+            if (nullIndex.isPresent()) {
+                encoder.writeIndex(isNull ? nullIndex.get().getIndex() : 1 ^ nullIndex.get().getIndex());
+            }
+            if (isNull) {
+                encoder.writeNull();
+            }
+            else {
+                encodeFromBlock(position, encoder);
+            }
+        }
+
+        void setBlock(Block block)
+        {
+            this.block = block;
+        }
+    }
+
+    private static BlockPositionEncoder createBlockPositionEncoder(Schema schema, AvroTypeManager avroTypeManager, Type type)
+            throws AvroTypeException
+    {
+        return createBlockPositionEncoder(schema, avroTypeManager, type, Optional.empty());
+    }
+
+    private static BlockPositionEncoder createBlockPositionEncoder(Schema schema, AvroTypeManager avroTypeManager, Type type, Optional<SimpleUnionNullIndex> nullIdx)
+            throws AvroTypeException
+    {
+        Optional<BiFunction<Block, Integer, Object>> overrideToAvroGenericObject = avroTypeManager.overrideBlockToAvroObject(schema, type);
+        if (overrideToAvroGenericObject.isPresent()) {
+            return new UserDefinedBlockPositionEncoder(nullIdx, schema, overrideToAvroGenericObject.get());
+        }
+        switch (schema.getType()) {
+            case NULL -> throw new AvroTypeException("No null support outside of union");
+            case BOOLEAN -> {
+                if (BOOLEAN.equals(type)) {
+                    return new BooleanBlockPositionEncoder(nullIdx);
+                }
+            }
+            case INT -> {
+                if (TINYINT.equals(type)) {
+                    return new IntBlockPositionEncoder(nullIdx, TINYINT::getByte);
+                }
+                if (SMALLINT.equals(type)) {
+                    return new IntBlockPositionEncoder(nullIdx, SMALLINT::getShort);
+                }
+                if (INTEGER.equals(type)) {
+                    return new IntBlockPositionEncoder(nullIdx, INTEGER::getInt);
+                }
+            }
+            case LONG -> {
+                if (TINYINT.equals(type)) {
+                    return new LongBlockPositionEncoder(nullIdx, TINYINT::getByte);
+                }
+                if (SMALLINT.equals(type)) {
+                    return new LongBlockPositionEncoder(nullIdx, SMALLINT::getShort);
+                }
+                if (INTEGER.equals(type)) {
+                    return new LongBlockPositionEncoder(nullIdx, INTEGER::getInt);
+                }
+                if (BIGINT.equals(type)) {
+                    return new LongBlockPositionEncoder(nullIdx, BIGINT::getLong);
+                }
+            }
+            case FLOAT -> {
+                if (REAL.equals(type)) {
+                    return new FloatBlockPositionEncoder(nullIdx);
+                }
+            }
+            case DOUBLE -> {
+                if (DOUBLE.equals(type)) {
+                    return new DoubleBlockPositionEncoder(nullIdx);
+                }
+            }
+            case STRING -> {
+                if (VARCHAR.equals(type)) {
+                    return new StringOrBytesPositionEncoder(nullIdx);
+                }
+            }
+            case BYTES -> {
+                if (VarbinaryType.VARBINARY.equals(type)) {
+                    return new StringOrBytesPositionEncoder(nullIdx);
+                }
+            }
+            case FIXED -> {
+                if (VarbinaryType.VARBINARY.equals(type)) {
+                    return new FixedBlockPositionEncoder(nullIdx, schema.getFixedSize());
+                }
+            }
+            case ENUM -> {
+                if (VARCHAR.equals(type)) {
+                    return new EnumBlockPositionEncoder(nullIdx, schema.getEnumSymbols());
+                }
+            }
+            case ARRAY -> {
+                if (type instanceof ArrayType arrayType) {
+                    return new ArrayBlockPositionEncoder(nullIdx, schema, avroTypeManager, arrayType);
+                }
+            }
+            case MAP -> {
+                if (type instanceof MapType mapType) {
+                    return new MapBlockPositionEncoder(nullIdx, schema, avroTypeManager, mapType);
+                }
+            }
+            case RECORD -> {
+                if (type instanceof RowType rowType) {
+                    return new RecordBlockPositionEncoder(nullIdx, schema, avroTypeManager, rowType);
+                }
+            }
+            case UNION -> {
+                if (isSimpleNullableUnion(schema)) {
+                    return createBlockPositionEncoder(unwrapNullableUnion(schema), avroTypeManager, type, Optional.of(getSimpleNullableUnionNullIndex(schema)));
+                }
+                else {
+                    throw new AvroTypeException("Unable to make writer for schema with non simple nullable union %s".formatted(schema));
+                }
+            }
+        }
+        throw new AvroTypeException("Schema and Trino Type mismatch between %s and %s".formatted(schema, type));
+    }
+
+    private static class BooleanBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        public BooleanBlockPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex)
+        {
+            super(isNullWithIndex);
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            encoder.writeBoolean(BOOLEAN.getBoolean(block, position));
+        }
+    }
+
+    private static class IntBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final ToIntBiFunction<Block, Integer> getInt;
+
+        public IntBlockPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex, ToIntBiFunction<Block, Integer> getInt)
+        {
+            super(isNullWithIndex);
+            this.getInt = requireNonNull(getInt, "getInt is null");
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            encoder.writeInt(getInt.applyAsInt(block, position));
+        }
+    }
+
+    private static class LongBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final ToLongBiFunction<Block, Integer> getLong;
+
+        public LongBlockPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex, ToLongBiFunction<Block, Integer> getLong)
+        {
+            super(isNullWithIndex);
+            this.getLong = requireNonNull(getLong, "getLong is null");
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            encoder.writeLong(getLong.applyAsLong(block, position));
+        }
+    }
+
+    private static class FloatBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        public FloatBlockPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex)
+        {
+            super(isNullWithIndex);
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            encoder.writeFloat(REAL.getFloat(block, position));
+        }
+    }
+
+    private static class DoubleBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        public DoubleBlockPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex)
+        {
+            super(isNullWithIndex);
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            encoder.writeDouble(DOUBLE.getDouble(block, position));
+        }
+    }
+
+    private static class StringOrBytesPositionEncoder
+            extends BlockPositionEncoder
+    {
+        public StringOrBytesPositionEncoder(Optional<SimpleUnionNullIndex> isNullWithIndex)
+        {
+            super(isNullWithIndex);
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            int length = block.getSliceLength(position);
+            encoder.writeLong(length);
+            encoder.writeFixed(block.getSlice(position, 0, length).getBytes());
+        }
+    }
+
+    private static class FixedBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final int fixedSize;
+
+        public FixedBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, int fixedSize)
+        {
+            super(nullIdx);
+            this.fixedSize = fixedSize;
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            int length = block.getSliceLength(position);
+            if (length != fixedSize) {
+                throw new IOException("Unable to write Avro fixed with size %s from slice of length %s".formatted(fixedSize, length));
+            }
+            encoder.writeFixed(block.getSlice(position, 0, length).getBytes());
+        }
+    }
+
+    private static class EnumBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final Map<Slice, Integer> symbolToIndex;
+
+        public EnumBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, List<String> symbols)
+        {
+            super(nullIdx);
+            ImmutableMap.Builder<Slice, Integer> symbolToIndex = ImmutableMap.builder();
+            for (int i = 0; i < symbols.size(); i++) {
+                symbolToIndex.put(Slices.utf8Slice(symbols.get(i)), i);
+            }
+            this.symbolToIndex = symbolToIndex.buildOrThrow();
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            int length = block.getSliceLength(position);
+            Integer symbolIndex = symbolToIndex.get(block.getSlice(position, 0, length));
+            if (symbolIndex == null) {
+                throw new IOException("Unable to write Avro Enum symbol %s. Not found in set %s".formatted(
+                        block.getSlice(position, 0, length).toStringUtf8(),
+                        symbolToIndex.keySet().stream().map(Slice::toStringUtf8).toList()));
+            }
+            encoder.writeEnum(symbolIndex);
+        }
+    }
+
+    private static class ArrayBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final BlockPositionEncoder elementBlockPositionEncoder;
+        private final ArrayType type;
+
+        public ArrayBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, Schema schema, AvroTypeManager avroTypeManager, ArrayType type)
+                throws AvroTypeException
+        {
+            super(nullIdx);
+            verify(requireNonNull(schema, "schema is null").getType() == Schema.Type.ARRAY);
+            this.type = requireNonNull(type, "type is null");
+            elementBlockPositionEncoder = createBlockPositionEncoder(schema.getElementType(), avroTypeManager, type.getElementType());
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            Block elementBlock = type.getObject(block, position);
+            elementBlockPositionEncoder.setBlock(elementBlock);
+            int size = elementBlock.getPositionCount();
+            encoder.writeArrayStart();
+            encoder.setItemCount(size);
+            for (int itemPos = 0; itemPos < size; itemPos++) {
+                encoder.startItem();
+                elementBlockPositionEncoder.encode(itemPos, encoder);
+            }
+            encoder.writeArrayEnd();
+        }
+    }
+
+    private static class MapBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final BlockPositionEncoder keyBlockPositionEncoder = new StringOrBytesPositionEncoder(Optional.empty());
+        private final BlockPositionEncoder valueBlockPositionEncoder;
+        private final MapType type;
+
+        public MapBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, Schema schema, AvroTypeManager avroTypeManager, MapType type)
+                throws AvroTypeException
+        {
+            super(nullIdx);
+            verify(requireNonNull(schema, "schema is null").getType() == Schema.Type.MAP);
+            this.type = requireNonNull(type, "type is null");
+            if (!VARCHAR.equals(this.type.getKeyType())) {
+                throw new AvroTypeException("Avro Maps must have String keys, invalid type: %s".formatted(this.type.getKeyType()));
+            }
+            valueBlockPositionEncoder = createBlockPositionEncoder(schema.getValueType(), avroTypeManager, type.getValueType());
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            Block mapBlock = type.getObject(block, position);
+            keyBlockPositionEncoder.setBlock(mapBlock);
+            valueBlockPositionEncoder.setBlock(mapBlock);
+            encoder.writeMapStart();
+            encoder.setItemCount(mapBlock.getPositionCount() / 2);
+            for (int mapIndex = 0; mapIndex < mapBlock.getPositionCount(); mapIndex += 2) {
+                encoder.startItem();
+                keyBlockPositionEncoder.encode(mapIndex, encoder);
+                valueBlockPositionEncoder.encode(mapIndex + 1, encoder);
+            }
+            encoder.writeMapEnd();
+        }
+    }
+
+    private static class RecordBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final RowType type;
+        private final BlockPositionEncoder[] channelEncoders;
+        private final int[] fieldToChannel;
+
+        // used only for nested row building
+        public RecordBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, Schema schema, AvroTypeManager avroTypeManager, RowType rowType)
+                throws AvroTypeException
+        {
+            this(nullIdx,
+                    schema,
+                    avroTypeManager,
+                    rowType.getFields().stream()
+                            .map(RowType.Field::getName)
+                            .map(optName -> optName.orElseThrow(() -> new IllegalArgumentException("Unable to use nested anonymous row type for avro writing")))
+                            .collect(toImmutableList()),
+                    rowType.getFields().stream()
+                            .map(RowType.Field::getType)
+                            .collect(toImmutableList()));
+        }
+
+        // used only for top level page building
+        public RecordBlockPositionEncoder(Schema schema, AvroTypeManager avroTypeManager, List<String> channelNames, List<Type> channelTypes)
+                throws AvroTypeException
+        {
+            this(Optional.empty(), schema, avroTypeManager, channelNames, channelTypes);
+        }
+
+        private RecordBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, Schema schema, AvroTypeManager avroTypeManager, List<String> channelNames, List<Type> channelTypes)
+                throws AvroTypeException
+        {
+            super(nullIdx);
+            type = RowType.anonymous(requireNonNull(channelTypes, "channelTypes is null"));
+            verify(requireNonNull(schema, "schema is null").getType() == Schema.Type.RECORD);
+            verify(schema.getFields().size() == channelTypes.size(), "Must have channel for each record field");
+            verify(requireNonNull(channelNames, "channelNames is null").size() == channelTypes.size(), "Must provide names for all channels");
+            fieldToChannel = new int[schema.getFields().size()];
+            channelEncoders = new BlockPositionEncoder[schema.getFields().size()];
+            for (int i = 0; i < channelNames.size(); i++) {
+                String fieldName = channelNames.get(i);
+                Schema.Field avroField = requireNonNull(schema.getField(fieldName), "no field with name %s in schema %s".formatted(fieldName, schema));
+                fieldToChannel[avroField.pos()] = i;
+                channelEncoders[i] = createBlockPositionEncoder(avroField.schema(), avroTypeManager, channelTypes.get(i));
+            }
+            verify(IntStream.of(fieldToChannel).sum() == (schema.getFields().size() * (schema.getFields().size() - 1) / 2), "all channels must be accounted for");
+        }
+
+        // Used only for nested rows
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            SingleRowBlock singleRowBlock = (SingleRowBlock) type.getObject(block, position);
+            for (BlockPositionEncoder channelEncoder : channelEncoders) {
+                channelEncoder.setBlock(singleRowBlock);
+            }
+            encodeInternal(i -> i, encoder);
+        }
+
+        public void setChannelBlocksFromPage(Page page)
+        {
+            verify(page.getChannelCount() == channelEncoders.length, "Page must have channels equal to provided type list");
+            for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                channelEncoders[channel].setBlock(page.getBlock(channel));
+            }
+        }
+
+        public void encodePositionInEachChannel(int position, Encoder encoder)
+                throws IOException
+        {
+            encodeInternal(ignore -> position, encoder);
+        }
+
+        private void encodeInternal(IntFunction<Integer> channelToPosition, Encoder encoder)
+                throws IOException
+        {
+            for (int channel : fieldToChannel) {
+                BlockPositionEncoder channelEncoder = channelEncoders[channel];
+                channelEncoder.encode(channelToPosition.apply(channel), encoder);
+            }
+        }
+    }
+
+    private static class UserDefinedBlockPositionEncoder
+            extends BlockPositionEncoder
+    {
+        private final GenericDatumWriter<Object> datumWriter;
+        private final BiFunction<Block, Integer, Object> toAvroGeneric;
+
+        public UserDefinedBlockPositionEncoder(Optional<SimpleUnionNullIndex> nullIdx, Schema schema, BiFunction<Block, Integer, Object> toAvroGeneric)
+        {
+            super(nullIdx);
+            datumWriter = new GenericDatumWriter<>(requireNonNull(schema, "schema is null"));
+            this.toAvroGeneric = requireNonNull(toAvroGeneric, "toAvroGeneric is null");
+        }
+
+        @Override
+        void encodeFromBlock(int position, Encoder encoder)
+                throws IOException
+        {
+            datumWriter.write(toAvroGeneric.apply(block, position), encoder);
+        }
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroTypeManager.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroTypeManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.hive.formats.avro;
 
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import org.apache.avro.Schema;
@@ -20,6 +21,7 @@ import org.apache.avro.Schema;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public interface AvroTypeManager
 {
@@ -40,5 +42,12 @@ public interface AvroTypeManager
      * Possible to override for each primitive type as well.
      */
     Optional<BiConsumer<BlockBuilder, Object>> overrideBuildingFunctionForSchema(Schema schema)
+            throws AvroTypeException;
+
+    /**
+     * Extract and convert the object from the given block at the given position and return the Avro Generic Data forum.
+     * Type is either provided explicitly to the writer or derived from the schema using this interface.
+     */
+    Optional<BiFunction<Block, Integer, Object>> overrideBlockToAvroObject(Schema schema, Type type)
             throws AvroTypeException;
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroTypeUtils.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroTypeUtils.java
@@ -92,7 +92,7 @@ public final class AvroTypeUtils
         return schema.getTypes().stream().filter(not(Schema::isNullable)).count() == 1L;
     }
 
-    private static Schema unwrapNullableUnion(Schema schema)
+    static Schema unwrapNullableUnion(Schema schema)
     {
         verify(schema.isUnion(), "Schema must be union");
         verify(schema.isNullable() && schema.getTypes().size() == 2);
@@ -110,5 +110,29 @@ public final class AvroTypeUtils
             }
         }
         return rowTypeForUnionOfTypes(unionTypes.build());
+    }
+
+    public static SimpleUnionNullIndex getSimpleNullableUnionNullIndex(Schema schema)
+    {
+        verify(schema.isUnion(), "Schema must be union");
+        verify(schema.isNullable() && schema.getTypes().size() == 2, "Invalid null union: %s", schema);
+        return schema.getTypes().get(0).getType() == Schema.Type.NULL ? SimpleUnionNullIndex.ZERO : SimpleUnionNullIndex.ONE;
+    }
+
+    enum SimpleUnionNullIndex
+    {
+        ZERO(0),
+        ONE(1);
+        private final int index;
+
+        SimpleUnionNullIndex(int index)
+        {
+            this.index = index;
+        }
+
+        public int getIndex()
+        {
+            return index;
+        }
     }
 }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/NoOpAvroTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/NoOpAvroTypeManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.hive.formats.avro;
 
+import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import org.apache.avro.Schema;
@@ -20,6 +21,7 @@ import org.apache.avro.Schema;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 
 public class NoOpAvroTypeManager
         implements AvroTypeManager
@@ -40,6 +42,13 @@ public class NoOpAvroTypeManager
 
     @Override
     public Optional<BiConsumer<BlockBuilder, Object>> overrideBuildingFunctionForSchema(Schema schema)
+            throws AvroTypeException
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<BiFunction<Block, Integer, Object>> overrideBlockToAvroObject(Schema schema, Type type)
             throws AvroTypeException
     {
         return Optional.empty();

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Longs;
+import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.local.LocalFileSystem;
+import io.trino.hive.formats.TrinoDataInputStream;
+import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.MapBlock;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.block.VariableWidthBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.VarbinaryType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.util.RandomData;
+import org.apache.avro.util.Utf8;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.block.BlockAssertions.assertBlockEquals;
+import static io.trino.block.BlockAssertions.createIntsBlock;
+import static io.trino.block.BlockAssertions.createRowBlock;
+import static io.trino.block.BlockAssertions.createStringsBlock;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Double.doubleToLongBits;
+import static java.lang.Float.floatToIntBits;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.within;
+
+public abstract class TestAvroBase
+{
+    protected static final TypeOperators TYPE_OPERATORS = new TypeOperators();
+    protected static final ArrayType ARRAY_INTEGER = new ArrayType(INTEGER);
+    protected static final MapType MAP_VARCHAR_VARCHAR = new MapType(VARCHAR, VARCHAR, TYPE_OPERATORS);
+    protected static final MapType MAP_VARCHAR_INTEGER = new MapType(VARCHAR, INTEGER, TYPE_OPERATORS);
+    protected TrinoFileSystem trinoLocalFilesystem;
+    protected Path tempDirectory;
+
+    protected static final Schema SIMPLE_RECORD_SCHEMA = SchemaBuilder.record("simpleRecord")
+            .fields()
+            .name("a")
+            .type().intType().noDefault()
+            .name("b")
+            .type().doubleType().noDefault()
+            .name("c")
+            .type().stringType().noDefault()
+            .endRecord();
+
+    protected static final Schema SIMPLE_ENUM_SCHEMA = SchemaBuilder.enumeration("myEnumType").symbols("A", "B", "C");
+
+    protected static final Schema ALL_TYPES_RECORD_SCHEMA = SchemaBuilder.builder()
+            .record("all")
+            .fields()
+            .name("aBoolean")
+            .type().booleanType().noDefault()
+            .name("aInt")
+            .type().intType().noDefault()
+            .name("aLong")
+            .type().longType().noDefault()
+            .name("aFloat")
+            .type().floatType().noDefault()
+            .name("aDouble")
+            .type().doubleType().noDefault()
+            .name("aString")
+            .type().stringType().noDefault()
+            .name("aBytes")
+            .type().bytesType().noDefault()
+            .name("aFixed")
+            .type().fixed("myFixedType").size(16).noDefault()
+            .name("anArray")
+            .type().array().items().intType().noDefault()
+            .name("aMap")
+            .type().map().values().intType().noDefault()
+            .name("anEnum")
+            .type(SIMPLE_ENUM_SCHEMA).noDefault()
+            .name("aRecord")
+            .type(SIMPLE_RECORD_SCHEMA).noDefault()
+            .name("aUnion")
+            .type().optional().stringType()
+            .endRecord();
+    protected static final GenericRecord ALL_TYPES_GENERIC_RECORD;
+    protected static final Page ALL_TYPES_PAGE;
+    protected static final GenericRecord SIMPLE_GENERIC_RECORD;
+    protected static final String A_STRING_VALUE = "a test string";
+    protected static final ByteBuffer A_BYTES_VALUE = ByteBuffer.wrap("a test byte array".getBytes(StandardCharsets.UTF_8));
+    protected static final GenericData.Fixed A_FIXED_VALUE;
+
+    static {
+        ImmutableList.Builder<Block> allTypeBlocks = ImmutableList.builder();
+        SIMPLE_GENERIC_RECORD = new GenericData.Record(SIMPLE_RECORD_SCHEMA);
+        SIMPLE_GENERIC_RECORD.put("a", 5);
+        SIMPLE_GENERIC_RECORD.put("b", 3.14159265358979);
+        SIMPLE_GENERIC_RECORD.put("c", "Simple Record String Field");
+
+        UUID fixed = UUID.nameUUIDFromBytes("a test fixed".getBytes(StandardCharsets.UTF_8));
+        A_FIXED_VALUE = new GenericData.Fixed(SchemaBuilder.builder().fixed("myFixedType").size(16), Bytes.concat(Longs.toByteArray(fixed.getMostSignificantBits()), Longs.toByteArray(fixed.getLeastSignificantBits())));
+
+        ALL_TYPES_GENERIC_RECORD = new GenericData.Record(ALL_TYPES_RECORD_SCHEMA);
+        ALL_TYPES_GENERIC_RECORD.put("aBoolean", true);
+        allTypeBlocks.add(new ByteArrayBlock(1, Optional.empty(), new byte[]{1}));
+        ALL_TYPES_GENERIC_RECORD.put("aInt", 42);
+        allTypeBlocks.add(new IntArrayBlock(1, Optional.empty(), new int[]{42}));
+        ALL_TYPES_GENERIC_RECORD.put("aLong", 3400L);
+        allTypeBlocks.add(new LongArrayBlock(1, Optional.empty(), new long[]{3400L}));
+        ALL_TYPES_GENERIC_RECORD.put("aFloat", 3.14f);
+        allTypeBlocks.add(new IntArrayBlock(1, Optional.empty(), new int[]{floatToIntBits(3.14f)}));
+        ALL_TYPES_GENERIC_RECORD.put("aDouble", 9.81);
+        allTypeBlocks.add(new LongArrayBlock(1, Optional.empty(), new long[]{doubleToLongBits(9.81)}));
+        ALL_TYPES_GENERIC_RECORD.put("aString", A_STRING_VALUE);
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.utf8Slice(A_STRING_VALUE), new int[] {0, Slices.utf8Slice(A_STRING_VALUE).length()}, Optional.empty()));
+        ALL_TYPES_GENERIC_RECORD.put("aBytes", A_BYTES_VALUE);
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedBuffer(A_BYTES_VALUE), new int[] {0, A_BYTES_VALUE.limit()}, Optional.empty()));
+        ALL_TYPES_GENERIC_RECORD.put("aFixed", A_FIXED_VALUE);
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedBuffer(A_FIXED_VALUE.bytes()), new int[] {0, A_FIXED_VALUE.bytes().length}, Optional.empty()));
+        ALL_TYPES_GENERIC_RECORD.put("anArray", ImmutableList.of(1, 2, 3, 4));
+        allTypeBlocks.add(ArrayBlock.fromElementBlock(1, Optional.empty(), new int[] {0, 4}, createIntsBlock(1, 2, 3, 4)));
+        ALL_TYPES_GENERIC_RECORD.put("aMap", ImmutableMap.of(new Utf8("key1"), 1, new Utf8("key2"), 2));
+        allTypeBlocks.add(MAP_VARCHAR_INTEGER.createBlockFromKeyValue(Optional.empty(),
+                new int[] {0, 2},
+                createStringsBlock("key1", "key2"),
+                createIntsBlock(1, 2)));
+        ALL_TYPES_GENERIC_RECORD.put("anEnum", new GenericData.EnumSymbol(SIMPLE_ENUM_SCHEMA, "A"));
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.utf8Slice("A"), new int[] {0, 1}, Optional.empty()));
+        ALL_TYPES_GENERIC_RECORD.put("aRecord", SIMPLE_GENERIC_RECORD);
+        allTypeBlocks.add(createRowBlock(ImmutableList.of(INTEGER, DoubleType.DOUBLE, VARCHAR), new Object[] {5, 3.14159265358979, "Simple Record String Field"}));
+        ALL_TYPES_GENERIC_RECORD.put("aUnion", null);
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedBuffer(), new int[] {0, 0}, Optional.of(new boolean[] {true})));
+        ALL_TYPES_PAGE = new Page(allTypeBlocks.build().toArray(Block[]::new));
+    }
+
+    @DataProvider(name = "testSchemas")
+    public Object[][] testSchemaProvider()
+    {
+        return new Object[][] {
+                {
+                        SIMPLE_RECORD_SCHEMA
+                },
+                {
+                     new Schema.Parser().parse("""
+                             {
+                                "type":"record",
+                                "name":"test",
+                                "fields":[
+                                    {
+                                        "name":"a",
+                                        "type":"int"
+                                    },
+                                    {
+                                        "name":"b",
+                                        "type":["null", {
+                                            "type":"array",
+                                            "items":[""" + SIMPLE_RECORD_SCHEMA.toString() + """
+                                            , "null"]
+                                        }]
+                                    },
+                                    {
+                                        "name":"c",
+                                        "type":
+                                        {
+                                            "type":"map",
+                                            "values":{
+                                                "type":"enum",
+                                                "name":"testingEnum",
+                                                "symbols":["Apples","Bananas","Kiwi"]
+                                            }
+                                        }
+                                    }
+                                ]
+                             }
+                             """)
+                },
+                {
+                    SchemaBuilder.builder().record("level1")
+                            .fields()
+                            .name("level1Field1")
+                            .type(SchemaBuilder.record("level2")
+                                    .fields()
+                                    .name("level2Field1")
+                                    .type(SchemaBuilder.record("level3")
+                                            .fields()
+                                            .name("level3Field1")
+                                            .type(ALL_TYPES_RECORD_SCHEMA)
+                                            .noDefault()
+                                            .endRecord())
+                                    .noDefault()
+                                    .name("level2Field2")
+                                    .type().optional().type(ALL_TYPES_RECORD_SCHEMA)
+                                    .endRecord())
+                            .noDefault()
+                            .name("level1Field2")
+                            .type(ALL_TYPES_RECORD_SCHEMA)
+                            .noDefault()
+                            .endRecord()
+                }
+        };
+    }
+
+    @BeforeClass
+    public void setup()
+    {
+        try {
+            tempDirectory = Files.createTempDirectory("testingAvro");
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        trinoLocalFilesystem = new LocalFileSystem(tempDirectory.toAbsolutePath());
+        // test identity
+        assertIsAllTypesPage(ALL_TYPES_PAGE);
+    }
+
+    @Test(dataProvider = "testSchemas")
+    public void testSerdeCycles(Schema schema)
+            throws IOException, AvroTypeException
+    {
+        for (AvroCompressionKind compressionKind : AvroCompressionKind.values()) {
+            if (compressionKind.isSupportedLocally()) {
+                testSerdeCycles(schema, compressionKind);
+            }
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+    {
+        try {
+            trinoLocalFilesystem.deleteDirectory((Location.of("local:///")));
+            Files.deleteIfExists(tempDirectory.toAbsolutePath());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void testSerdeCycles(Schema schema, AvroCompressionKind compressionKind)
+            throws IOException, AvroTypeException
+    {
+        assertThat(schema.getType()).isEqualTo(Schema.Type.RECORD);
+        Location temp1 = createLocalTempLocation();
+        Location temp2 = createLocalTempLocation();
+
+        int count = ThreadLocalRandom.current().nextInt(1000, 10000);
+        ImmutableList.Builder<GenericRecord> testRecordsExpected = ImmutableList.builder();
+        for (Object o : new RandomData(schema, count, true)) {
+            testRecordsExpected.add((GenericRecord) o);
+        }
+
+        ImmutableList.Builder<Page> pages = ImmutableList.builder();
+        try (AvroFileReader fileReader = new AvroFileReader(
+                createWrittenFileWithData(schema, testRecordsExpected.build(), temp1),
+                schema,
+                NoOpAvroTypeManager.INSTANCE)) {
+            while (fileReader.hasNext()) {
+                pages.add(fileReader.next());
+            }
+        }
+
+        try (AvroFileWriter fileWriter = new AvroFileWriter(
+                trinoLocalFilesystem.newOutputFile(temp2).create(),
+                schema,
+                NoOpAvroTypeManager.INSTANCE,
+                compressionKind,
+                ImmutableMap.of(),
+                schema.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
+                AvroTypeUtils.typeFromAvro(schema, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+            for (Page p : pages.build()) {
+                fileWriter.write(p);
+            }
+        }
+
+        ImmutableList.Builder<GenericRecord> testRecordsActual = ImmutableList.builder();
+        try (DataFileReader<GenericRecord> genericRecordDataFileReader = new DataFileReader<>(
+                new AvroFileReader.TrinoDataInputStreamAsAvroSeekableInput(new TrinoDataInputStream(trinoLocalFilesystem.newInputFile(temp2).newStream()), trinoLocalFilesystem.newInputFile(temp2).length()),
+                new GenericDatumReader<>())) {
+            while (genericRecordDataFileReader.hasNext()) {
+                testRecordsActual.add(genericRecordDataFileReader.next());
+            }
+        }
+        assertThat(testRecordsExpected.build().size()).isEqualTo(testRecordsActual.build().size());
+        List<GenericRecord> expected = testRecordsExpected.build();
+        List<GenericRecord> actual = testRecordsActual.build();
+        for (int i = 0; i < expected.size(); i++) {
+            assertThat(expected.get(i)).isEqualTo(actual.get(i));
+        }
+    }
+
+    protected Location createLocalTempLocation()
+    {
+        return Location.of("local:///" + UUID.randomUUID());
+    }
+
+    protected static void assertIsAllTypesPage(Page p)
+    {
+        // test boolean
+        assertThat(p.getBlock(0)).isInstanceOf(ByteArrayBlock.class);
+        assertThat(BooleanType.BOOLEAN.getBoolean(p.getBlock(0), 0)).isTrue();
+        // test int
+        assertThat(p.getBlock(1)).isInstanceOf(IntArrayBlock.class);
+        assertThat(INTEGER.getInt(p.getBlock(1), 0)).isEqualTo(42);
+        // test long
+        assertThat(p.getBlock(2)).isInstanceOf(LongArrayBlock.class);
+        assertThat(BigintType.BIGINT.getLong(p.getBlock(2), 0)).isEqualTo(3400L);
+        // test float
+        assertThat(p.getBlock(3)).isInstanceOf(IntArrayBlock.class);
+        assertThat(RealType.REAL.getFloat(p.getBlock(3), 0)).isCloseTo(3.14f, within(0.001f));
+        // test double
+        assertThat(p.getBlock(4)).isInstanceOf(LongArrayBlock.class);
+        assertThat(DoubleType.DOUBLE.getDouble(p.getBlock(4), 0)).isCloseTo(9.81, within(0.001));
+        // test string
+        assertThat(p.getBlock(5)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VARCHAR.getObject(p.getBlock(5), 0)).isEqualTo(Slices.utf8Slice(A_STRING_VALUE));
+        // test bytes
+        assertThat(p.getBlock(6)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(6), 0)).isEqualTo(Slices.wrappedBuffer(A_BYTES_VALUE));
+        // test fixed
+        assertThat(p.getBlock(7)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(7), 0)).isEqualTo(Slices.wrappedBuffer(A_FIXED_VALUE.bytes()));
+        //test array
+        assertThat(p.getBlock(8)).isInstanceOf(ArrayBlock.class);
+        assertThat(ARRAY_INTEGER.getObject(p.getBlock(8), 0)).isInstanceOf(IntArrayBlock.class);
+        assertBlockEquals(INTEGER, ARRAY_INTEGER.getObject(p.getBlock(8), 0), createIntsBlock(1, 2, 3, 4));
+        // test map
+        assertThat(p.getBlock(9)).isInstanceOf(MapBlock.class);
+        assertThat(MAP_VARCHAR_INTEGER.getObjectValue(null, p.getBlock(9), 0)).isEqualTo(ImmutableMap.of("key1", 1, "key2", 2));
+        // test enum
+        assertThat(p.getBlock(10)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(VARCHAR.getObject(p.getBlock(10), 0)).isEqualTo(Slices.utf8Slice("A"));
+        // test record
+        assertThat(p.getBlock(11)).isInstanceOf(RowBlock.class);
+        Block expected = createRowBlock(ImmutableList.of(INTEGER, DoubleType.DOUBLE, VARCHAR), new Object[] {5, 3.14159265358979, "Simple Record String Field"});
+        assertBlockEquals(RowType.anonymousRow(INTEGER, DoubleType.DOUBLE, VARCHAR), p.getBlock(11), expected);
+        // test nullable union
+        assertThat(p.getBlock(12)).isInstanceOf(VariableWidthBlock.class);
+        assertThat(p.getBlock(12).isNull(0)).isTrue();
+    }
+
+    protected TrinoInputFile createWrittenFileWithData(Schema schema, List<GenericRecord> records)
+            throws IOException
+    {
+        return createWrittenFileWithData(schema, records, createLocalTempLocation());
+    }
+
+    protected TrinoInputFile createWrittenFileWithData(Schema schema, List<GenericRecord> records, Location location)
+            throws IOException
+    {
+        try (DataFileWriter<GenericRecord> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>())) {
+            fileWriter.create(schema, trinoLocalFilesystem.newOutputFile(location).createOrOverwrite());
+            for (GenericRecord genericRecord : records) {
+                fileWriter.append(genericRecord);
+            }
+        }
+        return trinoLocalFilesystem.newInputFile(location);
+    }
+
+    protected TrinoInputFile createWrittenFileWithSchema(int count, Schema schema)
+            throws IOException
+    {
+        Iterator<Object> randomData = new RandomData(schema, count).iterator();
+        Location tempFile = createLocalTempLocation();
+        try (DataFileWriter<GenericRecord> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>())) {
+            fileWriter.create(schema, trinoLocalFilesystem.newOutputFile(tempFile).createOrOverwrite());
+            while (randomData.hasNext()) {
+                fileWriter.append((GenericRecord) randomData.next());
+            }
+        }
+        return trinoLocalFilesystem.newInputFile(tempFile);
+    }
+
+    static GenericRecord reorderGenericRecord(Schema reorderTo, GenericRecord record)
+    {
+        GenericRecordBuilder recordBuilder = new GenericRecordBuilder(reorderTo);
+        for (Schema.Field field : reorderTo.getFields()) {
+            if (field.schema().getType() == Schema.Type.RECORD) {
+                recordBuilder.set(field, reorderGenericRecord(field.schema(), (GenericRecord) record.get(field.name())));
+            }
+            else {
+                recordBuilder.set(field, record.get(field.name()));
+            }
+        }
+        return recordBuilder.build();
+    }
+
+    static <T> List<T> reorder(List<T> list)
+    {
+        List<T> l = new ArrayList<>(list);
+        Collections.shuffle(l);
+        return ImmutableList.copyOf(l);
+    }
+
+    static Schema reorderSchema(Schema schema)
+    {
+        verify(schema.getType() == Schema.Type.RECORD);
+        SchemaBuilder.FieldAssembler<Schema> fieldAssembler = SchemaBuilder.builder().record(schema.getName()).fields();
+        for (Schema.Field field : reorder(schema.getFields())) {
+            if (field.schema().getType() == Schema.Type.ENUM) {
+                fieldAssembler = fieldAssembler.name(field.name())
+                        .type(Schema.createEnum(field.schema().getName(), field.schema().getDoc(), field.schema().getNamespace(), Lists.reverse(field.schema().getEnumSymbols())))
+                        .noDefault();
+            }
+            else if (field.schema().getType() == Schema.Type.UNION) {
+                fieldAssembler = fieldAssembler.name(field.name())
+                        .type(Schema.createUnion(reorder(field.schema().getTypes())))
+                        .noDefault();
+            }
+            else if (field.schema().getType() == Schema.Type.RECORD) {
+                fieldAssembler = fieldAssembler.name(field.name())
+                        .type(reorderSchema(field.schema()))
+                        .noDefault();
+            }
+            else {
+                fieldAssembler = fieldAssembler.name(field.name()).type(field.schema()).noDefault();
+            }
+        }
+        return fieldAssembler.endRecord();
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
@@ -14,9 +14,13 @@
 package io.trino.hive.formats.avro;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Longs;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Int128;
@@ -26,12 +30,15 @@ import io.trino.spi.type.SqlTime;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Timestamps;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.UuidType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -40,19 +47,19 @@ import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.UUID;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.DATE_SCHEMA;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.TIMESTAMP_MICROS_SCHEMA;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.TIMESTAMP_MILLIS_SCHEMA;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.TIME_MICROS_SCHEMA;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.TIME_MILLIS_SCHEMA;
 import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.UUID_SCHEMA;
-import static io.trino.hive.formats.avro.TestAvroPageDataReaderWithoutTypeManager.createWrittenFileWithData;
-import static io.trino.hive.formats.avro.TestAvroPageDataReaderWithoutTypeManager.createWrittenFileWithSchema;
-import static io.trino.hive.formats.avro.TestLongFromBigEndian.padBigEndianCorrectly;
+import static io.trino.hive.formats.avro.NativeLogicalTypesAvroTypeManager.padBigEndianToSize;
 import static io.trino.spi.type.Decimals.MAX_SHORT_PRECISION;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class TestAvroPageDataReaderWithAvroNativeTypeManagement
+        extends TestAvroBase
 {
     private static final Schema DECIMAL_SMALL_BYTES_SCHEMA;
     private static final int SMALL_FIXED_SIZE = 8;
@@ -63,6 +70,12 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
     private static final Date testTime = new Date(780681600000L);
     private static final Type SMALL_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION - 1, 2);
     private static final Type LARGE_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION + 1, 2);
+    private static final Schema ALL_SUPPORTED_TYPES_SCHEMA;
+    private static final GenericRecord ALL_SUPPORTED_TYPES_GENERIC_RECORD;
+    private static final Page ALL_SUPPORTED_PAGE;
+    public static final GenericData.Fixed GENERIC_SMALL_FIXED_DECIMAL;
+    public static final GenericData.Fixed GENERIC_LARGE_FIXED_DECIMAL;
+    public static final UUID RANDOM_UUID = UUID.randomUUID();
 
     static {
         LogicalTypes.Decimal small = LogicalTypes.decimal(MAX_SHORT_PRECISION - 1, 2);
@@ -75,13 +88,10 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
         large.addToSchema(DECIMAL_LARGE_BYTES_SCHEMA);
         DECIMAL_LARGE_FIXED_SCHEMA = Schema.createFixed("largeDecimal", "myFixed", "namespace", (int) ((MAX_SHORT_PRECISION + 2) * Math.log(10) / Math.log(2) / 8) + 1);
         large.addToSchema(DECIMAL_LARGE_FIXED_SCHEMA);
-    }
+        GENERIC_SMALL_FIXED_DECIMAL = new GenericData.Fixed(DECIMAL_SMALL_FIXED_SCHEMA, padBigEndianToSize(78068160000000L, SMALL_FIXED_SIZE));
+        GENERIC_LARGE_FIXED_DECIMAL = new GenericData.Fixed(DECIMAL_LARGE_FIXED_SCHEMA, padBigEndianToSize(78068160000000L, LARGE_FIXED_SIZE));
 
-    @Test
-    public void testTypesSimple()
-            throws IOException, AvroTypeException
-    {
-        Schema schema = SchemaBuilder.builder()
+        ALL_SUPPORTED_TYPES_SCHEMA = SchemaBuilder.builder()
                 .record("allSupported")
                 .fields()
                 .name("timestampMillis")
@@ -106,62 +116,73 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
                 .type(UUID_SCHEMA).noDefault()
                 .endRecord();
 
-        GenericData.Fixed genericSmallFixedDecimal = new GenericData.Fixed(DECIMAL_SMALL_FIXED_SCHEMA);
-        genericSmallFixedDecimal.bytes(padBigEndianCorrectly(78068160000000L, SMALL_FIXED_SIZE));
-        GenericData.Fixed genericLargeFixedDecimal = new GenericData.Fixed(DECIMAL_LARGE_FIXED_SCHEMA);
-        genericLargeFixedDecimal.bytes(padBigEndianCorrectly(78068160000000L, LARGE_FIXED_SIZE));
-        UUID id = UUID.randomUUID();
+        ImmutableList.Builder<Block> blocks = ImmutableList.builder();
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD = new GenericData.Record(ALL_SUPPORTED_TYPES_SCHEMA);
 
-        GenericData.Record myRecord = new GenericData.Record(schema);
-        myRecord.put("timestampMillis", testTime.getTime());
-        myRecord.put("timestampMicros", testTime.getTime() * 1000);
-        myRecord.put("smallBytesDecimal", ByteBuffer.wrap(Longs.toByteArray(78068160000000L)));
-        myRecord.put("smallFixedDecimal", genericSmallFixedDecimal);
-        myRecord.put("largeBytesDecimal", ByteBuffer.wrap(Int128.fromBigEndian(Longs.toByteArray(78068160000000L)).toBigEndianBytes()));
-        myRecord.put("largeFixedDecimal", genericLargeFixedDecimal);
-        myRecord.put("date", 9035);
-        myRecord.put("timeMillis", 39_600_000);
-        myRecord.put("timeMicros", 39_600_000_000L);
-        myRecord.put("id", id.toString());
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("timestampMillis", testTime.getTime());
+        BlockBuilder timestampMilliBlock = TimestampType.TIMESTAMP_MILLIS.createBlockBuilder(null, 1);
+        TimestampType.TIMESTAMP_MILLIS.writeLong(timestampMilliBlock, testTime.getTime() * Timestamps.MICROSECONDS_PER_MILLISECOND);
+        blocks.add(timestampMilliBlock.build());
 
-        TrinoInputFile input = createWrittenFileWithData(schema, ImmutableList.of(myRecord));
-        try (AvroFileReader avroFileReader = new AvroFileReader(input, schema, new NativeLogicalTypesAvroTypeManager())) {
-            int totalRecords = 0;
-            while (avroFileReader.hasNext()) {
-                Page p = avroFileReader.next();
-                // Timestamps equal
-                SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getBlock(0), 0);
-                SqlTimestamp microTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MICROS.getObjectValue(null, p.getBlock(1), 0);
-                assertThat(milliTimestamp).isEqualTo(microTimestamp.roundTo(3));
-                assertThat(microTimestamp.getEpochMicros()).isEqualTo(testTime.getTime() * 1000);
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("timestampMicros", testTime.getTime() * 1000);
+        BlockBuilder timestampMicroBlock = TimestampType.TIMESTAMP_MICROS.createBlockBuilder(null, 1);
+        TimestampType.TIMESTAMP_MICROS.writeLong(timestampMicroBlock, testTime.getTime() * Timestamps.MICROSECONDS_PER_MILLISECOND);
+        blocks.add(timestampMicroBlock.build());
 
-                // Decimals Equal
-                SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(2), 0);
-                SqlDecimal smallFixedDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(3), 0);
-                SqlDecimal largeBytesDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(4), 0);
-                SqlDecimal largeFixedDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(5), 0);
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("smallBytesDecimal", ByteBuffer.wrap(Longs.toByteArray(78068160000000L)));
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("smallFixedDecimal", GENERIC_SMALL_FIXED_DECIMAL);
+        BlockBuilder smallDecimalBlock = SMALL_DECIMAL_TYPE.createBlockBuilder(null, 1);
+        SMALL_DECIMAL_TYPE.writeLong(smallDecimalBlock, 78068160000000L);
+        blocks.add(smallDecimalBlock.build());
+        blocks.add(smallDecimalBlock.build());
 
-                assertThat(smallBytesDecimal).isEqualTo(smallFixedDecimal);
-                assertThat(largeBytesDecimal).isEqualTo(largeFixedDecimal);
-                assertThat(smallBytesDecimal.toBigDecimal()).isEqualTo(largeBytesDecimal.toBigDecimal());
-                assertThat(smallBytesDecimal.getUnscaledValue()).isEqualTo(new BigInteger(Longs.toByteArray(78068160000000L)));
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("largeBytesDecimal", ByteBuffer.wrap(Int128.valueOf(78068160000000L).toBigEndianBytes()));
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("largeFixedDecimal", GENERIC_LARGE_FIXED_DECIMAL);
+        BlockBuilder largeDecimalBlock = LARGE_DECIMAL_TYPE.createBlockBuilder(null, 1);
+        LARGE_DECIMAL_TYPE.writeObject(largeDecimalBlock, Int128.valueOf(78068160000000L));
+        blocks.add(largeDecimalBlock.build());
+        blocks.add(largeDecimalBlock.build());
 
-                // Get date
-                SqlDate date = (SqlDate) DateType.DATE.getObjectValue(null, p.getBlock(6), 0);
-                assertThat(date.getDays()).isEqualTo(9035);
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("date", 9035);
+        BlockBuilder dateBlockBuilder = DateType.DATE.createBlockBuilder(null, 1);
+        DateType.DATE.writeInt(dateBlockBuilder, 9035);
+        blocks.add(dateBlockBuilder.build());
 
-                // Time equals
-                SqlTime timeMillis = (SqlTime) TimeType.TIME_MILLIS.getObjectValue(null, p.getBlock(7), 0);
-                SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getBlock(8), 0);
-                assertThat(timeMillis).isEqualTo(timeMicros.roundTo(3));
-                assertThat(timeMillis.getPicos()).isEqualTo(timeMicros.getPicos()).isEqualTo(39_600_000_000L * 1_000_000L);
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("timeMillis", 39_600_000);
+        BlockBuilder timeMillisBlock = TimeType.TIME_MILLIS.createBlockBuilder(null, 1);
+        TimeType.TIME_MILLIS.writeLong(timeMillisBlock, 39_600_000L * Timestamps.PICOSECONDS_PER_MILLISECOND);
+        blocks.add(timeMillisBlock.build());
 
-                //UUID
-                assertThat(id.toString()).isEqualTo(UuidType.UUID.getObjectValue(null, p.getBlock(9), 0));
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("timeMicros", 39_600_000_000L);
+        BlockBuilder timeMicrosBlock = TimeType.TIME_MICROS.createBlockBuilder(null, 1);
+        TimeType.TIME_MICROS.writeLong(timeMicrosBlock, 39_600_000_000L * Timestamps.PICOSECONDS_PER_MICROSECOND);
+        blocks.add(timeMicrosBlock.build());
 
-                totalRecords += p.getPositionCount();
+        ALL_SUPPORTED_TYPES_GENERIC_RECORD.put("id", RANDOM_UUID.toString());
+        BlockBuilder uuidBlock = UuidType.UUID.createBlockBuilder(null, 1);
+        UuidType.UUID.writeSlice(uuidBlock, UuidType.javaUuidToTrinoUuid(RANDOM_UUID));
+        blocks.add(uuidBlock.build());
+
+        ALL_SUPPORTED_PAGE = new Page(blocks.build().toArray(Block[]::new));
+    }
+
+    @BeforeClass
+    public void testStatics()
+    {
+        // Identity
+        assertIsAllSupportedTypePage(ALL_SUPPORTED_PAGE);
+    }
+
+    @Test
+    public void testTypesSimple()
+            throws IOException, AvroTypeException
+    {
+        TrinoInputFile input = createWrittenFileWithData(ALL_SUPPORTED_TYPES_SCHEMA, ImmutableList.of(ALL_SUPPORTED_TYPES_GENERIC_RECORD));
+        try (AvroFileReader pageIterator = new AvroFileReader(input, ALL_SUPPORTED_TYPES_SCHEMA, new NativeLogicalTypesAvroTypeManager())) {
+            while (pageIterator.hasNext()) {
+                Page p = pageIterator.next();
+                assertIsAllSupportedTypePage(p);
             }
-            assertThat(totalRecords).isEqualTo(1);
         }
     }
 
@@ -213,5 +234,65 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
             }
             assertThat(totalRecords).isEqualTo(10);
         }
+    }
+
+    @Test
+    public void testWriting()
+            throws IOException, AvroTypeException
+    {
+        Location testLocation = createLocalTempLocation();
+        try (AvroFileWriter fileWriter = new AvroFileWriter(
+                trinoLocalFilesystem.newOutputFile(testLocation).create(),
+                ALL_SUPPORTED_TYPES_SCHEMA,
+                new NativeLogicalTypesAvroTypeManager(),
+                AvroCompressionKind.NULL,
+                ImmutableMap.of(),
+                ALL_SUPPORTED_TYPES_SCHEMA.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
+                AvroTypeUtils.typeFromAvro(ALL_SUPPORTED_TYPES_SCHEMA, new NativeLogicalTypesAvroTypeManager()).getTypeParameters())) {
+            fileWriter.write(ALL_SUPPORTED_PAGE);
+        }
+
+        try (AvroFileReader fileReader = new AvroFileReader(
+                trinoLocalFilesystem.newInputFile(testLocation),
+                ALL_SUPPORTED_TYPES_SCHEMA,
+                new NativeLogicalTypesAvroTypeManager())) {
+            assertThat(fileReader.hasNext()).isTrue();
+            assertIsAllSupportedTypePage(fileReader.next());
+            assertThat(fileReader.hasNext()).isFalse();
+        }
+    }
+
+    private static void assertIsAllSupportedTypePage(Page p)
+    {
+        assertThat(p.getPositionCount()).isEqualTo(1);
+        // Timestamps equal
+        SqlTimestamp milliTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MILLIS.getObjectValue(null, p.getBlock(0), 0);
+        SqlTimestamp microTimestamp = (SqlTimestamp) TimestampType.TIMESTAMP_MICROS.getObjectValue(null, p.getBlock(1), 0);
+        assertThat(milliTimestamp).isEqualTo(microTimestamp.roundTo(3));
+        assertThat(microTimestamp.getEpochMicros()).isEqualTo(testTime.getTime() * 1000);
+
+        // Decimals Equal
+        SqlDecimal smallBytesDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(2), 0);
+        SqlDecimal smallFixedDecimal = (SqlDecimal) SMALL_DECIMAL_TYPE.getObjectValue(null, p.getBlock(3), 0);
+        SqlDecimal largeBytesDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(4), 0);
+        SqlDecimal largeFixedDecimal = (SqlDecimal) LARGE_DECIMAL_TYPE.getObjectValue(null, p.getBlock(5), 0);
+
+        assertThat(smallBytesDecimal).isEqualTo(smallFixedDecimal);
+        assertThat(largeBytesDecimal).isEqualTo(largeFixedDecimal);
+        assertThat(smallBytesDecimal.toBigDecimal()).isEqualTo(largeBytesDecimal.toBigDecimal());
+        assertThat(smallBytesDecimal.getUnscaledValue()).isEqualTo(new BigInteger(Longs.toByteArray(78068160000000L)));
+
+        // Get date
+        SqlDate date = (SqlDate) DateType.DATE.getObjectValue(null, p.getBlock(6), 0);
+        assertThat(date.getDays()).isEqualTo(9035);
+
+        // Time equals
+        SqlTime timeMillis = (SqlTime) TimeType.TIME_MILLIS.getObjectValue(null, p.getBlock(7), 0);
+        SqlTime timeMicros = (SqlTime) TimeType.TIME_MICROS.getObjectValue(null, p.getBlock(8), 0);
+        assertThat(timeMillis).isEqualTo(timeMicros.roundTo(3));
+        assertThat(timeMillis.getPicos()).isEqualTo(timeMicros.getPicos()).isEqualTo(39_600_000_000L * 1_000_000L);
+
+        //UUID
+        assertThat(RANDOM_UUID.toString()).isEqualTo(UuidType.UUID.getObjectValue(null, p.getBlock(9), 0));
     }
 }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
+import io.trino.hive.formats.TrinoDataInputStream;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.DictionaryBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.block.BlockAssertions.assertBlockEquals;
+import static io.trino.block.BlockAssertions.createRowBlock;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class TestAvroPageDataWriterWithoutTypeManager
+        extends TestAvroBase
+{
+    @Test
+    public void testAllTypesSimple()
+            throws IOException, AvroTypeException
+    {
+        testAllTypesWriting(ALL_TYPES_RECORD_SCHEMA);
+    }
+
+    @Test
+    public void testAllTypesReordered()
+            throws IOException, AvroTypeException
+    {
+        testAllTypesWriting(reorderSchema(ALL_TYPES_RECORD_SCHEMA));
+    }
+
+    private void testAllTypesWriting(Schema writeSchema)
+            throws AvroTypeException, IOException
+    {
+        Location tempTestLocation = createLocalTempLocation();
+        try (AvroFileWriter fileWriter = new AvroFileWriter(
+                trinoLocalFilesystem.newOutputFile(tempTestLocation).create(),
+                writeSchema,
+                NoOpAvroTypeManager.INSTANCE,
+                AvroCompressionKind.NULL,
+                ImmutableMap.of(),
+                ALL_TYPES_RECORD_SCHEMA.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
+                AvroTypeUtils.typeFromAvro(ALL_TYPES_RECORD_SCHEMA, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+            fileWriter.write(ALL_TYPES_PAGE);
+        }
+
+        try (AvroFileReader fileReader = new AvroFileReader(trinoLocalFilesystem.newInputFile(tempTestLocation), ALL_TYPES_RECORD_SCHEMA, NoOpAvroTypeManager.INSTANCE)) {
+            assertThat(fileReader.hasNext()).isTrue();
+            assertIsAllTypesPage(fileReader.next());
+            assertThat(fileReader.hasNext()).isFalse();
+        }
+
+        try (DataFileReader<GenericRecord> genericRecordDataFileReader = new DataFileReader<>(
+                new AvroFileReader.TrinoDataInputStreamAsAvroSeekableInput(new TrinoDataInputStream(trinoLocalFilesystem.newInputFile(tempTestLocation).newStream()), trinoLocalFilesystem.newInputFile(tempTestLocation).length()),
+                new GenericDatumReader<>(ALL_TYPES_RECORD_SCHEMA))) {
+            assertThat(genericRecordDataFileReader.hasNext()).isTrue();
+            assertThat(genericRecordDataFileReader.next()).isEqualTo(ALL_TYPES_GENERIC_RECORD);
+            assertThat(genericRecordDataFileReader.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    public void testRLEAndDictionaryBlocks()
+            throws IOException, AvroTypeException
+    {
+        Type simepleRecordType = RowType.anonymousRow(INTEGER, DoubleType.DOUBLE, VARCHAR);
+        Schema testBlocksSchema = SchemaBuilder.builder()
+                .record("testRLEAndDictionary")
+                .fields()
+                .name("rleInt")
+                .type().intType().noDefault()
+                .name("rleString")
+                .type().stringType().noDefault()
+                .name("dictString")
+                .type().stringType().noDefault()
+                .name("rleRow")
+                .type(SIMPLE_RECORD_SCHEMA).noDefault()
+                .name("dictRow")
+                .type(SIMPLE_RECORD_SCHEMA).noDefault()
+                .endRecord();
+
+        Block expectedRLERow = createRowBlock(ImmutableList.of(INTEGER, DoubleType.DOUBLE, VARCHAR), new Object[] {5, 3.14159265358979, "Simple Record String Field"});
+        Block expectedDictionaryRow = createRowBlock(ImmutableList.of(INTEGER, DoubleType.DOUBLE, VARCHAR), new Object[] {2, 27.9, "Sting1"});
+        Page toWrite = new Page(
+                RunLengthEncodedBlock.create(IntegerType.INTEGER, 2L, 2),
+                RunLengthEncodedBlock.create(VarcharType.VARCHAR, Slices.utf8Slice("rleString"), 2),
+                DictionaryBlock.create(2,
+                        VarcharType.VARCHAR.createBlockBuilder(null, 3, 1)
+                                .writeEntry(Slices.utf8Slice("A"))
+                                .writeEntry(Slices.utf8Slice("B"))
+                                .writeEntry(Slices.utf8Slice("C"))
+                                .build(),
+                        new int[] {1, 2}),
+                RunLengthEncodedBlock.create(
+                        expectedRLERow, 2),
+                DictionaryBlock.create(2,
+                        expectedDictionaryRow,
+                        new int[] {0, 0}));
+
+        Location testLocation = createLocalTempLocation();
+        try (AvroFileWriter avroFileWriter = new AvroFileWriter(
+                trinoLocalFilesystem.newOutputFile(testLocation).create(),
+                testBlocksSchema,
+                NoOpAvroTypeManager.INSTANCE,
+                AvroCompressionKind.NULL,
+                ImmutableMap.of(),
+                testBlocksSchema.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
+                AvroTypeUtils.typeFromAvro(testBlocksSchema, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+            avroFileWriter.write(toWrite);
+        }
+
+        try (AvroFileReader avroFileReader = new AvroFileReader(
+                trinoLocalFilesystem.newInputFile(testLocation),
+                testBlocksSchema,
+                NoOpAvroTypeManager.INSTANCE)) {
+            assertThat(avroFileReader.hasNext()).isTrue();
+            Page readPage = avroFileReader.next();
+            assertThat(INTEGER.getInt(readPage.getBlock(0), 0)).isEqualTo(2);
+            assertThat(INTEGER.getInt(readPage.getBlock(0), 1)).isEqualTo(2);
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(1), 0)).isEqualTo(Slices.utf8Slice("rleString"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(1), 1)).isEqualTo(Slices.utf8Slice("rleString"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(2), 0)).isEqualTo(Slices.utf8Slice("B"));
+            assertThat(VarcharType.VARCHAR.getSlice(readPage.getBlock(2), 1)).isEqualTo(Slices.utf8Slice("C"));
+            assertBlockEquals(simepleRecordType, readPage.getBlock(3).getSingleValueBlock(0), expectedRLERow);
+            assertBlockEquals(simepleRecordType, readPage.getBlock(3).getSingleValueBlock(1), expectedRLERow);
+            assertBlockEquals(simepleRecordType, readPage.getBlock(4).getSingleValueBlock(0), expectedDictionaryRow);
+            assertBlockEquals(simepleRecordType, readPage.getBlock(4).getSingleValueBlock(1), expectedDictionaryRow);
+            assertThat(avroFileReader.hasNext()).isFalse();
+        }
+    }
+
+    @Test
+    public void testBlockUpcasting()
+            throws IOException, AvroTypeException
+    {
+        Schema testCastingSchema = SchemaBuilder.builder()
+                .record("testUpCasting")
+                .fields()
+                .name("byteToInt")
+                .type().intType().noDefault()
+                .name("shortToInt")
+                .type().intType().noDefault()
+                .name("byteToLong")
+                .type().longType().noDefault()
+                .name("shortToLong")
+                .type().longType().noDefault()
+                .name("intToLong")
+                .type().longType().noDefault()
+                .endRecord();
+
+        BlockBuilder byteBlockBuilder = TINYINT.createBlockBuilder(null, 1);
+        TINYINT.writeByte(byteBlockBuilder, (byte) 1);
+        Block byteBlock = byteBlockBuilder.build();
+
+        BlockBuilder shortBlockBuilder = SMALLINT.createBlockBuilder(null, 1);
+        SMALLINT.writeShort(shortBlockBuilder, (short) 2);
+        Block shortBlock = shortBlockBuilder.build();
+
+        BlockBuilder integerBlockBuilder = INTEGER.createBlockBuilder(null, 1);
+        INTEGER.writeInt(integerBlockBuilder, 4);
+        Block integerBlock = integerBlockBuilder.build();
+
+        Page toWrite = new Page(byteBlock, shortBlock, byteBlock, shortBlock, integerBlock);
+        Location testLocation = createLocalTempLocation();
+        try (AvroFileWriter avroFileWriter = new AvroFileWriter(
+                trinoLocalFilesystem.newOutputFile(testLocation).create(),
+                testCastingSchema,
+                NoOpAvroTypeManager.INSTANCE,
+                AvroCompressionKind.NULL,
+                ImmutableMap.of(),
+                ImmutableList.of("byteToInt", "shortToInt", "byteToLong", "shortToLong", "intToLong"),
+                ImmutableList.of(TINYINT, SMALLINT, TINYINT, SMALLINT, INTEGER))) {
+            avroFileWriter.write(toWrite);
+        }
+
+        try (AvroFileReader avroFileReader = new AvroFileReader(
+                trinoLocalFilesystem.newInputFile(testLocation),
+                testCastingSchema,
+                NoOpAvroTypeManager.INSTANCE)) {
+            assertThat(avroFileReader.hasNext()).isTrue();
+            Page readPage = avroFileReader.next();
+            assertThat(INTEGER.getInt(readPage.getBlock(0), 0)).isEqualTo(1);
+            assertThat(INTEGER.getInt(readPage.getBlock(1), 0)).isEqualTo(2);
+            assertThat(BIGINT.getLong(readPage.getBlock(2), 0)).isEqualTo(1);
+            assertThat(BIGINT.getLong(readPage.getBlock(3), 0)).isEqualTo(2);
+            assertThat(BIGINT.getLong(readPage.getBlock(4), 0)).isEqualTo(4);
+            assertThat(avroFileReader.hasNext()).isFalse();
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodec.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodec.java
@@ -13,8 +13,8 @@
  */
 package io.trino.plugin.hive;
 
+import io.trino.hive.formats.avro.AvroCompressionKind;
 import io.trino.orc.metadata.CompressionKind;
-import org.apache.avro.file.DataFileConstants;
 import org.apache.parquet.format.CompressionCodec;
 
 import java.util.Optional;
@@ -23,30 +23,30 @@ import static java.util.Objects.requireNonNull;
 
 public enum HiveCompressionCodec
 {
-    NONE(null, CompressionKind.NONE, CompressionCodec.UNCOMPRESSED, DataFileConstants.NULL_CODEC),
-    SNAPPY(io.trino.hive.formats.compression.CompressionKind.SNAPPY, CompressionKind.SNAPPY, CompressionCodec.SNAPPY, DataFileConstants.SNAPPY_CODEC),
+    NONE(null, CompressionKind.NONE, CompressionCodec.UNCOMPRESSED, AvroCompressionKind.NULL),
+    SNAPPY(io.trino.hive.formats.compression.CompressionKind.SNAPPY, CompressionKind.SNAPPY, CompressionCodec.SNAPPY, AvroCompressionKind.SNAPPY),
     LZ4(io.trino.hive.formats.compression.CompressionKind.LZ4, CompressionKind.LZ4, CompressionCodec.LZ4, null),
-    ZSTD(io.trino.hive.formats.compression.CompressionKind.ZSTD, CompressionKind.ZSTD, CompressionCodec.ZSTD, DataFileConstants.ZSTANDARD_CODEC),
+    ZSTD(io.trino.hive.formats.compression.CompressionKind.ZSTD, CompressionKind.ZSTD, CompressionCodec.ZSTD, AvroCompressionKind.ZSTANDARD),
     // Using DEFLATE for GZIP for Avro for now so Avro files can be written in default configuration
     // TODO(https://github.com/trinodb/trino/issues/12580) change GZIP to be unsupported for Avro when we change Trino default compression to be storage format aware
-    GZIP(io.trino.hive.formats.compression.CompressionKind.GZIP, CompressionKind.ZLIB, CompressionCodec.GZIP, DataFileConstants.DEFLATE_CODEC);
+    GZIP(io.trino.hive.formats.compression.CompressionKind.GZIP, CompressionKind.ZLIB, CompressionCodec.GZIP, AvroCompressionKind.DEFLATE);
 
     private final Optional<io.trino.hive.formats.compression.CompressionKind> hiveCompressionKind;
     private final CompressionKind orcCompressionKind;
     private final CompressionCodec parquetCompressionCodec;
 
-    private final Optional<String> avroCompressionCodec;
+    private final Optional<AvroCompressionKind> avroCompressionKind;
 
     HiveCompressionCodec(
             io.trino.hive.formats.compression.CompressionKind hiveCompressionKind,
             CompressionKind orcCompressionKind,
             CompressionCodec parquetCompressionCodec,
-            String avroCompressionCodec)
+            AvroCompressionKind avroCompressionKind)
     {
         this.hiveCompressionKind = Optional.ofNullable(hiveCompressionKind);
         this.orcCompressionKind = requireNonNull(orcCompressionKind, "orcCompressionKind is null");
         this.parquetCompressionCodec = requireNonNull(parquetCompressionCodec, "parquetCompressionCodec is null");
-        this.avroCompressionCodec = Optional.ofNullable(avroCompressionCodec);
+        this.avroCompressionKind = Optional.ofNullable(avroCompressionKind);
     }
 
     public Optional<io.trino.hive.formats.compression.CompressionKind> getHiveCompressionKind()
@@ -64,8 +64,8 @@ public enum HiveCompressionCodec
         return parquetCompressionCodec;
     }
 
-    public Optional<String> getAvroCompressionCodec()
+    public Optional<AvroCompressionKind> getAvroCompressionKind()
     {
-        return avroCompressionCodec;
+        return avroCompressionKind;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCompressionCodecs.java
@@ -39,7 +39,7 @@ public final class HiveCompressionCodecs
         HiveCompressionCodec selectedCodec = selectCompressionCodec(compressionOption);
 
         // perform codec vs format validation
-        if (storageFormat == HiveStorageFormat.AVRO && selectedCodec.getAvroCompressionCodec().isEmpty()) {
+        if (storageFormat == HiveStorageFormat.AVRO && selectedCodec.getAvroCompressionKind().isEmpty()) {
             throw new TrinoException(HiveErrorCode.HIVE_UNSUPPORTED_FORMAT, "Compression codec " + selectedCodec + " not supported for " + storageFormat);
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsConfig.java
@@ -19,6 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 public class HiveFormatsConfig
 {
     private boolean avroFileNativeReaderEnabled = true;
+    private boolean avroFileNativeWriterEnabled = true;
     private boolean csvNativeReaderEnabled = true;
     private boolean csvNativeWriterEnabled = true;
     private boolean jsonNativeReaderEnabled = true;
@@ -41,6 +42,19 @@ public class HiveFormatsConfig
     public HiveFormatsConfig setAvroFileNativeReaderEnabled(boolean avroFileNativeReaderEnabled)
     {
         this.avroFileNativeReaderEnabled = avroFileNativeReaderEnabled;
+        return this;
+    }
+
+    public boolean isAvroFileNativeWriterEnabled()
+    {
+        return avroFileNativeWriterEnabled;
+    }
+
+    @Config("avro.native-writer.enabled")
+    @ConfigDescription("Use native Avro file writer")
+    public HiveFormatsConfig setAvroFileNativeWriterEnabled(boolean avroFileNativeWriterEnabled)
+    {
+        this.avroFileNativeWriterEnabled = avroFileNativeWriterEnabled;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -25,6 +25,7 @@ import io.trino.hdfs.HdfsNamenodeStats;
 import io.trino.hdfs.TrinoFileSystemCache;
 import io.trino.hdfs.TrinoFileSystemCacheStats;
 import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.avro.AvroHiveFileWriterFactory;
 import io.trino.plugin.hive.avro.AvroHivePageSourceFactory;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
@@ -160,6 +161,7 @@ public class HiveModule
         fileWriterFactoryBinder.addBinding().to(SimpleSequenceFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(AvroHiveFileWriterFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -66,6 +66,7 @@ public final class HiveSessionProperties
     private static final String FORCE_LOCAL_SCHEDULING = "force_local_scheduling";
     private static final String INSERT_EXISTING_PARTITIONS_BEHAVIOR = "insert_existing_partitions_behavior";
     private static final String AVRO_NATIVE_READER_ENABLED = "avro_native_reader_enabled";
+    private static final String AVRO_NATIVE_WRITER_ENABLED = "avro_native_writer_enabled";
     private static final String CSV_NATIVE_READER_ENABLED = "csv_native_reader_enabled";
     private static final String CSV_NATIVE_WRITER_ENABLED = "csv_native_writer_enabled";
     private static final String JSON_NATIVE_READER_ENABLED = "json_native_reader_enabled";
@@ -208,6 +209,11 @@ public final class HiveSessionProperties
                         AVRO_NATIVE_READER_ENABLED,
                         "Use native Avro file reader",
                         hiveFormatsConfig.isAvroFileNativeReaderEnabled(),
+                        false),
+                booleanProperty(
+                        AVRO_NATIVE_WRITER_ENABLED,
+                        "Use native Avro file writer",
+                        hiveFormatsConfig.isAvroFileNativeWriterEnabled(),
                         false),
                 booleanProperty(
                         CSV_NATIVE_READER_ENABLED,
@@ -668,6 +674,11 @@ public final class HiveSessionProperties
     public static boolean isAvroNativeReaderEnabled(ConnectorSession session)
     {
         return session.getProperty(AVRO_NATIVE_READER_ENABLED, Boolean.class);
+    }
+
+    public static boolean isAvroNativeWriterEnabled(ConnectorSession session)
+    {
+        return session.getProperty(AVRO_NATIVE_WRITER_ENABLED, Boolean.class);
     }
 
     public static boolean isCsvNativeReaderEnabled(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriter.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.avro;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CountingOutputStream;
+import io.trino.hive.formats.avro.AvroCompressionKind;
+import io.trino.hive.formats.avro.AvroFileWriter;
+import io.trino.hive.formats.avro.AvroTypeException;
+import io.trino.hive.formats.avro.AvroTypeManager;
+import io.trino.hive.formats.avro.AvroTypeUtils;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.plugin.hive.FileWriter;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.Type;
+import org.apache.avro.Schema;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class AvroHiveFileWriter
+        implements FileWriter
+{
+    private static final int INSTANCE_SIZE = instanceSize(AvroHiveFileWriter.class);
+
+    private final AvroFileWriter fileWriter;
+    private final List<Block> typeCorrectNullBlocks;
+    private final CountingOutputStream countingOutputStream;
+    private final AggregatedMemoryContext outputStreamMemoryContext;
+
+    private final Closeable rollbackAction;
+
+    public AvroHiveFileWriter(
+            OutputStream outputStream,
+            AggregatedMemoryContext outputStreamMemoryContext,
+            Schema fileSchema,
+            AvroTypeManager typeManager,
+            Closeable rollbackAction,
+            List<String> inputColumnNames,
+            List<Type> inputColumnTypes,
+            AvroCompressionKind compressionKind,
+            Map<String, String> metadata)
+            throws IOException, AvroTypeException
+    {
+        countingOutputStream = new CountingOutputStream(requireNonNull(outputStream, "outputStream is null"));
+        this.outputStreamMemoryContext = requireNonNull(outputStreamMemoryContext, "outputStreamMemoryContext is null");
+        verify(requireNonNull(fileSchema, "fileSchema is null").getType() == Schema.Type.RECORD, "file schema must be record schema");
+        verify(inputColumnNames.size() == inputColumnTypes.size(), "column names must be equal to column types");
+        // file writer will reorder input columns to schema, we just need to impute nulls for schema fields without input columns
+        ImmutableList.Builder<String> outputColumnNames = ImmutableList.<String>builder().addAll(inputColumnNames);
+        ImmutableList.Builder<Type> outputColumnTypes = ImmutableList.<Type>builder().addAll(inputColumnTypes);
+        Map<String, Schema> fields = fileSchema.getFields().stream().collect(Collectors.toMap(Schema.Field::name, Schema.Field::schema));
+        for (String inputColumnName : inputColumnNames) {
+            Schema fieldSchema = fields.remove(inputColumnName);
+            if (fieldSchema == null) {
+                throw new AvroTypeException("File schema doesn't have input field " + inputColumnName);
+            }
+        }
+        ImmutableList.Builder<Block> blocks = ImmutableList.builder();
+        for (Map.Entry<String, Schema> entry : fields.entrySet()) {
+            outputColumnNames.add(entry.getKey());
+            Type type = AvroTypeUtils.typeFromAvro(entry.getValue(), typeManager);
+            outputColumnTypes.add(type);
+            blocks.add(type.createBlockBuilder(null, 1).appendNull().build());
+        }
+        typeCorrectNullBlocks = blocks.build();
+        fileWriter = new AvroFileWriter(countingOutputStream, fileSchema, typeManager, compressionKind, metadata, outputColumnNames.build(), outputColumnTypes.build());
+        this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return countingOutputStream.getCount();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return INSTANCE_SIZE + fileWriter.getRetainedSize() + outputStreamMemoryContext.getBytes();
+    }
+
+    @Override
+    public void appendRows(Page dataPage)
+    {
+        try {
+            Block[] blocks = new Block[dataPage.getChannelCount() + typeCorrectNullBlocks.size()];
+            for (int i = 0; i < dataPage.getChannelCount(); i++) {
+                blocks[i] = dataPage.getBlock(i);
+            }
+            for (int i = 0; i < typeCorrectNullBlocks.size(); i++) {
+                blocks[i + dataPage.getChannelCount()] = RunLengthEncodedBlock.create(typeCorrectNullBlocks.get(i), dataPage.getPositionCount());
+            }
+            fileWriter.write(new Page(blocks));
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_WRITER_DATA_ERROR, "Failed to write data page to Avro file", e);
+        }
+    }
+
+    @Override
+    public Closeable commit()
+    {
+        try {
+            fileWriter.close();
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Failed to close AvroFileWriter", e);
+        }
+        return rollbackAction;
+    }
+
+    @Override
+    public void rollback()
+    {
+        try (rollbackAction) {
+            fileWriter.close();
+        }
+        catch (Exception e) {
+            throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);
+        }
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileWriterFactory.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.avro;
+
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.hive.formats.avro.AvroCompressionKind;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.plugin.hive.HiveFileWriterFactory;
+import io.trino.plugin.hive.HiveTimestampPrecision;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.WriterKind;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.plugin.hive.metastore.StorageFormat;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import org.apache.avro.Schema;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
+import static io.trino.plugin.hive.HiveMetadata.PRESTO_VERSION_NAME;
+import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.trino.plugin.hive.HiveSessionProperties.isAvroNativeWriterEnabled;
+import static io.trino.plugin.hive.util.HiveClassNames.AVRO_CONTAINER_OUTPUT_FORMAT_CLASS;
+import static io.trino.plugin.hive.util.HiveUtil.getColumnNames;
+import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
+import static java.util.Objects.requireNonNull;
+
+public class AvroHiveFileWriterFactory
+        implements HiveFileWriterFactory
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final TypeManager typeManager;
+    private final NodeVersion nodeVersion;
+
+    @Inject
+    public AvroHiveFileWriterFactory(
+            TrinoFileSystemFactory fileSystemFactory,
+            TypeManager typeManager,
+            NodeVersion nodeVersion)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion");
+    }
+
+    @Override
+    public Optional<FileWriter> createFileWriter(
+            Location location,
+            List<String> inputColumnNames,
+            StorageFormat storageFormat,
+            HiveCompressionCodec compressionCodec,
+            Properties schema,
+            ConnectorSession session,
+            OptionalInt bucketNumber,
+            AcidTransaction transaction,
+            boolean useAcidSchema,
+            WriterKind writerKind)
+    {
+        if (!isAvroNativeWriterEnabled(session)) {
+            return Optional.empty();
+        }
+        if (!AVRO_CONTAINER_OUTPUT_FORMAT_CLASS.equals(storageFormat.getOutputFormat())) {
+            return Optional.empty();
+        }
+
+        AvroCompressionKind compressionKind = compressionCodec.getAvroCompressionKind().orElse(AvroCompressionKind.NULL);
+        if (!compressionKind.isSupportedLocally()) {
+            throw new VerifyException("Avro Compression codec %s is not supported in the environment".formatted(compressionKind));
+        }
+
+        HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
+        // existing tables and partitions may have columns in a different order than the writer is providing, so build
+        // an index to rearrange columns in the proper order
+        List<String> fileColumnNames = getColumnNames(schema);
+        List<Type> fileColumnTypes = getColumnTypes(schema).stream()
+                .map(hiveType -> hiveType.getType(typeManager, hiveTimestampPrecision))
+                .collect(toImmutableList());
+
+        List<Type> inputColumnTypes = inputColumnNames.stream().map(inputColumnName -> {
+            int index = fileColumnNames.indexOf(inputColumnName);
+            checkArgument(index >= 0, "Input column name [%s] not preset in file columns names %s", inputColumnName, fileColumnNames);
+            return fileColumnTypes.get(index);
+        }).collect(toImmutableList());
+
+        try {
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity());
+            Schema fileSchema = AvroHiveFileUtils.determineSchemaOrThrowException(fileSystem, schema);
+            TrinoOutputFile outputFile = fileSystem.newOutputFile(location);
+            AggregatedMemoryContext outputStreamMemoryContext = newSimpleAggregatedMemoryContext();
+
+            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+
+            return Optional.of(new AvroHiveFileWriter(
+                    outputFile.create(outputStreamMemoryContext),
+                    outputStreamMemoryContext,
+                    fileSchema,
+                    new HiveAvroTypeManager(hiveTimestampPrecision),
+                    rollbackAction,
+                    inputColumnNames,
+                    inputColumnTypes,
+                    compressionKind,
+                    ImmutableMap.<String, String>builder()
+                            .put(PRESTO_VERSION_NAME, nodeVersion.toString())
+                            .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
+                            .buildOrThrow()));
+        }
+        catch (Exception e) {
+            throw new TrinoException(HIVE_WRITER_OPEN_ERROR, "Error creating Avro Container file", e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHivePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHivePageSourceFactory.java
@@ -116,6 +116,7 @@ public class AvroHivePageSourceFactory
 
         TrinoFileSystem trinoFileSystem = trinoFileSystemFactory.create(session.getIdentity());
         TrinoInputFile inputFile = new MonitoredInputFile(stats, trinoFileSystem.newInputFile(path));
+        HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
 
         Schema tableSchema;
         try {
@@ -154,7 +155,6 @@ public class AvroHivePageSourceFactory
             throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, "Avro type resolution error when initializing split from %s".formatted(path), e);
         }
 
-        HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
         if (maskedSchema.getFields().isEmpty()) {
             // no non-masked columns to select from partition schema
             // hack to return null rows with same total count as underlying data file

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/CompressionConfigUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/CompressionConfigUtil.java
@@ -51,7 +51,7 @@ public final class CompressionConfigUtil
         config.set(ParquetOutputFormat.COMPRESSION, compressionCodec.getParquetCompressionCodec().name());
 
         // For Avro
-        compressionCodec.getAvroCompressionCodec().ifPresent(codec -> config.set(AvroJob.OUTPUT_CODEC, codec));
+        compressionCodec.getAvroCompressionKind().ifPresent(kind -> config.set(AvroJob.OUTPUT_CODEC, kind.toString()));
 
         // For SequenceFile
         config.set(FileOutputFormat.COMPRESS_TYPE, BLOCK.toString());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AvroSchemaGenerationTests.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AvroSchemaGenerationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.filesystem.local.LocalFileSystem;
+import io.trino.hadoop.ConfigurationInstantiator;
+import io.trino.plugin.hive.avro.AvroHiveFileUtils;
+import io.trino.plugin.hive.avro.TrinoAvroSerDe;
+import io.trino.plugin.hive.type.TypeInfo;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.VarcharType;
+import org.apache.avro.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.trino.plugin.hive.avro.AvroHiveConstants.TABLE_NAME;
+import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMNS;
+import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_TYPES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AvroSchemaGenerationTests
+{
+    @Test
+    public void testOldVsNewSchemaGeneration()
+            throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty(TABLE_NAME, "testingTable");
+        properties.setProperty(LIST_COLUMNS, "a,b");
+        properties.setProperty(LIST_COLUMN_TYPES, Stream.of(HiveType.HIVE_INT, HiveType.HIVE_STRING).map(HiveType::getTypeInfo).map(TypeInfo::toString).collect(Collectors.joining(",")));
+        Schema actual = AvroHiveFileUtils.determineSchemaOrThrowException(new LocalFileSystem(Path.of("/")), properties);
+        Schema expected = new TrinoAvroSerDe().determineSchemaOrReturnErrorSchema(ConfigurationInstantiator.newEmptyConfiguration(), properties);
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testOldVsNewSchemaGenerationWithNested()
+            throws IOException
+    {
+        Properties properties = new Properties();
+        properties.setProperty(TABLE_NAME, "testingTable");
+        properties.setProperty(LIST_COLUMNS, "a,b");
+        properties.setProperty(LIST_COLUMN_TYPES, Stream.of(HiveType.toHiveType(RowType.rowType(RowType.field("a", VarcharType.VARCHAR))), HiveType.HIVE_STRING).map(HiveType::getTypeInfo).map(TypeInfo::toString).collect(Collectors.joining(",")));
+        Schema actual = AvroHiveFileUtils.determineSchemaOrThrowException(new LocalFileSystem(Path.of("/")), properties);
+        Schema expected = new TrinoAvroSerDe().determineSchemaOrReturnErrorSchema(ConfigurationInstantiator.newEmptyConfiguration(), properties);
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -411,7 +411,6 @@ public final class HiveQueryRunner
                 .setExtraProperties(ImmutableMap.of("http-server.http.port", "8080"))
                 .setHiveProperties(ImmutableMap.of("hive.security", ALLOW_ALL))
                 .setSkipTimezoneSetup(true)
-                .setHiveProperties(ImmutableMap.of())
                 .setInitialTables(TpchTable.getTables())
                 .setBaseDataDir(baseDataDir)
                 .setTpcdsCatalogEnabled(true)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -24,6 +24,7 @@ import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hive.formats.compression.CompressionKind;
 import io.trino.orc.OrcReaderOptions;
 import io.trino.orc.OrcWriterOptions;
+import io.trino.plugin.hive.avro.AvroHiveFileWriterFactory;
 import io.trino.plugin.hive.avro.AvroHivePageSourceFactory;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
@@ -433,6 +434,7 @@ public class TestHiveFileFormats
                 .withColumns(getTestColumnsSupportedByAvro())
                 .withRowsCount(rowCount)
                 .withFileSizePadding(fileSizePadding)
+                .withFileWriterFactory(new AvroHiveFileWriterFactory(FILE_SYSTEM_FACTORY, TESTING_TYPE_MANAGER, new NodeVersion("test_version")))
                 .isReadableByPageSource(new AvroHivePageSourceFactory(FILE_SYSTEM_FACTORY, STATS))
                 .isReadableByRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT));
     }
@@ -597,6 +599,7 @@ public class TestHiveFileFormats
         assertThatFileFormat(AVRO)
                 .withWriteColumns(ImmutableList.of(writeColumn))
                 .withReadColumns(ImmutableList.of(readColumn))
+                .withFileWriterFactory(new AvroHiveFileWriterFactory(FILE_SYSTEM_FACTORY, TESTING_TYPE_MANAGER, new NodeVersion("test_version")))
                 .isReadableByRecordCursor(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new AvroHivePageSourceFactory(FILE_SYSTEM_FACTORY, STATS));
 
@@ -635,6 +638,7 @@ public class TestHiveFileFormats
                 .withWriteColumns(writeColumns)
                 .withReadColumns(readColumns)
                 .withRowsCount(rowCount)
+                .withFileWriterFactory(new AvroHiveFileWriterFactory(FILE_SYSTEM_FACTORY, TESTING_TYPE_MANAGER, new NodeVersion("test_version")))
                 .isReadableByRecordCursorPageSource(createGenericHiveRecordCursorProvider(HDFS_ENVIRONMENT))
                 .isReadableByPageSource(new AvroHivePageSourceFactory(FILE_SYSTEM_FACTORY, STATS));
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFormatsConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFormatsConfig.java
@@ -29,6 +29,7 @@ public class TestHiveFormatsConfig
     {
         assertRecordedDefaults(recordDefaults(HiveFormatsConfig.class)
                 .setAvroFileNativeReaderEnabled(true)
+                .setAvroFileNativeWriterEnabled(true)
                 .setCsvNativeReaderEnabled(true)
                 .setCsvNativeWriterEnabled(true)
                 .setJsonNativeReaderEnabled(true)
@@ -47,6 +48,7 @@ public class TestHiveFormatsConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("avro.native-reader.enabled", "false")
+                .put("avro.native-writer.enabled", "false")
                 .put("csv.native-reader.enabled", "false")
                 .put("csv.native-writer.enabled", "false")
                 .put("json.native-reader.enabled", "false")
@@ -62,6 +64,7 @@ public class TestHiveFormatsConfig
 
         HiveFormatsConfig expected = new HiveFormatsConfig()
                 .setAvroFileNativeReaderEnabled(false)
+                .setAvroFileNativeWriterEnabled(false)
                 .setCsvNativeReaderEnabled(false)
                 .setCsvNativeWriterEnabled(false)
                 .setJsonNativeReaderEnabled(false)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -620,7 +620,7 @@ public class TestHiveStorageFormats
                 if ("AVRO".equals(format)) {
                     // TODO (https://github.com/trinodb/trino/issues/9285) Some versions of Hive cannot read Avro nested structs written by Trino
                     assertThat(e.getCause())
-                            .hasToString("java.sql.SQLException: java.io.IOException: org.apache.avro.AvroTypeException: Found default.record_1, expecting union");
+                            .hasToString("java.sql.SQLException: java.io.IOException: org.apache.avro.AvroTypeException: Found record_1, expecting union");
                 }
                 else {
                     throw e;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

A native implementation of Avro file writer

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
As part of the broader effort to decouple from the hive/hadoop libraries, this PR implements a custom DatumWriter that will encode positions of a given page set once and iterated over. Implements a plugin specific way to overwrite the behavior of the writer especially for given Avro Logical types.

Key classes:
- `io.trino.hive.formats.avro.AvroPagePositionDataWriter` 



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
New Native Avro file writer is enabled by default in the Hive plugin. 
Disable via config `avro.native-writer.enabled=false`
or via session `SET SESSION <catalog-name>.avro_native_writer_enabled = false`
```
