### PR TITLE
Fix formatting of json_table columns in SqlFormatter

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -343,7 +343,7 @@ public final class SqlFormatter
                     .append(" ")
                     .append(formatExpression(node.getType()))
                     .append(" FORMAT ")
-                    .append(node.getFormat().name());
+                    .append(node.getFormat().toString());
             node.getJsonPath().ifPresent(path ->
                     builder.append(" PATH ")
                             .append(formatExpression(path)));

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -5682,7 +5682,7 @@ public class TestSqlParser
                 "ordinal_number FOR ORDINALITY, " +
                 "customer_name varchar PATH 'lax $.cust_no' DEFAULT 'anonymous' ON EMPTY null ON ERROR, " +
                 "customer_countries varchar FORMAT JSON PATH 'lax.cust_ctr[*]' WITH WRAPPER KEEP QUOTES null ON EMPTY ERROR ON ERROR," +
-                "customer_regions varchar FORMAT JSON PATH 'lax.cust_reg[*]' EMPTY ARRAY ON EMPTY EMPTY OBJECT ON ERROR) " +
+                "customer_regions varchar FORMAT JSON ENCODING UTF16 PATH 'lax.cust_reg[*]' EMPTY ARRAY ON EMPTY EMPTY OBJECT ON ERROR) " +
                 "EMPTY ON ERROR)"))
                 .isEqualTo(selectAllFrom(new JsonTable(
                         location(1, 15),
@@ -5718,8 +5718,8 @@ public class TestSqlParser
                                         location(1, 281),
                                         new Identifier(location(1, 281), "customer_regions", false),
                                         new GenericDataType(location(1, 298), new Identifier(location(1, 298), "varchar", false), ImmutableList.of()),
-                                        JSON,
-                                        Optional.of(new StringLiteral(location(1, 323), "lax.cust_reg[*]")),
+                                        UTF16,
+                                        Optional.of(new StringLiteral(location(1, 338), "lax.cust_reg[*]")),
                                         JsonQuery.ArrayWrapperBehavior.WITHOUT,
                                         Optional.empty(),
                                         JsonQuery.EmptyOrErrorBehavior.EMPTY_ARRAY,


### PR DESCRIPTION
A formatter fix, not visible to the user.
No release notes or docs required.