### PR TITLE
Retry Delta query when the error message contains `TEMPORARILY_UNAVAILABLE`

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryExecutors.java
@@ -119,6 +119,7 @@ public final class QueryExecutors
 
         RetryPolicy<QueryResult> databricksRetryPolicy = RetryPolicy.<QueryResult>builder()
                 .handleIf(throwable -> throwable.getMessage().contains("HTTP Response code: 502"))
+                .handleIf(throwable -> throwable.getMessage().contains("TEMPORARILY_UNAVAILABLE"))
                 .withBackoff(1, 10, ChronoUnit.SECONDS)
                 .withMaxRetries(60)
                 .onRetry(event -> log.warn(event.getLastException(), "Query failed on attempt %d, will retry.", event.getAttemptCount()))


### PR DESCRIPTION
## Description

Fix flaky Databricks product tests. 
* https://github.com/trinodb/trino/actions/runs/5435975713
* https://github.com/trinodb/trino/actions/runs/5435625880
* https://github.com/trinodb/trino/actions/runs/5429890734

Setting `TemporarilyUnavailableRetryTimeout ` didn't help https://github.com/trinodb/trino/actions/runs/5441042991/jobs/9894721240?pr=18107

## Release notes

(x) This is not user-visible or docs only and no release notes are required.