### PR TITLE
Remove redundant `ORDER BY` clause from `CTE`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -140,6 +140,9 @@ public class Analysis
     private final Map<NodeRef<QuerySpecification>, Scope> implicitFromScopes = new LinkedHashMap<>();
 
     private final Map<NodeRef<Node>, Scope> scopes = new LinkedHashMap<>();
+
+    private final Set<Scope> topLevelWithScopes = new HashSet<>();
+
     private final Map<NodeRef<Expression>, ResolvedField> columnReferences = new LinkedHashMap<>();
 
     // a map of users to the columns per table that they access
@@ -217,7 +220,6 @@ public class Analysis
 
     private final Multiset<ColumnMaskScopeEntry> columnMaskScopes = HashMultiset.create();
     private final Map<NodeRef<Table>, Map<String, Expression>> columnMasks = new LinkedHashMap<>();
-
     private final Map<NodeRef<Unnest>, UnnestAnalysis> unnestAnalysis = new LinkedHashMap<>();
     private Optional<Create> create = Optional.empty();
     private Optional<Insert> insert = Optional.empty();
@@ -600,6 +602,16 @@ public class Analysis
     public void setScope(Node node, Scope scope)
     {
         scopes.put(NodeRef.of(node), scope);
+    }
+
+    public void markScopeAsWithinTopLevelWith(Scope scope)
+    {
+        topLevelWithScopes.add(scope);
+    }
+
+    public boolean isScopeWithinTopLevelWith(Scope scope)
+    {
+        return scope.findLocally(topLevelWithScopes::contains).isPresent();
     }
 
     public RelationType getOutputDescriptor()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
@@ -140,7 +140,7 @@ public class Scope
      * Starting from this, finds the closest scope which satisfies given predicate,
      * within the query boundary.
      */
-    private Optional<Scope> findLocally(Predicate<Scope> match)
+    Optional<Scope> findLocally(Predicate<Scope> match)
     {
         Scope scope = this;
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestOrderBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestOrderBy.java
@@ -13,17 +13,29 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.SortNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import org.testng.annotations.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.topN;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
+import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
+import static io.trino.sql.tree.SortItem.Ordering.DESCENDING;
 
 public class TestOrderBy
         extends BasePlanTest
@@ -93,5 +105,82 @@ public class TestOrderBy
                         node(ExchangeNode.class,
                                 node(ValuesNode.class),
                                 node(ValuesNode.class))));
+    }
+
+    @Test
+    public void testRedundantOrderByInCTEAndOrderByInOuterQuery()
+    {
+        assertPlan("""
+                            WITH t(a, b) AS (SELECT * FROM (VALUES (2, 0),(1, 0)) t(a, b) ORDER BY b ASC)
+                            SELECT * FROM t ORDER BY a DESC
+                   """,
+                output(
+                        exchange(LOCAL,
+                                sort(ImmutableList.of(sort("a", DESCENDING, LAST)),
+                                        exchange(LOCAL,
+                                                values("a", "b"))))));
+    }
+
+    @Test
+    public void testRedundantOrderByInCTE()
+    {
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a)
+                            SELECT * FROM t
+                   """,
+                output(node(ValuesNode.class)));
+    }
+
+    @Test
+    public void testRedundantOrderByInSubQueryInCTE()
+    {
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a))
+                            SELECT * FROM t
+                   """,
+                output(node(ValuesNode.class)));
+    }
+
+    @Test
+    public void testOrderByInTopLevelCTEWithLimit()
+    {
+        // with LIMIT
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a LIMIT 1)
+                            SELECT * FROM t
+                   """,
+                output(
+                        topN(1, ImmutableList.of(sort("c", ASCENDING, LAST)), TopNNode.Step.FINAL,
+                                topN(1, ImmutableList.of(sort("c", ASCENDING, LAST)), TopNNode.Step.PARTIAL,
+                                        values("c")))));
+        // without LIMIT
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a)
+                            SELECT * FROM t
+                   """,
+                output(node(ValuesNode.class)));
+    }
+
+    @Test
+    public void testOrderByInTopLevelCTEWithOffset()
+    {
+        // with OFFSET
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a OFFSET 1)
+                            SELECT * FROM t
+                   """,
+                output(
+                        node(ProjectNode.class,
+                                node(FilterNode.class,
+                                        node(RowNumberNode.class,
+                                                exchange(LOCAL,
+                                                        sort(exchange(LOCAL,
+                                                                    values("c")))))))));
+        // without OFFSET
+        assertPlan("""
+                            WITH t(a) AS (SELECT * FROM (VALUES (2),(1)) t(a) ORDER BY a)
+                            SELECT * FROM t
+                   """,
+                output(values("c")));
     }
 }


### PR DESCRIPTION
## Description
Remove redundant `ORDER BY` clause from `CTE`


## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(*) Release notes are required, please propose a release note for me.
() Release notes are required, with the following suggested text:
