### PR TITLE
Throw exceptions when pinot grpc query incomplete

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotGrpcDataFetcher.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotGrpcDataFetcher.java
@@ -25,6 +25,7 @@ import io.trino.plugin.pinot.query.PinotProxyGrpcRequestBuilder;
 import io.trino.spi.connector.ConnectorSession;
 import jakarta.annotation.PreDestroy;
 import org.apache.pinot.common.config.GrpcConfig;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
@@ -40,7 +41,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.pinot.PinotErrorCode.PINOT_EXCEPTION;
 import static java.lang.Boolean.FALSE;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.pinot.common.config.GrpcConfig.CONFIG_MAX_INBOUND_MESSAGE_BYTES_SIZE;
 import static org.apache.pinot.common.config.GrpcConfig.CONFIG_USE_PLAIN_TEXT;
@@ -254,17 +258,19 @@ public class PinotGrpcDataFetcher
                 grpcRequestBuilder.setHostName(mappedHostAndPort.getHost()).setPort(grpcPort);
             }
             Server.ServerRequest serverRequest = grpcRequestBuilder.build();
-            return new ResponseIterator(client.submit(serverRequest));
+            return new ResponseIterator(client.submit(serverRequest), query);
         }
 
         public static class ResponseIterator
                 extends AbstractIterator<PinotDataTableWithSize>
         {
             private final Iterator<Server.ServerResponse> responseIterator;
+            private final String query;
 
-            public ResponseIterator(Iterator<Server.ServerResponse> responseIterator)
+            public ResponseIterator(Iterator<Server.ServerResponse> responseIterator, String query)
             {
                 this.responseIterator = requireNonNull(responseIterator, "responseIterator is null");
+                this.query = requireNonNull(query, "query is null");
             }
 
             @Override
@@ -279,12 +285,22 @@ public class PinotGrpcDataFetcher
                     return endOfData();
                 }
                 ByteBuffer buffer = response.getPayload().asReadOnlyByteBuffer();
+                DataTable dataTable;
                 try {
-                    return new PinotDataTableWithSize(DataTableFactory.getDataTable(buffer), buffer.remaining());
+                    dataTable = DataTableFactory.getDataTable(buffer);
                 }
                 catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
+                if (!dataTable.getExceptions().isEmpty()) {
+                    List<String> exceptions = dataTable.getExceptions().entrySet().stream()
+                            .map(entry -> format("Error code: %d Error message: %s", entry.getKey(), entry.getValue()))
+                            .collect(toImmutableList());
+
+                    throw new PinotException(PINOT_EXCEPTION, Optional.of(query), format("Encountered %d exceptions: %s", exceptions.size(), exceptions));
+                }
+
+                return new PinotDataTableWithSize(dataTable, buffer.remaining());
             }
         }
     }


### PR DESCRIPTION
bugfix fro trino-pinot connector
We maintain several Pinot Clusters. And some of clients use Trino as query engine due to the limitation of pinot (join or sub-query). And Trino Cluster enabled grpc to increase the speed of fetching data. But in some scenarios, some of clients report some incidents. Although the query is successful, They still couldn't fetch completed query result. We found some error log s about trino grpc that indicates some of servers didn't give the completed result. So we change trino codes to report error when pinot query result comes with exceptions, such timetoutexception.
So it can notify clients query result uncompleted which would drive clients to query again.
Please trino team help me to review.