### PR TITLE
Reduce Hive file system listing

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
@@ -13,6 +13,7 @@
  */
 package io.trino.filesystem.hdfs;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.stats.TimeStat;
 import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
@@ -48,6 +49,13 @@ import static java.util.stream.Collectors.toList;
 class HdfsFileSystem
         implements TrinoFileSystem
 {
+    private static final Map<String, Boolean> KNOWN_HIERARCHICAL_FILESYSTEMS = ImmutableMap.<String, Boolean>builder()
+            .put("s3", false)
+            .put("s3a", false)
+            .put("s3n", false)
+            .put("hdfs", true)
+            .buildOrThrow();
+
     private final HdfsEnvironment environment;
     private final HdfsContext context;
     private final TrinoHdfsFileSystemStats stats;
@@ -224,6 +232,11 @@ class HdfsFileSystem
 
     private boolean hierarchical(FileSystem fileSystem, Location rootLocation)
     {
+        Boolean knownResult = KNOWN_HIERARCHICAL_FILESYSTEMS.get(fileSystem.getScheme());
+        if (knownResult != null) {
+            return knownResult;
+        }
+
         Boolean cachedResult = hierarchicalFileSystemCache.get(fileSystem);
         if (cachedResult != null) {
             return cachedResult;


### PR DESCRIPTION
## Description

Reduce the number of times Hive needs to call the file system listing API when using common file systems.

## Additional context and related issues

Relates to: https://github.com/trinodb/trino/pull/17323

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: