### PR TITLE
Make ServerIT work with different Temurin JDK versions

### DIFF
--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -18,7 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
-import org.testng.annotations.Parameters;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -42,30 +42,27 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class ServerIT
 {
-    private static final String BASE_IMAGE = "ghcr.io/trinodb/testing/centos7-oj17";
+    private static final String BASE_IMAGE_PREFIX = "eclipse-temurin:";
+    private static final String BASE_IMAGE_SUFFIX = "-jre-centos7";
 
-    @Parameters("rpm")
-    @Test
-    public void testWithJava17(String rpm)
+    @Test(dataProvider = "rpmJavaTestDataProvider")
+    public void testInstall(String rpmHostPath, String javaVersion)
     {
-        testServer(rpm, "17");
+        testServer(rpmHostPath, javaVersion);
     }
 
-    @Parameters("rpm")
-    @Test
-    public void testUninstall(String rpmHostPath)
+    @Test(dataProvider = "rpmJavaTestDataProvider")
+    public void testUninstall(String rpmHostPath, String javaVersion)
             throws Exception
     {
         String rpm = "/" + new File(rpmHostPath).getName();
         String installAndStartTrino = "" +
+                // install RPM
                 "yum localinstall -q -y " + rpm + "\n" +
-                // update default JDK to 17
-                "alternatives --set java /usr/lib/jvm/zulu-17/bin/java\n" +
-                "alternatives --set javac /usr/lib/jvm/zulu-17/bin/javac\n" +
                 "/etc/init.d/trino start\n" +
                 // allow tail to work with Docker's non-local file system
                 "tail ---disable-inotify -F /var/log/trino/server.log\n";
-        try (GenericContainer<?> container = new GenericContainer<>(BASE_IMAGE)) {
+        try (GenericContainer<?> container = new GenericContainer<>(BASE_IMAGE_PREFIX + javaVersion + BASE_IMAGE_SUFFIX)) {
             container.withFileSystemBind(rpmHostPath, rpm, BindMode.READ_ONLY)
                     .withCommand("sh", "-xeuc", installAndStartTrino)
                     .waitingFor(forLogMessage(".*SERVER STARTED.*", 1).withStartupTimeout(Duration.ofMinutes(5)))
@@ -85,6 +82,15 @@ public class ServerIT
         }
     }
 
+    @DataProvider
+    public static Object[][] rpmJavaTestDataProvider()
+    {
+        String rpmHostPath = requireNonNull(System.getProperty("rpm"), "rpm is null");
+        return new Object[][]{
+                {rpmHostPath, "17"},
+                {rpmHostPath, "19"}};
+    }
+
     private static void assertPathDeleted(GenericContainer<?> container, String path)
             throws Exception
     {
@@ -96,16 +102,12 @@ public class ServerIT
         assertEquals(actualResult.getExitCode(), 0);
     }
 
-    private static void testServer(String rpmHostPath, String expectedJavaVersion)
+    private static void testServer(String rpmHostPath, String javaVersion)
     {
         String rpm = "/" + new File(rpmHostPath).getName();
-
         String command = "" +
                 // install RPM
                 "yum localinstall -q -y " + rpm + "\n" +
-                // update default JDK to 17
-                "alternatives --set java /usr/lib/jvm/zulu-17/bin/java\n" +
-                "alternatives --set javac /usr/lib/jvm/zulu-17/bin/javac\n" +
                 // create Hive catalog file
                 "mkdir /etc/trino/catalog\n" +
                 "echo CONFIG_ENV[HMS_PORT]=9083 >> /etc/trino/env.sh\n" +
@@ -124,7 +126,7 @@ public class ServerIT
                 // allow tail to work with Docker's non-local file system
                 "tail ---disable-inotify -F /var/log/trino/server.log\n";
 
-        try (GenericContainer<?> container = new GenericContainer<>(BASE_IMAGE)) {
+        try (GenericContainer<?> container = new GenericContainer<>(BASE_IMAGE_PREFIX + javaVersion + BASE_IMAGE_SUFFIX)) {
             container.withExposedPorts(8080)
                     // the RPM is hundreds MB and file system bind is much more efficient
                     .withFileSystemBind(rpmHostPath, rpm, BindMode.READ_ONLY)
@@ -137,7 +139,7 @@ public class ServerIT
             // TODO remove usage of assertEventually once https://github.com/trinodb/trino/issues/2214 is fixed
             assertEventually(
                     new io.airlift.units.Duration(1, MINUTES),
-                    () -> assertEquals(queryRunner.execute("SELECT specversion FROM jmx.current.\"java.lang:type=runtime\""), ImmutableSet.of(asList(expectedJavaVersion))));
+                    () -> assertEquals(queryRunner.execute("SELECT specversion FROM jmx.current.\"java.lang:type=runtime\""), ImmutableSet.of(asList(javaVersion))));
         }
     }
 


### PR DESCRIPTION
Add testing for JDK 19 to complement maven-checks running on 19.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
