### PR TITLE
Allow dictionary processing for date type in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/AbstractColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/AbstractColumnReader.java
@@ -25,6 +25,8 @@ import io.trino.parquet.reader.flat.RowRangesIterator;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.type.AbstractVariableWidthType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 import org.apache.parquet.io.ParquetDecodingException;
 
@@ -149,9 +151,7 @@ public abstract class AbstractColumnReader<BufferType>
         //   2. Number of dictionary entries exceeds a threshold (Integer.MAX_VALUE for parquet-mr by default).
         // Trino dictionary blocks are produced only when the entire column chunk is dictionary encoded
         if (pageReader.hasOnlyDictionaryEncodedPages()) {
-            // TODO: DictionaryBlocks are currently restricted to variable width types where dictionary processing is most beneficial.
-            //   Dictionary processing for other data types can be enabled after validating improvements on benchmarks.
-            if (!(field.getType() instanceof AbstractVariableWidthType)) {
+            if (!shouldProduceDictionaryForType(field.getType())) {
                 return false;
             }
             requireNonNull(dictionaryDecoder, "dictionaryDecoder is null");
@@ -161,6 +161,13 @@ public abstract class AbstractColumnReader<BufferType>
                     .orElse(true);
         }
         return false;
+    }
+
+    static boolean shouldProduceDictionaryForType(Type type)
+    {
+        // TODO: DictionaryBlocks are currently restricted to variable width and date types where dictionary processing is most beneficial.
+        //   Dictionary processing for other data types can be enabled after validating improvements on benchmarks.
+        return type instanceof AbstractVariableWidthType || type instanceof DateType;
     }
 
     private static long getMaxDictionaryBlockSize(Block dictionary, long batchSize)

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/AbstractColumnReaderTest.java
@@ -31,7 +31,6 @@ import io.trino.parquet.reader.TestingColumnReader.DataPageVersion;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.spi.type.AbstractVariableWidthType;
 import jakarta.annotation.Nullable;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -57,6 +56,7 @@ import static io.trino.parquet.ParquetEncoding.PLAIN_DICTIONARY;
 import static io.trino.parquet.ParquetEncoding.RLE;
 import static io.trino.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
+import static io.trino.parquet.reader.AbstractColumnReader.shouldProduceDictionaryForType;
 import static io.trino.parquet.reader.TestingColumnReader.DataPageVersion.V1;
 import static io.trino.parquet.reader.TestingColumnReader.getDictionaryPage;
 import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
@@ -86,7 +86,7 @@ public abstract class AbstractColumnReaderTest
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         assertThat(actual.mayHaveNull()).isFalse();
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(actual).isInstanceOf(DictionaryBlock.class);
         }
         format.assertBlock(values, actual);
@@ -109,7 +109,7 @@ public abstract class AbstractColumnReaderTest
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
         assertThat(actual.mayHaveNull()).isTrue();
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(actual).isInstanceOf(DictionaryBlock.class);
         }
         format.assertBlock(values, actual);
@@ -131,7 +131,7 @@ public abstract class AbstractColumnReaderTest
         reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(actual).isInstanceOf(DictionaryBlock.class);
             assertThat(actual.mayHaveNull()).isTrue();
         }
@@ -154,7 +154,7 @@ public abstract class AbstractColumnReaderTest
         reader.setPageReader(getPageReaderMock(List.of(page), dictionaryPage, true), Optional.empty());
         reader.prepareNextRead(2);
         Block actual = reader.readPrimitive().getBlock();
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(actual).isInstanceOf(DictionaryBlock.class);
             assertThat(actual.mayHaveNull()).isFalse();
         }
@@ -204,7 +204,7 @@ public abstract class AbstractColumnReaderTest
         reader.prepareNextRead(2);
         Block block2 = reader.readPrimitive().getBlock();
 
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(block1).isInstanceOf(DictionaryBlock.class);
             assertThat(block2).isInstanceOf(DictionaryBlock.class);
 
@@ -359,7 +359,7 @@ public abstract class AbstractColumnReaderTest
         Block actual2 = readBlock(reader, 3);
         Block actual3 = readBlock(reader, 4);
 
-        if (field.getType() instanceof AbstractVariableWidthType) {
+        if (shouldProduceDictionaryForType(field.getType())) {
             assertThat(actual1).isInstanceOf(DictionaryBlock.class);
             assertThat(actual2).isInstanceOf(DictionaryBlock.class);
             assertThat(actual3).isInstanceOf(DictionaryBlock.class);


### PR DESCRIPTION
## Description
Date columns are usually low cardinality

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
