### PR TITLE
Expose erroneous handling for recursive listing in S3

### DIFF
--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -29,6 +29,26 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
@@ -199,6 +219,24 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <!-- dependency plugin fails to recognize software.amazon.awssdk libraries as a compile-time dependencies,
+                             because we only explicitly use them in the test code -->
+                        <ignoredDependency>software.amazon.awssdk:auth</ignoredDependency>
+                        <ignoredDependency>software.amazon.awssdk:aws-core</ignoredDependency>
+                        <ignoredDependency>software.amazon.awssdk:s3</ignoredDependency>
+                        <ignoredDependency>software.amazon.awssdk:sdk-core</ignoredDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>default</id>

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemS3.java
@@ -13,21 +13,46 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
+import com.google.common.net.MediaType;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hdfs.ConfigurationInitializer;
 import io.trino.hdfs.DynamicHdfsConfiguration;
 import io.trino.hdfs.HdfsConfig;
 import io.trino.hdfs.HdfsConfiguration;
 import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsNamenodeStats;
+import io.trino.hdfs.TrinoHdfsFileSystemStats;
 import io.trino.hdfs.s3.HiveS3Config;
 import io.trino.hdfs.s3.TrinoS3ConfigurationInitializer;
+import io.trino.plugin.hive.fs.FileSystemDirectoryLister;
+import io.trino.plugin.hive.fs.HiveFileIterator;
+import io.trino.plugin.hive.fs.TrinoFileStatus;
+import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.StorageFormat;
+import io.trino.plugin.hive.metastore.Table;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.hive.HiveTestUtils.SESSION;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static java.lang.String.format;
 import static org.testng.Assert.assertFalse;
 import static org.testng.util.Strings.isNullOrEmpty;
@@ -35,10 +60,14 @@ import static org.testng.util.Strings.isNullOrEmpty;
 public abstract class AbstractTestHiveFileSystemS3
         extends AbstractTestHiveFileSystem
 {
+    private static final MediaType DIRECTORY_MEDIA_TYPE = MediaType.create("application", "x-directory");
+    private static final String PATH_SEPARATOR = "/";
+
     private String awsAccessKey;
     private String awsSecretKey;
     private String writableBucket;
     private String testDirectory;
+    private S3Client s3Client;
 
     protected void setup(
             String host,
@@ -60,7 +89,10 @@ public abstract class AbstractTestHiveFileSystemS3
         this.awsSecretKey = awsSecretKey;
         this.writableBucket = writableBucket;
         this.testDirectory = testDirectory;
-
+        this.s3Client = S3Client.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(awsAccessKey, awsSecretKey)))
+                .build();
         setup(host, port, databaseName, s3SelectPushdownEnabled, createHdfsConfiguration());
     }
 
@@ -92,5 +124,116 @@ public abstract class AbstractTestHiveFileSystemS3
         fs.create(filePath).close();
 
         assertFalse(Arrays.stream(fs.listStatus(basePath)).anyMatch(file -> file.getPath().getName().equalsIgnoreCase(markerFileName)));
+    }
+
+    @Test
+    public void testFileIteratorTooSlashedListing()
+            throws Exception
+    {
+        Table.Builder tableBuilder = Table.builder()
+                .setDatabaseName(table.getSchemaName())
+                .setTableName(table.getTableName())
+                .setDataColumns(ImmutableList.of(new Column("data", HIVE_LONG, Optional.empty())))
+                .setPartitionColumns(ImmutableList.of())
+                .setOwner(Optional.empty())
+                .setTableType("fake");
+        tableBuilder.getStorageBuilder()
+                .setStorageFormat(StorageFormat.fromHiveStorageFormat(HiveStorageFormat.CSV));
+        Table fakeTable = tableBuilder.build();
+
+        // Expected file system tree:
+        // test-file-iterator-too-slashed-listing/
+        //      .hidden/
+        //          nested-file-in-hidden.txt
+        //      nested/
+        //          _nested-hidden-file.txt
+        //          nested-file.txt
+        //      /
+        //         too-slashed-nested-file.txt
+        //      base-path-file.txt
+        //      empty-directory/
+        //      .hidden-in-base.txt
+        Path basePath = new Path(getBasePath(), "test-file-iterator-too-slashed-listing");
+        FileSystem fs = hdfsEnvironment.getFileSystem(TESTING_CONTEXT, basePath);
+        TrinoFileSystem trinoFileSystem = new HdfsFileSystemFactory(hdfsEnvironment, new TrinoHdfsFileSystemStats()).create(SESSION);
+        fs.mkdirs(basePath);
+        String basePrefix = basePath.toUri().getPath().substring(1);
+
+        // create file in hidden folder
+        createFile(writableBucket, basePrefix, ".hidden/nested-file-in-hidden.txt");
+        // create nested file in non-hidden folder
+        createFile(writableBucket, basePrefix, "nested/nested-file.txt");
+        // create hidden file in non-hidden folder
+        createFile(writableBucket, basePrefix, "nested/_nested-hidden-file.txt");
+        createFile(writableBucket, basePrefix, "/too-slashed-nested-file.txt");
+        // create file in base path
+        createFile(writableBucket, basePrefix, "base-path-file.txt");
+        // create hidden file in base path
+        createFile(writableBucket, basePrefix, ".hidden-in-base.txt");
+        // create empty subdirectory
+        createDirectory(writableBucket, basePrefix, "empty-directory");
+
+        // List recursively through hive file iterator
+        HiveFileIterator recursiveIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.RECURSE);
+
+        List<String> recursiveDirectoryListing = Streams.stream(recursiveIterator)
+                .map(TrinoFileStatus::getPath)
+                .map(s -> s.substring(basePath.toString().length() + 1))
+                .toList();
+        // Should not include directories, or files underneath hidden directories
+        assertEqualsIgnoreOrder(
+                recursiveDirectoryListing,
+                ImmutableList.of(
+                        //TODO FIXME the key suffix `too-slashed-nested-file.txt` should be actually `/too-slashed-nested-file.txt`
+                        "too-slashed-nested-file.txt",
+                        "base-path-file.txt",
+                        "nested/nested-file.txt"));
+
+        HiveFileIterator shallowIterator = new HiveFileIterator(
+                fakeTable,
+                Location.of(basePath.toString()),
+                trinoFileSystem,
+                new FileSystemDirectoryLister(),
+                new HdfsNamenodeStats(),
+                HiveFileIterator.NestedDirectoryPolicy.IGNORED);
+        List<String> shallowDirectoryListing = Streams.stream(shallowIterator)
+                .map(TrinoFileStatus::getPath)
+                .map(s -> s.substring(basePath.toString().length() + 1))
+                .toList();
+        assertEqualsIgnoreOrder(shallowDirectoryListing, ImmutableList.of(
+                //TODO FIXME the file `too-slashed-nested-file.txt` should not be retrieved because it is not at the base level in the directory
+                "too-slashed-nested-file.txt",
+                "base-path-file.txt"));
+    }
+
+    private void createDirectory(String bucketName, String prefix, String key)
+    {
+        // create a PutObjectRequest passing the folder name suffixed by /
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(format("%s/%s", prefix, key) + PATH_SEPARATOR)
+                // create meta-data for your folder and set content-length to 0
+                .metadata(ImmutableMap.of(
+                        "Content-Length", "0",
+                        "Content-Type", DIRECTORY_MEDIA_TYPE.toString()))
+                .build();
+        // send request to S3 to create folder
+        s3Client.putObject(putObjectRequest, RequestBody.empty());
+    }
+
+    private void createFile(String bucketName, String prefix, String key)
+    {
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(format("%s/%s", prefix, key))
+                        .build(),
+                RequestBody.empty());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -32,7 +32,6 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.FAIL;
 import static io.trino.plugin.hive.fs.HiveFileIterator.NestedDirectoryPolicy.RECURSE;
-import static java.net.URLDecoder.decode;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.fs.Path.SEPARATOR_CHAR;
 
@@ -46,8 +45,8 @@ public class HiveFileIterator
         FAIL
     }
 
-    private final String pathPrefix;
     private final Table table;
+    private final Location location;
     private final TrinoFileSystem fileSystem;
     private final DirectoryLister directoryLister;
     private final HdfsNamenodeStats namenodeStats;
@@ -62,8 +61,8 @@ public class HiveFileIterator
             HdfsNamenodeStats namenodeStats,
             NestedDirectoryPolicy nestedDirectoryPolicy)
     {
-        this.pathPrefix = location.toString();
         this.table = requireNonNull(table, "table is null");
+        this.location = requireNonNull(location, "location is null");
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
@@ -80,7 +79,7 @@ public class HiveFileIterator
             // Ignore hidden files and directories
             if (nestedDirectoryPolicy == RECURSE) {
                 // Search the full sub-path under the listed prefix for hidden directories
-                if (isHiddenOrWithinHiddenParentDirectory(new Path(status.getPath()), pathPrefix)) {
+                if (isHiddenOrWithinHiddenParentDirectory(Location.of(status.getPath()), location)) {
                     continue;
                 }
             }
@@ -121,9 +120,10 @@ public class HiveFileIterator
     }
 
     @VisibleForTesting
-    static boolean isHiddenOrWithinHiddenParentDirectory(Path path, String prefix)
+    static boolean isHiddenOrWithinHiddenParentDirectory(Location path, Location rootLocation)
     {
-        String pathString = decode(path.toUri().toString());
+        String pathString = path.toString();
+        String prefix = rootLocation.toString();
         checkArgument(pathString.startsWith(prefix), "path %s does not start with prefix %s", pathString, prefix);
         return containsHiddenPathPartAfterIndex(pathString, prefix.endsWith("/") ? prefix.length() : prefix.length() + 1);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/TestCachingDirectoryListerRecursiveFilesOnly.java
@@ -30,6 +30,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.hive.HiveQueryRunner.TPCH_SCHEMA;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -100,9 +101,11 @@ public class TestCachingDirectoryListerRecursiveFilesOnly
     {
         // Create partitioned table with special characters
         assertUpdate("CREATE TABLE recursive_directories_with_special_chars (payload varchar, event_name varchar) WITH (format = 'ORC', partitioned_by = ARRAY['event_name'])");
-        assertUpdate("INSERT INTO recursive_directories_with_special_chars VALUES ('data', 'level1|level2'), ('data', 'level1 | level2')", 2);
+        String values = "VALUES (VARCHAR 'data', VARCHAR 'level1|level2'), ('data', 'level1 | level2'), ('plus sign', 'foo+bar')";
+        assertUpdate("INSERT INTO recursive_directories_with_special_chars " + values, 3);
         // Check that all files can be read
-        assertQuery("SELECT count(*) FROM recursive_directories_with_special_chars", "VALUES (2)");
+        assertThat(query("TABLE recursive_directories_with_special_chars"))
+                .matches(values);
         assertUpdate("DROP TABLE recursive_directories_with_special_chars");
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

AWS S3 allows having keys containing multiple slashes

e.g. : `s3://bucket/schema/table//file`

This test cases exposes the fact that the recursive listing in
Hive does erroneously handle keys containing multiple slashes.

Contains cherry-pick from https://github.com/trinodb/trino/pull/18167

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
