### PR TITLE
Simplify getRawSystemTable in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableName.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 
 import static io.trino.plugin.deltalake.DeltaLakeTableType.DATA;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static java.util.Objects.requireNonNull;
 
 public final class DeltaLakeTableName
 {
@@ -31,12 +30,6 @@ public final class DeltaLakeTableName
     private static final Pattern TABLE_PATTERN = Pattern.compile("" +
             "(?<table>[^$@]+)" +
             "(?:\\$(?<type>[^@]+))?");
-
-    public static String tableNameWithType(String tableName, DeltaLakeTableType tableType)
-    {
-        requireNonNull(tableName, "tableName is null");
-        return tableName + "$" + tableType.name().toLowerCase(Locale.ENGLISH);
-    }
 
     public static String tableNameFrom(String name)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -377,6 +377,7 @@ public class TestDeltaLakeBasic
 
         // Assert queries fail cleanly
         assertQueryFails("TABLE " + tableName, "Metadata not found in transaction log for tpch." + tableName);
+        assertQueryFails("SELECT * FROM \"" + tableName + "$history\"", ".* Table '.*\\$history' does not exist");
         assertQueryFails("SELECT * FROM " + tableName + " WHERE false", "Metadata not found in transaction log for tpch." + tableName);
         assertQueryFails("SELECT 1 FROM " + tableName + " WHERE false", "Metadata not found in transaction log for tpch." + tableName);
         assertQueryFails("SHOW CREATE TABLE " + tableName, "Metadata not found in transaction log for tpch." + tableName);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
@@ -71,13 +71,6 @@ public class TestDeltaLakeTableName
         assertEquals(DeltaLakeTableName.tableTypeFrom("abc$invalid"), Optional.empty());
     }
 
-    @Test
-    public void testTableNameWithType()
-    {
-        assertEquals(DeltaLakeTableName.tableNameWithType("abc", DATA), "abc$data");
-        assertEquals(DeltaLakeTableName.tableNameWithType("abc", HISTORY), "abc$history");
-    }
-
     private static void assertNoValidTableType(String inputName)
     {
         Assertions.assertThat(DeltaLakeTableName.tableTypeFrom(inputName))


### PR DESCRIPTION
## Description

Simplify getRawSystemTable in Delta Lake. After this change, we can avoid a new field for `DeltaLakeTableHandle` in #17592

## Release notes

(x) This is not user-visible or docs only and no release notes are required.