### PR TITLE
Add exception guards for scheduleWithFixedDelay

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -504,7 +504,15 @@ public class QueuedStatementResource
 
         public void initialize(DispatchManager dispatchManager)
         {
-            scheduledExecutorService.scheduleWithFixedDelay(() -> syncWith(dispatchManager), 200, 200, MILLISECONDS);
+            scheduledExecutorService.scheduleWithFixedDelay(() -> {
+                try {
+                    syncWith(dispatchManager);
+                }
+                catch (Throwable e) {
+                    // ignore to avoid getting unscheduled
+                    log.error(e, "Unexpected error synchronizing with dispatch manager");
+                }
+            }, 200, 200, MILLISECONDS);
         }
 
         public void destroy()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -165,7 +165,15 @@ public class BinPackingNodeAllocatorService
         }
 
         refreshNodePoolMemoryInfos();
-        executor.scheduleWithFixedDelay(this::refreshNodePoolMemoryInfos, 1, 1, TimeUnit.SECONDS);
+        executor.scheduleWithFixedDelay(() -> {
+            try {
+                refreshNodePoolMemoryInfos();
+            }
+            catch (Throwable e) {
+                // ignore to avoid getting unscheduled
+                log.error(e, "Unexpected error while refreshing node pool memory infos");
+            }
+        }, 1, 1, TimeUnit.SECONDS);
     }
 
     @PreDestroy


### PR DESCRIPTION
There were some remaining routines called via scheduleWithFixedDelay which were not guarded with try...catch all clause. It is important to have such clause so routine is not silently unscheduled in case of unexpected error.

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
