### PR TITLE
Move test to `AbstractTestHiveFileSystem`

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -170,6 +170,10 @@ public abstract class AbstractTestHiveFileSystemS3
         //             nested-file.txt
         //      part=plus+sign/
         //          plus-file.txt
+        //      part=percent%sign/
+        //          percent-file.txt
+        //      part=url%20encoded/
+        //          url-encoded-file.txt
         //      part=level1|level2/
         //          pipe-file.txt
         //          parent1/
@@ -186,6 +190,8 @@ public abstract class AbstractTestHiveFileSystemS3
         createFile(writableBucket, format("%s/part=nested/parent/_nested-hidden-file.txt", basePrefix));
         createFile(writableBucket, format("%s/part=nested/parent/nested-file.txt", basePrefix));
         createFile(writableBucket, format("%s/part=plus+sign/plus-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=percent%%sign/percent-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=url%%20encoded/url-encoded-file.txt", basePrefix));
         createFile(writableBucket, format("%s/part=level1|level2/pipe-file.txt", basePrefix));
         createFile(writableBucket, format("%s/part=level1|level2/parent1/parent2/deeply-nested-file.txt", basePrefix));
         createFile(writableBucket, format("%s/part=level1 | level2/pipe-blanks-file.txt", basePrefix));
@@ -209,6 +215,8 @@ public abstract class AbstractTestHiveFileSystemS3
                 format("%s/part=simple/plain-file.txt", basePath),
                 format("%s/part=nested/parent/nested-file.txt", basePath),
                 format("%s/part=plus+sign/plus-file.txt", basePath),
+                format("%s/part=percent%%sign/percent-file.txt", basePath),
+                format("%s/part=url%%20encoded/url-encoded-file.txt", basePath),
                 format("%s/part=level1|level2/pipe-file.txt", basePath),
                 format("%s/part=level1|level2/parent1/parent2/deeply-nested-file.txt", basePath),
                 format("%s/part=level1 | level2/pipe-blanks-file.txt", basePath));

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -13,37 +13,69 @@
  */
 package io.trino.plugin.hive;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import com.google.common.net.MediaType;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hdfs.ConfigurationInitializer;
 import io.trino.hdfs.DynamicHdfsConfiguration;
 import io.trino.hdfs.HdfsConfig;
 import io.trino.hdfs.HdfsConfiguration;
 import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsNamenodeStats;
+import io.trino.hdfs.TrinoHdfsFileSystemStats;
 import io.trino.hdfs.s3.HiveS3Config;
 import io.trino.hdfs.s3.TrinoS3ConfigurationInitializer;
+import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
+import io.trino.plugin.hive.fs.HiveFileIterator;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
+import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.StorageFormat;
+import io.trino.plugin.hive.metastore.Table;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.hive.HiveTestUtils.SESSION;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
+import static io.trino.plugin.hive.HiveType.HIVE_STRING;
+import static java.io.InputStream.nullInputStream;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.util.Strings.isNullOrEmpty;
 
 public abstract class AbstractTestHiveFileSystemS3
         extends AbstractTestHiveFileSystem
 {
+    private static final MediaType DIRECTORY_MEDIA_TYPE = MediaType.create("application", "x-directory");
+
     private String awsAccessKey;
     private String awsSecretKey;
     private String writableBucket;
     private String testDirectory;
+    private AmazonS3 s3Client;
 
     protected void setup(
             String host,
             int port,
             String databaseName,
+            String s3endpoint,
             String awsAccessKey,
             String awsSecretKey,
             String writableBucket,
@@ -54,12 +86,18 @@ public abstract class AbstractTestHiveFileSystemS3
         checkArgument(!isNullOrEmpty(databaseName), "Expected non empty databaseName");
         checkArgument(!isNullOrEmpty(awsAccessKey), "Expected non empty awsAccessKey");
         checkArgument(!isNullOrEmpty(awsSecretKey), "Expected non empty awsSecretKey");
+        checkArgument(!isNullOrEmpty(s3endpoint), "Expected non empty s3endpoint");
         checkArgument(!isNullOrEmpty(writableBucket), "Expected non empty writableBucket");
         checkArgument(!isNullOrEmpty(testDirectory), "Expected non empty testDirectory");
         this.awsAccessKey = awsAccessKey;
         this.awsSecretKey = awsSecretKey;
         this.writableBucket = writableBucket;
         this.testDirectory = testDirectory;
+
+        s3Client = AmazonS3Client.builder()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(s3endpoint, null))
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(awsAccessKey, awsSecretKey)))
+                .build();
 
         setup(host, port, databaseName, s3SelectPushdownEnabled, createHdfsConfiguration());
     }
@@ -92,5 +130,124 @@ public abstract class AbstractTestHiveFileSystemS3
         fs.create(filePath).close();
 
         assertFalse(Arrays.stream(fs.listStatus(basePath)).anyMatch(file -> file.getPath().getName().equalsIgnoreCase(markerFileName)));
+    }
+
+    /**
+     * Tests the same functionality like {@link #testFileIteratorPartitionedListing()} with the
+     * setup done by native {@link AmazonS3}
+     */
+    @Test
+    public void testFileIteratorPartitionedListingNativeS3Client()
+            throws Exception
+    {
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(table.getSchemaName())
+                .setTableName(table.getTableName())
+                .setDataColumns(ImmutableList.of(new Column("data", HIVE_LONG, Optional.empty())))
+                .setPartitionColumns(ImmutableList.of(new Column("part", HIVE_STRING, Optional.empty())))
+                .setOwner(Optional.empty())
+                .setTableType("fake");
+        tableBuilder.getStorageBuilder()
+                .setStorageFormat(StorageFormat.fromHiveStorageFormat(HiveStorageFormat.CSV));
+        Table fakeTable = tableBuilder.build();
+
+        Path basePath = new Path(getBasePath(), "test-file-iterator-partitioned-listing-native-setup");
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
+        TrinoFileSystem trinoFileSystem = new HdfsFileSystemFactory(hdfsEnvironment, new TrinoHdfsFileSystemStats()).create(SESSION);
+        fs.mkdirs(basePath);
+        String basePrefix = basePath.toUri().getPath().substring(1);
+
+        // Expected file system tree:
+        // test-file-iterator-partitioned-listing-native-setup/
+        //      .hidden/
+        //          nested-file-in-hidden.txt
+        //      part=simple/
+        //          _hidden-file.txt
+        //          plain-file.txt
+        //      part=nested/
+        //          parent/
+        //             _nested-hidden-file.txt
+        //             nested-file.txt
+        //      part=plus+sign/
+        //          plus-file.txt
+        //      part=level1|level2/
+        //          pipe-file.txt
+        //          parent1/
+        //             parent2/
+        //                deeply-nested-file.txt
+        //      part=level1 | level2/
+        //          pipe-blanks-file.txt
+        //      empty-directory/
+        //      .hidden-in-base.txt
+
+        createFile(writableBucket, format("%s/.hidden/nested-file-in-hidden.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=simple/_hidden-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=simple/plain-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=nested/parent/_nested-hidden-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=nested/parent/nested-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=plus+sign/plus-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=level1|level2/pipe-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=level1|level2/parent1/parent2/deeply-nested-file.txt", basePrefix));
+        createFile(writableBucket, format("%s/part=level1 | level2/pipe-blanks-file.txt", basePrefix));
+        createDirectory(writableBucket, format("%s/empty-directory/", basePrefix));
+        createFile(writableBucket, format("%s/.hidden-in-base.txt", basePrefix));
+
+        // List recursively through hive file iterator
+        HiveFileIterator recursiveIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.RECURSE);
+
+        List<String> recursiveListing = Streams.stream(recursiveIterator)
+                .map(TrinoFileStatus::getPath)
+                .toList();
+        // Should not include directories, or files underneath hidden directories
+        assertThat(recursiveListing).containsExactlyInAnyOrder(
+                format("%s/part=simple/plain-file.txt", basePath),
+                format("%s/part=nested/parent/nested-file.txt", basePath),
+                format("%s/part=plus+sign/plus-file.txt", basePath),
+                format("%s/part=level1|level2/pipe-file.txt", basePath),
+                format("%s/part=level1|level2/parent1/parent2/deeply-nested-file.txt", basePath),
+                format("%s/part=level1 | level2/pipe-blanks-file.txt", basePath));
+
+        HiveFileIterator shallowIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.IGNORED);
+        List<Path> shallowListing = Streams.stream(shallowIterator)
+                .map(TrinoFileStatus::getPath)
+                .map(Path::new)
+                .toList();
+        // Should not include any hidden files, folders, or nested files
+        assertThat(shallowListing).isEmpty();
+    }
+
+    protected void createDirectory(String bucketName, String key)
+    {
+        // create meta-data for your folder and set content-length to 0
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(0);
+        metadata.setContentType(DIRECTORY_MEDIA_TYPE.toString());
+        // create a PutObjectRequest passing the folder name suffixed by /
+        if (!key.endsWith("/")) {
+            key += "/";
+        }
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, nullInputStream(), metadata);
+        // send request to S3 to create folder
+        s3Client.putObject(putObjectRequest);
+    }
+
+    protected void createFile(String bucketName, String key)
+    {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(0);
+        PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, nullInputStream(), metadata);
+        s3Client.putObject(putObjectRequest);
     }
 }

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveFileSystemS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveFileSystemS3.java
@@ -23,14 +23,15 @@ public class TestHiveFileSystemS3
             "hive.hadoop2.metastoreHost",
             "hive.hadoop2.metastorePort",
             "hive.hadoop2.databaseName",
+            "hive.hadoop2.s3.endpoint",
             "hive.hadoop2.s3.awsAccessKey",
             "hive.hadoop2.s3.awsSecretKey",
             "hive.hadoop2.s3.writableBucket",
             "hive.hadoop2.s3.testDirectory",
     })
     @BeforeClass
-    public void setup(String host, int port, String databaseName, String awsAccessKey, String awsSecretKey, String writableBucket, String testDirectory)
+    public void setup(String host, int port, String databaseName, String s3endpoint, String awsAccessKey, String awsSecretKey, String writableBucket, String testDirectory)
     {
-        super.setup(host, port, databaseName, awsAccessKey, awsSecretKey, writableBucket, testDirectory, false);
+        super.setup(host, port, databaseName, s3endpoint, awsAccessKey, awsSecretKey, writableBucket, testDirectory, false);
     }
 }

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/TestHiveFileSystemS3SelectPushdown.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/s3select/TestHiveFileSystemS3SelectPushdown.java
@@ -41,15 +41,16 @@ public class TestHiveFileSystemS3SelectPushdown
             "hive.hadoop2.metastoreHost",
             "hive.hadoop2.metastorePort",
             "hive.hadoop2.databaseName",
+            "hive.hadoop2.s3.endpoint",
             "hive.hadoop2.s3.awsAccessKey",
             "hive.hadoop2.s3.awsSecretKey",
             "hive.hadoop2.s3.writableBucket",
             "hive.hadoop2.s3.testDirectory",
     })
     @BeforeClass
-    public void setup(String host, int port, String databaseName, String awsAccessKey, String awsSecretKey, String writableBucket, String testDirectory)
+    public void setup(String host, int port, String databaseName, String s3endpoint, String awsAccessKey, String awsSecretKey, String writableBucket, String testDirectory)
     {
-        super.setup(host, port, databaseName, awsAccessKey, awsSecretKey, writableBucket, testDirectory, true);
+        super.setup(host, port, databaseName, s3endpoint, awsAccessKey, awsSecretKey, writableBucket, testDirectory, true);
         tableWithPipeDelimiter = new SchemaTableName(database, "trino_s3select_test_external_fs_with_pipe_delimiter");
         tableWithCommaDelimiter = new SchemaTableName(database, "trino_s3select_test_external_fs_with_comma_delimiter");
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -115,6 +115,7 @@ import static io.trino.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvi
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.trino.plugin.hive.HiveTestUtils.getTypes;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
+import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
@@ -129,6 +130,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -503,6 +505,118 @@ public abstract class AbstractTestHiveFileSystem
                 .toList();
         // Should not include any hidden files, folders, or nested files
         assertEqualsIgnoreOrder(shallowListing, ImmutableList.of(baseFile));
+    }
+
+    @Test
+    public void testFileIteratorPartitionedListing()
+            throws Exception
+    {
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(table.getSchemaName())
+                .setTableName(table.getTableName())
+                .setDataColumns(ImmutableList.of(new Column("data", HIVE_LONG, Optional.empty())))
+                .setPartitionColumns(ImmutableList.of(new Column("part", HIVE_STRING, Optional.empty())))
+                .setOwner(Optional.empty())
+                .setTableType("fake");
+        tableBuilder.getStorageBuilder()
+                .setStorageFormat(StorageFormat.fromHiveStorageFormat(HiveStorageFormat.CSV));
+        Table fakeTable = tableBuilder.build();
+
+        // Expected file system tree:
+        // test-file-iterator-partitioned-listing/
+        //      .hidden/
+        //          nested-file-in-hidden.txt
+        //      part=simple/
+        //          _hidden-file.txt
+        //          plain-file.txt
+        //      part=nested/
+        //          parent/
+        //             _nested-hidden-file.txt
+        //             nested-file.txt
+        //      part=plus+sign/
+        //          plus-file.txt
+        //      part=level1|level2/
+        //          pipe-file.txt
+        //          parent1/
+        //             parent2/
+        //                deeply-nested-file.txt
+        //      part=level1 | level2/
+        //          pipe-blanks-file.txt
+        //      empty-directory/
+        //      .hidden-in-base.txt
+        Path basePath = new Path(getBasePath(), "test-file-iterator-partitioned-listing");
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
+        TrinoFileSystem trinoFileSystem = new HdfsFileSystemFactory(hdfsEnvironment, new TrinoHdfsFileSystemStats()).create(SESSION);
+        fs.mkdirs(basePath);
+
+        // create file in hidden folder
+        Path fileInHiddenParent = new Path(new Path(basePath, ".hidden"), "nested-file-in-hidden.txt");
+        fs.createNewFile(fileInHiddenParent);
+        // create hidden file in non-hidden folder
+        Path hiddenFileUnderPartitionSimple = new Path(new Path(basePath, "part=simple"), "_hidden-file.txt");
+        fs.createNewFile(hiddenFileUnderPartitionSimple);
+        // create file in `part=simple` non-hidden folder
+        Path plainFilePartitionSimple = new Path(new Path(basePath, "part=simple"), "plain-file.txt");
+        fs.createNewFile(plainFilePartitionSimple);
+        Path nestedFilePartitionNested = new Path(new Path(new Path(basePath, "part=nested"), "parent"), "nested-file.txt");
+        fs.createNewFile(nestedFilePartitionNested);
+        // create hidden file in non-hidden folder
+        Path nestedHiddenFilePartitionNested = new Path(new Path(new Path(basePath, "part=nested"), "parent"), "_nested-hidden-file.txt");
+        fs.createNewFile(nestedHiddenFilePartitionNested);
+        // create file in `part=plus+sign` non-hidden folder (which contains `+` special character)
+        Path plainFilePartitionPlusSign = new Path(new Path(basePath, "part=plus+sign"), "plus-file.txt");
+        fs.createNewFile(plainFilePartitionPlusSign);
+        // create file in `part=level1|level2` non-hidden folder (which contains `|` special character)
+        Path plainFilePartitionPipeSign = new Path(new Path(basePath, "part=level1|level2"), "pipe-file.txt");
+        fs.createNewFile(plainFilePartitionPipeSign);
+        Path deeplyNestedFilePartitionPipeSign = new Path(new Path(new Path(new Path(basePath, "part=level1|level2"), "parent1"), "parent2"), "deeply-nested-file.txt");
+        fs.createNewFile(deeplyNestedFilePartitionPipeSign);
+        // create file in `part=level1 | level2` non-hidden folder (which contains `|` and blank space special characters)
+        Path plainFilePartitionPipeSignBlanks = new Path(new Path(basePath, "part=level1 | level2"), "pipe-blanks-file.txt");
+        fs.createNewFile(plainFilePartitionPipeSignBlanks);
+
+        // create empty subdirectory
+        Path emptyDirectory = new Path(basePath, "empty-directory");
+        fs.mkdirs(emptyDirectory);
+        // create hidden file in base path
+        Path hiddenBase = new Path(basePath, ".hidden-in-base.txt");
+        fs.createNewFile(hiddenBase);
+
+        // List recursively through hive file iterator
+        HiveFileIterator recursiveIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.RECURSE);
+
+        List<Path> recursiveListing = Streams.stream(recursiveIterator)
+                .map(TrinoFileStatus::getPath)
+                .map(Path::new)
+                .toList();
+        // Should not include directories, or files underneath hidden directories
+        assertThat(recursiveListing).containsExactlyInAnyOrder(
+                plainFilePartitionSimple,
+                nestedFilePartitionNested,
+                plainFilePartitionPlusSign,
+                plainFilePartitionPipeSign,
+                deeplyNestedFilePartitionPipeSign,
+                plainFilePartitionPipeSignBlanks);
+
+        HiveFileIterator shallowIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.IGNORED);
+        List<Path> shallowListing = Streams.stream(shallowIterator)
+                .map(TrinoFileStatus::getPath)
+                .map(Path::new)
+                .toList();
+        // Should not include any hidden files, folders, or nested files
+        assertThat(shallowListing).isEmpty();
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -535,6 +535,10 @@ public abstract class AbstractTestHiveFileSystem
         //             nested-file.txt
         //      part=plus+sign/
         //          plus-file.txt
+        //      part=percent%sign/
+        //          percent-file.txt
+        //      part=url%20encoded/
+        //          url-encoded-file.txt
         //      part=level1|level2/
         //          pipe-file.txt
         //          parent1/
@@ -566,6 +570,12 @@ public abstract class AbstractTestHiveFileSystem
         // create file in `part=plus+sign` non-hidden folder (which contains `+` special character)
         Path plainFilePartitionPlusSign = new Path(new Path(basePath, "part=plus+sign"), "plus-file.txt");
         fs.createNewFile(plainFilePartitionPlusSign);
+        // create file in `part=percent%sign` non-hidden folder (which contains `%` special character)
+        Path plainFilePartitionPercentSign = new Path(new Path(basePath, "part=percent%sign"), "percent-file.txt");
+        fs.createNewFile(plainFilePartitionPercentSign);
+        // create file in `part=url%20encoded` non-hidden folder (which contains `%` special character)
+        Path plainFilePartitionUrlEncoded = new Path(new Path(basePath, "part=url%20encoded"), "url-encoded-file.txt");
+        fs.createNewFile(plainFilePartitionUrlEncoded);
         // create file in `part=level1|level2` non-hidden folder (which contains `|` special character)
         Path plainFilePartitionPipeSign = new Path(new Path(basePath, "part=level1|level2"), "pipe-file.txt");
         fs.createNewFile(plainFilePartitionPipeSign);
@@ -600,6 +610,8 @@ public abstract class AbstractTestHiveFileSystem
                 plainFilePartitionSimple,
                 nestedFilePartitionNested,
                 plainFilePartitionPlusSign,
+                plainFilePartitionPercentSign,
+                plainFilePartitionUrlEncoded,
                 plainFilePartitionPipeSign,
                 deeplyNestedFilePartitionPipeSign,
                 plainFilePartitionPipeSignBlanks);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -30,7 +30,6 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -94,18 +93,5 @@ public class TestCachingDirectoryListerRecursiveFilesOnly
         assertUpdate("DROP TABLE recursive_directories");
 
         assertFalse(isCached(tableLocation));
-    }
-
-    @Test
-    public void testRecursiveDirectoriesWithSpecialCharacters()
-    {
-        // Create partitioned table with special characters
-        assertUpdate("CREATE TABLE recursive_directories_with_special_chars (payload varchar, event_name varchar) WITH (format = 'ORC', partitioned_by = ARRAY['event_name'])");
-        String values = "VALUES (VARCHAR 'data', VARCHAR 'level1|level2'), ('data', 'level1 | level2'), ('plus sign', 'foo+bar')";
-        assertUpdate("INSERT INTO recursive_directories_with_special_chars " + values, 3);
-        // Check that all files can be read
-        assertThat(query("TABLE recursive_directories_with_special_chars"))
-                .matches(values);
-        assertUpdate("DROP TABLE recursive_directories_with_special_chars");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



The test `testRecursiveDirectoriesWithSpecialCharacters()` is being
moved to `AbstractTestHiveFileSystem` for being able to test it on
multiple object storage file systems.

Contains cherry-pick from https://github.com/trinodb/trino/pull/18167

Fixes #18169

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
