### PR TITLE
Support updates when Delta table location has two trailing slashes

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -179,6 +179,20 @@ public final class Location
     }
 
     /**
+     * Returns a new location with the same parent directory as the current location,
+     * but with the filename corresponding to the specified name.
+     * The location must be a valid file location.
+     */
+    public Location sibling(String name)
+    {
+        requireNonNull(name, "name is null");
+        checkArgument(!name.isEmpty(), "name is empty");
+        verifyValidFileLocation();
+
+        return this.withPath(location.substring(0, location.lastIndexOf('/') + 1) + name, path.substring(0, path.lastIndexOf('/') + 1) + name);
+    }
+
+    /**
      * Creates a new location with all characters removed after the last slash in the path.
      * This should only be used once, as recursive calls for blob paths may lead to incorrect results.
      *

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -363,6 +363,49 @@ class TestLocation
     }
 
     @Test
+    void testSibling()
+    {
+        assertSiblingFailure("/", "sibling", IllegalStateException.class, "File location must contain a path: /");
+        assertSiblingFailure("//", "sibling", IllegalStateException.class, "File location must contain a path: /");
+        assertSiblingFailure("file:/", "sibling", IllegalStateException.class, "File location must contain a path: file:/");
+        assertSiblingFailure("file://", "sibling", IllegalStateException.class, "File location must contain a path: file://");
+        assertSiblingFailure("file:///", "sibling", IllegalStateException.class, "File location must contain a path: file:///");
+        assertSiblingFailure("s3://bucket/", "sibling", IllegalStateException.class, "File location must contain a path: s3://bucket/");
+        assertSiblingFailure("scheme://userInfo@host/path/", "sibling", IllegalStateException.class, "File location cannot end with '/'");
+
+        assertSiblingFailure("scheme://userInfo@host/path/filename", null, NullPointerException.class, "name is null");
+        assertSiblingFailure("scheme://userInfo@host/path/filename", "", IllegalArgumentException.class, "name is empty");
+
+        assertSibling("scheme://userInfo@host/path/name", "sibling", "scheme://userInfo@host/path/sibling");
+        assertSibling("scheme://userInfo@host/path//name", "sibling", "scheme://userInfo@host/path//sibling");
+        assertSibling("scheme://userInfo@host/path///name", "sibling", "scheme://userInfo@host/path///sibling");
+        assertSibling("scheme://userInfo@host/level1/level2/name", "sibling", "scheme://userInfo@host/level1/level2/sibling");
+        assertSibling("scheme://userInfo@host/level1//level2/name", "sibling", "scheme://userInfo@host/level1//level2/sibling");
+
+        assertSibling("file:/path/name", "sibling", "file:/path/sibling");
+        assertSibling("s3://bucket/directory/filename with spaces", "sibling", "s3://bucket/directory/sibling");
+        assertSibling("/path/name", "sibling", "/path/sibling");
+        assertSibling("/name", "sibling", "/sibling");
+    }
+
+    private static void assertSiblingFailure(String locationString, String siblingName, Class<?> exceptionClass, String exceptionMessage)
+    {
+        assertThatThrownBy(() -> Location.of(locationString).sibling(siblingName))
+                .isInstanceOf(exceptionClass)
+                .hasMessageContaining(exceptionMessage);
+    }
+
+    private static void assertSibling(String locationString, String siblingName, String expectedLocationString)
+    {
+        // fileName method only works with valid file locations
+        Location location = Location.of(locationString);
+        location.verifyValidFileLocation();
+        Location siblingLocation = location.sibling(siblingName);
+
+        assertLocation(siblingLocation, Location.of(expectedLocationString));
+    }
+
+    @Test
     void testParentDirectory()
     {
         assertParentDirectoryFailure("scheme:/", "File location must contain a path: scheme:/");

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -330,7 +330,7 @@ public class DeltaLakeMergeSink
             Location sourceLocation = Location.of(sourcePath);
             String sourceRelativePath = relativePath(tablePath, sourcePath);
 
-            Location targetLocation = sourceLocation.parentDirectory().appendPath(session.getQueryId() + "_" + randomUUID());
+            Location targetLocation = sourceLocation.sibling(session.getQueryId() + "_" + randomUUID());
             String targetRelativePath = relativePath(tablePath, targetLocation.toString());
             FileWriter fileWriter = createParquetFileWriter(targetLocation, dataColumns);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
@@ -79,7 +79,7 @@ public class S3NativeTransactionLogSynchronizer
     public void write(ConnectorSession session, String clusterId, Location newLogEntryPath, byte[] entryContents)
     {
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        Location locksDirectory = newLogEntryPath.parentDirectory().appendPath(LOCK_DIRECTORY);
+        Location locksDirectory = newLogEntryPath.sibling(LOCK_DIRECTORY);
         String newEntryFilename = newLogEntryPath.fileName();
         Optional<LockInfo> myLockInfo = Optional.empty();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OriginalFilesUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OriginalFilesUtils.java
@@ -54,7 +54,7 @@ public final class OriginalFilesUtils
         long rowCount = 0;
         for (OriginalFileInfo originalFileInfo : originalFileInfos) {
             if (originalFileInfo.getName().compareTo(splitPath.fileName()) < 0) {
-                Location path = splitPath.parentDirectory().appendPath(originalFileInfo.getName());
+                Location path = splitPath.sibling(originalFileInfo.getName());
                 TrinoInputFile inputFile = fileSystemFactory.create(identity)
                         .newInputFile(path, originalFileInfo.getFileSize());
                 rowCount += getRowsInFile(inputFile, options, stats);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Alternative approach to https://github.com/trinodb/trino/pull/18155 for obtaining a sibling file location.

Fixes https://github.com/trinodb/trino/issues/17966

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
