### PR TITLE
Simplify array functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
@@ -144,6 +144,9 @@ class PolymorphicScalarFunction
             }
             methodParameterIndex += argumentConvention.getParameterCount();
         }
+        if (returnConvention == InvocationReturnConvention.BLOCK_BUILDER) {
+            throw new UnsupportedOperationException("BLOCK_BUILDER return convention is not yet supported");
+        }
         return method.getReturnType().equals(getNullAwareContainerType(boundSignature.getReturnType().getJavaType(), returnConvention));
     }
 
@@ -174,6 +177,7 @@ class PolymorphicScalarFunction
         return switch (returnConvention) {
             case NULLABLE_RETURN -> Primitives.wrap(clazz);
             case DEFAULT_ON_NULL, FAIL_ON_NULL -> clazz;
+            case BLOCK_BUILDER -> void.class;
         };
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -134,6 +134,7 @@ import io.trino.operator.scalar.GenericHashCodeOperator;
 import io.trino.operator.scalar.GenericIndeterminateOperator;
 import io.trino.operator.scalar.GenericLessThanOperator;
 import io.trino.operator.scalar.GenericLessThanOrEqualOperator;
+import io.trino.operator.scalar.GenericReadValueOperator;
 import io.trino.operator.scalar.GenericXxHash64Operator;
 import io.trino.operator.scalar.HmacFunctions;
 import io.trino.operator.scalar.HyperLogLogFunctions;
@@ -569,6 +570,7 @@ public final class SystemFunctionBundle
                 .functions(MAP_FILTER_FUNCTION, new MapTransformKeysFunction(blockTypeOperators), MAP_TRANSFORM_VALUES_FUNCTION)
                 .function(FORMAT_FUNCTION)
                 .function(TRY_CAST)
+                .function(new GenericReadValueOperator(typeOperators))
                 .function(new GenericEqualOperator(typeOperators))
                 .function(new GenericHashCodeOperator(typeOperators))
                 .function(new GenericXxHash64Operator(typeOperators))

--- a/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/FunctionsParserHelper.java
@@ -63,6 +63,7 @@ import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.function.OperatorType.IS_DISTINCT_FROM;
 import static io.trino.spi.function.OperatorType.LESS_THAN;
 import static io.trino.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.spi.function.OperatorType.XX_HASH_64;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
@@ -118,6 +119,9 @@ public final class FunctionsParserHelper
                     else {
                         verifyTypeSignatureDoesNotContainAnyTypeParameters(typeSignature, typeSignature, typeParameterNames);
                     }
+                }
+                else if (operator == READ_VALUE) {
+                    verifyOperatorSignature(operator, argumentTypes);
                 }
                 else {
                     throw new IllegalArgumentException("Operator dependency on " + operator + " is not allowed");

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAllMatchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayAllMatchFunction.java
@@ -14,15 +14,20 @@
 package io.trino.operator.scalar;
 
 import io.trino.spi.block.Block;
+import io.trino.spi.function.Convention;
 import io.trino.spi.function.Description;
+import io.trino.spi.function.OperatorDependency;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.StandardTypes;
-import io.trino.spi.type.Type;
 
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static java.lang.Boolean.FALSE;
 
 @Description("Returns true if all elements of the array match the given predicate")
@@ -32,110 +37,20 @@ public final class ArrayAllMatchFunction
     private ArrayAllMatchFunction() {}
 
     @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = Object.class)
     @SqlType(StandardTypes.BOOLEAN)
     @SqlNullable
-    public static Boolean allMatchObject(
-            @TypeParameter("T") Type elementType,
+    public static Boolean allMatch(
+            @OperatorDependency(operator = READ_VALUE, argumentTypes = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = FAIL_ON_NULL)) MethodHandle readValue,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") ObjectToBooleanFunction function)
+            throws Throwable
     {
         boolean hasNullResult = false;
         int positionCount = arrayBlock.getPositionCount();
         for (int i = 0; i < positionCount; i++) {
             Object element = null;
             if (!arrayBlock.isNull(i)) {
-                element = elementType.getObject(arrayBlock, i);
-            }
-            Boolean match = function.apply(element);
-            if (FALSE.equals(match)) {
-                return false;
-            }
-            if (match == null) {
-                hasNullResult = true;
-            }
-        }
-        if (hasNullResult) {
-            return null;
-        }
-        return true;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean allMatchLong(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") LongToBooleanFunction function)
-    {
-        boolean hasNullResult = false;
-        int positionCount = arrayBlock.getPositionCount();
-        for (int i = 0; i < positionCount; i++) {
-            Long element = null;
-            if (!arrayBlock.isNull(i)) {
-                element = elementType.getLong(arrayBlock, i);
-            }
-            Boolean match = function.apply(element);
-            if (FALSE.equals(match)) {
-                return false;
-            }
-            if (match == null) {
-                hasNullResult = true;
-            }
-        }
-        if (hasNullResult) {
-            return null;
-        }
-        return true;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean allMatchDouble(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
-    {
-        boolean hasNullResult = false;
-        int positionCount = arrayBlock.getPositionCount();
-        for (int i = 0; i < positionCount; i++) {
-            Double element = null;
-            if (!arrayBlock.isNull(i)) {
-                element = elementType.getDouble(arrayBlock, i);
-            }
-            Boolean match = function.apply(element);
-            if (FALSE.equals(match)) {
-                return false;
-            }
-            if (match == null) {
-                hasNullResult = true;
-            }
-        }
-        if (hasNullResult) {
-            return null;
-        }
-        return true;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean allMatchBoolean(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
-    {
-        boolean hasNullResult = false;
-        int positionCount = arrayBlock.getPositionCount();
-        for (int i = 0; i < positionCount; i++) {
-            Boolean element = null;
-            if (!arrayBlock.isNull(i)) {
-                element = elementType.getBoolean(arrayBlock, i);
+                element = readValue.invoke(arrayBlock, i);
             }
             Boolean match = function.apply(element);
             if (FALSE.equals(match)) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConcatFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayConcatFunction.java
@@ -13,13 +13,11 @@
  */
 package io.trino.operator.scalar;
 
-import com.google.common.collect.ImmutableList;
 import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.metadata.SqlScalarFunction;
-import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.BufferedArrayValueBuilder;
 import io.trino.spi.function.BoundSignature;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.Signature;
@@ -29,6 +27,7 @@ import io.trino.spi.type.TypeSignature;
 import io.trino.sql.gen.VarArgsToArrayAdapterGenerator;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.util.Optional;
 
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -36,7 +35,8 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.sql.gen.VarArgsToArrayAdapterGenerator.generateVarArgsToArrayAdapter;
-import static io.trino.util.Reflection.methodHandle;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.lang.invoke.MethodType.methodType;
 import static java.util.Collections.nCopies;
 
 public final class ArrayConcatFunction
@@ -47,8 +47,19 @@ public final class ArrayConcatFunction
     private static final String FUNCTION_NAME = "concat";
     private static final String DESCRIPTION = "Concatenates given arrays";
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayConcatFunction.class, "concat", Type.class, Object.class, Block[].class);
-    private static final MethodHandle USER_STATE_FACTORY = methodHandle(ArrayConcatFunction.class, "createState", Type.class);
+    private static final MethodHandle METHOD_HANDLE;
+    private static final MethodHandle USER_STATE_FACTORY;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = lookup();
+            METHOD_HANDLE = lookup.findStatic(ArrayConcatFunction.class, "concat", methodType(Block.class, Type.class, Object.class, Block[].class));
+            USER_STATE_FACTORY = lookup.findStatic(ArrayConcatFunction.class, "createState", methodType(Object.class, ArrayType.class));
+        }
+        catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     private ArrayConcatFunction()
     {
@@ -78,7 +89,7 @@ public final class ArrayConcatFunction
                 Block.class,
                 boundSignature.getArity(),
                 METHOD_HANDLE.bindTo(arrayType.getElementType()),
-                USER_STATE_FACTORY.bindTo(arrayType.getElementType()));
+                USER_STATE_FACTORY.bindTo(arrayType));
 
         return new ChoicesSpecializedSqlScalarFunction(
                 boundSignature,
@@ -89,9 +100,9 @@ public final class ArrayConcatFunction
     }
 
     @UsedByGeneratedCode
-    public static Object createState(Type elementType)
+    public static Object createState(ArrayType arrayType)
     {
-        return new PageBuilder(ImmutableList.of(elementType));
+        return BufferedArrayValueBuilder.createBuffered(arrayType);
     }
 
     @UsedByGeneratedCode
@@ -99,12 +110,12 @@ public final class ArrayConcatFunction
     {
         int resultPositionCount = 0;
 
-        // fast path when there is at most one non empty block
+        // fast path when there is at most one non-empty block
         Block nonEmptyBlock = null;
-        for (int i = 0; i < blocks.length; i++) {
-            resultPositionCount += blocks[i].getPositionCount();
-            if (blocks[i].getPositionCount() > 0) {
-                nonEmptyBlock = blocks[i];
+        for (Block value : blocks) {
+            resultPositionCount += value.getPositionCount();
+            if (value.getPositionCount() > 0) {
+                nonEmptyBlock = value;
             }
         }
         if (nonEmptyBlock == null) {
@@ -114,19 +125,12 @@ public final class ArrayConcatFunction
             return nonEmptyBlock;
         }
 
-        PageBuilder pageBuilder = (PageBuilder) state;
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
-        for (int blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
-            Block block = blocks[blockIndex];
-            for (int i = 0; i < block.getPositionCount(); i++) {
-                elementType.appendTo(block, i, blockBuilder);
+        return ((BufferedArrayValueBuilder) state).build(resultPositionCount, elementBuilder -> {
+            for (Block block : blocks) {
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    elementType.appendTo(block, i, elementBuilder);
+                }
             }
-        }
-        pageBuilder.declarePositions(resultPositionCount);
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - resultPositionCount, resultPositionCount);
+        });
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMaxFunction.java
@@ -21,16 +21,13 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_FIRST;
-import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.RealType.REAL;
-import static io.trino.util.Failures.internalError;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 
 @ScalarFunction("array_max")
 @Description("Get maximum value of array")
@@ -41,139 +38,28 @@ public final class ArrayMaxFunction
     @TypeParameter("T")
     @SqlType("T")
     @SqlNullable
-    public static Long longArrayMax(
+    public static Object arrayMax(
             @OperatorDependency(
                     operator = COMPARISON_UNORDERED_FIRST,
                     argumentTypes = {"T", "T"},
                     convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
+            @OperatorDependency(operator = READ_VALUE, argumentTypes = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = FAIL_ON_NULL)) MethodHandle readValue,
             @SqlType("array(T)") Block block)
+            throws Throwable
     {
-        int selectedPosition = findMaxArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getLong(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Boolean booleanArrayMax(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_FIRST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMaxArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getBoolean(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Double doubleArrayMax(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_FIRST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMaxArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getDouble(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Object objectArrayMax(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_FIRST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMaxArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getObject(block, selectedPosition);
-    }
-
-    private static int findMaxArrayElement(MethodHandle compareMethodHandle, Block block)
-    {
-        try {
-            int selectedPosition = -1;
-            for (int position = 0; position < block.getPositionCount(); position++) {
-                if (block.isNull(position)) {
-                    return -1;
-                }
-                if (selectedPosition < 0 || ((long) compareMethodHandle.invokeExact(block, position, block, selectedPosition)) > 0) {
-                    selectedPosition = position;
-                }
-            }
-            return selectedPosition;
-        }
-        catch (Throwable t) {
-            throw internalError(t);
-        }
-    }
-
-    @SqlType("double")
-    @SqlNullable
-    public static Double doubleTypeArrayMax(@SqlType("array(double)") Block block)
-    {
-        if (block.getPositionCount() == 0) {
-            return null;
-        }
         int selectedPosition = -1;
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (block.isNull(position)) {
                 return null;
             }
-            if (selectedPosition < 0 || doubleGreater(DOUBLE.getDouble(block, position), DOUBLE.getDouble(block, selectedPosition))) {
+            if (selectedPosition < 0 || ((long) compareMethodHandle.invokeExact(block, position, block, selectedPosition)) > 0) {
                 selectedPosition = position;
             }
         }
-        return DOUBLE.getDouble(block, selectedPosition);
-    }
 
-    private static boolean doubleGreater(double left, double right)
-    {
-        return (left > right) || Double.isNaN(right);
-    }
-
-    @SqlType("real")
-    @SqlNullable
-    public static Long realTypeArrayMax(@SqlType("array(real)") Block block)
-    {
-        if (block.getPositionCount() == 0) {
+        if (selectedPosition < 0) {
             return null;
         }
-        int selectedPosition = -1;
-        for (int position = 0; position < block.getPositionCount(); position++) {
-            if (block.isNull(position)) {
-                return null;
-            }
-            if (selectedPosition < 0 || floatGreater(REAL.getFloat(block, position), REAL.getFloat(block, selectedPosition))) {
-                selectedPosition = position;
-            }
-        }
-        return REAL.getLong(block, selectedPosition);
-    }
-
-    private static boolean floatGreater(float left, float right)
-    {
-        return (left > right) || Float.isNaN(right);
+        return readValue.invoke(block, selectedPosition);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMinFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayMinFunction.java
@@ -21,14 +21,13 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
-import static io.trino.util.Failures.internalError;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 
 @ScalarFunction("array_min")
 @Description("Get minimum value of array")
@@ -39,91 +38,28 @@ public final class ArrayMinFunction
     @TypeParameter("T")
     @SqlType("T")
     @SqlNullable
-    public static Long longArrayMin(
+    public static Object arrayMin(
             @OperatorDependency(
                     operator = COMPARISON_UNORDERED_LAST,
                     argumentTypes = {"T", "T"},
                     convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
+            @OperatorDependency(operator = READ_VALUE, argumentTypes = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = FAIL_ON_NULL)) MethodHandle readValue,
             @SqlType("array(T)") Block block)
+            throws Throwable
     {
-        int selectedPosition = findMinArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getLong(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Boolean booleanArrayMin(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_LAST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMinArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getBoolean(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Double doubleArrayMin(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_LAST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMinArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getDouble(block, selectedPosition);
-    }
-
-    @TypeParameter("T")
-    @SqlType("T")
-    @SqlNullable
-    public static Object objectArrayMin(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_LAST,
-                    argumentTypes = {"T", "T"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) MethodHandle compareMethodHandle,
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block block)
-    {
-        int selectedPosition = findMinArrayElement(compareMethodHandle, block);
-        if (selectedPosition < 0) {
-            return null;
-        }
-        return elementType.getObject(block, selectedPosition);
-    }
-
-    private static int findMinArrayElement(MethodHandle compareMethodHandle, Block block)
-    {
-        try {
-            int selectedPosition = -1;
-            for (int position = 0; position < block.getPositionCount(); position++) {
-                if (block.isNull(position)) {
-                    return -1;
-                }
-                if (selectedPosition < 0 || ((long) compareMethodHandle.invokeExact(block, position, block, selectedPosition)) < 0) {
-                    selectedPosition = position;
-                }
+        int selectedPosition = -1;
+        for (int position = 0; position < block.getPositionCount(); position++) {
+            if (block.isNull(position)) {
+                return null;
             }
-            return selectedPosition;
+            if (selectedPosition < 0 || ((long) compareMethodHandle.invokeExact(block, position, block, selectedPosition)) < 0) {
+                selectedPosition = position;
+            }
         }
-        catch (Throwable t) {
-            throw internalError(t);
+        if (selectedPosition < 0) {
+            return null;
         }
+
+        return readValue.invoke(block, selectedPosition);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayNoneMatchFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayNoneMatchFunction.java
@@ -14,14 +14,20 @@
 package io.trino.operator.scalar;
 
 import io.trino.spi.block.Block;
+import io.trino.spi.function.Convention;
 import io.trino.spi.function.Description;
+import io.trino.spi.function.OperatorDependency;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.StandardTypes;
-import io.trino.spi.type.Type;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 
 @Description("Returns true if all elements of the array don't match the given predicate")
 @ScalarFunction("none_match")
@@ -30,63 +36,15 @@ public final class ArrayNoneMatchFunction
     private ArrayNoneMatchFunction() {}
 
     @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = Object.class)
     @SqlType(StandardTypes.BOOLEAN)
     @SqlNullable
-    public static Boolean noneMatchObject(
-            @TypeParameter("T") Type elementType,
+    public static Boolean noneMatch(
+            @OperatorDependency(operator = READ_VALUE, argumentTypes = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = FAIL_ON_NULL)) MethodHandle readValue,
             @SqlType("array(T)") Block arrayBlock,
             @SqlType("function(T, boolean)") ObjectToBooleanFunction function)
+            throws Throwable
     {
-        Boolean anyMatchResult = ArrayAnyMatchFunction.anyMatchObject(elementType, arrayBlock, function);
-        if (anyMatchResult == null) {
-            return null;
-        }
-        return !anyMatchResult;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean noneMatchLong(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") LongToBooleanFunction function)
-    {
-        Boolean anyMatchResult = ArrayAnyMatchFunction.anyMatchLong(elementType, arrayBlock, function);
-        if (anyMatchResult == null) {
-            return null;
-        }
-        return !anyMatchResult;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean noneMatchDouble(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") DoubleToBooleanFunction function)
-    {
-        Boolean anyMatchResult = ArrayAnyMatchFunction.anyMatchDouble(elementType, arrayBlock, function);
-        if (anyMatchResult == null) {
-            return null;
-        }
-        return !anyMatchResult;
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    @SqlNullable
-    public static Boolean noneMatchBoolean(
-            @TypeParameter("T") Type elementType,
-            @SqlType("array(T)") Block arrayBlock,
-            @SqlType("function(T, boolean)") BooleanToBooleanFunction function)
-    {
-        Boolean anyMatchResult = ArrayAnyMatchFunction.anyMatchBoolean(elementType, arrayBlock, function);
+        Boolean anyMatchResult = ArrayAnyMatchFunction.anyMatch(readValue, arrayBlock, function);
         if (anyMatchResult == null) {
             return null;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortComparatorFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortComparatorFunction.java
@@ -19,18 +19,24 @@ import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.Convention;
 import io.trino.spi.function.Description;
+import io.trino.spi.function.OperatorDependency;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.lambda.LambdaFunctionInterface;
 
+import java.lang.invoke.MethodHandle;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.OperatorType.READ_VALUE;
 import static io.trino.util.Failures.checkCondition;
 
 @ScalarFunction("array_sort")
@@ -48,79 +54,27 @@ public final class ArraySortComparatorFunction
     }
 
     @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
     @SqlType("array(T)")
-    public Block sortLong(
+    public Block sort(
             @TypeParameter("T") Type type,
-            @SqlType("array(T)") Block block,
-            @SqlType("function(T, T, integer)") ComparatorLongLambda function)
-    {
-        int arrayLength = block.getPositionCount();
-        initPositionsList(arrayLength);
-
-        Comparator<Integer> comparator = (x, y) -> comparatorResult(function.apply(
-                block.isNull(x) ? null : type.getLong(block, x),
-                block.isNull(y) ? null : type.getLong(block, y)));
-
-        sortPositions(arrayLength, comparator);
-
-        return computeResultBlock(type, block, arrayLength);
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
-    @SqlType("array(T)")
-    public Block sortDouble(
-            @TypeParameter("T") Type type,
-            @SqlType("array(T)") Block block,
-            @SqlType("function(T, T, integer)") ComparatorDoubleLambda function)
-    {
-        int arrayLength = block.getPositionCount();
-        initPositionsList(arrayLength);
-
-        Comparator<Integer> comparator = (x, y) -> comparatorResult(function.apply(
-                block.isNull(x) ? null : type.getDouble(block, x),
-                block.isNull(y) ? null : type.getDouble(block, y)));
-
-        sortPositions(arrayLength, comparator);
-
-        return computeResultBlock(type, block, arrayLength);
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
-    @SqlType("array(T)")
-    public Block sortBoolean(
-            @TypeParameter("T") Type type,
-            @SqlType("array(T)") Block block,
-            @SqlType("function(T, T, integer)") ComparatorBooleanLambda function)
-    {
-        int arrayLength = block.getPositionCount();
-        initPositionsList(arrayLength);
-
-        Comparator<Integer> comparator = (x, y) -> comparatorResult(function.apply(
-                block.isNull(x) ? null : type.getBoolean(block, x),
-                block.isNull(y) ? null : type.getBoolean(block, y)));
-
-        sortPositions(arrayLength, comparator);
-
-        return computeResultBlock(type, block, arrayLength);
-    }
-
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = Object.class)
-    @SqlType("array(T)")
-    public Block sortObject(
-            @TypeParameter("T") Type type,
+            @OperatorDependency(operator = READ_VALUE, argumentTypes = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = FAIL_ON_NULL)) MethodHandle readValue,
             @SqlType("array(T)") Block block,
             @SqlType("function(T, T, integer)") ComparatorObjectLambda function)
     {
         int arrayLength = block.getPositionCount();
         initPositionsList(arrayLength);
 
-        Comparator<Integer> comparator = (x, y) -> comparatorResult(function.apply(
-                block.isNull(x) ? null : type.getObject(block, x),
-                block.isNull(y) ? null : type.getObject(block, y)));
+        Comparator<Integer> comparator = (x, y) -> {
+            try {
+                return comparatorResult(function.apply(
+                        block.isNull(x) ? null : readValue.invoke(block, x),
+                        block.isNull(y) ? null : readValue.invoke(block, y)));
+            }
+            catch (Throwable e) {
+                throwIfUnchecked(e);
+                throw new RuntimeException(e);
+            }
+        };
 
         sortPositions(arrayLength, comparator);
 
@@ -172,27 +126,6 @@ public final class ArraySortComparatorFunction
                 INVALID_FUNCTION_ARGUMENT,
                 "Lambda comparator must return either -1, 0, or 1");
         return result.intValue();
-    }
-
-    @FunctionalInterface
-    public interface ComparatorLongLambda
-            extends LambdaFunctionInterface
-    {
-        Long apply(Long x, Long y);
-    }
-
-    @FunctionalInterface
-    public interface ComparatorDoubleLambda
-            extends LambdaFunctionInterface
-    {
-        Long apply(Double x, Double y);
-    }
-
-    @FunctionalInterface
-    public interface ComparatorBooleanLambda
-            extends LambdaFunctionInterface
-    {
-        Long apply(Boolean x, Boolean y);
     }
 
     @FunctionalInterface

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToArrayCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToArrayCast.java
@@ -21,13 +21,12 @@ import io.trino.spi.function.Convention;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.Type;
 
 import java.lang.invoke.MethodHandle;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.BLOCK_BUILDER;
 import static io.trino.spi.function.OperatorType.CAST;
 
 @ScalarOperator(CAST)
@@ -37,11 +36,10 @@ public final class ArrayToArrayCast
 
     @TypeParameter("F")
     @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = long.class)
     @SqlType("array(T)")
-    public static Block filterLong(
+    public static Block filter(
             @TypeParameter("T") Type resultType,
-            @CastDependency(fromType = "F", toType = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = NULLABLE_RETURN, session = true)) MethodHandle cast,
+            @CastDependency(fromType = "F", toType = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = BLOCK_BUILDER, session = true)) MethodHandle cast,
             ConnectorSession session,
             @SqlType("array(F)") Block array)
             throws Throwable
@@ -49,92 +47,12 @@ public final class ArrayToArrayCast
         int positionCount = array.getPositionCount();
         BlockBuilder resultBuilder = resultType.createBlockBuilder(null, positionCount);
         for (int position = 0; position < positionCount; position++) {
-            if (!array.isNull(position)) {
-                Long value = (Long) cast.invokeExact(session, array, position);
-                if (value != null) {
-                    resultType.writeLong(resultBuilder, value);
-                    continue;
-                }
+            if (array.isNull(position)) {
+                resultBuilder.appendNull();
             }
-            resultBuilder.appendNull();
-        }
-        return resultBuilder.build();
-    }
-
-    @TypeParameter("F")
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = double.class)
-    @SqlType("array(T)")
-    public static Block filterDouble(
-            @TypeParameter("T") Type resultType,
-            @CastDependency(fromType = "F", toType = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = NULLABLE_RETURN, session = true)) MethodHandle cast,
-            ConnectorSession session,
-            @SqlType("array(F)") Block array)
-            throws Throwable
-    {
-        int positionCount = array.getPositionCount();
-        BlockBuilder resultBuilder = resultType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            if (!array.isNull(position)) {
-                Double value = (Double) cast.invokeExact(session, array, position);
-                if (value != null) {
-                    resultType.writeDouble(resultBuilder, value);
-                    continue;
-                }
+            else {
+                cast.invokeExact(session, array, position, resultBuilder);
             }
-            resultBuilder.appendNull();
-        }
-        return resultBuilder.build();
-    }
-
-    @TypeParameter("F")
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = boolean.class)
-    @SqlType("array(T)")
-    public static Block filterBoolean(
-            @TypeParameter("T") Type resultType,
-            @CastDependency(fromType = "F", toType = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = NULLABLE_RETURN, session = true)) MethodHandle cast,
-            ConnectorSession session,
-            @SqlType("array(F)") Block array)
-            throws Throwable
-    {
-        int positionCount = array.getPositionCount();
-        BlockBuilder resultBuilder = resultType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            if (!array.isNull(position)) {
-                Boolean value = (Boolean) cast.invokeExact(session, array, position);
-                if (value != null) {
-                    resultType.writeBoolean(resultBuilder, value);
-                    continue;
-                }
-            }
-            resultBuilder.appendNull();
-        }
-        return resultBuilder.build();
-    }
-
-    @TypeParameter("F")
-    @TypeParameter("T")
-    @TypeParameterSpecialization(name = "T", nativeContainerType = Object.class)
-    @SqlType("array(T)")
-    public static Block filterObject(
-            @TypeParameter("T") Type resultType,
-            @CastDependency(fromType = "F", toType = "T", convention = @Convention(arguments = BLOCK_POSITION_NOT_NULL, result = NULLABLE_RETURN, session = true)) MethodHandle cast,
-            ConnectorSession session,
-            @SqlType("array(F)") Block array)
-            throws Throwable
-    {
-        int positionCount = array.getPositionCount();
-        BlockBuilder resultBuilder = resultType.createBlockBuilder(null, positionCount);
-        for (int position = 0; position < positionCount; position++) {
-            if (!array.isNull(position)) {
-                Object value = (Object) cast.invoke(session, array, position);
-                if (value != null) {
-                    resultType.writeObject(resultBuilder, value);
-                    continue;
-                }
-            }
-            resultBuilder.appendNull();
         }
         return resultBuilder.build();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ChoicesSpecializedSqlScalarFunction.java
@@ -112,6 +112,7 @@ public final class ChoicesSpecializedSqlScalarFunction
         ScalarImplementationChoice bestChoice = Collections.max(choices, comparingInt(ScalarImplementationChoice::getScore));
         MethodHandle methodHandle = ScalarFunctionAdapter.adapt(
                 bestChoice.getMethodHandle(),
+                boundSignature.getReturnType(),
                 boundSignature.getArgumentTypes(),
                 bestChoice.getInvocationConvention(),
                 invocationConvention);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/GenericReadValueOperator.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.trino.metadata.SqlScalarFunction;
+import io.trino.spi.function.BoundSignature;
+import io.trino.spi.function.FunctionMetadata;
+import io.trino.spi.function.ScalarFunctionImplementation;
+import io.trino.spi.function.Signature;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.spi.type.TypeSignature;
+
+import java.lang.invoke.MethodHandle;
+
+import static io.trino.spi.function.OperatorType.READ_VALUE;
+import static java.util.Objects.requireNonNull;
+
+public class GenericReadValueOperator
+        extends SqlScalarFunction
+{
+    private final TypeOperators typeOperators;
+
+    public GenericReadValueOperator(TypeOperators typeOperators)
+    {
+        super(FunctionMetadata.scalarBuilder()
+                .signature(Signature.builder()
+                        .operatorType(READ_VALUE)
+                        .typeVariable("T")
+                        .returnType(new TypeSignature("T"))
+                        .argumentType(new TypeSignature("T"))
+                        .build())
+                .build());
+        this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
+    }
+
+    @Override
+    protected SpecializedSqlScalarFunction specialize(BoundSignature boundSignature)
+    {
+        Type type = boundSignature.getArgumentType(0);
+        return invocationConvention -> {
+            MethodHandle methodHandle = typeOperators.getReadValueOperator(type, invocationConvention);
+            return ScalarFunctionImplementation.builder()
+                    .methodHandle(methodHandle)
+                    .build();
+        };
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/Re2JRegexpReplaceLambdaFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/Re2JRegexpReplaceLambdaFunction.java
@@ -13,19 +13,18 @@
  */
 package io.trino.operator.scalar;
 
-import com.google.common.collect.ImmutableList;
 import com.google.re2j.Matcher;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
-import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.BufferedArrayValueBuilder;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
+import io.trino.spi.type.ArrayType;
 import io.trino.sql.gen.lambda.UnaryFunctionInterface;
 import io.trino.type.Re2JRegexp;
 import io.trino.type.Re2JRegexpType;
@@ -36,7 +35,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 @Description("Replaces substrings matching a regular expression using a lambda function")
 public final class Re2JRegexpReplaceLambdaFunction
 {
-    private final PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(VARCHAR));
+    private final BufferedArrayValueBuilder arrayValueBuilder = BufferedArrayValueBuilder.createBuffered(new ArrayType(VARCHAR));
 
     @LiteralParameters("x")
     @SqlType("varchar")
@@ -54,13 +53,6 @@ public final class Re2JRegexpReplaceLambdaFunction
 
         SliceOutput output = new DynamicSliceOutput(source.length());
 
-        // Prepare a BlockBuilder that will be used to create the target block
-        // that will be passed to the lambda function.
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
-
         int groupCount = matcher.groupCount();
         int appendPosition = 0;
 
@@ -75,17 +67,17 @@ public final class Re2JRegexpReplaceLambdaFunction
             appendPosition = end;
 
             // Append the capturing groups to the target block that will be passed to lambda
-            for (int i = 1; i <= groupCount; i++) {
-                Slice matchedGroupSlice = matcher.group(i);
-                if (matchedGroupSlice != null) {
-                    VARCHAR.writeSlice(blockBuilder, matchedGroupSlice);
+            Block target = arrayValueBuilder.build(groupCount, elementBuilder -> {
+                for (int i = 1; i <= groupCount; i++) {
+                    Slice matchedGroupSlice = matcher.group(i);
+                    if (matchedGroupSlice != null) {
+                        VARCHAR.writeSlice(elementBuilder, matchedGroupSlice);
+                    }
+                    else {
+                        elementBuilder.appendNull();
+                    }
                 }
-                else {
-                    blockBuilder.appendNull();
-                }
-            }
-            pageBuilder.declarePositions(groupCount);
-            Block target = blockBuilder.getRegion(blockBuilder.getPositionCount() - groupCount, groupCount);
+            });
 
             // Call the lambda function to replace the block, and append the result to output
             Slice replaced = (Slice) replaceFunction.apply(target);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/OperatorValidator.java
@@ -73,6 +73,7 @@ public final class OperatorValidator
             case IS_DISTINCT_FROM:
             case XX_HASH_64:
             case INDETERMINATE:
+            case READ_VALUE:
                 // TODO
         }
     }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -450,6 +450,11 @@
                                     <newVisibility>private</newVisibility>
                                     <justification>Constructor should have never been public as there is a static factory method</justification>
                                 </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method java.lang.invoke.MethodHandle io.trino.spi.function.ScalarFunctionAdapter::adapt(java.lang.invoke.MethodHandle, java.util.List&lt;io.trino.spi.type.Type&gt;, io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</old>
+                                    <new>method java.lang.invoke.MethodHandle io.trino.spi.function.ScalarFunctionAdapter::adapt(java.lang.invoke.MethodHandle, io.trino.spi.type.Type, java.util.List&lt;io.trino.spi.type.Type&gt;, io.trino.spi.function.InvocationConvention, io.trino.spi.function.InvocationConvention)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/InvocationConvention.java
@@ -163,10 +163,10 @@ public class InvocationConvention
         /**
          * The function will never return a null value.
          * It is not possible to adapt a NEVER_NULL argument to a
-         * BOXED_NULLABLE or NULL_FLAG argument when the this return
+         * BOXED_NULLABLE or NULL_FLAG argument when this return
          * convention is used.
          */
-        FAIL_ON_NULL(false),
+        FAIL_ON_NULL(false, 0),
         /**
          * When a null is passed to a never null argument, the function
          * will not be invoked, and the Java default value for the return
@@ -174,24 +174,37 @@ public class InvocationConvention
          * This can not be used as an actual function return convention,
          * and instead is only used for adaptation.
          */
-        DEFAULT_ON_NULL(false),
+        DEFAULT_ON_NULL(false, 0),
         /**
          * The function may return a null value.
          * When a null is passed to a never null argument, the function
          * will not be invoked, and a null value is returned.
          */
-        NULLABLE_RETURN(true);
+        NULLABLE_RETURN(true, 0),
+        /**
+         * Return value is witten to a BlockBuilder passed as the last argument.
+         * When a null is passed to a never null argument, the function
+         * will not be invoked, and a null is written to the block builder.
+         */
+        BLOCK_BUILDER(true, 1);
 
         private final boolean nullable;
+        private final int parameterCount;
 
-        InvocationReturnConvention(boolean nullable)
+        InvocationReturnConvention(boolean nullable, int parameterCount)
         {
             this.nullable = nullable;
+            this.parameterCount = parameterCount;
         }
 
         public boolean isNullable()
         {
             return nullable;
+        }
+
+        public int getParameterCount()
+        {
+            return parameterCount;
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/OperatorType.java
@@ -38,7 +38,9 @@ public enum OperatorType
     SATURATED_FLOOR_CAST("SATURATED FLOOR CAST", 1),
     IS_DISTINCT_FROM("IS DISTINCT FROM", 2),
     XX_HASH_64("XX HASH 64", 1),
-    INDETERMINATE("INDETERMINATE", 1);
+    INDETERMINATE("INDETERMINATE", 1),
+    READ_VALUE("READ VALUE", 1),
+    /**/;
 
     private final String operator;
     private final int argumentCount;

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperatorDeclaration.java
@@ -14,6 +14,7 @@
 package io.trino.spi.type;
 
 import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.BlockIndex;
 import io.trino.spi.function.BlockPosition;
@@ -41,6 +42,7 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NULL_FLAG;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.BLOCK_BUILDER;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
@@ -400,6 +402,7 @@ public final class TypeOperatorDeclaration
             int expectedParameterCount = convention.getArgumentConventions().stream()
                     .mapToInt(InvocationArgumentConvention::getParameterCount)
                     .sum();
+            expectedParameterCount += convention.getReturnConvention().getParameterCount();
             checkArgument(expectedParameterCount == methodType.parameterCount(),
                     "Expected %s method parameters, but got %s", expectedParameterCount, methodType.parameterCount());
 
@@ -445,6 +448,12 @@ public final class TypeOperatorDeclaration
                     checkArgument(methodType.returnType().equals(wrap(returnJavaType)),
                             "Expected return type to be %s, but is %s", returnJavaType, wrap(methodType.returnType()));
                     break;
+                case BLOCK_BUILDER:
+                    checkArgument(methodType.lastParameterType().equals(BlockBuilder.class),
+                            "Expected last argument type to be BlockBuilder, but is %s", methodType.returnType());
+                    checkArgument(methodType.returnType().equals(void.class),
+                            "Expected return type to be void, but is %s", methodType.returnType());
+                    break;
                 default:
                     throw new UnsupportedOperationException("Unknown return convention: " + returnConvention);
             }
@@ -458,6 +467,8 @@ public final class TypeOperatorDeclaration
 
             List<Class<?>> parameterTypes = List.of(method.getParameterTypes());
             List<Annotation[]> parameterAnnotations = List.of(method.getParameterAnnotations());
+            parameterTypes = parameterTypes.subList(0, parameterTypes.size() - returnConvention.getParameterCount());
+            parameterAnnotations = parameterAnnotations.subList(0, parameterAnnotations.size() - returnConvention.getParameterCount());
 
             InvocationArgumentConvention leftArgumentConvention = extractNextArgumentConvention(typeJavaType, parameterTypes, parameterAnnotations, operatorType, method);
             if (leftArgumentConvention.getParameterCount() == parameterTypes.size()) {
@@ -490,6 +501,11 @@ public final class TypeOperatorDeclaration
             }
             else if (method.isAnnotationPresent(SqlNullable.class) && method.getReturnType().equals(wrap(expectedReturnType))) {
                 returnConvention = NULLABLE_RETURN;
+            }
+            else if (method.getReturnType().equals(void.class) &&
+                    method.getParameterCount() >= 1 &&
+                    method.getParameterTypes()[method.getParameterCount() - 1].equals(BlockBuilder.class)) {
+                returnConvention = BLOCK_BUILDER;
             }
             else {
                 throw new IllegalArgumentException(format("Expected %s operator to return %s: %s", operatorType, expectedReturnType, method));


### PR DESCRIPTION
## Description
* Add `BLOCK_BUILDER` return convention that writes the result directly to a `BlockBuilder`
* Add `READ_VALUE` operator that can read a value from any argument convention to any return convention
* Using the above two techniques, most array functions with an implementation per stack type are converted to a simple single generic implementation
* Migrate more array functions from `PageBuilder` cache to use the simpler `BufferedArrayValueBuilder`

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Add `BLOCK_BUILDER` return convention that writes the function result directly to a `BlockBuilder`. ({issue}`18094`)
* Add `READ_VALUE` operator that can read a value from any argument convention to any return convention.  ({issue}`18094`)
```
