### PR TITLE
Update protoc-jar-maven-plugin config so it can build on M1 macs

### DIFF
--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -371,6 +371,8 @@
                         </goals>
                         <phase>generate-test-sources</phase>
                         <configuration>
+                            <!-- allows building on M1 Macs per: https://github.com/os72/protoc-jar/issues/93#issuecomment-1142635897 -->
+                            <protocArtifact>com.google.protobuf:protoc:3.21.1</protocArtifact>
                             <protocVersion>${dep.protobuf.version}</protocVersion>
                             <addSources>none</addSources>
                             <inputDirectories>


### PR DESCRIPTION
## Description

See: https://github.com/os72/protoc-jar/issues/93#issuecomment-1142635897

On my M1 Mac I get this error:

```
[ERROR] Failed to execute goal com.github.os72:protoc-jar-maven-plugin:3.11.4:run (generate-test-sources) on project trino-kafka: Error extracting protoc for version 3.22.2: Unsupported platform: protoc-3.22.2-osx-aarch_64.exe -> [Help 1]
```

## Additional context and related issues


## Release notes

(X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
