### PR TITLE
Fix recursive listing from Hive partitions containing non-alphabetic values

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -32,7 +32,6 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.FAIL;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.RECURSE;
-import static java.net.URLDecoder.decode;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.Path.SEPARATOR_CHAR;
 
@@ -46,8 +45,8 @@ public class HiveFileIterator
         FAIL
     }
 
-    private final String pathPrefix;
     private final Table table;
+    private final Location location;
     private final TrinoFileSystem fileSystem;
     private final DirectoryLister directoryLister;
     private final HdfsNamenodeStats namenodeStats;
@@ -62,8 +61,8 @@ public class HiveFileIterator
             HdfsNamenodeStats namenodeStats,
             NestedDirectoryPolicy nestedDirectoryPolicy)
     {
-        this.pathPrefix = location.toString();
         this.table = requireNonNull(table, "table is null");
+        this.location = requireNonNull(location, "location is null");
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
@@ -80,7 +79,7 @@ public class HiveFileIterator
             // Ignore hidden files and directories
             if (nestedDirectoryPolicy == RECURSE) {
                 // Search the full sub-path under the listed prefix for hidden directories
-                if (isHiddenOrWithinHiddenParentDirectory(new Path(status.getPath()), pathPrefix)) {
+                if (isHiddenOrWithinHiddenParentDirectory(Location.of(status.getPath()), location)) {
                     continue;
                 }
             }
@@ -121,9 +120,10 @@ public class HiveFileIterator
     }
 
     @VisibleForTesting
-    static boolean isHiddenOrWithinHiddenParentDirectory(Path path, String prefix)
+    static boolean isHiddenOrWithinHiddenParentDirectory(Location path, Location rootLocation)
     {
-        String pathString = decode(path.toUri().toString());
+        String pathString = path.toString();
+        String prefix = rootLocation.toString();
         checkArgument(pathString.startsWith(prefix), "path %s does not start with prefix %s", pathString, prefix);
         return containsHiddenPathPartAfterIndex(pathString, prefix.endsWith("/") ? prefix.length() : prefix.length() + 1);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -30,6 +30,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -100,9 +101,11 @@ public class TestCachingDirectoryListerRecursiveFilesOnly
     {
         // Create partitioned table with special characters
         assertUpdate("CREATE TABLE recursive_directories_with_special_chars (payload varchar, event_name varchar) WITH (format = 'ORC', partitioned_by = ARRAY['event_name'])");
-        assertUpdate("INSERT INTO recursive_directories_with_special_chars VALUES ('data', 'level1|level2'), ('data', 'level1 | level2')", 2);
+        String values = "VALUES (VARCHAR 'data', VARCHAR 'level1|level2'), ('data', 'level1 | level2'), ('plus sign', 'foo+bar')";
+        assertUpdate("INSERT INTO recursive_directories_with_special_chars " + values, 3);
         // Check that all files can be read
-        assertQuery("SELECT count(*) FROM recursive_directories_with_special_chars", "VALUES (2)");
+        assertThat(query("TABLE recursive_directories_with_special_chars"))
+                .matches(values);
         assertUpdate("DROP TABLE recursive_directories_with_special_chars");
     }
 }


### PR DESCRIPTION
Fix query failure when `hive.recursive-directories` is used and the partition directory contains any url-encoded characters, i.e. when partition value contains pretty much anything other than letters/digits.

Fixes https://github.com/trinodb/trino/issues/18149