### PR TITLE
Add a hive connector property to disable SSL hostname verification

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -451,6 +451,9 @@ properties:
    * - ``hive.metastore.thrift.client.ssl.trust-certificate-password``
      - Password for the trust store.
      -
+   * - ``hive.metastore.thrift.client.ssl.disable-hostname-verification``
+     - Disable Hostname Verification when SSL is enabled.
+     -
    * - ``hive.metastore.service.principal``
      - The Kerberos principal of the Hive metastore service.
      -

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -45,6 +45,7 @@ public class ThriftMetastoreConfig
     private Duration maxWaitForTransactionLock = new Duration(10, TimeUnit.MINUTES);
 
     private boolean tlsEnabled;
+    private boolean disableHostNameVerification;
     private File keystorePath;
     private String keystorePassword;
     private File truststorePath;
@@ -237,6 +238,19 @@ public class ThriftMetastoreConfig
     public ThriftMetastoreConfig setTlsEnabled(boolean tlsEnabled)
     {
         this.tlsEnabled = tlsEnabled;
+        return this;
+    }
+
+    public boolean isDisableHostNameVerification()
+    {
+        return disableHostNameVerification;
+    }
+
+    @Config("hive.metastore.thrift.client.ssl.disable-hostname-verification")
+    @ConfigDescription("Whether TLS Hostname verification is enabled")
+    public ThriftMetastoreConfig setDisableHostNameVerification(boolean disableHostNameVerification)
+    {
+        this.disableHostNameVerification = disableHostNameVerification;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreConfig.java
@@ -56,7 +56,8 @@ public class TestThriftMetastoreConfig
                 .setDeleteFilesOnDrop(false)
                 .setMaxWaitForTransactionLock(new Duration(10, MINUTES))
                 .setAssumeCanonicalPartitionKeys(false)
-                .setWriteStatisticsThreads(20));
+                .setWriteStatisticsThreads(20)
+                .setDisableHostNameVerification(false));
     }
 
     @Test
@@ -87,6 +88,7 @@ public class TestThriftMetastoreConfig
                 .put("hive.metastore.thrift.write-statistics-threads", "10")
                 .put("hive.metastore.thrift.assume-canonical-partition-keys", "true")
                 .put("hive.metastore.thrift.use-spark-table-statistics-fallback", "false")
+                .put("hive.metastore.thrift.client.ssl.disable-hostname-verification", "true")
                 .buildOrThrow();
 
         ThriftMetastoreConfig expected = new ThriftMetastoreConfig()
@@ -109,7 +111,8 @@ public class TestThriftMetastoreConfig
                 .setMaxWaitForTransactionLock(new Duration(5, MINUTES))
                 .setAssumeCanonicalPartitionKeys(true)
                 .setWriteStatisticsThreads(10)
-                .setUseSparkTableStatisticsFallback(false);
+                .setUseSparkTableStatisticsFallback(false)
+                .setDisableHostNameVerification(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Introduces a new flag `hive.metastore.thrift.client.ssl.disable-hostname-verification` which allows us to use SSL without verifying hostname. This makes it easier to run Trino in test environments that use self-signed certificates with TLS enabled.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The current patch solves the issue for the binary thrift protocol.
A [new PR currently in review](https://github.com/trinodb/trino/pull/17925) adds support for HTTP thrift protocol. We have a tested and ready patch for the same, which we can subsequently follow up with, once this patch is merged (assuming this one makes sense to take up).


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
