### PR TITLE
Support optimized local scheduling of kudu splits

### DIFF
--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -61,6 +61,9 @@ replacing the properties as appropriate:
    ## Disable Kudu client's collection of statistics.
    #kudu.client.disable-statistics = false
 
+   ## Assign Kudu splits to replica host if worker and kudu share the same cluster
+   #kudu.allow-local-scheduling = false
+
 Kerberos support
 ----------------
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
@@ -44,6 +44,7 @@ public class KuduClientConfig
     private boolean schemaEmulationEnabled;
     private String schemaEmulationPrefix = "presto::";
     private Duration dynamicFilteringWaitTimeout = new Duration(0, MINUTES);
+    private boolean allowLocalScheduling;
 
     @NotNull
     @Size(min = 1)
@@ -141,6 +142,19 @@ public class KuduClientConfig
     public KuduClientConfig setDynamicFilteringWaitTimeout(Duration dynamicFilteringWaitTimeout)
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
+        return this;
+    }
+
+    public boolean isAllowLocalScheduling()
+    {
+        return allowLocalScheduling;
+    }
+
+    @Config("kudu.allow-local-scheduling")
+    @ConfigDescription("Assign Kudu splits to replica host if worker and kudu share the same cluster")
+    public KuduClientConfig setAllowLocalScheduling(boolean allowLocalScheduling)
+    {
+        this.allowLocalScheduling = allowLocalScheduling;
         return this;
     }
 }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSecurityModule.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSecurityModule.java
@@ -115,6 +115,6 @@ public class KuduSecurityModule
         else {
             strategy = new NoSchemaEmulation();
         }
-        return new KuduClientSession(client, strategy);
+        return new KuduClientSession(client, strategy, config.isAllowLocalScheduling());
     }
 }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
@@ -36,19 +36,22 @@ public class KuduSplit
     private final int primaryKeyColumnCount;
     private final byte[] serializedScanToken;
     private final int bucketNumber;
+    private final List<HostAddress> addresses;
 
     @JsonCreator
     public KuduSplit(
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
             @JsonProperty("primaryKeyColumnCount") int primaryKeyColumnCount,
             @JsonProperty("serializedScanToken") byte[] serializedScanToken,
-            @JsonProperty("bucketNumber") int bucketNumber)
+            @JsonProperty("bucketNumber") int bucketNumber,
+            @JsonProperty("addresses") List<HostAddress> addresses)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.primaryKeyColumnCount = primaryKeyColumnCount;
         this.serializedScanToken = requireNonNull(serializedScanToken, "serializedScanToken is null");
         checkArgument(bucketNumber >= 0, "bucketNumber is negative");
         this.bucketNumber = bucketNumber;
+        this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
     }
 
     @JsonProperty
@@ -81,10 +84,11 @@ public class KuduSplit
         return true;
     }
 
+    @JsonProperty
     @Override
     public List<HostAddress> getAddresses()
     {
-        return ImmutableList.of();
+        return addresses;
     }
 
     @Override

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduClientConfig.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduClientConfig.java
@@ -37,7 +37,8 @@ public class TestKuduClientConfig
                 .setDisableStatistics(false)
                 .setSchemaEmulationEnabled(false)
                 .setSchemaEmulationPrefix("presto::")
-                .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES)));
+                .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
+                .setAllowLocalScheduling(false));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestKuduClientConfig
                 .put("kudu.schema-emulation.enabled", "true")
                 .put("kudu.schema-emulation.prefix", "trino::")
                 .put("kudu.dynamic-filtering.wait-timeout", "30m")
+                .put("kudu.allow-local-scheduling", "true")
                 .buildOrThrow();
 
         KuduClientConfig expected = new KuduClientConfig()
@@ -60,7 +62,8 @@ public class TestKuduClientConfig
                 .setDisableStatistics(true)
                 .setSchemaEmulationEnabled(true)
                 .setSchemaEmulationPrefix("trino::")
-                .setDynamicFilteringWaitTimeout(new Duration(30, MINUTES));
+                .setDynamicFilteringWaitTimeout(new Duration(30, MINUTES))
+                .setAllowLocalScheduling(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
For now the Hive Connector supports optimized local scheduling when Trino workers are deployed on the same nodes with HDFS, but Kudu doesn't,  which we can see from `KuduSplit.getAddresses()`:  
![image](https://github.com/trinodb/trino/assets/26461591/0b154a87-46f3-49f7-b3a6-5e4579a9e881)
Kudu scanner clients fetch data from tablet leaders by default, so we add leaders' host addresses from `KuduScanToken` into `KuduSplit` to support this.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Support optimized local scheduling of kudu splits. ({issue}`18121`)
```
