### PR TITLE
Support files with locations ending with whitespace

### DIFF
--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -63,8 +63,11 @@ public abstract class AbstractTestS3FileSystem
         fileSystemFactory = null;
     }
 
+    /**
+     * Tests same things as {@link #testFileWithTrailingWhitespace()} but with setup and assertions using {@link S3Client}.
+     */
     @Test
-    public void testFileWithTrailingWhitespace()
+    public void testFileWithTrailingWhitespaceAgainstNativeClient()
             throws IOException
     {
         try (S3Client s3Client = createS3Client()) {

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -13,16 +13,30 @@
  */
 package io.trino.filesystem.s3;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
 import io.airlift.log.Logging;
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.FileEntry;
+import io.trino.filesystem.FileIterator;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
 import io.trino.spi.security.ConnectorIdentity;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractTestS3FileSystem
@@ -47,6 +61,50 @@ public abstract class AbstractTestS3FileSystem
         fileSystem = null;
         fileSystemFactory.destroy();
         fileSystemFactory = null;
+    }
+
+    @Test
+    public void testFileWithTrailingWhitespace()
+            throws IOException
+    {
+        try (S3Client s3Client = createS3Client()) {
+            String key = "foo/bar with whitespace ";
+            byte[] contents = "abc foo bar".getBytes(UTF_8);
+            s3Client.putObject(
+                    request -> request.bucket(bucket()).key(key),
+                    RequestBody.fromBytes(contents.clone()));
+            try {
+                // Verify listing
+                List<FileEntry> listing = toList(fileSystem.listFiles(getRootLocation().appendPath("foo")));
+                assertThat(listing).hasSize(1);
+                FileEntry fileEntry = getOnlyElement(listing);
+                assertThat(fileEntry.location()).isEqualTo(getRootLocation().appendPath(key));
+                assertThat(fileEntry.length()).isEqualTo(contents.length);
+
+                // Verify reading
+                TrinoInputFile inputFile = fileSystem.newInputFile(fileEntry.location());
+                assertThat(inputFile.exists()).as("exists").isTrue();
+                try (TrinoInputStream inputStream = inputFile.newStream()) {
+                    byte[] bytes = ByteStreams.toByteArray(inputStream);
+                    assertThat(bytes).isEqualTo(contents);
+                }
+
+                // Verify writing
+                byte[] newContents = "bar bar baz new content".getBytes(UTF_8);
+                try (OutputStream outputStream = fileSystem.newOutputFile(fileEntry.location()).createOrOverwrite()) {
+                    outputStream.write(newContents.clone());
+                }
+                assertThat(s3Client.getObjectAsBytes(request -> request.bucket(bucket()).key(key)).asByteArray())
+                        .isEqualTo(newContents);
+
+                // Verify deleting
+                fileSystem.deleteFile(fileEntry.location());
+                assertThat(inputFile.exists()).as("exists after delete").isFalse();
+            }
+            finally {
+                s3Client.deleteObject(delete -> delete.bucket(bucket()).key(key));
+            }
+        }
     }
 
     @Override
@@ -103,4 +161,14 @@ public abstract class AbstractTestS3FileSystem
     protected abstract S3FileSystemFactory createS3FileSystemFactory();
 
     protected abstract S3Client createS3Client();
+
+    protected List<FileEntry> toList(FileIterator fileIterator)
+            throws IOException
+    {
+        ImmutableList.Builder<FileEntry> list = ImmutableList.builder();
+        while (fileIterator.hasNext()) {
+            list.add(fileIterator.next());
+        }
+        return list.build();
+    }
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Location.java
@@ -23,7 +23,6 @@ import java.util.OptionalInt;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getLast;
-import static java.lang.Character.isWhitespace;
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
@@ -266,7 +265,7 @@ public final class Location
     }
 
     /**
-     * Verifies the location is valid for a file reference.  Specifically, the path must not be empty, must not end with a slash or whitespace.
+     * Verifies the location is valid for a file reference.  Specifically, the path must not be empty and must not end with a slash.
      *
      * @throws IllegalStateException if the location is not a valid file location
      */
@@ -277,8 +276,6 @@ public final class Location
         checkState(!path.isEmpty() && !path.equals("/"), "File location must contain a path: %s", location);
         // file path cannot end with a slash
         checkState(!path.endsWith("/"), "File location cannot end with '/': %s", location);
-        // file path cannot end with whitespace
-        checkState(!isWhitespace(path.charAt(path.length() - 1)), "File location cannot end with whitespace: %s", location);
     }
 
     @Override

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -101,13 +101,6 @@ public abstract class AbstractTestTrinoFileSystem
         assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo/")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(createLocation("foo/").toString());
-        // an input file location cannot end with whitespace
-        assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo ")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo\t")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
 
         try (TempBlob tempBlob = randomBlobLocation("inputFileMetadata")) {
             TrinoInputFile inputFile = getFileSystem().newInputFile(tempBlob.location());
@@ -152,13 +145,6 @@ public abstract class AbstractTestTrinoFileSystem
         assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo/"), 22))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(createLocation("foo/").toString());
-        // an input file location cannot end with whitespace
-        assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo "), 22))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().newInputFile(createLocation("foo\t"), 22))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
 
         try (TempBlob tempBlob = randomBlobLocation("inputFileWithLengthMetadata")) {
             TrinoInputFile inputFile = getFileSystem().newInputFile(tempBlob.location(), 22);
@@ -436,13 +422,6 @@ public abstract class AbstractTestTrinoFileSystem
         assertThatThrownBy(() -> getFileSystem().newOutputFile(createLocation("foo/")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(createLocation("foo/").toString());
-        // an output file location cannot end with whitespace
-        assertThatThrownBy(() -> getFileSystem().newOutputFile(createLocation("foo ")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().newOutputFile(createLocation("foo\t")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
 
         try (TempBlob tempBlob = randomBlobLocation("outputFile")) {
             TrinoOutputFile outputFile = getFileSystem().newOutputFile(tempBlob.location());
@@ -604,13 +583,6 @@ public abstract class AbstractTestTrinoFileSystem
         assertThatThrownBy(() -> getFileSystem().deleteFile(createLocation("foo/")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(createLocation("foo/").toString());
-        // delete file location cannot end with whitespace
-        assertThatThrownBy(() -> getFileSystem().deleteFile(createLocation("foo ")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().deleteFile(createLocation("foo\t")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
 
         try (TempBlob tempBlob = randomBlobLocation("delete")) {
             if (deleteFileFailsIfNotExists()) {
@@ -727,19 +699,6 @@ public abstract class AbstractTestTrinoFileSystem
         assertThatThrownBy(() -> getFileSystem().renameFile(createLocation("file"), createLocation("foo/")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(createLocation("foo/").toString());
-        // rename file locations cannot end with whitespace
-        assertThatThrownBy(() -> getFileSystem().renameFile(createLocation("foo "), createLocation("file")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().renameFile(createLocation("file"), createLocation("foo ")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo ").toString());
-        assertThatThrownBy(() -> getFileSystem().renameFile(createLocation("foo\t"), createLocation("file")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
-        assertThatThrownBy(() -> getFileSystem().renameFile(createLocation("file"), createLocation("foo\t")))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(createLocation("foo\t").toString());
 
         // todo rename to existing file name
         try (TempBlob sourceBlob = randomBlobLocation("renameSource");

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -314,17 +314,18 @@ class TestLocation
     {
         Location.of("scheme://userInfo@host/name").verifyValidFileLocation();
         Location.of("scheme://userInfo@host/path/name").verifyValidFileLocation();
+        Location.of("scheme://userInfo@host/name ").verifyValidFileLocation();
 
         Location.of("/name").verifyValidFileLocation();
         Location.of("/path/name").verifyValidFileLocation();
+        Location.of("/path/name ").verifyValidFileLocation();
+        Location.of("/name ").verifyValidFileLocation();
 
         assertInvalidFileLocation("scheme://userInfo@host/", "File location must contain a path: scheme://userInfo@host/");
         assertInvalidFileLocation("scheme://userInfo@host/name/", "File location cannot end with '/': scheme://userInfo@host/name/");
-        assertInvalidFileLocation("scheme://userInfo@host/name ", "File location cannot end with whitespace: scheme://userInfo@host/name ");
 
         assertInvalidFileLocation("/", "File location must contain a path: /");
         assertInvalidFileLocation("/name/", "File location cannot end with '/': /name/");
-        assertInvalidFileLocation("/name ", "File location cannot end with whitespace: /name ");
     }
 
     private static void assertInvalidFileLocation(String locationString, String expectedErrorMessage)

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocation.java
@@ -124,6 +124,9 @@ class TestLocation
         assertThatThrownBy(() -> Location.of("x"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("No scheme for file system location: x");
+        assertThatThrownBy(() -> Location.of("dev/null"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No scheme for file system location: dev/null");
         assertThatThrownBy(() -> Location.of("scheme://host:invalid/path"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid port in file system location: scheme://host:invalid/path");


### PR DESCRIPTION
Whitespace, and especially trailing whitespace, may have confusing consequences when used in file locations so it's not recommended. However, whitespace, including trailing whitespace, is valid part of file locations and Trino should be able to read such files (objects).

```markdown
# Hive, Iceberg, Delta, Hudi
* Fix query failure when table has a file with location ending with a whitespace. 
```
