### PR TITLE
Fix caching of expressions with like pattern

### DIFF
--- a/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
@@ -25,9 +25,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class LikeMatcher
 {
-    private final String pattern;
-    private final Optional<Character> escape;
-
     private final int minSize;
     private final OptionalInt maxSize;
     private final byte[] prefix;
@@ -35,31 +32,17 @@ public class LikeMatcher
     private final Optional<Matcher> matcher;
 
     private LikeMatcher(
-            String pattern,
-            Optional<Character> escape,
             int minSize,
             OptionalInt maxSize,
             byte[] prefix,
             byte[] suffix,
             Optional<Matcher> matcher)
     {
-        this.pattern = pattern;
-        this.escape = escape;
         this.minSize = minSize;
         this.maxSize = maxSize;
         this.prefix = prefix;
         this.suffix = suffix;
         this.matcher = matcher;
-    }
-
-    public String getPattern()
-    {
-        return pattern;
-    }
-
-    public Optional<Character> getEscape()
-    {
-        return escape;
     }
 
     public static LikeMatcher compile(String pattern)
@@ -154,8 +137,6 @@ public class LikeMatcher
         }
 
         return new LikeMatcher(
-                pattern,
-                escape,
                 minSize,
                 unbounded ? OptionalInt.empty() : OptionalInt.of(maxSize),
                 prefix,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.Session;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.metadata.LiteralFunction;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.plugin.base.expression.ConnectorExpressions;
@@ -64,6 +63,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.type.JoniRegexp;
 import io.trino.type.LikeFunctions;
+import io.trino.type.LikePattern;
 import io.trino.type.Re2JRegexp;
 import io.trino.type.Re2JRegexpType;
 
@@ -706,7 +706,7 @@ public final class ConnectorExpressionTranslator
             Expression patternArgument = node.getArguments().get(1);
             if (isEffectivelyLiteral(plannerContext, session, patternArgument)) {
                 // the pattern argument has been constant folded, so extract the underlying pattern and escape
-                LikeMatcher matcher = (LikeMatcher) evaluateConstantExpression(
+                LikePattern matcher = (LikePattern) evaluateConstantExpression(
                         patternArgument,
                         typeOf(patternArgument),
                         plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -22,7 +22,6 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.Session;
 import io.trino.connector.CatalogServiceProvider;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.metadata.AnalyzePropertyManager;
 import io.trino.metadata.OperatorNotFoundException;
 import io.trino.metadata.ResolvedFunction;
@@ -70,6 +69,7 @@ import io.trino.sql.tree.StringLiteral;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.transaction.NoOpTransactionManager;
 import io.trino.type.LikeFunctions;
+import io.trino.type.LikePattern;
 import io.trino.type.LikePatternType;
 import io.trino.type.TypeCoercion;
 import jakarta.annotation.Nullable;
@@ -1086,7 +1086,7 @@ public final class DomainTranslator
                 return Optional.empty();
             }
 
-            LikeMatcher matcher = (LikeMatcher) evaluateConstantExpression(
+            LikePattern matcher = (LikePattern) evaluateConstantExpression(
                     patternArgument,
                     typeAnalyzer.getType(session, types, patternArgument),
                     plannerContext,

--- a/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikeFunctions.java
@@ -15,7 +15,6 @@ package io.trino.type;
 
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.spi.TrinoException;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
@@ -41,7 +40,7 @@ public final class LikeFunctions
     @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true)
     @LiteralParameters("x")
     @SqlType(StandardTypes.BOOLEAN)
-    public static boolean likeChar(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice value, @SqlType(LikePatternType.NAME) LikeMatcher pattern)
+    public static boolean likeChar(@LiteralParameter("x") Long x, @SqlType("char(x)") Slice value, @SqlType(LikePatternType.NAME) LikePattern pattern)
     {
         return likeVarchar(padSpaces(value, x.intValue()), pattern);
     }
@@ -49,27 +48,27 @@ public final class LikeFunctions
     // TODO: this should not be callable from SQL
     @ScalarFunction(value = LIKE_FUNCTION_NAME, hidden = true)
     @SqlType(StandardTypes.BOOLEAN)
-    public static boolean likeVarchar(@SqlType("varchar") Slice value, @SqlType(LikePatternType.NAME) LikeMatcher matcher)
+    public static boolean likeVarchar(@SqlType("varchar") Slice value, @SqlType(LikePatternType.NAME) LikePattern pattern)
     {
         if (value.hasByteArray()) {
-            return matcher.match(value.byteArray(), value.byteArrayOffset(), value.length());
+            return pattern.getMatcher().match(value.byteArray(), value.byteArrayOffset(), value.length());
         }
-        return matcher.match(value.getBytes(), 0, value.length());
+        return pattern.getMatcher().match(value.getBytes(), 0, value.length());
     }
 
     @ScalarFunction(value = LIKE_PATTERN_FUNCTION_NAME, hidden = true)
     @SqlType(LikePatternType.NAME)
-    public static LikeMatcher likePattern(@SqlType("varchar") Slice pattern)
+    public static LikePattern likePattern(@SqlType("varchar") Slice pattern)
     {
-        return LikeMatcher.compile(pattern.toStringUtf8(), Optional.empty(), false);
+        return LikePattern.compile(pattern.toStringUtf8(), Optional.empty(), false);
     }
 
     @ScalarFunction(value = LIKE_PATTERN_FUNCTION_NAME, hidden = true)
     @SqlType(LikePatternType.NAME)
-    public static LikeMatcher likePattern(@SqlType("varchar") Slice pattern, @SqlType("varchar") Slice escape)
+    public static LikePattern likePattern(@SqlType("varchar") Slice pattern, @SqlType("varchar") Slice escape)
     {
         try {
-            return LikeMatcher.compile(pattern.toStringUtf8(), getEscapeCharacter(Optional.of(escape)), false);
+            return LikePattern.compile(pattern.toStringUtf8(), getEscapeCharacter(Optional.of(escape)), false);
         }
         catch (RuntimeException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);

--- a/core/trino-main/src/main/java/io/trino/type/LikePattern.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikePattern.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.trino.likematcher.LikeMatcher;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * LikePattern can be a part of the cache key in projection/filter compiled class caches in ExpressionCompiler.
+ * Equality for this class is dependent on the pattern and escape alone, as the matcher is expected to be derived from those.
+ */
+public class LikePattern
+{
+    private final String pattern;
+    private final Optional<Character> escape;
+    private final LikeMatcher matcher;
+
+    public static LikePattern compile(String pattern, Optional<Character> escape)
+    {
+        return new LikePattern(pattern, escape, LikeMatcher.compile(pattern, escape));
+    }
+
+    public static LikePattern compile(String pattern, Optional<Character> escape, boolean optimize)
+    {
+        return new LikePattern(pattern, escape, LikeMatcher.compile(pattern, escape, optimize));
+    }
+
+    private LikePattern(String pattern, Optional<Character> escape, LikeMatcher matcher)
+    {
+        this.pattern = requireNonNull(pattern, "pattern is null");
+        this.escape = requireNonNull(escape, "escape is null");
+        this.matcher = requireNonNull(matcher, "likeMatcher is null");
+    }
+
+    public String getPattern()
+    {
+        return pattern;
+    }
+
+    public Optional<Character> getEscape()
+    {
+        return escape;
+    }
+
+    public LikeMatcher getMatcher()
+    {
+        return matcher;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LikePattern that = (LikePattern) o;
+        return Objects.equals(pattern, that.pattern) && Objects.equals(escape, that.escape);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(pattern, escape);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("pattern", pattern)
+                .add("escape", escape)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/type/LikePatternType.java
+++ b/core/trino-main/src/main/java/io/trino/type/LikePatternType.java
@@ -14,7 +14,6 @@
 package io.trino.type;
 
 import io.airlift.slice.Slice;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.VariableWidthBlockBuilder;
@@ -35,7 +34,7 @@ public class LikePatternType
 
     private LikePatternType()
     {
-        super(new TypeSignature(NAME), LikeMatcher.class);
+        super(new TypeSignature(NAME), LikePattern.class);
     }
 
     @Override
@@ -72,24 +71,24 @@ public class LikePatternType
             escape = Optional.of((char) block.getInt(position, offset));
         }
 
-        return LikeMatcher.compile(pattern, escape);
+        return LikePattern.compile(pattern, escape);
     }
 
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        LikeMatcher matcher = (LikeMatcher) value;
+        LikePattern likePattern = (LikePattern) value;
         ((VariableWidthBlockBuilder) blockBuilder).buildEntry(valueWriter -> {
-            Slice pattern = utf8Slice(matcher.getPattern());
+            Slice pattern = utf8Slice(likePattern.getPattern());
             int length = pattern.length();
             valueWriter.writeInt(length);
             valueWriter.writeBytes(pattern, 0, length);
-            if (matcher.getEscape().isEmpty()) {
+            if (likePattern.getEscape().isEmpty()) {
                 valueWriter.writeByte(0);
             }
             else {
                 valueWriter.writeByte(1);
-                valueWriter.writeInt(matcher.getEscape().get());
+                valueWriter.writeInt(likePattern.getEscape().get());
             }
         });
     }

--- a/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
@@ -14,6 +14,7 @@
 package io.trino.likematcher;
 
 import com.google.common.base.Strings;
+import io.trino.type.LikePattern;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -95,10 +96,10 @@ public class TestLikeMatcher
         assertFalse(match("%abaaa%", "ababaa"));
 
         // utf-8
-        LikeMatcher singleOptimized = LikeMatcher.compile("_", Optional.empty(), true);
-        LikeMatcher multipleOptimized = LikeMatcher.compile("_a%b_", Optional.empty(), true); // prefix and suffix with _a and b_ to avoid optimizations
-        LikeMatcher single = LikeMatcher.compile("_", Optional.empty(), false);
-        LikeMatcher multiple = LikeMatcher.compile("_a%b_", Optional.empty(), false); // prefix and suffix with _a and b_ to avoid optimizations
+        LikeMatcher singleOptimized = LikePattern.compile("_", Optional.empty(), true).getMatcher();
+        LikeMatcher multipleOptimized = LikePattern.compile("_a%b_", Optional.empty(), true).getMatcher(); // prefix and suffix with _a and b_ to avoid optimizations
+        LikeMatcher single = LikePattern.compile("_", Optional.empty(), false).getMatcher();
+        LikeMatcher multiple = LikePattern.compile("_a%b_", Optional.empty(), false).getMatcher(); // prefix and suffix with _a and b_ to avoid optimizations
         for (int i = 0; i < Character.MAX_CODE_POINT; i++) {
             assertTrue(singleOptimized.match(Character.toString(i).getBytes(StandardCharsets.UTF_8)));
             assertTrue(single.match(Character.toString(i).getBytes(StandardCharsets.UTF_8)));

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
@@ -15,9 +15,9 @@ package io.trino.operator.scalar;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.spi.TrinoException;
 import io.trino.sql.query.QueryAssertions;
+import io.trino.type.LikePattern;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeBasic()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("f%b__").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("f%b__").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("foobar"), matcher));
         assertTrue(likeVarchar(offsetHeapSlice("foobar"), matcher));
 
@@ -108,7 +108,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeChar()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("f%b__").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("f%b__").toStringUtf8(), Optional.empty());
         assertTrue(likeChar(6L, utf8Slice("foobar"), matcher));
         assertTrue(likeChar(6L, offsetHeapSlice("foobar"), matcher));
         assertTrue(likeChar(6L, utf8Slice("foob"), matcher));
@@ -201,7 +201,7 @@ public class TestLikeFunctions
     @Test
     public void testLikeSpacesInPattern()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("ala  ").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("ala  ").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("ala  "), matcher));
         assertFalse(likeVarchar(utf8Slice("ala"), matcher));
     }
@@ -209,28 +209,28 @@ public class TestLikeFunctions
     @Test
     public void testLikeNewlineInPattern()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("%o\nbar").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("%o\nbar").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), matcher));
     }
 
     @Test
     public void testLikeNewlineBeforeMatch()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("%b%").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("%b%").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), matcher));
     }
 
     @Test
     public void testLikeNewlineInMatch()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("f%b%").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("f%b%").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("foo\nbar"), matcher));
     }
 
     @Test
     public void testLikeUtf8Pattern()
     {
-        LikeMatcher matcher = likePattern(utf8Slice("%\u540d\u8a89%"), utf8Slice("\\"));
+        LikePattern matcher = likePattern(utf8Slice("%\u540d\u8a89%"), utf8Slice("\\"));
         assertFalse(likeVarchar(utf8Slice("foo"), matcher));
     }
 
@@ -238,28 +238,28 @@ public class TestLikeFunctions
     public void testLikeInvalidUtf8Value()
     {
         Slice value = Slices.wrappedBuffer(new byte[] {'a', 'b', 'c', (byte) 0xFF, 'x', 'y'});
-        LikeMatcher matcher = likePattern(utf8Slice("%b%"), utf8Slice("\\"));
+        LikePattern matcher = likePattern(utf8Slice("%b%"), utf8Slice("\\"));
         assertTrue(likeVarchar(value, matcher));
     }
 
     @Test
     public void testBackslashesNoSpecialTreatment()
     {
-        LikeMatcher matcher = LikeMatcher.compile(utf8Slice("\\abc\\/\\\\").toStringUtf8(), Optional.empty());
+        LikePattern matcher = LikePattern.compile(utf8Slice("\\abc\\/\\\\").toStringUtf8(), Optional.empty());
         assertTrue(likeVarchar(utf8Slice("\\abc\\/\\\\"), matcher));
     }
 
     @Test
     public void testSelfEscaping()
     {
-        LikeMatcher matcher = likePattern(utf8Slice("\\\\abc\\%"), utf8Slice("\\"));
+        LikePattern matcher = likePattern(utf8Slice("\\\\abc\\%"), utf8Slice("\\"));
         assertTrue(likeVarchar(utf8Slice("\\abc%"), matcher));
     }
 
     @Test
     public void testAlternateEscapedCharacters()
     {
-        LikeMatcher matcher = likePattern(utf8Slice("xxx%x_abcxx"), utf8Slice("x"));
+        LikePattern matcher = likePattern(utf8Slice("xxx%x_abcxx"), utf8Slice("x"));
         assertTrue(likeVarchar(utf8Slice("x%_abcx"), matcher));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import io.trino.likematcher.LikeMatcher;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.predicate.Domain;
@@ -49,6 +48,7 @@ import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.transaction.TestingTransactionManager;
+import io.trino.type.LikePattern;
 import io.trino.type.LikePatternType;
 import io.trino.type.TypeCoercion;
 import org.joda.time.DateTime;
@@ -2132,7 +2132,7 @@ public class TestDomainTranslator
     {
         return new FunctionCall(QualifiedName.of(LIKE_FUNCTION_NAME), ImmutableList.of(
                 symbol.toSymbolReference(),
-                literalEncoder.toExpression(TEST_SESSION, LikeMatcher.compile(pattern, Optional.empty()), LikePatternType.LIKE_PATTERN)));
+                literalEncoder.toExpression(TEST_SESSION, LikePattern.compile(pattern, Optional.empty()), LikePatternType.LIKE_PATTERN)));
     }
 
     private FunctionCall like(Symbol symbol, Expression pattern, Expression escape)
@@ -2144,7 +2144,7 @@ public class TestDomainTranslator
     {
         return new FunctionCall(QualifiedName.of(LIKE_FUNCTION_NAME), ImmutableList.of(
                 symbol.toSymbolReference(),
-                literalEncoder.toExpression(TEST_SESSION, LikeMatcher.compile(pattern, Optional.of(escape)), LikePatternType.LIKE_PATTERN)));
+                literalEncoder.toExpression(TEST_SESSION, LikePattern.compile(pattern, Optional.of(escape)), LikePatternType.LIKE_PATTERN)));
     }
 
     private static FunctionCall startsWith(Symbol symbol, Expression expression)

--- a/core/trino-main/src/test/java/io/trino/type/TestLikePatternType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLikePatternType.java
@@ -13,7 +13,6 @@
  */
 package io.trino.type;
 
-import io.trino.likematcher.LikeMatcher;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.PageBuilderStatus;
@@ -30,15 +29,15 @@ public class TestLikePatternType
     public void testGetObject()
     {
         BlockBuilder blockBuilder = LIKE_PATTERN.createBlockBuilder(new PageBuilderStatus().createBlockBuilderStatus(), 10);
-        LIKE_PATTERN.writeObject(blockBuilder, LikeMatcher.compile("helloX_world", Optional.of('X')));
-        LIKE_PATTERN.writeObject(blockBuilder, LikeMatcher.compile("foo%_bar"));
+        LIKE_PATTERN.writeObject(blockBuilder, LikePattern.compile("helloX_world", Optional.of('X')));
+        LIKE_PATTERN.writeObject(blockBuilder, LikePattern.compile("foo%_bar", Optional.empty()));
         Block block = blockBuilder.build();
 
-        LikeMatcher pattern = (LikeMatcher) LIKE_PATTERN.getObject(block, 0);
+        LikePattern pattern = (LikePattern) LIKE_PATTERN.getObject(block, 0);
         assertThat(pattern.getPattern()).isEqualTo("helloX_world");
         assertThat(pattern.getEscape()).isEqualTo(Optional.of('X'));
 
-        pattern = (LikeMatcher) LIKE_PATTERN.getObject(block, 1);
+        pattern = (LikePattern) LIKE_PATTERN.getObject(block, 1);
         assertThat(pattern.getPattern()).isEqualTo("foo%_bar");
         assertThat(pattern.getEscape()).isEqualTo(Optional.empty());
     }


### PR DESCRIPTION
## Description
Compiled filter/projections can currently contain LikeMatcher as a
ConstantExpression. Added a new wrapper class LikePatternMatcher
which defines hashCode/equals to avoid recompiling classes and
filling up compiled classes cache

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
