### PR TITLE
Rename version checking method for more clarity

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/Versions.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/Versions.java
@@ -28,8 +28,10 @@ public final class Versions
      * Using plugins built for a different version of Trino may fail at runtime, especially if plugin author
      * chooses not to maintain compatibility with older SPI versions, as happens for plugins maintained together with
      * the Trino project.
+     *
+     * @implNote This method is designed only for plugins distributed with Trino
      */
-    public static void checkSpiVersion(ConnectorContext context, ConnectorFactory connectorFactory)
+    public static void checkStrictSpiVersionMatch(ConnectorContext context, ConnectorFactory connectorFactory)
     {
         String spiVersion = context.getSpiVersion();
         String compileTimeSpiVersion = SpiVersionHolder.SPI_COMPILE_TIME_VERSION;

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
@@ -23,7 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class AccumuloConnectorFactory
@@ -43,7 +43,7 @@ public class AccumuloConnectorFactory
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
         requireNonNull(context, "context is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class AtopConnectorFactory
@@ -54,7 +54,7 @@ public class AtopConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnectorFactory.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcConnectorFactory
@@ -55,7 +55,7 @@ public class JdbcConnectorFactory
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
         requireNonNull(module, "module is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()),

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorFactory.java
@@ -24,7 +24,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryConnectorFactory
@@ -41,7 +41,7 @@ public class BigQueryConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnectorFactory.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 
 public class BlackHoleConnectorFactory
@@ -37,7 +37,7 @@ public class BlackHoleConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ListeningScheduledExecutorService executorService = listeningDecorator(newSingleThreadScheduledExecutor(daemonThreadsNamed("blackhole")));
         return new BlackHoleConnector(

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnectorFactory.java
@@ -24,7 +24,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraConnectorFactory
@@ -40,7 +40,7 @@ public class CassandraConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeConnectorFactory.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeConnectorFactory
@@ -47,7 +47,7 @@ public class DeltaLakeConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -28,7 +28,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class ElasticsearchConnectorFactory
@@ -47,7 +47,7 @@ public class ElasticsearchConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleConnectorFactory.java
@@ -23,7 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class ExampleConnectorFactory
@@ -39,7 +39,7 @@ public class ExampleConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsConnectorFactory.java
@@ -23,7 +23,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class SheetsConnectorFactory
@@ -39,7 +39,7 @@ public class SheetsConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnectorFactory.java
@@ -23,7 +23,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class HiveConnectorFactory
@@ -50,7 +50,7 @@ public class HiveConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnectorFactory.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnectorFactory.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 
 public class HudiConnectorFactory
         implements ConnectorFactory
@@ -39,7 +39,7 @@ public class HudiConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergConnectorFactory
@@ -51,7 +51,7 @@ public class IcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnectorFactory.java
@@ -25,7 +25,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 
 public class JmxConnectorFactory
         implements ConnectorFactory
@@ -39,7 +39,7 @@ public class JmxConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanServerModule(),

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorFactory.java
@@ -27,7 +27,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class KafkaConnectorFactory
@@ -51,7 +51,7 @@ public class KafkaConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisConnectorFactory.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class KinesisConnectorFactory
@@ -46,7 +46,7 @@ public class KinesisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         try {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnectorFactory.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class KuduConnectorFactory
@@ -42,7 +42,7 @@ public class KuduConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileConnectorFactory.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class LocalFileConnectorFactory
@@ -38,7 +38,7 @@ public class LocalFileConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 binder -> binder.bind(NodeManager.class).toInstance(context.getNodeManager()),

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryConnectorFactory.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class MemoryConnectorFactory
@@ -38,7 +38,7 @@ public class MemoryConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         // A plugin is not required to use Guice; it is just very convenient
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class MongoConnectorFactory
@@ -49,7 +49,7 @@ public class MongoConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
@@ -26,7 +26,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixConnectorFactory
@@ -49,7 +49,7 @@ public class PhoenixConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -28,7 +28,7 @@ import org.weakref.jmx.guice.MBeanModule;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class PinotConnectorFactory
@@ -52,7 +52,7 @@ public class PinotConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         ImmutableList.Builder<Module> modulesBuilder = ImmutableList.<Module>builder()
                 .add(new JsonModule())

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorFactory.java
@@ -24,7 +24,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class PrometheusConnectorFactory
@@ -40,7 +40,7 @@ public class PrometheusConnectorFactory
     public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         try {
             // A plugin is not required to use Guice; it is just very convenient

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnectorFactory.java
@@ -37,7 +37,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class RaptorConnectorFactory
@@ -64,7 +64,7 @@ public class RaptorConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new CatalogNameModule(catalogName),

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisConnectorFactory.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class RedisConnectorFactory
@@ -53,7 +53,7 @@ public class RedisConnectorFactory
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new JsonModule(),

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorFactory.java
@@ -28,7 +28,7 @@ import org.weakref.jmx.guice.MBeanModule;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class ThriftConnectorFactory
@@ -52,7 +52,7 @@ public class ThriftConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(
                 new MBeanModule(),

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsConnectorFactory.java
@@ -21,7 +21,7 @@ import io.trino.spi.connector.ConnectorFactory;
 
 import java.util.Map;
 
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 
 public class TpcdsConnectorFactory
         implements ConnectorFactory
@@ -35,7 +35,7 @@ public class TpcdsConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         Bootstrap app = new Bootstrap(new TpcdsModule(context.getNodeManager()));
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchConnectorFactory.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.lang.Boolean.FALSE;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
@@ -76,7 +76,7 @@ public class TpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         int splitsPerNode = getSplitsPerNode(properties);
         ColumnNaming columnNaming = ColumnNaming.valueOf(properties.getOrDefault(TPCH_COLUMN_NAMING_PROPERTY, ColumnNaming.SIMPLIFIED.name()).toUpperCase(ENGLISH));

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/IndexedTpchConnectorFactory.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static io.trino.plugin.base.Versions.checkSpiVersion;
+import static io.trino.plugin.base.Versions.checkStrictSpiVersionMatch;
 import static java.util.Objects.requireNonNull;
 
 public class IndexedTpchConnectorFactory
@@ -61,7 +61,7 @@ public class IndexedTpchConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> properties, ConnectorContext context)
     {
-        checkSpiVersion(context, this);
+        checkStrictSpiVersionMatch(context, this);
 
         int splitsPerNode = getSplitsPerNode(properties);
         TpchIndexedData indexedData = new TpchIndexedData(indexSpec);


### PR DESCRIPTION
It was observed that people are inclined to change version check behavior rather than stop calling that method when they maintain 3rd party plugins.

Follows eg https://github.com/trinodb/trino/pull/18072