### PR TITLE
Use UUID instead of parent directory name in computing the file prefix

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -587,7 +587,7 @@ public class HiveWriterFactory
             if (sortedWritingTempStagingPathEnabled) {
                 String stagingPath = sortedWritingTempStagingPath.replace("${USER}", session.getIdentity().getUser());
                 Location tempPrefix = setSchemeToFileIfAbsent(Location.of(stagingPath));
-                tempFilePath = tempPrefix.appendPath(".tmp-sort.%s.%s".formatted(path.parentDirectory().fileName(), path.fileName()));
+                tempFilePath = tempPrefix.appendPath(".tmp-sort.%s.%s".formatted(UUID.randomUUID().toString(), path.fileName()));
             }
             else {
                 tempFilePath = path.parentDirectory().appendPath(".tmp-sort." + path.fileName());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In a table with multiple partition columns, it may happen that there exists a file with the same name and the same value for the least significant partition column which would lead to having the same temporary file name prefix.

Discovered while working on https://github.com/trinodb/trino/pull/18178


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
