### PR TITLE
 "show create table" command supports displaying user-defined table comment

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -1051,6 +1051,12 @@ public final class ExpressionFormatter
         }
     }
 
+    static String formatSingleQuotedString(String s)
+    {
+        s = s.replace("'", "''");
+        return "'" + s + "'";
+    }
+
     static String formatStringLiteral(String s)
     {
         s = s.replace("'", "''");

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -162,6 +162,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.sql.ExpressionFormatter.formatGroupBy;
 import static io.trino.sql.ExpressionFormatter.formatJsonPathInvocation;
 import static io.trino.sql.ExpressionFormatter.formatOrderBy;
+import static io.trino.sql.ExpressionFormatter.formatSingleQuotedString;
 import static io.trino.sql.ExpressionFormatter.formatSkipTo;
 import static io.trino.sql.ExpressionFormatter.formatStringLiteral;
 import static io.trino.sql.ExpressionFormatter.formatWindowSpecification;
@@ -1136,7 +1137,7 @@ public final class SqlFormatter
 
             node.getComment().ifPresent(comment -> builder
                     .append(" COMMENT ")
-                    .append(formatStringLiteral(comment)));
+                    .append(formatSingleQuotedString(comment)));
 
             node.getSecurity().ifPresent(security -> builder
                     .append(" SECURITY ")


### PR DESCRIPTION
## Description
Fix issue https://github.com/trinodb/trino/issues/5061
Before this PR : `show create table` Chinese display exception. Non-ASCII will be converted to Unicode.
But It should respect user-defined comments instead of converting to Unicode.  

