### PR TITLE
Do not allow overriding OIDC discovery results

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -38,6 +38,8 @@ import static io.trino.server.security.oauth2.OAuth2Service.OPENID_SCOPE;
 
 public class OAuth2Config
 {
+    public static final String ACCESS_TOKEN_ISSUER = "http-server.authentication.oauth2.access-token-issuer";
+
     private Optional<String> stateKey = Optional.empty();
     private String issuer;
     private String clientId;
@@ -52,6 +54,7 @@ public class OAuth2Config
     private Optional<File> userMappingFile = Optional.empty();
     private boolean enableRefreshTokens;
     private boolean enableDiscovery = true;
+    private Optional<String> accessTokenIssuer = Optional.empty();
 
     public Optional<String> getStateKey()
     {
@@ -244,6 +247,20 @@ public class OAuth2Config
     public OAuth2Config setEnableDiscovery(boolean enableDiscovery)
     {
         this.enableDiscovery = enableDiscovery;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getAccessTokenIssuer()
+    {
+        return accessTokenIssuer;
+    }
+
+    @Config(ACCESS_TOKEN_ISSUER)
+    @ConfigDescription("The required issuer for access tokens")
+    public OAuth2Config setAccessTokenIssuer(String accessTokenIssuer)
+    {
+        this.accessTokenIssuer = Optional.ofNullable(accessTokenIssuer);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscoveryConfig.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscoveryConfig.java
@@ -19,26 +19,12 @@ import io.airlift.units.Duration;
 
 import javax.validation.constraints.NotNull;
 
-import java.util.Optional;
-
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.ACCESS_TOKEN_ISSUER;
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.AUTH_URL;
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.JWKS_URL;
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.TOKEN_URL;
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.USERINFO_URL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class OidcDiscoveryConfig
 {
     private Duration discoveryTimeout = new Duration(30, SECONDS);
     private boolean userinfoEndpointEnabled = true;
-
-    //TODO Left for backward compatibility, remove after the next release/a couple of releases
-    private Optional<String> accessTokenIssuer = Optional.empty();
-    private Optional<String> authUrl = Optional.empty();
-    private Optional<String> tokenUrl = Optional.empty();
-    private Optional<String> jwksUrl = Optional.empty();
-    private Optional<String> userinfoUrl = Optional.empty();
 
     @NotNull
     public Duration getDiscoveryTimeout()
@@ -64,76 +50,6 @@ public class OidcDiscoveryConfig
     public OidcDiscoveryConfig setUserinfoEndpointEnabled(boolean userinfoEndpointEnabled)
     {
         this.userinfoEndpointEnabled = userinfoEndpointEnabled;
-        return this;
-    }
-
-    @NotNull
-    public Optional<String> getAccessTokenIssuer()
-    {
-        return accessTokenIssuer;
-    }
-
-    @Config(ACCESS_TOKEN_ISSUER)
-    @ConfigDescription("The required issuer for access tokens")
-    public OidcDiscoveryConfig setAccessTokenIssuer(String accessTokenIssuer)
-    {
-        this.accessTokenIssuer = Optional.ofNullable(accessTokenIssuer);
-        return this;
-    }
-
-    @NotNull
-    public Optional<String> getAuthUrl()
-    {
-        return authUrl;
-    }
-
-    @Config(AUTH_URL)
-    @ConfigDescription("URL of the authorization server's authorization endpoint")
-    public OidcDiscoveryConfig setAuthUrl(String authUrl)
-    {
-        this.authUrl = Optional.ofNullable(authUrl);
-        return this;
-    }
-
-    @NotNull
-    public Optional<String> getTokenUrl()
-    {
-        return tokenUrl;
-    }
-
-    @Config(TOKEN_URL)
-    @ConfigDescription("URL of the authorization server's token endpoint")
-    public OidcDiscoveryConfig setTokenUrl(String tokenUrl)
-    {
-        this.tokenUrl = Optional.ofNullable(tokenUrl);
-        return this;
-    }
-
-    @NotNull
-    public Optional<String> getJwksUrl()
-    {
-        return jwksUrl;
-    }
-
-    @Config(JWKS_URL)
-    @ConfigDescription("URL of the authorization server's JWKS (JSON Web Key Set) endpoint")
-    public OidcDiscoveryConfig setJwksUrl(String jwksUrl)
-    {
-        this.jwksUrl = Optional.ofNullable(jwksUrl);
-        return this;
-    }
-
-    @NotNull
-    public Optional<String> getUserinfoUrl()
-    {
-        return userinfoUrl;
-    }
-
-    @Config(USERINFO_URL)
-    @ConfigDescription("URL of the userinfo endpoint")
-    public OidcDiscoveryConfig setUserinfoUrl(String userinfoUrl)
-    {
-        this.userinfoUrl = Optional.ofNullable(userinfoUrl);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
@@ -23,14 +23,14 @@ public class StaticConfigurationProvider
     private final OAuth2ServerConfig config;
 
     @Inject
-    StaticConfigurationProvider(StaticOAuth2ServerConfiguration config)
+    StaticConfigurationProvider(OAuth2Config config, StaticOAuth2ServerConfiguration staticConfig)
     {
         this.config = new OAuth2ServerConfig(
                 config.getAccessTokenIssuer(),
-                URI.create(config.getAuthUrl()),
-                URI.create(config.getTokenUrl()),
-                URI.create(config.getJwksUrl()),
-                config.getUserinfoUrl().map(URI::create));
+                URI.create(staticConfig.getAuthUrl()),
+                URI.create(staticConfig.getTokenUrl()),
+                URI.create(staticConfig.getJwksUrl()),
+                staticConfig.getUserinfoUrl().map(URI::create));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfiguration.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfiguration.java
@@ -22,31 +22,15 @@ import java.util.Optional;
 
 public class StaticOAuth2ServerConfiguration
 {
-    public static final String ACCESS_TOKEN_ISSUER = "http-server.authentication.oauth2.access-token-issuer";
     public static final String AUTH_URL = "http-server.authentication.oauth2.auth-url";
     public static final String TOKEN_URL = "http-server.authentication.oauth2.token-url";
     public static final String JWKS_URL = "http-server.authentication.oauth2.jwks-url";
     public static final String USERINFO_URL = "http-server.authentication.oauth2.userinfo-url";
 
-    private Optional<String> accessTokenIssuer = Optional.empty();
     private String authUrl;
     private String tokenUrl;
     private String jwksUrl;
     private Optional<String> userinfoUrl = Optional.empty();
-
-    @NotNull
-    public Optional<String> getAccessTokenIssuer()
-    {
-        return accessTokenIssuer;
-    }
-
-    @Config(ACCESS_TOKEN_ISSUER)
-    @ConfigDescription("The required issuer for access tokens")
-    public StaticOAuth2ServerConfiguration setAccessTokenIssuer(String accessTokenIssuer)
-    {
-        this.accessTokenIssuer = Optional.ofNullable(accessTokenIssuer);
-        return this;
-    }
 
     @NotNull
     public String getAuthUrl()

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -49,7 +49,8 @@ public class TestOAuth2Config
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null)
                 .setEnableRefreshTokens(false)
-                .setEnableDiscovery(true));
+                .setEnableDiscovery(true)
+                .setAccessTokenIssuer(null));
     }
 
     @Test
@@ -72,6 +73,7 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
                 .put("http-server.authentication.oauth2.refresh-tokens", "true")
                 .put("http-server.authentication.oauth2.oidc.discovery", "false")
+                .put("http-server.authentication.oauth2.access-token-issuer", "https://issuer.com/at")
                 .buildOrThrow();
 
         OAuth2Config expected = new OAuth2Config()
@@ -88,7 +90,8 @@ public class TestOAuth2Config
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile())
                 .setEnableRefreshTokens(true)
-                .setEnableDiscovery(false);
+                .setEnableDiscovery(false)
+                .setAccessTokenIssuer("https://issuer.com/at");
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscoveryConfig.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscoveryConfig.java
@@ -32,12 +32,7 @@ public class TestOidcDiscoveryConfig
     {
         assertRecordedDefaults(recordDefaults(OidcDiscoveryConfig.class)
                 .setDiscoveryTimeout(new Duration(30, SECONDS))
-                .setUserinfoEndpointEnabled(true)
-                .setAccessTokenIssuer(null)
-                .setAuthUrl(null)
-                .setTokenUrl(null)
-                .setJwksUrl(null)
-                .setUserinfoUrl(null));
+                .setUserinfoEndpointEnabled(true));
     }
 
     @Test
@@ -46,21 +41,11 @@ public class TestOidcDiscoveryConfig
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("http-server.authentication.oauth2.oidc.discovery.timeout", "1m")
                 .put("http-server.authentication.oauth2.oidc.use-userinfo-endpoint", "false")
-                .put("http-server.authentication.oauth2.access-token-issuer", "https://issuer.com/at")
-                .put("http-server.authentication.oauth2.auth-url", "https://issuer.com/auth")
-                .put("http-server.authentication.oauth2.token-url", "https://issuer.com/token")
-                .put("http-server.authentication.oauth2.jwks-url", "https://issuer.com/jwks.json")
-                .put("http-server.authentication.oauth2.userinfo-url", "https://issuer.com/user")
                 .buildOrThrow();
 
         OidcDiscoveryConfig expected = new OidcDiscoveryConfig()
                 .setDiscoveryTimeout(new Duration(1, MINUTES))
-                .setUserinfoEndpointEnabled(false)
-                .setAccessTokenIssuer("https://issuer.com/at")
-                .setAuthUrl("https://issuer.com/auth")
-                .setTokenUrl("https://issuer.com/token")
-                .setJwksUrl("https://issuer.com/jwks.json")
-                .setUserinfoUrl("https://issuer.com/user");
+                .setUserinfoEndpointEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/docs/src/main/sphinx/security/oauth2.rst
+++ b/docs/src/main/sphinx/security/oauth2.rst
@@ -104,25 +104,18 @@ The following configuration properties are available:
        Defaults to the value of ``http-server.authentication.oauth2.issuer``.
    * - ``http-server.authentication.oauth2.auth-url``
      - The authorization URL. The URL a user's browser will be redirected to in
-       order to begin the OAuth 2.0 authorization process. Providing this value
-       while OIDC discovery is enabled overrides the value from the OpenID
-       provider metadata document.
+       order to begin the OAuth 2.0 authorization process.
    * - ``http-server.authentication.oauth2.token-url``
      - The URL of the endpoint on the authorization server which Trino uses to
-       obtain an access token. Providing this value while OIDC discovery is
-       enabled overrides the value from the OpenID provider metadata document.
+       obtain an access token.
    * - ``http-server.authentication.oauth2.jwks-url``
      - The URL of the JSON Web Key Set (JWKS) endpoint on the authorization
        server. It provides Trino the set of keys containing the public key
        to verify any JSON Web Token (JWT) from the authorization server.
-       Providing this value while OIDC discovery is enabled overrides the value
-       from the OpenID provider metadata document.
    * - ``http-server.authentication.oauth2.userinfo-url``
      - The URL of the IdPs ``/userinfo`` endpoint. If supplied then this URL is
        used to validate the OAuth access token and retrieve any associated
-       claims. This is required if the IdP issues opaque tokens. Providing this
-       value while OIDC discovery is enabled overrides the value from the OpenID
-       provider metadata document.
+       claims. This is required if the IdP issues opaque tokens.
    * - ``http-server.authentication.oauth2.client-id``
      - The public identifier of the Trino client.
    * - ``http-server.authentication.oauth2.client-secret``


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Overriding OIDC discovery results was supported in order to maintain backward compatibility after OIDC discovery (#9788) was introduced. Since this feature was added > 1 year ago users had enough time to adjust their configs.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Security
* Remove OIDC discovery results overriding mechanism.
```
