### PR TITLE
Ignore tokens without required principal claim

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -78,9 +78,12 @@ public class OAuth2Authenticator
         if (claims.isEmpty()) {
             return Optional.empty();
         }
-        String principal = (String) claims.get().get(principalField);
-        Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal));
-        builder.withPrincipal(new BasicPrincipal(principal));
+        Optional<String> principal = Optional.ofNullable((String) claims.get().get(principalField));
+        if (principal.isEmpty()) {
+            return Optional.empty();
+        }
+        Identity.Builder builder = Identity.forUser(userMapping.mapUser(principal.get()));
+        builder.withPrincipal(new BasicPrincipal(principal.get()));
         groupsField.flatMap(field -> Optional.ofNullable((List<String>) claims.get().get(field)))
                 .ifPresent(groups -> builder.withGroups(ImmutableSet.copyOf(groups)));
         return Optional.of(builder.build());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
OAuth2 implementation should ignore JWT tokens that does not contain required principal claim as these tokens may be intended for other authentication methods.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix error when using `http-server.authentication.type=oauth2,jwt` and different values for `principal-field`
```
