### PR TITLE
Ensure final task info set on worker node failure

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -960,7 +960,7 @@ public final class HttpRemoteTask
                     // if cleanup operation has not at least started task termination, mark the task failed
                     TaskState taskState = getTaskInfo().getTaskStatus().getState();
                     if (!taskState.isTerminatingOrDone()) {
-                        fatalUnacknowledgedFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), format("Unable to %s task at %s, last known state was: %s", action, request.getUri(), taskState)));
+                        fatalAsyncCleanupFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), format("Unable to %s task at %s, last known state was: %s", action, request.getUri(), taskState)));
                     }
                 }
             }
@@ -977,7 +977,7 @@ public final class HttpRemoteTask
                 if (t instanceof RejectedExecutionException && httpClient.isClosed()) {
                     String message = format("Unable to %s task at %s. HTTP client is closed.", action, request.getUri());
                     logError(t, message);
-                    fatalUnacknowledgedFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), message));
+                    fatalAsyncCleanupFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), message));
                     return;
                 }
 
@@ -985,7 +985,7 @@ public final class HttpRemoteTask
                 if (cleanupBackoff.failure()) {
                     String message = format("Unable to %s task at %s. Back off depleted.", action, request.getUri());
                     logError(t, message);
-                    fatalUnacknowledgedFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), message));
+                    fatalAsyncCleanupFailure(new TrinoTransportException(REMOTE_TASK_ERROR, fromUri(request.getUri()), message));
                     return;
                 }
 
@@ -996,6 +996,29 @@ public final class HttpRemoteTask
                 }
                 else {
                     errorScheduledExecutor.schedule(() -> doScheduleAsyncCleanupRequest(cleanupBackoff, request, action), delayNanos, NANOSECONDS);
+                }
+            }
+
+            private void fatalAsyncCleanupFailure(TrinoTransportException cause)
+            {
+                synchronized (HttpRemoteTask.this) {
+                    try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
+                        TaskStatus taskStatus = getTaskStatus();
+                        if (taskStatus.getState().isDone()) {
+                            log.warn("Task %s already in terminal state %s; cannot overwrite with FAILED due to %s",
+                                    taskStatus.getTaskId(),
+                                    taskStatus.getState(),
+                                    cause);
+                        }
+                        else {
+                            List<ExecutionFailureInfo> failures = ImmutableList.<ExecutionFailureInfo>builderWithExpectedSize(taskStatus.getFailures().size() + 1)
+                                    .add(toFailure(cause))
+                                    .addAll(taskStatus.getFailures())
+                                    .build();
+                            taskStatus = failWith(taskStatus, FAILED, failures);
+                        }
+                        updateTaskInfo(getTaskInfo().withTaskStatus(taskStatus));
+                    }
                 }
             }
         }, executor);


### PR DESCRIPTION
With current logic in HttpRemoteTask.fatalUnacknowledgedFailure() it was possible that we only set `FAILED` status in TaskStatus in ContinuesTaskStatusFetcher but TaskInfo in TaskInfoFetcher will not be updated.

It happened when we entered the `else` branch for
`(cause instanceof TrinoTransportException)` condition. The `TaskInfoFetcher.taskInfo` was not updated then. Subsequent calls to `fatalUnacknowledgedFailure` where then no-op due to `!taskStatus.getState().isDone()` condition at the top. While at this time `TaskInfoFetcher` may no longer be able to update task Info (worker node can be gone already) and it will remain stale forever.

It resulted in a split brain scenario that parts of the system observe Task as failed while others (those depending on TaskInfo) reported that task is some other state (I observed either ABORTING or FAILING, but other people reported RUNNING too).

It was mostly visible in UI which reported task information based on TaskInfo.


**The bigger problem which it caused was that it cased queries to hang
forever. The reason for that is that
EventDrivenFaultTolerantQueryScheduler uses finalTaskInfo delivery as a
trigger for remote task completion logic.**

Investigated it together with @findepi 

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Fix bug where queries run with `task.retry-policy=TASK` could to hang in presence of worker node failures. ({issue}`18175 `)
```
