### PR TITLE
Support migrating Hive bucketed table as non-bucketed Iceberg table

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -590,8 +590,9 @@ Iceberg.
 
 Use the procedure ``system.migrate`` to move a table from the Hive format to the
 Iceberg format, loaded with the source’s data files. Table schema, partitioning,
-properties, and location are copied from the source table. The data files in the
-Hive table must use the Parquet, ORC, or Avro file format.
+properties, and location are copied from the source table. A bucketed Hive table
+will be migrated as a non-bucketed Iceberg table. The data files in the Hive table
+must use the Parquet, ORC, or Avro file format.
 
 The procedure must be called for a specific catalog ``example`` with the
 relevant schema and table names supplied with the required parameters

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/MigrateProcedure.java
@@ -387,10 +387,6 @@ public class MigrateProcedure
     {
         ImmutableList.Builder<String> fields = ImmutableList.builder();
         fields.addAll(getPartitionColumnNames(table));
-        table.getStorage().getBucketProperty()
-                .ifPresent(bucket -> {
-                    throw new TrinoException(NOT_SUPPORTED, "Cannot migrate bucketed table: " + bucket.getBucketedBy());
-                });
         return fields.build();
     }
 


### PR DESCRIPTION
## Description

Support migrating Hive bucketed table as non-bucketed Iceberg table

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Support migrating Hive bucketed table as non-bucketed Iceberg table. ({issue}`issuenumber`)
```
