### PR TITLE
Add special handling for multiple trailing slashes in the parent directory

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -197,7 +197,10 @@ public final class Location
             return withPath(newLocation, "");
         }
 
-        String newPath = path.substring(0, lastIndexOfSlash);
+        // Special handling for the case where the parent path contains multiple trailing slashes
+        // The parent directory for `s3://bucket/directory//file` is `s3://bucket/directory//`
+        int parentDirectoryEndIndex = (lastIndexOfSlash > 0 && path.charAt(lastIndexOfSlash - 1) == '/') ? lastIndexOfSlash + 1 : lastIndexOfSlash;
+        String newPath = path.substring(0, parentDirectoryEndIndex);
         String newLocation = location.substring(0, location.length() - (path.length() - newPath.length()));
         return withPath(newLocation, newPath);
     }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -380,8 +380,8 @@ class TestLocation
         assertParentDirectory("scheme://userInfo@host/path/name", Location.of("scheme://userInfo@host/path"));
         assertParentDirectory("scheme://userInfo@host:1234/name", Location.of("scheme://userInfo@host:1234/"));
 
-        assertParentDirectory("scheme://userInfo@host/path//name", Location.of("scheme://userInfo@host/path/"));
-        assertParentDirectory("scheme://userInfo@host/path///name", Location.of("scheme://userInfo@host/path//"));
+        assertParentDirectory("scheme://userInfo@host/path//name", Location.of("scheme://userInfo@host/path//"));
+        assertParentDirectory("scheme://userInfo@host/path///name", Location.of("scheme://userInfo@host/path///"));
         assertParentDirectory("scheme://userInfo@host/path:/name", Location.of("scheme://userInfo@host/path:"));
 
         assertParentDirectoryFailure("/", "File location must contain a path: /");
@@ -392,8 +392,8 @@ class TestLocation
         assertParentDirectoryFailure("/path/name/", "File location cannot end with '/': /path/name/");
         assertParentDirectoryFailure("/name/", "File location cannot end with '/': /name/");
 
-        assertParentDirectory("/path//name", Location.of("/path/"));
-        assertParentDirectory("/path///name", Location.of("/path//"));
+        assertParentDirectory("/path//name", Location.of("/path//"));
+        assertParentDirectory("/path///name", Location.of("/path///"));
         assertParentDirectory("/path:/name", Location.of("/path:"));
 
         // all valid file locations must have a parent directory


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

AWS S3 object storage provider allows paths containing multiple trailing slashes

`s3://bucket/path/directory//`

This leads to the situation where a file with the following location

`s3://bucket/path/directory//file`

would have the parent

`s3://bucket/path/directory//`

This PR adds special handling in retrieving the parent directory for a file in case it contains trailing slashes.

Fixes #17966

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
