### PR TITLE
Use parquet as the default file format for iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.trino.plugin.hive.HiveCompressionCodec.ZSTD;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
-import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -49,7 +49,7 @@ public class IcebergConfig
     public static final String EXPIRE_SNAPSHOTS_MIN_RETENTION = "iceberg.expire_snapshots.min-retention";
     public static final String REMOVE_ORPHAN_FILES_MIN_RETENTION = "iceberg.remove_orphan_files.min-retention";
 
-    private IcebergFileFormat fileFormat = ORC;
+    private IcebergFileFormat fileFormat = PARQUET;
     private HiveCompressionCodec compressionCodec = ZSTD;
     private boolean useFileSizeFromMetadata = true;
     private int maxPartitionsPerWriter = 100;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -160,6 +160,7 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE MATERIALIZED VIEW test_mv_show_create " +
                 "WITH (\n" +
                 "   partitioning = ARRAY['_date'],\n" +
+                "   format = 'ORC',\n" +
                 "   orc_bloom_filter_columns = ARRAY['_date'],\n" +
                 "   orc_bloom_filter_fpp = 0.1) AS " +
                 "SELECT _bigint, _date FROM base_table1");
@@ -442,7 +443,7 @@ public abstract class BaseIcebergMaterializedViewTest
         assertThat((String) computeScalar("SHOW CREATE MATERIALIZED VIEW materialized_view_window"))
                 .matches("\\QCREATE MATERIALIZED VIEW " + qualifiedMaterializedViewName + "\n" +
                         "WITH (\n" +
-                        "   format = 'ORC',\n" +
+                        "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         "   location = '" + getSchemaDirectory() + "/st_\\E[0-9a-f]+-[0-9a-f]+\\Q',\n" +
                         "   partitioning = ARRAY['_date'],\n" +

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -41,7 +41,7 @@ public class TestIcebergConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(IcebergConfig.class)
-                .setFileFormat(ORC)
+                .setFileFormat(PARQUET)
                 .setCompressionCodec(ZSTD)
                 .setUseFileSizeFromMetadata(true)
                 .setMaxPartitionsPerWriter(100)
@@ -68,7 +68,7 @@ public class TestIcebergConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("iceberg.file-format", "Parquet")
+                .put("iceberg.file-format", "ORC")
                 .put("iceberg.compression-codec", "NONE")
                 .put("iceberg.use-file-size-from-metadata", "false")
                 .put("iceberg.max-partitions-per-writer", "222")
@@ -92,7 +92,7 @@ public class TestIcebergConfig
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
-                .setFileFormat(PARQUET)
+                .setFileFormat(ORC)
                 .setCompressionCodec(HiveCompressionCodec.NONE)
                 .setUseFileSizeFromMetadata(false)
                 .setMaxPartitionsPerWriter(222)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
@@ -57,6 +57,7 @@ public class TestIcebergConnectorSmokeTest
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .setMetastoreDirectory(metastoreDir)
                 .setIcebergProperties(ImmutableMap.of(
+                        "iceberg.file-format", format.name(),
                         "iceberg.register-table-procedure.enabled", "true",
                         "iceberg.writer-sort-buffer-size", "1MB"))
                 .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergInputInfo.java
@@ -45,7 +45,7 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_with_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " WITH (partitioning = ARRAY['regionkey', 'truncate(name, 1)']) AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, true, "ORC");
+        assertInputInfo(tableName, true, "PARQUET");
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -54,16 +54,16 @@ public class TestIcebergInputInfo
     {
         String tableName = "test_input_info_without_part_" + randomNameSuffix();
         assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, false, "ORC");
+        assertInputInfo(tableName, false, "PARQUET");
         assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test
-    public void testInputWithParquetFileFormat()
+    public void testInputWithOrcFileFormat()
     {
-        String tableName = "test_input_info_with_parquet_file_format_" + randomNameSuffix();
-        assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'PARQUET') AS SELECT * FROM nation WHERE nationkey < 10", 10);
-        assertInputInfo(tableName, false, "PARQUET");
+        String tableName = "test_input_info_with_orc_file_format_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " WITH (format = 'ORC') AS SELECT * FROM nation WHERE nationkey < 10", 10);
+        assertInputInfo(tableName, false, "ORC");
         assertUpdate("DROP TABLE " + tableName);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -572,7 +572,7 @@ public class TestIcebergMetadataFileOperations
             if (path.endsWith(".stats")) {
                 return STATS;
             }
-            if (path.contains("/data/") && path.endsWith(".orc")) {
+            if (path.contains("/data/") && (path.endsWith(".orc") || path.endsWith(".parquet"))) {
                 return DATA;
             }
             throw new IllegalArgumentException("File not recognized: " + path);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.CatalogName;
@@ -83,7 +84,7 @@ public class TestIcebergOrcMetricsCollection
         HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
 
         queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(new TestingIcebergFileMetastoreCatalogModule(metastore)), Optional.empty(), EMPTY_MODULE));
-        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg");
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of("iceberg.file-format", "ORC"));
 
         TrinoFileSystemFactory fileSystemFactory = getFileSystemFactory(queryRunner);
         tableOperationsProvider = new FileMetastoreTableOperationsProvider(fileSystemFactory);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcSystemTables.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
+
+public class TestIcebergOrcSystemTables
+        extends BaseIcebergSystemTables
+{
+    public TestIcebergOrcSystemTables()
+    {
+        super(ORC);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcWithBloomFilters.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcWithBloomFilters.java
@@ -35,7 +35,7 @@ public class TestIcebergOrcWithBloomFilters
     protected String getTableProperties(String bloomFilterColumnName, String bucketingColumnName)
     {
         return format(
-                "orc_bloom_filter_columns = ARRAY['%s'], partitioning = ARRAY['bucket(%s, 1)']",
+                "format = 'ORC', orc_bloom_filter_columns = ARRAY['%s'], partitioning = ARRAY['bucket(%s, 1)']",
                 bloomFilterColumnName,
                 bucketingColumnName);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetSystemTables.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+
+public class TestIcebergParquetSystemTables
+        extends BaseIcebergSystemTables
+{
+    public TestIcebergParquetSystemTables()
+    {
+        super(PARQUET);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergStatistics.java
@@ -64,8 +64,8 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, 25, 0, null, '0', '24'),
                   ('regionkey', null, 5, 0, null, '0', '4'),
-                  ('comment', null, 25, 0, null, null, null),
-                  ('name', null, 25, 0, null, null, null),
+                  ('comment', 2178.0, 25, 0, null, null, null),
+                  ('name', 594.0, 25, 0, null, null, null),
                   (null, null, null, null, 25, null, null)""";
 
         if (collectOnStatsOnWrites) {
@@ -78,8 +78,8 @@ public class TestIcebergStatistics
                             VALUES
                               ('nationkey', null, null, 0, null, '0', '24'),
                               ('regionkey', null, null, 0, null, '0', '4'),
-                              ('comment', null, null, 0, null, null, null),
-                              ('name', null, null, 0, null, null, null),
+                              ('comment', 2178.0, null, 0, null, null, null),
+                              ('name', 594.0, null, 0, null, null, null),
                               (null, null, null, null, 25, null, null)""");
         }
 
@@ -96,8 +96,8 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, 25, 0, null, '0', '24'),
                   ('regionkey', null, 5, 0, null, '0', '4'),
-                  ('comment', null, 25, 0, null, null, null),
-                  ('name', null, 25, 0, null, null, null),
+                  ('comment', 4357.0, 25, 0, null, null, null),
+                  ('name', 1188.0, 25, 0, null, null, null),
                   (null, null, null, null, 50, null, null)""";
         assertUpdate("ANALYZE " + tableName);
         assertQuery("SHOW STATS FOR " + tableName, goodStatsAfterFirstInsert);
@@ -108,8 +108,8 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, 50, 0, null, '0', '49'),
                   ('regionkey', null, 10, 0, null, '0', '9'),
-                  ('comment', null, 50, 0, null, null, null),
-                  ('name', null, 50, 0, null, null, null),
+                  ('comment', 6517.0, 50, 0, null, null, null),
+                  ('name', 1800.0, 50, 0, null, null, null),
                   (null, null, null, null, 75, null, null)""";
 
         if (collectOnStatsOnWrites) {
@@ -123,8 +123,8 @@ public class TestIcebergStatistics
                             VALUES
                               ('nationkey', null, 25, 0, null, '0', '49'),
                               ('regionkey', null, 5, 0, null, '0', '9'),
-                              ('comment', null, 25, 0, null, null, null),
-                              ('name', null, 25, 0, null, null, null),
+                              ('comment', 6517.0, 25, 0, null, null, null),
+                              ('name', 1800.0, 25, 0, null, null, null),
                               (null, null, null, null, 75, null, null)""");
         }
 
@@ -154,8 +154,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('name', null, 25, 0, null, null, null),
-                          ('info', null, null, 0, null, null, null),
+                          ('name', 1314.0, 25, 0, null, null, null),
+                          ('info', 4417.0, null, 0, null, null, null),
                           (null, null, null, null, 25, null, null)""");
 
         assertUpdate("ANALYZE " + tableName);
@@ -165,8 +165,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('name', null, 25, 0, null, null, null),
-                          ('info', null, 25, 0, null, null, null),
+                          ('name', 1314.0, 25, 0, null, null, null),
+                          ('info', 4417.0, 25, 0, null, null, null),
                           (null, null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -182,8 +182,8 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, 25, 0, null, '0', '24'),
                   ('regionkey', null, 5, 0, null, '0', '4'),
-                  ('comment', null, 25, 0, null, null, null),
-                  ('name', null, 25, 0, null, null, null),
+                  ('comment', 3558.0, 25, 0, null, null, null),
+                  ('name', 1231.0, 25, 0, null, null, null),
                   (null, null, null, null, 25, null, null)""";
 
         if (collectOnStatsOnWrites) {
@@ -196,8 +196,8 @@ public class TestIcebergStatistics
                             VALUES
                               ('nationkey', null, null, 0, null, '0', '24'),
                               ('regionkey', null, null, 0, null, '0', '4'),
-                              ('comment', null, null, 0, null, null, null),
-                              ('name', null, null, 0, null, null, null),
+                              ('comment', 3558.0, null, 0, null, null, null),
+                              ('name', 1231.0, null, 0, null, null, null),
                               (null, null, null, null, 25, null, null)""");
         }
 
@@ -214,8 +214,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name', null, 25, 0, null, null, null),
+                          ('comment', 7117.0, 25, 0, null, null, null),
+                          ('name', 2462.0, 25, 0, null, null, null),
                           (null, null, null, null, 50, null, null)""");
 
         // insert modified rows
@@ -224,8 +224,8 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, 50, 0, null, '0', '49'),
                   ('regionkey', null, 10, 0, null, '0', '9'),
-                  ('comment', null, 50, 0, null, null, null),
-                  ('name', null, 50, 0, null, null, null),
+                  ('comment', 10659.0, 50, 0, null, null, null),
+                  ('name', 3715.0, 50, 0, null, null, null),
                   (null, null, null, null, 75, null, null)""";
 
         if (collectOnStatsOnWrites) {
@@ -239,8 +239,8 @@ public class TestIcebergStatistics
                             VALUES
                               ('nationkey', null, 25, 0, null, '0', '49'),
                               ('regionkey', null, 5, 0, null, '0', '9'),
-                              ('comment', null, 25, 0, null, null, null),
-                              ('name', null, 25, 0, null, null, null),
+                              ('comment', 10659.0, 25, 0, null, null, null),
+                              ('name', 3715.0, 25, 0, null, null, null),
                               (null, null, null, null, 75, null, null)""");
         }
 
@@ -291,8 +291,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name', null, 25, 0, null, null, null),
+                          ('comment', 2178.0, 25, 0, null, null, null),
+                          ('name', 594.0, 25, 0, null, null, null),
                           (null, null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -316,16 +316,18 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 7, 0, null, '0', '9'),
                           ('regionkey', null, 3, 0, null, '0', '2'),
-                          ('comment', null, 7, 0, null, null, null),
-                          ('name', null, 7, 0, null, null, null),
+                          ('comment', %s, 7, 0, null, null, null),
+                          ('name', %s, 7, 0, null, null, null),
                           (null, null, null, null, 7, null, null)"""
+                        .formatted(partitioned ? "1328.0" : "954.9999999999999", partitioned ? "501.99999999999994" : "280.0")
                         : """
                         VALUES
                           ('nationkey', null, null, 0, null, '0', '9'),
                           ('regionkey', null, null, 0, null, '0', '2'),
-                          ('comment', null, null, 0, null, null, null),
-                          ('name', null, null, 0, null, null, null),
-                          (null, null, null, null, 7, null, null)""");
+                          ('comment', %s, null, 0, null, null, null),
+                          ('name', %s, null, 0, null, null, null),
+                          (null, null, null, null, 7, null, null)"""
+                        .formatted(partitioned ? "1328.0" : "954.9999999999999", partitioned ? "501.99999999999994" : "280.0"));
 
         assertUpdate(withStatsOnWrite(getSession(), true), "INSERT INTO " + tableName + " SELECT * FROM tpch.sf1.nation WHERE nationkey >= 12 OR regionkey >= 3", 18);
         assertQuery(
@@ -335,16 +337,18 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name', null, 25, 0, null, null, null),
+                          ('comment', %s, 25, 0, null, null, null),
+                          ('name', %s, 25, 0, null, null, null),
                           (null, null, null, null, 25, null, null)"""
+                        .formatted(partitioned ? "4141.0" : "2659.0", partitioned ? "1533.0" : "745.0")
                         : """
                         VALUES
                           ('nationkey', null, null, 0, null, '0', '24'),
                           ('regionkey', null, null, 0, null, '0', '4'),
-                          ('comment', null, null, 0, null, null, null),
-                          ('name', null, null, 0, null, null, null),
-                          (null, null, null, null, 25, null, null)""");
+                          ('comment', %s, null, 0, null, null, null),
+                          ('name', %s, null, 0, null, null, null),
+                          (null, null, null, null, 25, null, null)"""
+                        .formatted(partitioned ? "4141.0" : "2659.0", partitioned ? "1533.0" : "745.0"));
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -377,9 +381,10 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name', null, 25, 0, null, null, null),
-                          (null, null, null, null, 25, null, null)""");
+                          ('comment', %f, 25, 0, null, null, null),
+                          ('name', %f, 25, 0, null, null, null),
+                          (null, null, null, null, 25, null, null)"""
+                        .formatted(partitioned ? 3558.0 : 2178.0, partitioned ? 1231.0 : 594.0));
 
         assertUpdate("DROP TABLE " + tableName);
     }
@@ -505,8 +510,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, null, 0, null, null, null),
-                          ('name', null, null, 0, null, null, null),
+                          ('comment', 2178.0, null, 0, null, null, null),
+                          ('name', 594.0, null, 0, null, null, null),
                           (null, null, null, null, 25, null, null)""");
 
         // insert modified rows
@@ -520,8 +525,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 50, 0, null, '0', '49'),
                           ('regionkey', null, 10, 0, null, '0', '9'),
-                          ('comment', null, null, 0, null, null, null),
-                          ('name', null, null, 0, null, null, null),
+                          ('comment', 4471.0, null, 0, null, null, null),
+                          ('name', 1215.0, null, 0, null, null, null),
                           (null, null, null, null, 50, null, null)""");
 
         // drop stats
@@ -535,8 +540,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 50, 0, null, '0', '49'),
                           ('regionkey', null, 10, 0, null, '0', '9'),
-                          ('comment', null, 50, 0, null, null, null),
-                          ('name', null, 50, 0, null, null, null),
+                          ('comment', 4471.0, 50, 0, null, null, null),
+                          ('name', 1215.0, 50, 0, null, null, null),
                           (null, null, null, null, 50, null, null)""");
 
         // insert modified rows
@@ -549,8 +554,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 50, 0, null, '0', '74'),
                           ('regionkey', null, 10, 0, null, '0', '14'),
-                          ('comment', null, 50, 0, null, null, null),
-                          ('name', null, 50, 0, null, null, null),
+                          ('comment', 6746.999999999999, 50, 0, null, null, null),
+                          ('name', 1836.0, 50, 0, null, null, null),
                           (null, null, null, null, 75, null, null)""");
 
         // reanalyze with a subset of columns
@@ -561,8 +566,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 75, 0, null, '0', '74'),
                           ('regionkey', null, 15, 0, null, '0', '14'),
-                          ('comment', null, 50, 0, null, null, null), -- result of previous analyze
-                          ('name', null, 50, 0, null, null, null), -- result of previous analyze
+                          ('comment', 6746.999999999999, 50, 0, null, null, null), -- result of previous analyze
+                          ('name', 1836.0, 50, 0, null, null, null), -- result of previous analyze
                           (null, null, null, null, 75, null, null)""");
 
         // analyze all columns
@@ -573,8 +578,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 75, 0, null, '0', '74'),
                           ('regionkey', null, 15, 0, null, '0', '14'),
-                          ('comment', null, 75, 0, null, null, null),
-                          ('name', null, 75, 0, null, null, null),
+                          ('comment', 6746.999999999999, 75, 0, null, null, null),
+                          ('name', 1836.0, 75, 0, null, null, null),
                           (null, null, null, null, 75, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -617,15 +622,15 @@ public class TestIcebergStatistics
                 VALUES
                   ('nationkey', null, null, 0, null, '0', '24'),
                   ('regionkey', null, null, 0, null, '0', '4'),
-                  ('comment', null, null, 0, null, null, null),
-                  ('name',  null, null, 0, null, null, null),
+                  ('comment', 2178.0, null, 0, null, null, null),
+                  ('name',  594.0, null, 0, null, null, null),
                   (null,  null, null, null, 25, null, null)""";
         String extendedStats = """
                 VALUES
                   ('nationkey', null, 25, 0, null, '0', '24'),
                   ('regionkey', null, 5, 0, null, '0', '4'),
-                  ('comment', null, 25, 0, null, null, null),
-                  ('name',  null, 25, 0, null, null, null),
+                  ('comment', 2178.0, 25, 0, null, null, null),
+                  ('name',  594.0, 25, 0, null, null, null),
                   (null,  null, null, null, 25, null, null)""";
 
         assertQuery("SHOW STATS FOR " + tableName, extendedStats);
@@ -655,8 +660,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, null, 0, null, '0', '24'),
                           ('regionkey', null, null, 0, null, '0', '4'),
-                          ('comment', null, null, 0, null, null, null),
-                          ('name',  null, null, 0, null, null, null),
+                          ('comment', 2178.0, null, 0, null, null, null),
+                          ('name',  594.0, null, 0, null, null, null),
                           (null,  null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -724,8 +729,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name',  null, 25, 0, null, null, null),
+                          ('comment', 2475.0, 25, 0, null, null, null),
+                          ('name',  726.0, 25, 0, null, null, null),
                           (null,  null, null, null, 26, null, null)""");
 
         assertUpdate(format("CALL system.rollback_to_snapshot('%s', '%s', %s)", schema, tableName, createSnapshot));
@@ -736,8 +741,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name',  null, 25, 0, null, null, null),
+                          ('comment', 2178.0, 25, 0, null, null, null),
+                          ('name',  594.0, 25, 0, null, null, null),
                           (null,  null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -762,8 +767,8 @@ public class TestIcebergStatistics
                         VALUES
                           ('nationkey', null, 25, 0, null, '0', '24'),
                           ('regionkey', null, 5, 0, null, '0', '4'),
-                          ('comment', null, 25, 0, null, null, null),
-                          ('name',  null, 25, 0, null, null, null),
+                          ('comment', 2178.0, 25, 0, null, null, null),
+                          ('name',  594.0, 25, 0, null, null, null),
                           (null,  null, null, null, 25, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -807,8 +812,8 @@ public class TestIcebergStatistics
                 "SHOW STATS FOR " + tableName,
                 """
                         VALUES
-                          ('a', null, null, 0, null, null, null),
-                          ('b', null, null, 0, null, null, null),
+                          ('a', null, null, null, null, null, null),
+                          ('b', null, null, null, null, null, null),
                           (null,  null, null, null, 2, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);
@@ -829,8 +834,8 @@ public class TestIcebergStatistics
                 "SHOW STATS FOR " + tableName,
                 """
                         VALUES
-                          ('a', null, null, 0, null, null, null),
-                          ('b', null, null, 0, null, null, null),
+                          ('a', null, null, null, null, null, null),
+                          ('b', null, null, null, null, null, null),
                           (null,  null, null, null, 2, null, null)""");
 
         // On non-empty table
@@ -843,8 +848,8 @@ public class TestIcebergStatistics
                 "SHOW STATS FOR " + tableName,
                 """
                         VALUES
-                          ('a', null, null, 0, null, null, null),
-                          ('b', null, null, 0, null, null, null),
+                          ('a', null, null, null, null, null, null),
+                          ('b', null, null, null, null, null, null),
                           (null,  null, null, null, 2, null, null)""");
 
         // write with stats collection
@@ -856,8 +861,8 @@ public class TestIcebergStatistics
                 "SHOW STATS FOR " + tableName,
                 """
                         VALUES
-                          ('a', null, null, 0, null, null, null),
-                          ('b', null, null, 0, null, null, null),
+                          ('a', null, null, null, null, null, null),
+                          ('b', null, null, null, null, null, null),
                           (null,  null, null, null, 4, null, null)""");
 
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -416,7 +416,7 @@ public class TestIcebergV2
         assertUpdate("ALTER TABLE " + tableName + " SET PROPERTIES format_version = DEFAULT, format = DEFAULT, partitioning = DEFAULT, sorted_by = DEFAULT");
         table = loadTable(tableName);
         assertEquals(table.operations().current().formatVersion(), 2);
-        assertTrue(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT).equalsIgnoreCase("ORC"));
+        assertTrue(table.properties().get(TableProperties.DEFAULT_FILE_FORMAT).equalsIgnoreCase("PARQUET"));
         assertTrue(table.spec().isUnpartitioned());
         assertTrue(table.sortOrder().isUnsorted());
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation");
@@ -563,12 +563,12 @@ public class TestIcebergV2
                 """
                                VALUES
                                        (0,
-                                        'ORC',
+                                        'PARQUET',
                                         25L,
-                                        null,
+                                        JSON '{"1":141,"2":220,"3":99,"4":807}',
                                         JSON '{"1":25,"2":25,"3":25,"4":25}',
-                                        JSON '{"1":0,"2":0,"3":0,"4":0}',
-                                        null,
+                                        jSON '{"1":0,"2":0,"3":0,"4":0}',
+                                        jSON '{}',
                                         JSON '{"1":"0","2":"ALGERIA","3":"0","4":" haggle. careful"}',
                                         JSON '{"1":"24","2":"VIETNAM","3":"4","4":"y final packaget"}',
                                         null,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -90,6 +90,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
         return IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.of(
+                                "iceberg.file-format", format.name(),
                                 "iceberg.catalog.type", "glue",
                                 "hive.metastore.glue.default-warehouse-dir", schemaPath(),
                                 "iceberg.register-table-procedure.enabled", "true",
@@ -125,7 +126,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                                 "   comment varchar\n" +
                                 ")\n" +
                                 "WITH (\n" +
-                                "   format = 'ORC',\n" +
+                                "   format = 'PARQUET',\n" +
                                 "   format_version = 2,\n" +
                                 "   location = '%2$s/%1$s.db/region-\\E.*\\Q'\n" +
                                 ")\\E",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
@@ -60,7 +60,7 @@ public class TestIcebergS3AndGlueMetastoreTest
         {
             String locationDirectory = location.endsWith("/") ? location : location + "/";
             String partitionPart = partitionColumn.isEmpty() ? "" : partitionColumn + "=[a-z0-9]+/";
-            assertThat(dataFile).matches("^" + locationDirectory + "data/" + partitionPart + "[a-zA-Z0-9_-]+.orc$");
+            assertThat(dataFile).matches("^" + locationDirectory + "data/" + partitionPart + "[a-zA-Z0-9_-]+.(orc|parquet)$");
             verifyPathExist(dataFile);
         });
     }
@@ -119,9 +119,10 @@ public class TestIcebergS3AndGlueMetastoreTest
 
             String expectedStatistics = """
                     VALUES
-                    ('col_str', null, 4.0, 0.0, null, null, null),
+                    ('col_str', %s, 4.0, 0.0, null, null, null),
                     ('col_int', null, 4.0, 0.0, null, 1, 4),
-                    (null, null, null, null, 4.0, null, null)""";
+                    (null, null, null, null, 4.0, null, null)"""
+                    .formatted(partitioned ? "475.0" : "264.0");
 
             // Check extended statistics collection on write
             assertQuery("SHOW STATS FOR " + tableName, expectedStatistics);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/jdbc/TestIcebergJdbcCatalogConnectorSmokeTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.PASSWORD;
 import static io.trino.plugin.iceberg.catalog.jdbc.TestingIcebergJdbcServer.USER;
 import static java.lang.String.format;
@@ -42,6 +43,7 @@ import static org.apache.iceberg.CatalogProperties.CATALOG_IMPL;
 import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
 import static org.apache.iceberg.CatalogUtil.buildIcebergCatalog;
+import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.apache.iceberg.jdbc.JdbcCatalog.PROPERTY_PREFIX;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -173,6 +175,9 @@ public class TestIcebergJdbcCatalogConnectorSmokeTest
     @Override
     protected boolean isFileSorted(Location path, String sortColumnName)
     {
+        if (format == PARQUET) {
+            return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+        }
         return checkOrcFileSorting(fileSystem, path, sortColumnName);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
@@ -35,7 +35,9 @@ import java.util.Optional;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static java.lang.String.format;
+import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergNessieCatalogConnectorSmokeTest
@@ -246,6 +248,9 @@ public class TestIcebergNessieCatalogConnectorSmokeTest
     @Override
     protected boolean isFileSorted(Location path, String sortColumnName)
     {
+        if (format == PARQUET) {
+            return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+        }
         return checkOrcFileSorting(fileSystem, path, sortColumnName);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -36,8 +36,10 @@ import java.util.Optional;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.iceberg.IcebergTestUtils.checkOrcFileSorting;
+import static io.trino.plugin.iceberg.IcebergTestUtils.checkParquetFileSorting;
 import static io.trino.plugin.iceberg.catalog.rest.RestCatalogTestUtils.backendCatalog;
 import static java.lang.String.format;
+import static org.apache.iceberg.FileFormat.PARQUET;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergTrinoRestCatalogConnectorSmokeTest
@@ -261,6 +263,9 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     @Override
     protected boolean isFileSorted(Location path, String sortColumnName)
     {
+        if (format == PARQUET) {
+            return checkParquetFileSorting(fileSystem.newInputFile(path), sortColumnName);
+        }
         return checkOrcFileSorting(fileSystem, path, sortColumnName);
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -295,7 +295,7 @@ public class TestHiveRedirectionToIceberg
                         "   comment varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'ORC',\n" +
+                        "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
                         format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s-\\E.*\\Q',\n", tableName) +
                         "   partitioning = ARRAY['regionkey']\n" + // 'partitioning' comes from Iceberg
@@ -316,9 +316,9 @@ public class TestHiveRedirectionToIceberg
         assertThat(onTrino().executeQuery("SHOW STATS FOR " + hiveTableName))
                 .containsOnly(
                         row("nationkey", null, 25d, 0d, null, "0", "24"),
-                        row("name", null, 25d, 0d, null, null, null),
+                        row("name", 1231d, 25d, 0d, null, null, null),
                         row("regionkey", null, 5d, 0d, null, "0", "4"),
-                        row("comment", null, 25d, 0d, null, null, null),
+                        row("comment", 3558d, 25d, 0d, null, null, null),
                         row(null, null, null, null, 25d, null, null));
 
         onTrino().executeQuery("DROP TABLE " + icebergTableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -51,7 +51,7 @@ public class TestIcebergPartitionEvolution
                                 "   c varchar\n" +
                                 ")\n" +
                                 "WITH (\n" +
-                                "   format = 'ORC',\n" +
+                                "   format = 'PARQUET',\n" +
                                 "   format_version = 1,\n" +
                                 "   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/test_dropped_partition_field-\\E.*\\Q',\n" +
                                 "   partitioning = ARRAY[" + (dropFirst ? "'void(a)','b'" : "'a','void(b)'") + "]\n" +
@@ -68,9 +68,9 @@ public class TestIcebergPartitionEvolution
 
         assertThat(onTrino().executeQuery("SHOW STATS FOR test_dropped_partition_field"))
                 .containsOnly(
-                        row("a", null, 3.0, 1. / 6, null, null, null),
-                        row("b", null, 3.0, 1. / 6, null, null, null),
-                        row("c", null, 4.0, 0., null, null, null),
+                        row("a", 664.0, 3.0, 1. / 6, null, null, null),
+                        row("b", 666.0, 3.0, 1. / 6, null, null, null),
+                        row("c", 639.0, 4.0, 0., null, null, null),
                         row(null, null, null, null, 6., null, null));
 
         assertThat(onTrino().executeQuery("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'test_dropped_partition_field$partitions'"))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -365,7 +365,7 @@ public class TestIcebergSparkCompatibility
                 // TODO Iceberg Spark integration needs yet to gain support
                 //  once this is supported, merge this test with testSparkReadingTrinoData()
                 .isInstanceOf(SQLException.class)
-                .hasMessageMatching("org.apache.hive.service.cli.HiveSQLException: Error running query:.*\\Q java.lang.ClassCastException\\E(?s:.*)");
+                .hasMessageMatching("org.apache.hive.service.cli.HiveSQLException: Error running query:.*\\Q java.lang.UnsupportedOperationException\\E(?s:.*)");
 
         onTrino().executeQuery("DROP TABLE " + trinoTableName);
     }


### PR DESCRIPTION
## Description
Use parquet as the default file format for iceberg

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Parquet writer has comparable performance to ORC.
[Hive insert benchmark ORC vs parquet.pdf](https://github.com/trinodb/trino/files/11980809/Hive.insert.benchmark.ORC.vs.parquet.pdf)
<img width="640" alt="Screenshot 2023-07-07 at 4 00 45 PM" src="https://github.com/trinodb/trino/assets/4344846/d672d2b0-3ba1-4bb6-a219-7866e9d61366">

Parquet reader has comparable or better performance to ORC.
[Iceberg unpartitioned sf1k orc vs parquet.pdf](https://github.com/trinodb/trino/files/11980825/Iceberg.unpartitioned.sf1k.orc.vs.parquet.pdf)
<img width="1318" alt="Screenshot 2023-07-07 at 4 01 36 PM" src="https://github.com/trinodb/trino/assets/4344846/a4f36ecd-ef65-4ab1-ae7a-95eaee82d7eb">

[Iceberg partitioned sf1k orc vs parquet.pdf](https://github.com/trinodb/trino/files/11980816/Iceberg.partitioned.sf1k.orc.vs.parquet.pdf)
<img width="1320" alt="Screenshot 2023-07-07 at 4 02 05 PM" src="https://github.com/trinodb/trino/assets/4344846/fe1eea2e-deb9-4717-8428-e0730005bd1d">

Since there are no longer major performance benefits to staying on ORC and parquet is the popular format,
we can switch the default to parquet

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* The default file format is changed to PARQUET. The catalog configuration `iceberg.file-format` can be used to specify a different file format as the default. ({issue}`18170`)
```
