### PR TITLE
Throw TrinoException if window functions (without over) are used in invalid clauses

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -50,6 +50,7 @@ import static io.trino.spi.StandardErrorCode.FUNCTION_IMPLEMENTATION_MISSING;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.function.FunctionKind.AGGREGATE;
 import static io.trino.spi.function.FunctionKind.SCALAR;
+import static io.trino.spi.function.FunctionKind.WINDOW;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypeSignatures;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.lang.String.format;
@@ -75,6 +76,20 @@ public class FunctionResolver
                         .map(CatalogFunctionMetadata::getFunctionMetadata)
                         .map(FunctionMetadata::getKind)
                         .anyMatch(AGGREGATE::equals);
+            }
+        }
+        return false;
+    }
+
+    boolean isWindowFunction(Session session, QualifiedFunctionName name, Function<CatalogSchemaFunctionName, Collection<CatalogFunctionMetadata>> candidateLoader)
+    {
+        for (CatalogSchemaFunctionName catalogSchemaFunctionName : toPath(session, name)) {
+            Collection<CatalogFunctionMetadata> candidates = candidateLoader.apply(catalogSchemaFunctionName);
+            if (!candidates.isEmpty()) {
+                return candidates.stream()
+                        .map(CatalogFunctionMetadata::getFunctionMetadata)
+                        .map(FunctionMetadata::getKind)
+                        .anyMatch(WINDOW::equals);
             }
         }
         return false;

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -640,6 +640,8 @@ public interface Metadata
      */
     boolean isAggregationFunction(Session session, QualifiedName name);
 
+    boolean isWindowFunction(Session session, QualifiedName name);
+
     FunctionMetadata getFunctionMetadata(Session session, ResolvedFunction resolvedFunction);
 
     AggregationFunctionMetadata getAggregationFunctionMetadata(Session session, ResolvedFunction resolvedFunction);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2321,6 +2321,11 @@ public final class MetadataManager
         return functionResolver.isAggregationFunction(session, toQualifiedFunctionName(name), catalogSchemaFunctionName -> getFunctions(session, catalogSchemaFunctionName));
     }
 
+    public boolean isWindowFunction(Session session, QualifiedName name)
+    {
+        return functionResolver.isWindowFunction(session, toQualifiedFunctionName(name), catalogSchemaFunctionName -> getFunctions(session, catalogSchemaFunctionName));
+    }
+
     private Collection<CatalogFunctionMetadata> getFunctions(Session session, CatalogSchemaFunctionName name)
     {
         if (name.getCatalogName().equals(GlobalSystemConnector.NAME)) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -114,7 +114,7 @@ public class Analyzer
     {
         List<FunctionCall> aggregates = extractAggregateFunctions(ImmutableList.of(predicate), session, metadata);
 
-        List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate));
+        List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, metadata);
 
         List<GroupingOperation> groupingOperations = extractExpressions(ImmutableList.of(predicate), GroupingOperation.class);
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionTreeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionTreeUtils.java
@@ -52,9 +52,22 @@ public final class ExpressionTreeUtils
                 .build();
     }
 
+    static List<Expression> extractWindowExpressions(Iterable<? extends Node> nodes, Session session, Metadata metadata)
+    {
+        return ImmutableList.<Expression>builder()
+                .addAll(extractWindowFunctions(nodes, session, metadata))
+                .addAll(extractWindowMeasures(nodes))
+                .build();
+    }
+
     static List<FunctionCall> extractWindowFunctions(Iterable<? extends Node> nodes)
     {
         return extractExpressions(nodes, FunctionCall.class, ExpressionTreeUtils::isWindowFunction);
+    }
+
+    static List<FunctionCall> extractWindowFunctions(Iterable<? extends Node> nodes, Session session, Metadata metadata)
+    {
+        return extractExpressions(nodes, FunctionCall.class, function -> isWindow(function, session, metadata));
     }
 
     static List<WindowOperation> extractWindowMeasures(Iterable<? extends Node> nodes)
@@ -74,6 +87,12 @@ public final class ExpressionTreeUtils
         return ((metadata.isAggregationFunction(session, functionCall.getName()) || functionCall.getFilter().isPresent())
                 && functionCall.getWindow().isEmpty())
                 || functionCall.getOrderBy().isPresent();
+    }
+
+    private static boolean isWindow(FunctionCall functionCall, Session session, Metadata metadata)
+    {
+        return metadata.isWindowFunction(session, functionCall.getName())
+                || functionCall.getWindow().isPresent();
     }
 
     private static boolean isWindowFunction(FunctionCall functionCall)

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1153,6 +1153,16 @@ public class TracingMetadata
     }
 
     @Override
+    public boolean isWindowFunction(Session session, QualifiedName name)
+    {
+        Span span = startSpan("isWindowFunction")
+                .setAllAttributes(attribute(TrinoAttributes.FUNCTION, extractFunctionName(name)));
+        try (var ignored = scopedSpan(span)) {
+            return delegate.isWindowFunction(session, name);
+        }
+    }
+
+    @Override
     public FunctionMetadata getFunctionMetadata(Session session, ResolvedFunction resolvedFunction)
     {
         Span span = startSpan("getFunctionMetadata")

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -787,6 +787,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public boolean isWindowFunction(Session session, QualifiedName name)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public FunctionMetadata getFunctionMetadata(Session session, ResolvedFunction resolvedFunction)
     {
         BoundSignature signature = resolvedFunction.getSignature();

--- a/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/CountingAccessMetadata.java
@@ -780,6 +780,12 @@ public class CountingAccessMetadata
     }
 
     @Override
+    public boolean isWindowFunction(Session session, QualifiedName name)
+    {
+        return delegate.isWindowFunction(session, name);
+    }
+
+    @Override
     public FunctionMetadata getFunctionMetadata(Session session, ResolvedFunction resolvedFunction)
     {
         return delegate.getFunctionMetadata(session, resolvedFunction);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -799,6 +799,15 @@ public class TestAnalyzer
         assertFails("SELECT * FROM t1 WHERE foo() over () > 1")
                 .hasErrorCode(EXPRESSION_NOT_SCALAR)
                 .hasMessage("line 1:38: WHERE clause cannot contain aggregations, window functions or grouping operations: [foo() OVER ()]");
+        assertFails("SELECT * FROM t1 WHERE lag(t1.a) > t1.a")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessage("line 1:34: WHERE clause cannot contain aggregations, window functions or grouping operations: [lag(t1.a)]");
+        assertFails("SELECT * FROM t1 WHERE rank() > 1")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessage("line 1:31: WHERE clause cannot contain aggregations, window functions or grouping operations: [rank()]");
+        assertFails("SELECT * FROM t1 WHERE first_value(t1.a) > t1.a")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessage("line 1:42: WHERE clause cannot contain aggregations, window functions or grouping operations: [first_value(t1.a)]");
         assertFails("SELECT * FROM t1 GROUP BY rank() over ()")
                 .hasErrorCode(EXPRESSION_NOT_SCALAR)
                 .hasMessage("line 1:27: GROUP BY clause cannot contain aggregations, window functions or grouping operations: [rank() OVER ()]");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
- This change fixes the behaviour of `verifyNoAggregateWindowOrGroupingFunctions` when checking for `WINDOW` functions.
- With this change, we are now throwing a TrinoException (`WHERE clause cannot contain aggregations, window functions or grouping operations`) instead of Internal error when a window function is present in an invalid clause.

## Detailed Description
- The main reason behind these failures is that Trino fails to identify window functions if they are used without `OVER()`. 
- In these cases, Trino would continue executions and fails with `is not a scalar` or `ClassCastException` as it is trying to cast a window function into a scalar value.
- The change updates the extractWindow functions behaviour to check for the presence of any window function (by name) as well as if it contains `OVER()`.
  


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
To reproduce the behaviour
- Working example with Aggergation 
 `select row_number() over() from information_schema.tables where count() > 5 ;`
- Working example with Window (with over) 
 `select row_number() over() from information_schema.tables where row_number() over() > 5 ;`
- Failing example with Window (without over) 
 `select row_number() over() from information_schema.tables where row_number() > 5 ;`
- Failing example with Window (without over) 
 `select row_number() over() from information_schema.tables where rank() > 5 ;`

An alternative approach would be to move the check for the OVER() clause to throw an invalid window function prior to checking for the existence of the window function.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`[6447](https://github.com/trinodb/trino/issues/6447)`)
```
