### PR TITLE
Remove fall back to legacy type mapping in Redshift

### DIFF
--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -598,8 +598,10 @@ public class RedshiftClient
                         longTimestampWithTimeZoneWriteFunction()));
         }
 
-        // Fall back to default behavior
-        return legacyToColumnMapping(session, type);
+        if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
+            return mapToUnboundedVarchar(type);
+        }
+        return Optional.empty();
     }
 
     private Optional<ColumnMapping> legacyToColumnMapping(ConnectorSession session, JdbcTypeHandle typeHandle)
@@ -718,10 +720,7 @@ public class RedshiftClient
             return WriteMapping.objectMapping("timestamptz", longTimestampWithTimeZoneWriteFunction());
         }
 
-        // Fall back to legacy behavior
-        // TODO we should not fall back to legacy behavior, the mappings should be explicit (the legacyToWriteMapping
-        //  is just a copy of some generic default mappings that used to exist)
-        return legacyToWriteMapping(type);
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
     }
 
     @Override


### PR DESCRIPTION
We should not fall back to legacy behavior,
the mappings should be explicit (the legacyToWriteMapping is just a
copy of some generic default mappings that used to exist)<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:
Remove fall back to legacy type mapping in Redshift.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
