### PR TITLE
Simplify version parsing from metadata file name

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -707,19 +707,19 @@ public final class IcebergUtil
         }
     }
 
-    public static OptionalInt parseVersion(String metadataLocation)
+    public static OptionalInt parseVersion(String metadataFileName)
             throws TrinoException
     {
-        int versionStart = metadataLocation.lastIndexOf('/') + 1; // if '/' isn't found, this will be 0
-        int versionEnd = metadataLocation.indexOf('-', versionStart);
-        if (versionStart == 0 || versionEnd == -1) {
-            throw new TrinoException(ICEBERG_BAD_DATA, "Invalid metadata location: " + metadataLocation);
+        checkArgument(!metadataFileName.contains("/"), "Not a file name: %s", metadataFileName);
+        int versionEnd = metadataFileName.indexOf('-');
+        if (versionEnd == -1) {
+            throw new TrinoException(ICEBERG_BAD_DATA, "Invalid metadata file name: " + metadataFileName);
         }
         try {
-            return OptionalInt.of(parseInt(metadataLocation.substring(versionStart, versionEnd)));
+            return OptionalInt.of(parseInt(metadataFileName.substring(0, versionEnd)));
         }
         catch (NumberFormatException e) {
-            log.warn(e, "Unable to parse version from metadata location: %s", metadataLocation);
+            log.warn(e, "Unable to parse version from metadata file name: %s", metadataFileName);
             return OptionalInt.empty();
         }
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.trino.annotation.NotThreadSafe;
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.iceberg.util.HiveSchemaUtil;
@@ -108,7 +109,7 @@ public abstract class AbstractIcebergTableOperations
         currentMetadata = tableMetadata;
         currentMetadataLocation = tableMetadata.metadataFileLocation();
         shouldRefresh = false;
-        version = parseVersion(currentMetadataLocation);
+        version = parseVersion(Location.of(currentMetadataLocation).fileName());
     }
 
     @Override
@@ -258,7 +259,7 @@ public abstract class AbstractIcebergTableOperations
 
         currentMetadata = newMetadata;
         currentMetadataLocation = newLocation;
-        version = parseVersion(newLocation);
+        version = parseVersion(Location.of(newLocation).fileName());
         shouldRefresh = false;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -109,7 +109,7 @@ public abstract class AbstractIcebergTableOperations
         currentMetadata = tableMetadata;
         currentMetadataLocation = tableMetadata.metadataFileLocation();
         shouldRefresh = false;
-        version = parseVersion(Location.of(currentMetadataLocation).fileName());
+        version = OptionalInt.of(parseVersion(Location.of(currentMetadataLocation).fileName()));
     }
 
     @Override
@@ -259,7 +259,7 @@ public abstract class AbstractIcebergTableOperations
 
         currentMetadata = newMetadata;
         currentMetadataLocation = newLocation;
-        version = parseVersion(Location.of(newLocation).fileName());
+        version = OptionalInt.of(parseVersion(Location.of(newLocation).fileName()));
         shouldRefresh = false;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
@@ -175,16 +175,17 @@ public class RegisterTableProcedure
 
     public static String getLatestMetadataLocation(TrinoFileSystem fileSystem, String location)
     {
-        List<String> latestMetadataLocations = new ArrayList<>();
+        List<Location> latestMetadataLocations = new ArrayList<>();
         String metadataDirectoryLocation = format("%s/%s", stripTrailingSlash(location), METADATA_FOLDER_NAME);
         try {
             int latestMetadataVersion = -1;
             FileIterator fileIterator = fileSystem.listFiles(Location.of(metadataDirectoryLocation));
             while (fileIterator.hasNext()) {
                 FileEntry fileEntry = fileIterator.next();
-                String fileLocation = fileEntry.location().toString();
-                if (fileLocation.contains(METADATA_FILE_EXTENSION)) {
-                    OptionalInt version = parseVersion(fileLocation);
+                Location fileLocation = fileEntry.location();
+                String fileName = fileLocation.fileName();
+                if (fileName.endsWith(METADATA_FILE_EXTENSION)) {
+                    OptionalInt version = parseVersion(fileName);
                     if (version.isPresent()) {
                         int versionNumber = version.getAsInt();
                         if (versionNumber > latestMetadataVersion) {
@@ -211,7 +212,7 @@ public class RegisterTableProcedure
         catch (IOException e) {
             throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Failed checking table location: " + location, e);
         }
-        return getOnlyElement(latestMetadataLocations);
+        return getOnlyElement(latestMetadataLocations).toString();
     }
 
     private static void validateMetadataLocation(TrinoFileSystem fileSystem, Location location)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/procedure/RegisterTableProcedure.java
@@ -37,7 +37,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
@@ -185,17 +184,14 @@ public class RegisterTableProcedure
                 Location fileLocation = fileEntry.location();
                 String fileName = fileLocation.fileName();
                 if (fileName.endsWith(METADATA_FILE_EXTENSION)) {
-                    OptionalInt version = parseVersion(fileName);
-                    if (version.isPresent()) {
-                        int versionNumber = version.getAsInt();
-                        if (versionNumber > latestMetadataVersion) {
-                            latestMetadataVersion = versionNumber;
-                            latestMetadataLocations.clear();
-                            latestMetadataLocations.add(fileLocation);
-                        }
-                        else if (versionNumber == latestMetadataVersion) {
-                            latestMetadataLocations.add(fileLocation);
-                        }
+                    int versionNumber = parseVersion(fileName);
+                    if (versionNumber > latestMetadataVersion) {
+                        latestMetadataVersion = versionNumber;
+                        latestMetadataLocations.clear();
+                        latestMetadataLocations.add(fileLocation);
+                    }
+                    else if (versionNumber == latestMetadataVersion) {
+                        latestMetadataLocations.add(fileLocation);
                     }
                 }
             }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
@@ -15,8 +15,6 @@ package io.trino.plugin.iceberg;
 
 import org.testng.annotations.Test;
 
-import java.util.OptionalInt;
-
 import static io.trino.plugin.iceberg.IcebergUtil.parseVersion;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -26,10 +24,10 @@ public class TestIcebergUtil
     @Test
     public void testParseVersion()
     {
-        assertEquals(parseVersion("00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(0));
-        assertEquals(parseVersion("99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(99999));
-        assertEquals(parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(10));
-        assertEquals(parseVersion("00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(11));
+        assertEquals(parseVersion("00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 0);
+        assertEquals(parseVersion("99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 99999);
+        assertEquals(parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 10);
+        assertEquals(parseVersion("00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), 11);
 
         assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
                 .hasMessageMatching("Not a file name: .*");
@@ -40,7 +38,9 @@ public class TestIcebergUtil
         assertThatThrownBy(() -> parseVersion("00010_409702ba_4735_4645_8f14_09537cc0b2c8.metadata.json"))
                 .hasMessageMatching("Invalid metadata file name:.*");
 
-        assertEquals(parseVersion("00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
-        assertEquals(parseVersion("-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
+        assertThatThrownBy(() -> parseVersion("00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergUtil.java
@@ -26,22 +26,21 @@ public class TestIcebergUtil
     @Test
     public void testParseVersion()
     {
-        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(0));
-        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(99999));
-        assertEquals(parseVersion("s3://krvikash-test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(10));
-        assertEquals(parseVersion("/var/test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(11));
+        assertEquals(parseVersion("00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(0));
+        assertEquals(parseVersion("99999-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(99999));
+        assertEquals(parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(10));
+        assertEquals(parseVersion("00011-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.of(11));
 
-        assertThatThrownBy(() -> parseVersion("00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
-                .hasMessageMatching(".*Invalid metadata location: .*");
-        assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5_581fad8517934af6be1857a903559d44"))
-                .hasMessageMatching(".*Invalid metadata location: .*");
-        assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata"))
-                .hasMessageMatching(".*Invalid metadata location:.*");
-        assertThatThrownBy(() -> parseVersion("s3://krvikash-test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/00010_409702ba_4735_4645_8f14_09537cc0b2c8.metadata.json"))
-                .hasMessageMatching(".*Invalid metadata location:.*");
-        assertThatThrownBy(() -> parseVersion("orders_5_581fad8517934af6be1857a903559d44")).hasMessageMatching(".*Invalid metadata location:.*");
+        assertThatThrownBy(() -> parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00000-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"))
+                .hasMessageMatching("Not a file name: .*");
+        assertThatThrownBy(() -> parseVersion("orders_5_581fad8517934af6be1857a903559d44"))
+                .hasMessageMatching("Invalid metadata file name: .*");
+        assertThatThrownBy(() -> parseVersion("metadata"))
+                .hasMessageMatching("Invalid metadata file name:.*");
+        assertThatThrownBy(() -> parseVersion("00010_409702ba_4735_4645_8f14_09537cc0b2c8.metadata.json"))
+                .hasMessageMatching("Invalid metadata file name:.*");
 
-        assertEquals(parseVersion("hdfs://hadoop-master:9000/user/hive/warehouse/orders_5-581fad8517934af6be1857a903559d44/metadata/00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
-        assertEquals(parseVersion("/var/test/test_icerberg_util/orders_93p93eniuw-30fa27a68c734c2bafac881e905351a9/metadata/-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
+        assertEquals(parseVersion("00003_409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
+        assertEquals(parseVersion("-00010-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json"), OptionalInt.empty());
     }
 }


### PR DESCRIPTION
Use Pattern for code simplicity. Uniformly return when pattern not
found. Previously either exception was raised or empty returned, but
this could lead to problems like `AbstractIcebergTableOperations`
incorrectly resetting version to 0.

Relates to: https://github.com/trinodb/trino/pull/17863