### PR TITLE
Enable Error Prone check: BadComparable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2338,6 +2338,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>
                                     -Xplugin:ErrorProne \
+                                    -Xep:BadComparable:ERROR \
                                     -Xep:BadInstanceof:ERROR \
                                     -Xep:BoxedPrimitiveConstructor:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
