### PR TITLE
Don't project _id field in Mongo DB connector when it's not required

### DIFF
--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -49,6 +49,34 @@ public class TestMongoSession
     private static final MongoColumnHandle COL5 = createColumnHandle("col5", BIGINT);
     private static final MongoColumnHandle COL6 = createColumnHandle("grandparent", createUnboundedVarcharType(), "parent", "col6");
 
+    private static final MongoColumnHandle ID_COL = new MongoColumnHandle("_id", ImmutableList.of(), ObjectIdType.OBJECT_ID, false, false, Optional.empty());
+
+    @Test
+    public void testBuildProjectionWithoutId()
+    {
+        List<MongoColumnHandle> columns = ImmutableList.of(COL1, COL2);
+
+        Document output = MongoSession.buildProjection(columns);
+        Document expected = new Document()
+                .append(COL1.getBaseName(), 1)
+                .append(COL2.getBaseName(), 1)
+                .append(ID_COL.getBaseName(), 0);
+        assertEquals(output, expected);
+    }
+
+    @Test
+    public void testBuildProjectionWithId()
+    {
+        List<MongoColumnHandle> columns = ImmutableList.of(COL1, COL2, ID_COL);
+
+        Document output = MongoSession.buildProjection(columns);
+        Document expected = new Document()
+                .append(COL1.getBaseName(), 1)
+                .append(COL2.getBaseName(), 1)
+                .append(ID_COL.getBaseName(), 1);
+        assertEquals(output, expected);
+    }
+
     @Test
     public void testBuildQuery()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, _id field is retrieved even when it's not necessary. We can exclude by https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/builders/projections/#exclusion-of-_id.

Fixes https://github.com/trinodb/trino/issues/17970



## Release notes

(x) This is not user-visible or docs only and no release notes are required.