### PR TITLE
Display Hive partition projection column properties

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/aws/athena/PartitionProjectionService.java
@@ -99,7 +99,7 @@ public final class PartitionProjectionService
         return trinoTablePropertiesBuilder.buildOrThrow();
     }
 
-    public Map<String, Object> getPartitionProjectionTrinoColumnProperties(Table table, String columnName)
+    public static Map<String, Object> getPartitionProjectionTrinoColumnProperties(Table table, String columnName)
     {
         Map<String, String> metastoreTableProperties = table.getParameters();
         return rewriteColumnProjectionProperties(metastoreTableProperties, columnName);
@@ -293,7 +293,7 @@ public final class PartitionProjectionService
         return new PartitionProjection(projectionEnabledProperty.orElse(false), storageLocationTemplate, columnProjections);
     }
 
-    private Map<String, Object> rewriteColumnProjectionProperties(Map<String, String> metastoreTableProperties, String columnName)
+    private static Map<String, Object> rewriteColumnProjectionProperties(Map<String, String> metastoreTableProperties, String columnName)
     {
         ImmutableMap.Builder<String, Object> trinoTablePropertiesBuilder = ImmutableMap.builder();
         rewriteProperty(
@@ -307,13 +307,13 @@ public final class PartitionProjectionService
                 trinoTablePropertiesBuilder,
                 getMetastoreProjectionPropertyKey(columnName, COLUMN_PROJECTION_VALUES_SUFFIX),
                 COLUMN_PROJECTION_VALUES,
-                this::splitCommaSeparatedString);
+                PartitionProjectionService::splitCommaSeparatedString);
         rewriteProperty(
                 metastoreTableProperties,
                 trinoTablePropertiesBuilder,
                 getMetastoreProjectionPropertyKey(columnName, COLUMN_PROJECTION_RANGE_SUFFIX),
                 COLUMN_PROJECTION_RANGE,
-                this::splitCommaSeparatedString);
+                PartitionProjectionService::splitCommaSeparatedString);
         rewriteProperty(
                 metastoreTableProperties,
                 trinoTablePropertiesBuilder,
@@ -355,7 +355,7 @@ public final class PartitionProjectionService
         return projectionFactory.create(columnName, columnType, columnProperties);
     }
 
-    private <I, V> void rewriteProperty(
+    private static <I, V> void rewriteProperty(
             Map<String, I> sourceProperties,
             ImmutableMap.Builder<String, V> targetPropertiesBuilder,
             String sourcePropertyKey,
@@ -371,7 +371,7 @@ public final class PartitionProjectionService
         return new TrinoException(INVALID_COLUMN_PROPERTY, message);
     }
 
-    private List<String> splitCommaSeparatedString(String value)
+    private static List<String> splitCommaSeparatedString(String value)
     {
         return Splitter.on(',')
                 .trimResults()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -35,6 +35,7 @@ import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.avro.TrinoAvroSerDe;
+import io.trino.plugin.hive.aws.athena.PartitionProjectionService;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.plugin.hive.metastore.Table;
@@ -1188,6 +1189,7 @@ public final class HiveUtil
                 .setComment(handle.isHidden() ? Optional.empty() : columnComment.get(handle.getName()))
                 .setExtraInfo(Optional.ofNullable(columnExtraInfo(handle.isPartitionKey())))
                 .setHidden(handle.isHidden())
+                .setProperties(PartitionProjectionService.getPartitionProjectionTrinoColumnProperties(table, handle.getName()))
                 .build();
     }
 


### PR DESCRIPTION
## Description

When running `SHOW CREATE TABLE` include column properties present for Hive partition projection.

## Additional context and related issues

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Display Hive partition projection column properties in `SHOW CREATE TABLE` output.
```
