### PR TITLE
Add opentracing to DistributedQueryRunner

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -13,6 +13,7 @@
  */
 package io.trino.testing.containers;
 
+import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
@@ -20,6 +21,7 @@ import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
 import io.airlift.log.Logger;
 import io.trino.testing.ResourcePresence;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -111,6 +113,16 @@ public abstract class BaseTestContainer
                                 // and mounted from there.
                                 .getResolvedPath()),
                 dockerPath);
+    }
+
+    protected void mountDirectory(String hostPath, String dockerPath)
+    {
+        container.addFileSystemBind(hostPath, dockerPath, BindMode.READ_WRITE);
+    }
+
+    protected void withCreateContainerModifier(Consumer<CreateContainerCmd> modifier)
+    {
+        container.withCreateContainerCmdModifier(modifier);
     }
 
     protected HostAndPort getMappedHostAndPortForExposedPort(int exposedPort)

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/OpenTracingCollector.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/OpenTracingCollector.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.net.UrlEscapers.urlFragmentEscaper;
+
+public class OpenTracingCollector
+        extends BaseTestContainer
+{
+    private static final Path storageDirectory;
+
+    static {
+        try {
+            storageDirectory = Files.createTempDirectory("tracing-collector");
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static final int COLLECTOR_PORT = 4317;
+    private static final int HTTP_PORT = 16686;
+
+    public OpenTracingCollector()
+    {
+        super(
+                "jaegertracing/all-in-one:latest",
+                "opentracing-collector",
+                Set.of(COLLECTOR_PORT, HTTP_PORT),
+                Map.of(),
+                Map.of(
+                    "COLLECTOR_OTLP_ENABLED", "true",
+                    "SPAN_STORAGE_TYPE", "badger", // KV that stores spans to the disk
+                    "GOMAXPROCS", "2"), // limit number of threads used for goroutines
+                Optional.empty(),
+                1);
+
+        withRunCommand(List.of(
+                "--badger.ephemeral=false",
+                "--badger.span-store-ttl=15m",
+                "--badger.directory-key=/badger/data",
+                "--badger.directory-value=/badger/data",
+                "--badger.maintenance-interval=30s"));
+
+        withCreateContainerModifier(command -> command.getHostConfig()
+                .withMemory(2 * 1024 * 1024 * 1024L)); // 1 GB limit
+        mountDirectory(storageDirectory.toString(), "/badger");
+    }
+
+    @Override
+    public void close()
+    {
+        super.close();
+        try (Stream<File> files = Files.walk(storageDirectory)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)) {
+            files.forEach(File::delete);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public URI getExporterEndpoint()
+    {
+        return URI.create("http://" + getMappedHostAndPortForExposedPort(COLLECTOR_PORT));
+    }
+
+    public URI searchForQueryId(String queryId)
+    {
+        String query = "{\"trino.query_id\": \"%s\"}".formatted(queryId);
+        return URI.create("http://%s/search?operation=query&service=trino&tags=%s".formatted(getMappedHostAndPortForExposedPort(HTTP_PORT), urlFragmentEscaper().escape(query)));
+    }
+}

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -120,6 +120,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
This change makes it easier to access tracing information while using `DistributedQueryRunner`-s to work with tests.

Trace search link is printed to the console so it's easier to access trace information directly:

<img width="1591" alt="Screenshot 2023-07-08 at 00 07 15" src="https://github.com/trinodb/trino/assets/66972/0c1cf737-45ba-4cf1-b72d-4ff7fc671f58">

The standard Jeager ui is used:

<img width="1720" alt="Screenshot 2023-07-08 at 00 08 32" src="https://github.com/trinodb/trino/assets/66972/944e647d-d190-4b9b-bd26-a68cb83b90b7">
