### PR TITLE
Fix Hive sorted write failure when user identity contains @ sign (v2)

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -14,7 +14,6 @@
 package io.trino.filesystem;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 
 import java.io.File;
 import java.util.List;
@@ -23,6 +22,7 @@ import java.util.OptionalInt;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getLast;
 import static java.lang.Character.isWhitespace;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
@@ -78,11 +78,11 @@ public final class Location
         if (afterScheme.startsWith("//")) {
             // Locations with an authority must begin with a double slash
             afterScheme = afterScheme.substring(2);
-            List<String> userInfoSplit = USER_INFO_SPLITTER.splitToList(afterScheme);
-            Optional<String> userInfo = userInfoSplit.size() == 2 ? Optional.of(userInfoSplit.get(0)) : Optional.empty();
 
-            List<String> authoritySplit = AUTHORITY_SPLITTER.splitToList(Iterables.getLast(userInfoSplit));
-            List<String> hostAndPortSplit = HOST_AND_PORT_SPLITTER.splitToList(authoritySplit.get(0));
+            List<String> authoritySplit = AUTHORITY_SPLITTER.splitToList(afterScheme);
+            List<String> userInfoSplit = USER_INFO_SPLITTER.splitToList(authoritySplit.get(0));
+            Optional<String> userInfo = userInfoSplit.size() == 2 ? Optional.of(userInfoSplit.get(0)) : Optional.empty();
+            List<String> hostAndPortSplit = HOST_AND_PORT_SPLITTER.splitToList(getLast(userInfoSplit));
 
             Optional<String> host = Optional.of(hostAndPortSplit.get(0)).filter(not(String::isEmpty));
 

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -40,7 +40,7 @@ class TestLocation
 
         // host can be empty string
         assertLocation("scheme:///some/path", "scheme", Optional.empty(), "", "some/path");
-        // userInfo can be empty string
+        // host can be empty string when userInfo is present
         assertLocation("scheme://user@/some/path", "scheme", Optional.of("user"), "", "some/path");
         // userInfo can be arbitrary string (note: this documents current state, but does not imply the intent to support such locations)
         assertLocation("scheme://host:1234/some/path//@here:444/there", Optional.of("scheme"), Optional.of("host:1234/some/path//"), Optional.of("here"), OptionalInt.of(444), "there");

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -16,8 +16,12 @@ package io.trino.filesystem;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,7 +35,7 @@ class TestLocation
         // case is preserved
         assertLocation("SCHEME://USER_INFO@HOST/SOME/PATH", "SCHEME", Optional.of("USER_INFO"), "HOST", "SOME/PATH");
         // whitespace is allowed
-        assertLocation("sc heme://user info@ho st/so me/pa th", "sc heme", Optional.of("user info"), "ho st", "so me/pa th");
+        assertLocation("sc heme://user info@ho st/so me/pa th", Optional.of("sc heme"), Optional.of("user info"), Optional.of("ho st"), OptionalInt.empty(), "so me/pa th", Set.of("Illegal character in scheme name at index 2: sc heme://user info@ho st/so me/pa th"));
 
         // userInfo is optional
         assertLocation("scheme://host/some/path", "scheme", Optional.empty(), "host", "some/path");
@@ -41,20 +45,30 @@ class TestLocation
         // host can be empty string
         assertLocation("scheme:///some/path", "scheme", Optional.empty(), "", "some/path");
         // host can be empty string when userInfo is present
-        assertLocation("scheme://user@/some/path", "scheme", Optional.of("user"), "", "some/path");
+        assertLocation("scheme://user@/some/path", Optional.of("scheme"), Optional.of("user"), Optional.empty(), OptionalInt.empty(), "some/path", Set.of("userInfo compared with URI: expected [Optional.empty], was [Optional[user]]"));
         // userInfo can be arbitrary string (note: this documents current state, but does not imply the intent to support such locations)
-        assertLocation("scheme://host:1234/some/path//@here:444/there", Optional.of("scheme"), Optional.of("host:1234/some/path//"), Optional.of("here"), OptionalInt.of(444), "there");
+        assertLocation("scheme://host:1234/some/path//@here:444/there", Optional.of("scheme"), Optional.of("host:1234/some/path//"), Optional.of("here"), OptionalInt.of(444), "there", Set.of(
+                "userInfo compared with URI: expected [Optional.empty], was [Optional[host:1234/some/path//]]",
+                "host compared with URI: expected [Optional[host]], was [Optional[here]]",
+                "port compared with URI: expected [OptionalInt[1234]], was [OptionalInt[444]]",
+                "'/path' compared with URI: expected [/some/path//@here:444/there], was [/there]"));
         // host and userInfo can both be empty
-        assertLocation("scheme://@/some/path", "scheme", Optional.of(""), "", "some/path");
+        assertLocation("scheme://@/some/path", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.empty(), "some/path", Set.of("userInfo compared with URI: expected [Optional.empty], was [Optional[]]"));
         // port or userInfo can be given even if host is not (note: this documents current state, but does not imply the intent to support such locations)
-        assertLocation("scheme://:1/some/path", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "some/path");
-        assertLocation("scheme://@:1/some/path", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "some/path");
-        assertLocation("scheme://@/", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.empty(), "");
-        assertLocation("scheme://@:1/", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "");
-        assertLocation("scheme://:1/", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "");
-        assertLocation("scheme://@//", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.empty(), "/");
-        assertLocation("scheme://@:1//", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "/");
-        assertLocation("scheme://:1//", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "/");
+        assertLocation("scheme://:1/some/path", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "some/path", Set.of("port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
+        assertLocation("scheme://@:1/some/path", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "some/path", Set.of(
+                "userInfo compared with URI: expected [Optional.empty], was [Optional[]]",
+                "port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
+        assertLocation("scheme://@/", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.empty(), "", Set.of("userInfo compared with URI: expected [Optional.empty], was [Optional[]]"));
+        assertLocation("scheme://@:1/", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "", Set.of(
+                "userInfo compared with URI: expected [Optional.empty], was [Optional[]]",
+                "port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
+        assertLocation("scheme://:1/", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "", Set.of("port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
+        assertLocation("scheme://@//", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.empty(), "/", Set.of("userInfo compared with URI: expected [Optional.empty], was [Optional[]]"));
+        assertLocation("scheme://@:1//", Optional.of("scheme"), Optional.of(""), Optional.empty(), OptionalInt.of(1), "/", Set.of(
+                "userInfo compared with URI: expected [Optional.empty], was [Optional[]]",
+                "port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
+        assertLocation("scheme://:1//", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.of(1), "/", Set.of("port compared with URI: expected [OptionalInt.empty], was [OptionalInt[1]]"));
 
         // port is allowed
         assertLocation("hdfs://hadoop:9000/some/path", "hdfs", "hadoop", 9000, "some/path");
@@ -64,14 +78,14 @@ class TestLocation
 
         assertLocation("scheme://host/path/../../other", "scheme", Optional.empty(), "host", "path/../../other");
 
-        assertLocation("scheme://host/path/%41%illegal", "scheme", Optional.empty(), "host", "path/%41%illegal");
+        assertLocation("scheme://host/path/%41%illegal", Optional.of("scheme"), Optional.empty(), Optional.of("host"), OptionalInt.empty(), "path/%41%illegal", Set.of("Malformed escape pair at index 22: scheme://host/path/%41%illegal"));
 
         assertLocation("scheme://host///path", "scheme", Optional.empty(), "host", "//path");
 
         assertLocation("scheme://host///path//", "scheme", Optional.empty(), "host", "//path//");
 
         // the path can be empty
-        assertLocation("scheme://", "scheme", Optional.empty(), "", "");
+        assertLocation("scheme://", Optional.of("scheme"), Optional.empty(), Optional.empty(), OptionalInt.empty(), "", Set.of("Expected authority at index 9: scheme://"));
         assertLocation("scheme://host/", "scheme", Optional.empty(), "host", "");
         assertLocation("scheme:///", "scheme", Optional.empty(), "", "");
 
@@ -81,17 +95,17 @@ class TestLocation
 
         // the location can be just a path
         assertLocation("/", "");
-        assertLocation("//", "/");
-        assertLocation("///", "//");
+        assertLocation("//", "/", Set.of("Expected authority at index 2: //"));
+        assertLocation("///", "//", Set.of("'/path' compared with URI: expected [/], was [///]"));
         assertLocation("/abc", "abc");
-        assertLocation("//abc", "/abc");
-        assertLocation("///abc", "//abc");
+        assertLocation("//abc", "/abc", Set.of("host compared with URI: expected [Optional[abc]], was [Optional.empty]", "'/path' compared with URI: expected [], was [//abc]"));
+        assertLocation("///abc", "//abc", Set.of("'/path' compared with URI: expected [/abc], was [///abc]"));
         assertLocation("/abc/xyz", "abc/xyz");
         assertLocation("/foo://host:port/path", "foo://host:port/path");
 
         // special handling for Locations without hostnames
         assertLocation("file:/", "file", "");
-        assertLocation("file://", "file", "");
+        assertLocation("file://", Optional.of("file"), Optional.empty(), Optional.empty(), OptionalInt.empty(), "", Set.of("Expected authority at index 7: file://"));
         assertLocation("file:///", "file", "");
         assertLocation("file:////", "file", "/");
         assertLocation("file://///", "file", "//");
@@ -188,36 +202,62 @@ class TestLocation
     private static void assertLocation(String locationString, String scheme, Optional<String> userInfo, String host, String path)
     {
         Optional<String> expectedHost = host.isEmpty() ? Optional.empty() : Optional.of(host);
-        assertLocation(locationString, Optional.of(scheme), userInfo, expectedHost, OptionalInt.empty(), path);
+        assertLocation(locationString, Optional.of(scheme), userInfo, expectedHost, OptionalInt.empty(), path, Set.of());
     }
 
     private static void assertLocation(String locationString, String scheme, String path)
     {
-        assertLocation(locationString, Optional.of(scheme), Optional.empty(), Optional.empty(), OptionalInt.empty(), path);
+        assertLocation(locationString, Optional.of(scheme), Optional.empty(), Optional.empty(), OptionalInt.empty(), path, Set.of());
     }
 
     private static void assertLocation(String locationString, String scheme, String host, int port, String path)
     {
-        assertLocation(locationString, Optional.of(scheme), Optional.empty(), Optional.of(host), OptionalInt.of(port), path);
+        assertLocation(locationString, Optional.of(scheme), Optional.empty(), Optional.of(host), OptionalInt.of(port), path, Set.of());
     }
 
     private static void assertLocation(String locationString, String path)
     {
-        assertLocation(locationString, Optional.empty(), Optional.empty(), Optional.empty(), OptionalInt.empty(), path);
+        assertLocation(locationString, path, Set.of());
+    }
+
+    private static void assertLocation(String locationString, String path, Set<String> uriIncompatibilities)
+    {
+        assertLocation(locationString, Optional.empty(), Optional.empty(), Optional.empty(), OptionalInt.empty(), path, uriIncompatibilities);
     }
 
     private static void assertLocation(Location actual, Location expected)
     {
-        assertLocation(actual, expected.toString(), expected.scheme(), expected.userInfo(), expected.host(), expected.port(), expected.path());
+        assertLocation(actual, expected.toString(), expected.scheme(), expected.userInfo(), expected.host(), expected.port(), expected.path(), true, Set.of("skipped"));
     }
 
     private static void assertLocation(String locationString, Optional<String> scheme, Optional<String> userInfo, Optional<String> host, OptionalInt port, String path)
     {
-        Location location = Location.of(locationString);
-        assertLocation(location, locationString, scheme, userInfo, host, port, path);
+        assertLocation(locationString, scheme, userInfo, host, port, path, Set.of());
     }
 
-    private static void assertLocation(Location location, String locationString, Optional<String> scheme, Optional<String> userInfo, Optional<String> host, OptionalInt port, String path)
+    private static void assertLocation(
+            String locationString,
+            Optional<String> scheme,
+            Optional<String> userInfo,
+            Optional<String> host,
+            OptionalInt port,
+            String path,
+            Set<String> uriIncompatibilities)
+    {
+        Location location = Location.of(locationString);
+        assertLocation(location, locationString, scheme, userInfo, host, port, path, false, uriIncompatibilities);
+    }
+
+    private static void assertLocation(
+            Location location,
+            String locationString,
+            Optional<String> scheme,
+            Optional<String> userInfo,
+            Optional<String> host,
+            OptionalInt port,
+            String path,
+            boolean skipUriTesting,
+            Set<String> uriIncompatibilities)
     {
         assertThat(location.toString()).isEqualTo(locationString);
         assertThat(location.scheme()).isEqualTo(scheme);
@@ -226,12 +266,47 @@ class TestLocation
         assertThat(location.port()).isEqualTo(port);
         assertThat(location.path()).isEqualTo(path);
 
+        if (!skipUriTesting) {
+            int observedIncompatibilities = 0;
+            URI uri = null;
+            try {
+                uri = new URI(locationString);
+            }
+            catch (URISyntaxException e) {
+                assertThat(uriIncompatibilities).contains(e.getMessage());
+                observedIncompatibilities++;
+            }
+            // Locations are not URIs but they follow URI structure
+            if (uri != null) {
+                observedIncompatibilities += assertEqualsOrVerifyDeviation(Optional.ofNullable(uri.getScheme()), location.scheme(), "scheme compared with URI", uriIncompatibilities);
+                observedIncompatibilities += assertEqualsOrVerifyDeviation(Optional.ofNullable(uri.getUserInfo()), location.userInfo(), "userInfo compared with URI", uriIncompatibilities);
+                observedIncompatibilities += assertEqualsOrVerifyDeviation(Optional.ofNullable(uri.getHost()), location.host(), "host compared with URI", uriIncompatibilities);
+                observedIncompatibilities += assertEqualsOrVerifyDeviation(uri.getPort() == -1 ? OptionalInt.empty() : OptionalInt.of(uri.getPort()), location.port(), "port compared with URI", uriIncompatibilities);
+                // For some reason, URI.getPath returns paths starting with "/", while Location does not.
+                observedIncompatibilities += assertEqualsOrVerifyDeviation(uri.getPath(), "/" + location.path(), "'/path' compared with URI", uriIncompatibilities);
+            }
+            assertThat(uriIncompatibilities).hasSize(observedIncompatibilities);
+        }
+        else {
+            assertThat(uriIncompatibilities).isEqualTo(Set.of("skipped"));
+        }
+
         assertThat(location).isEqualTo(location);
         assertThat(location).isEqualTo(Location.of(locationString));
         assertThat(location.hashCode()).isEqualTo(location.hashCode());
         assertThat(location.hashCode()).isEqualTo(Location.of(locationString).hashCode());
 
         assertThat(location.toString()).isEqualTo(locationString);
+    }
+
+    private static <T> int assertEqualsOrVerifyDeviation(T expected, T actual, String message, Set<String> expectedDifferences)
+    {
+        if (Objects.equals(expected, actual)) {
+            return 0;
+        }
+        String key = "%s: expected [%s], was [%s]".formatted(message, expected, actual);
+        assertThat(expectedDifferences).contains(key);
+        return 1;
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveWriterFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveWriterFactory.java
@@ -70,5 +70,12 @@ public class TestHiveWriterFactory
         resultUri = new Path(result).toUri();
         assertThat(resultUri.getScheme()).isEqualTo("s3");
         assertThat(resultUri.getPath()).isEqualTo("/file 1/path");
+
+        String pathWithAtSign = "/tmp/user@example.com";
+        result = setSchemeToFileIfAbsent(Location.of(pathWithAtSign)).toString();
+        assertThat(result).isEqualTo("file:///tmp/user@example.com");
+        resultUri = new Path(result).toUri();
+        assertThat(resultUri.getScheme()).isEqualTo("file");
+        assertThat(resultUri.getPath()).isEqualTo("/tmp/user@example.com");
     }
 }


### PR DESCRIPTION
It's common for staging path to contain `${USER}` placeholder and be on
local file system. When username contains an AT sign (`name@domain`),
the `setSchemeToFileIfAbsent` used to fail, because `Location` couldn't
parse e.g. `file:///tmp/user@example.com`, treating the `@` sign as
userInfo separator. The parsing logic (split by `@ first or split by `/`
first) was different than in the URI class. This PR makes them more
similar.

Fixes https://github.com/trinodb/trino/issues/18132