### PR TITLE
Remove redundant ORDER BY from WITH and views

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -32,7 +32,6 @@ import io.trino.sql.tree.Statement;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_SCALAR;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
@@ -94,7 +93,7 @@ public class Analyzer
         StatementAnalyzer analyzer = statementAnalyzerFactory.createStatementAnalyzer(analysis, session, warningCollector, CorrelationSupport.ALLOWED);
 
         try (var ignored = scopedSpan(tracer, "analyze")) {
-            analyzer.analyze(rewrittenStatement, Optional.empty());
+            analyzer.analyze(rewrittenStatement);
         }
 
         try (var ignored = scopedSpan(tracer, "access-control")) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -3403,9 +3403,10 @@ class StatementAnalyzer
                 throw semanticException(NOT_SUPPORTED, merge, "Cannot merge into a table with check constraints");
             }
 
-            Scope targetTableScope = analyzer.analyzeForUpdate(relation, scope, UpdateKind.MERGE);
-            Scope sourceTableScope = process(merge.getSource(), scope);
-            Scope joinScope = createAndAssignScope(merge, scope, targetTableScope.getRelationType().joinWith(sourceTableScope.getRelationType()));
+            Scope mergeScope = createScope(scope);
+            Scope targetTableScope = analyzer.analyzeForUpdate(relation, Optional.of(mergeScope), UpdateKind.MERGE);
+            Scope sourceTableScope = process(merge.getSource(), mergeScope);
+            Scope joinScope = createAndAssignScope(merge, Optional.of(mergeScope), targetTableScope.getRelationType().joinWith(sourceTableScope.getRelationType()));
 
             for (ColumnSchema column : dataColumnSchemas) {
                 if (accessControl.getColumnMask(session.toSecurityContext(), tableName, column.getName(), column.getType()).isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -457,23 +457,23 @@ class StatementAnalyzer
 
     public Scope analyze(Node node)
     {
-        return analyze(node, Optional.empty());
+        return analyze(node, Optional.empty(), true);
     }
 
     public Scope analyze(Node node, Scope outerQueryScope)
     {
-        return analyze(node, Optional.of(outerQueryScope));
+        return analyze(node, Optional.of(outerQueryScope), false);
     }
 
-    private Scope analyze(Node node, Optional<Scope> outerQueryScope)
+    private Scope analyze(Node node, Optional<Scope> outerQueryScope, boolean isTopLevel)
     {
-        return new Visitor(outerQueryScope, warningCollector, Optional.empty())
+        return new Visitor(outerQueryScope, warningCollector, Optional.empty(), isTopLevel)
                 .process(node, Optional.empty());
     }
 
     public Scope analyzeForUpdate(Relation relation, Optional<Scope> outerQueryScope, UpdateKind updateKind)
     {
-        return new Visitor(outerQueryScope, warningCollector, Optional.of(updateKind))
+        return new Visitor(outerQueryScope, warningCollector, Optional.of(updateKind), true)
                 .process(relation, Optional.empty());
     }
 
@@ -492,15 +492,17 @@ class StatementAnalyzer
     private final class Visitor
             extends AstVisitor<Scope, Optional<Scope>>
     {
+        private final boolean isTopLevel;
         private final Optional<Scope> outerQueryScope;
         private final WarningCollector warningCollector;
         private final Optional<UpdateKind> updateKind;
 
-        private Visitor(Optional<Scope> outerQueryScope, WarningCollector warningCollector, Optional<UpdateKind> updateKind)
+        private Visitor(Optional<Scope> outerQueryScope, WarningCollector warningCollector, Optional<UpdateKind> updateKind, boolean isTopLevel)
         {
             this.outerQueryScope = requireNonNull(outerQueryScope, "outerQueryScope is null");
             this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
             this.updateKind = requireNonNull(updateKind, "updateKind is null");
+            this.isTopLevel = isTopLevel;
         }
 
         @Override
@@ -1496,7 +1498,7 @@ class StatementAnalyzer
             if (node.getOrderBy().isPresent()) {
                 orderByExpressions = analyzeOrderBy(node, getSortItemsFromOrderBy(node.getOrderBy()), queryBodyScope);
 
-                if (queryBodyScope.getOuterQueryParent().isPresent() && node.getLimit().isEmpty() && node.getOffset().isEmpty()) {
+                if ((queryBodyScope.getOuterQueryParent().isPresent() || !isTopLevel) && node.getLimit().isEmpty() && node.getOffset().isEmpty()) {
                     // not the root scope and ORDER BY is ineffective
                     analysis.markRedundantOrderBy(node.getOrderBy().get());
                     warningCollector.add(new TrinoWarning(REDUNDANT_ORDER_BY, "ORDER BY in subquery may have no effect"));
@@ -2991,7 +2993,7 @@ class StatementAnalyzer
 
                 orderByExpressions = analyzeOrderBy(node, orderBy.getSortItems(), orderByScope.get());
 
-                if (sourceScope.getOuterQueryParent().isPresent() && node.getLimit().isEmpty() && node.getOffset().isEmpty()) {
+                if ((sourceScope.getOuterQueryParent().isPresent() || !isTopLevel) && node.getLimit().isEmpty() && node.getOffset().isEmpty()) {
                     // not the root scope and ORDER BY is ineffective
                     analysis.markRedundantOrderBy(orderBy);
                     warningCollector.add(new TrinoWarning(REDUNDANT_ORDER_BY, "ORDER BY in subquery may have no effect"));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestOrderBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestOrderBy.java
@@ -13,17 +13,28 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.SortNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.topN;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.ExchangeNode.Scope.LOCAL;
+import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
+import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
 
 public class TestOrderBy
         extends BasePlanTest
@@ -93,5 +104,52 @@ public class TestOrderBy
                         node(ExchangeNode.class,
                                 node(ValuesNode.class),
                                 node(ValuesNode.class))));
+    }
+
+    @Test
+    public void testRedundantOrderByInWith()
+    {
+        assertPlan("""
+                        WITH t(a) AS (
+                            SELECT * FROM (VALUES 2, 1) t(a)
+                            ORDER BY a)
+                        SELECT * FROM t
+                        """,
+                output(node(ValuesNode.class)));
+    }
+
+    @Test
+    public void testOrderByInWithLimit()
+    {
+        assertPlan("""
+                        WITH t(a) AS (
+                            SELECT * FROM (VALUES 2, 1) t(a)
+                            ORDER BY a
+                            LIMIT 1)
+                        SELECT * FROM t
+                        """,
+                output(
+                        topN(1, ImmutableList.of(sort("c", ASCENDING, LAST)), TopNNode.Step.FINAL,
+                                topN(1, ImmutableList.of(sort("c", ASCENDING, LAST)), TopNNode.Step.PARTIAL,
+                                        values("c")))));
+    }
+
+    @Test
+    public void testOrderByInWithOffset()
+    {
+        assertPlan("""
+                        WITH t(a) AS (
+                            SELECT * FROM (VALUES (2),(1)) t(a)
+                            ORDER BY a
+                            OFFSET 1)
+                        SELECT * FROM t
+                        """,
+                output(
+                        node(ProjectNode.class,
+                                node(FilterNode.class,
+                                        node(RowNumberNode.class,
+                                                exchange(LOCAL,
+                                                        sort(exchange(LOCAL,
+                                                                values("c")))))))));
     }
 }


### PR DESCRIPTION
ORDER BY without LIMIT / OFFSET is irrelevant unless it's in the top-level query.

Alternative to https://github.com/trinodb/trino/pull/18153

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* TBD
```
