### PR TITLE
Add CachingGroupProviderModule to trino-plugin-toolkit

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.inject.Inject;
+import io.trino.cache.EvictableCacheBuilder;
+import io.trino.plugin.base.group.CachingGroupProviderModule.ForCachingGroupProvider;
+import io.trino.spi.security.GroupProvider;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class CachingGroupProvider
+        implements GroupProvider, GroupCacheInvalidationController
+{
+    private final LoadingCache<String, Set<String>> cache;
+
+    @Inject
+    public CachingGroupProvider(CachingGroupProviderConfig config, @ForCachingGroupProvider GroupProvider delegate)
+    {
+        requireNonNull(delegate, "delegate is null");
+        this.cache = EvictableCacheBuilder.newBuilder()
+                .maximumSize(config.getCacheMaximumSize())
+                .expireAfterWrite(config.getTtl().toMillis(), MILLISECONDS)
+                .shareNothingWhenDisabled()
+                .build(CacheLoader.from(delegate::getGroups));
+    }
+
+    @Override
+    public Set<String> getGroups(String user)
+    {
+        return cache.getUnchecked(user);
+    }
+
+    @Override
+    public void invalidate(String user)
+    {
+        cache.invalidate(user);
+    }
+
+    @Override
+    public void invalidateAll()
+    {
+        cache.invalidateAll();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProviderConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import jakarta.validation.constraints.Min;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class CachingGroupProviderConfig
+{
+    private Duration ttl = new Duration(5, SECONDS);
+    private long cacheMaximumSize = Long.MAX_VALUE;
+
+    public Duration getTtl()
+    {
+        return ttl;
+    }
+
+    @Config("cache.ttl")
+    @ConfigDescription("Determines how long group information will be cached for each user")
+    public CachingGroupProviderConfig setTtl(Duration ttl)
+    {
+        this.ttl = requireNonNull(ttl, "ttl is null");
+        return this;
+    }
+
+    @Min(1)
+    public long getCacheMaximumSize()
+    {
+        return cacheMaximumSize;
+    }
+
+    @Config("cache.maximum-size")
+    @ConfigDescription("Maximum number of users for which groups are stored in the cache")
+    public CachingGroupProviderConfig setCacheMaximumSize(long cacheMaximumSize)
+    {
+        this.cacheMaximumSize = cacheMaximumSize;
+        return this;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProviderModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/CachingGroupProviderModule.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.inject.Binder;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.spi.security.GroupProvider;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * If added to the list of {@link com.google.inject.Module}s used in initialization of a Guice context in a
+ * {@link io.trino.spi.security.GroupProviderFactory}, it will (almost) automatically add caching capability to the
+ * group provider. Requirements:
+ * <ul>
+ *     <li>The {@link GroupProvider} available in the Guice context must be bound annotated with
+ *     {@link ForCachingGroupProvider} binding annotation</li>
+ * </ul>
+ * The module will make the following configuration options available (to be set in {@code etc/group-provider.properties}:
+ * <ul>
+ *     <li>{@code cache.enabled} - the toggle to enable or disable caching</li>
+ *     <li>{@code cache.ttl} - determines how long group information will be cached for each user</li>
+ *     <li>{@code cache.maximum-size} - maximum number of users for which groups are stored in the cache</li>
+ * </ul>
+ * These properties can optionally have an arbitrary prefix ({@link Builder#withPrefix(String)})
+ * and/or a binding annotation for the resulting binding of {@link GroupProvider} ({@link Builder#withBindingAnnotation(Class)}).
+ * <p>
+ * An additional object of type {@link GroupCacheInvalidationController} will also be bound, with which one can invalidate
+ * all or part of the cache.
+ */
+public class CachingGroupProviderModule
+        extends AbstractConfigurationAwareModule
+{
+    private final Optional<String> prefix;
+    private final Optional<Class<? extends Annotation>> bindingAnnotation;
+
+    private CachingGroupProviderModule(Optional<String> prefix, Optional<Class<? extends Annotation>> bindingAnnotation)
+    {
+        this.prefix = requireNonNull(prefix, "prefix is null");
+        this.bindingAnnotation = requireNonNull(bindingAnnotation, "bindingAnnotation is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(GroupProviderConfig.class, prefix.orElse(null));
+        prefix.ifPresentOrElse(
+                prefix -> install(conditionalModule(
+                        GroupProviderConfig.class,
+                        prefix,
+                        GroupProviderConfig::isCachingEnabled,
+                        new CacheModule(Optional.of(prefix), bindingAnnotation),
+                        new NonCacheModule(bindingAnnotation))),
+                () -> install(conditionalModule(
+                        GroupProviderConfig.class,
+                        GroupProviderConfig::isCachingEnabled,
+                        new CacheModule(Optional.empty(), bindingAnnotation),
+                        new NonCacheModule(bindingAnnotation))));
+    }
+
+    private static class CacheModule
+            implements Module
+    {
+        private final Optional<String> prefix;
+        private final Optional<Class<? extends Annotation>> bindingAnnotation;
+
+        public CacheModule(Optional<String> prefix, Optional<Class<? extends Annotation>> bindingAnnotation)
+        {
+            this.prefix = requireNonNull(prefix, "prefix is null");
+            this.bindingAnnotation = requireNonNull(bindingAnnotation, "bindingAnnotation is null");
+        }
+
+        @Override
+        public void configure(Binder binder)
+        {
+            configBinder(binder).bindConfig(CachingGroupProviderConfig.class, prefix.orElse(null));
+            binder.bind(CachingGroupProvider.class).in(Scopes.SINGLETON);
+            binder.bind(bindingAnnotation
+                            .map(bindingAnnotation -> Key.get(GroupProvider.class, bindingAnnotation))
+                            .orElseGet(() -> Key.get(GroupProvider.class)))
+                    .to(CachingGroupProvider.class)
+                    .in(Scopes.SINGLETON);
+            binder.bind(GroupCacheInvalidationController.class)
+                    .to(CachingGroupProvider.class)
+                    .in(Scopes.SINGLETON);
+        }
+    }
+
+    private static class NonCacheModule
+            implements Module
+    {
+        private final Optional<Class<? extends Annotation>> bindingAnnotation;
+
+        public NonCacheModule(Optional<Class<? extends Annotation>> bindingAnnotation)
+        {
+            this.bindingAnnotation = requireNonNull(bindingAnnotation, "bindingAnnotation is null");
+        }
+
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(bindingAnnotation
+                            .map(bindingAnnotation -> Key.get(GroupProvider.class, bindingAnnotation))
+                            .orElseGet(() -> Key.get(GroupProvider.class)))
+                    .to(Key.get(GroupProvider.class, ForCachingGroupProvider.class))
+                    .in(Scopes.SINGLETON);
+            binder.bind(GroupCacheInvalidationController.class)
+                    .to(NoOpGroupCacheInvalidationController.class)
+                    .in(Scopes.SINGLETON);
+        }
+    }
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    public @interface ForCachingGroupProvider
+    {
+    }
+
+    public static CachingGroupProviderModule create()
+    {
+        return builder().build();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Optional<String> prefix = Optional.empty();
+        private Optional<Class<? extends Annotation>> bindingAnnotation = Optional.empty();
+
+        private Builder() {}
+
+        @CanIgnoreReturnValue
+        public Builder withPrefix(String prefix)
+        {
+            this.prefix = Optional.of(prefix);
+            return this;
+        }
+
+        @CanIgnoreReturnValue
+        public Builder withBindingAnnotation(Class<? extends Annotation> bindingAnnotation)
+        {
+            this.bindingAnnotation = Optional.of(bindingAnnotation);
+            return this;
+        }
+
+        public CachingGroupProviderModule build()
+        {
+            return new CachingGroupProviderModule(prefix, bindingAnnotation);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/GroupCacheInvalidationController.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/GroupCacheInvalidationController.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+public interface GroupCacheInvalidationController
+{
+    void invalidate(String user);
+
+    void invalidateAll();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/GroupProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/GroupProviderConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class GroupProviderConfig
+{
+    private boolean isCachingEnabled;
+
+    public boolean isCachingEnabled()
+    {
+        return isCachingEnabled;
+    }
+
+    @Config("cache.enabled")
+    @ConfigDescription("Enables caching for the group provider")
+    public GroupProviderConfig setCachingEnabled(boolean isCachingEnabled)
+    {
+        this.isCachingEnabled = isCachingEnabled;
+        return this;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/NoOpGroupCacheInvalidationController.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/group/NoOpGroupCacheInvalidationController.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+public class NoOpGroupCacheInvalidationController
+        implements GroupCacheInvalidationController
+{
+    @Override
+    public void invalidate(String user) {}
+
+    @Override
+    public void invalidateAll() {}
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestCachingGroupProvider.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestCachingGroupProvider.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import io.airlift.bootstrap.Bootstrap;
+import io.trino.plugin.base.group.CachingGroupProviderModule.ForCachingGroupProvider;
+import io.trino.spi.security.GroupProvider;
+import io.trino.spi.security.GroupProviderFactory;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestCachingGroupProvider
+{
+    @Test
+    public void testWithOutCaching()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "cache.enabled", "false");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.empty(), Optional.empty()).create(properties);
+
+        innerTestWithOutCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithOutCachingWithBindingAnnotation()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "cache.enabled", "false");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.empty(), Optional.of(ForTesting.class)).create(properties);
+
+        innerTestWithOutCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithOutCachingWithPrefix()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "group-provider.cache.enabled", "false");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.of("group-provider"), Optional.empty()).create(properties);
+
+        innerTestWithOutCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithOutCachingWithPrefixWithBindingAnnotation()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "group-provider.cache.enabled", "false");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.of("group-provider"), Optional.of(ForTesting.class)).create(properties);
+
+        innerTestWithOutCaching(countingGroupProvider, groupProvider);
+    }
+
+    private static void innerTestWithOutCaching(CountingGroupProvider countingGroupProvider, TestingGroupProvider groupProvider)
+    {
+        assertThat(countingGroupProvider.getCount()).isEqualTo(0);
+
+        // first batch
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(1);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(2);
+
+        // second batch
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(3);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(4);
+
+        // invalidate user
+        groupProvider.invalidate("testUser1");
+        // no effect:
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(5);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(6);
+
+        // invalidate all
+        groupProvider.invalidateAll();
+        // no effect:
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(7);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(8);
+    }
+
+    @Test
+    public void testWithCaching()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "cache.enabled", "true",
+                "cache.ttl", "1 h");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.empty(), Optional.empty()).create(properties);
+
+        innerTestWithCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithCachingWithBindingAnnotation()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "cache.enabled", "true",
+                "cache.ttl", "1 h");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.empty(), Optional.of(ForTesting.class)).create(properties);
+
+        innerTestWithCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithCachingWithPrefix()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "group-provider.cache.enabled", "true",
+                "group-provider.cache.ttl", "1 h");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.of("group-provider"), Optional.empty()).create(properties);
+
+        innerTestWithCaching(countingGroupProvider, groupProvider);
+    }
+
+    @Test
+    public void testWithCachingWithPrefixWithBindingAnnotation()
+    {
+        CountingGroupProvider countingGroupProvider = new CountingGroupProvider();
+        Map<String, String> properties = ImmutableMap.of(
+                "group-provider.cache.enabled", "true",
+                "group-provider.cache.ttl", "1 h");
+        TestingGroupProvider groupProvider = new TestingGroupProviderFactory(countingGroupProvider, Optional.of("group-provider"), Optional.of(ForTesting.class)).create(properties);
+
+        innerTestWithCaching(countingGroupProvider, groupProvider);
+    }
+
+    private static void innerTestWithCaching(CountingGroupProvider countingGroupProvider, TestingGroupProvider groupProvider)
+    {
+        assertThat(countingGroupProvider.getCount()).isEqualTo(0);
+
+        // first batch
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(1);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(2);
+
+        // second batch is handled by the cache so delegate not invoked
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(2);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(2);
+
+        // invalidate user
+        groupProvider.invalidate("testUser1");
+        // effect on testUser1 only:
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(3);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(3);
+
+        // invalidate all
+        groupProvider.invalidateAll();
+        // effect on both:
+        assertThat(groupProvider.getGroups("testUser1")).containsOnly("test", "testUser1");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(4);
+        assertThat(groupProvider.getGroups("testUser2")).containsOnly("test", "testUser2");
+        assertThat(countingGroupProvider.getCount()).isEqualTo(5);
+    }
+
+    private static class CountingGroupProvider
+            implements GroupProvider
+    {
+        private final AtomicInteger counter = new AtomicInteger(0);
+
+        @Override
+        public Set<String> getGroups(String user)
+        {
+            counter.incrementAndGet();
+            return ImmutableSet.of("test", user);
+        }
+
+        public int getCount()
+        {
+            return counter.get();
+        }
+    }
+
+    private static class TestingGroupProviderFactory
+            implements GroupProviderFactory
+    {
+        private final CountingGroupProvider groupProvider;
+        private final Optional<String> prefix;
+        private final Optional<Class<? extends Annotation>> bindingAnnotation;
+
+        private TestingGroupProviderFactory(CountingGroupProvider groupProvider, Optional<String> prefix, Optional<Class<? extends Annotation>> bindingAnnotation)
+        {
+            this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
+            this.prefix = requireNonNull(prefix, "prefix is null");
+            this.bindingAnnotation = requireNonNull(bindingAnnotation, "bindingAnnotation is null");
+        }
+
+        @Override
+        public String getName()
+        {
+            return "counting";
+        }
+
+        @Override
+        public TestingGroupProvider create(Map<String, String> config)
+        {
+            CachingGroupProviderModule.Builder moduleBuilder = CachingGroupProviderModule.builder();
+            prefix.ifPresent(moduleBuilder::withPrefix);
+            bindingAnnotation.ifPresent(moduleBuilder::withBindingAnnotation);
+
+            Bootstrap app = new Bootstrap(
+                    moduleBuilder.build(),
+                    binder -> {
+                        binder.bind(Key.get(GroupProvider.class, ForCachingGroupProvider.class))
+                                .toInstance(groupProvider);
+                        bindingAnnotation.ifPresent(bindingAnnotation ->
+                                binder.bind(GroupProvider.class).to(Key.get(GroupProvider.class, bindingAnnotation)));
+                        binder.bind(TestingGroupProvider.class);
+                    });
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+
+            return injector.getInstance(TestingGroupProvider.class);
+        }
+    }
+
+    private static class TestingGroupProvider
+            implements GroupProvider, GroupCacheInvalidationController
+    {
+        private final GroupProvider delegate;
+        private final GroupCacheInvalidationController invalidationController;
+
+        @Inject
+        public TestingGroupProvider(GroupProvider delegate, GroupCacheInvalidationController invalidationController)
+        {
+            this.delegate = requireNonNull(delegate, "delegate");
+            this.invalidationController = requireNonNull(invalidationController, "invalidationController is null");
+        }
+
+        @Override
+        public Set<String> getGroups(String user)
+        {
+            return delegate.getGroups(user);
+        }
+
+        @Override
+        public void invalidate(String user)
+        {
+            invalidationController.invalidate(user);
+        }
+
+        @Override
+        public void invalidateAll()
+        {
+            invalidationController.invalidateAll();
+        }
+    }
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    private @interface ForTesting
+    {
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestCachingGroupProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestCachingGroupProviderConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestCachingGroupProviderConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(CachingGroupProviderConfig.class)
+                .setTtl(new Duration(5, SECONDS))
+                .setCacheMaximumSize(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.of(
+                "cache.ttl", "10 s",
+                "cache.maximum-size", "10");
+
+        CachingGroupProviderConfig expected = new CachingGroupProviderConfig()
+                .setTtl(new Duration(10, SECONDS))
+                .setCacheMaximumSize(10);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestGroupProviderConfig.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/group/TestGroupProviderConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.group;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestGroupProviderConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(GroupProviderConfig.class)
+                .setCachingEnabled(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.of("cache.enabled", "true");
+
+        GroupProviderConfig expected = new GroupProviderConfig()
+                .setCachingEnabled(true);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderFactory.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderFactory.java
@@ -15,6 +15,7 @@ package io.trino.plugin.ldapgroup;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
+import io.trino.plugin.base.group.CachingGroupProviderModule;
 import io.trino.plugin.base.ldap.LdapClientModule;
 import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.GroupProviderFactory;
@@ -38,6 +39,7 @@ public class LdapGroupProviderFactory
         requireNonNull(requiredConfig, "config is null");
 
         Bootstrap app = new Bootstrap(
+                CachingGroupProviderModule.create(),
                 new LdapClientModule(),
                 new LdapGroupProviderModule());
 

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
@@ -36,7 +36,7 @@ public class LdapGroupProviderModule
                     innerBinder.bind(GroupProvider.class).to(LdapFilteringGroupProvider.class).in(Scopes.SINGLETON);
                 },
                 innerBinder -> {
-                    configBinder(binder).bindConfig(LdapSingleQueryGroupProviderConfig.class);
+                    configBinder(innerBinder).bindConfig(LdapSingleQueryGroupProviderConfig.class);
                     innerBinder.bind(GroupProvider.class).to(LdapSingleQueryGroupProvider.class).in(Scopes.SINGLETON);
                 }));
     }

--- a/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
+++ b/plugin/trino-ldap-group-provider/src/main/java/io/trino/plugin/ldapgroup/LdapGroupProviderModule.java
@@ -16,6 +16,7 @@ package io.trino.plugin.ldapgroup;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.base.group.CachingGroupProviderModule.ForCachingGroupProvider;
 import io.trino.spi.security.GroupProvider;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
@@ -33,11 +34,11 @@ public class LdapGroupProviderModule
                 LdapGroupProviderConfig::getLdapUseGroupFilter,
                 innerBinder -> {
                     configBinder(innerBinder).bindConfig(LdapFilteringGroupProviderConfig.class);
-                    innerBinder.bind(GroupProvider.class).to(LdapFilteringGroupProvider.class).in(Scopes.SINGLETON);
+                    innerBinder.bind(GroupProvider.class).annotatedWith(ForCachingGroupProvider.class).to(LdapFilteringGroupProvider.class).in(Scopes.SINGLETON);
                 },
                 innerBinder -> {
                     configBinder(innerBinder).bindConfig(LdapSingleQueryGroupProviderConfig.class);
-                    innerBinder.bind(GroupProvider.class).to(LdapSingleQueryGroupProvider.class).in(Scopes.SINGLETON);
+                    innerBinder.bind(GroupProvider.class).annotatedWith(ForCachingGroupProvider.class).to(LdapSingleQueryGroupProvider.class).in(Scopes.SINGLETON);
                 }));
     }
 }

--- a/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
+++ b/plugin/trino-ldap-group-provider/src/test/java/io/trino/plugin/ldapgroup/TestLdapGroupProviderIntegration.java
@@ -50,17 +50,36 @@ public class TestLdapGroupProviderIntegration
 
     static {
         ConfigBuilder withMemberOf = builder -> {
+            builder.put("cache.enabled", "false");
             builder.put("ldap.user-member-of-attribute", "memberOf");
             return builder;
         };
 
         ConfigBuilder withGroupFilter = builder -> {
+            builder.put("cache.enabled", "false");
             builder.put("ldap.use-group-filter", "true");
             builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
             return builder;
         };
 
-        CONFIG_BUILDERS = ImmutableList.of(withMemberOf, withGroupFilter);
+        ConfigBuilder cacheEnabledWithMemberOf = builder -> {
+            builder.put("cache.enabled", "true");
+            builder.put("cache.ttl", "5s");
+            builder.put("cache.maximum-size", "10");
+            builder.put("ldap.user-member-of-attribute", "memberOf");
+            return builder;
+        };
+
+        ConfigBuilder cacheEnabledWithGroupFilter = builder -> {
+            builder.put("cache.enabled", "true");
+            builder.put("cache.ttl", "5s");
+            builder.put("cache.maximum-size", "10");
+            builder.put("ldap.use-group-filter", "true");
+            builder.put("ldap.group-base-dn", "ou=groups,dc=trino,dc=testldap,dc=com");
+            return builder;
+        };
+
+        CONFIG_BUILDERS = ImmutableList.of(withMemberOf, withGroupFilter, cacheEnabledWithMemberOf, cacheEnabledWithGroupFilter);
     }
 
     private Closer closer;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If added to the list of `Module`s used in initialization of a Guice context in a `GroupProviderFactory`, it will (almost) automatically add caching capability to the group provider. Requirements:

* The `GroupProvider` available in the Guice context must be bound annotated with `@ForCachingGroupProvider` binding annotation

The module will make the following configuration options available (to be set in `etc/group-provider.properties`:

* `<prefix>.cache.enabled` - the toggle to enable or disable caching
* `<prefix>.cache.ttl` - determines how long group information will be cached for each user
* `<prefix>.cache.maximum-size` - maximum number of users for which groups are stored in the cache

Where `<prefix>` is optional and configurable. Also configurable is a binding annotation with which the "output" `GroupProvider` interface will be bound (useful in some cases when the module is not strictly isolated).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Security
* Introduce option to enable caching of group information retrieved from group providers.
```