### PR TITLE
Increase maxLocalExchangeBufferSize to 128MB

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -50,7 +50,7 @@ public class TaskManagerConfig
     private boolean statisticsCpuTimerEnabled = true;
     private DataSize maxPartialAggregationMemoryUsage = DataSize.of(16, Unit.MEGABYTE);
     private DataSize maxPartialTopNMemory = DataSize.of(16, Unit.MEGABYTE);
-    private DataSize maxLocalExchangeBufferSize = DataSize.of(32, Unit.MEGABYTE);
+    private DataSize maxLocalExchangeBufferSize = DataSize.of(128, Unit.MEGABYTE);
     private DataSize maxIndexMemoryUsage = DataSize.of(64, Unit.MEGABYTE);
     private boolean shareIndexLoading;
     private int maxWorkerThreads = Runtime.getRuntime().availableProcessors() * 2;

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -58,7 +58,7 @@ public class TestTaskManagerConfig
                 .setShareIndexLoading(false)
                 .setMaxPartialAggregationMemoryUsage(DataSize.of(16, Unit.MEGABYTE))
                 .setMaxPartialTopNMemory(DataSize.of(16, Unit.MEGABYTE))
-                .setMaxLocalExchangeBufferSize(DataSize.of(32, Unit.MEGABYTE))
+                .setMaxLocalExchangeBufferSize(DataSize.of(128, Unit.MEGABYTE))
                 .setSinkMaxBufferSize(DataSize.of(32, Unit.MEGABYTE))
                 .setSinkMaxBroadcastBufferSize(DataSize.of(200, Unit.MEGABYTE))
                 .setMaxPagePartitioningBufferSize(DataSize.of(32, Unit.MEGABYTE))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -225,6 +225,9 @@ public abstract class BaseHiveConnectorTest
                 // Make weighted split scheduling more conservative to avoid OOMs in test
                 .addHiveProperty("hive.minimum-assigned-split-weight", "0.5")
                 .addHiveProperty("hive.partition-projection-enabled", "true")
+                // This is needed for e2e scale writers test otherwise 50% threshold of
+                // bufferSize won't get exceeded for scaling to happen.
+                .addExtraProperty("task.max-local-exchange-buffer-size", "32MB")
                 .setInitialTables(REQUIRED_TPCH_TABLES)
                 .setTpchBucketedCatalogEnabled(true)
                 .build();


### PR DESCRIPTION
This change will help increase the performance of writes when local exchange is used either due to partitioning the data or scaling the writers.

Benchmarks for unpartitioned write:

Before:ku
Input Size: 6B rows
Time: 4:46 mins
Peak Mem: 59.9GB

After:
Input Size: 6B rows
Time: 3:45 mins
Peak Mem: 61.2GB

Benchmarks for partitioned write:

Before:
Input Size: 3B rows (3 skewed partitions)
Time: 2:33 mins
Peak Mem: 89.8GB

After:
Input Size: 3B rows (3 skewed partitions)
Time: 1:57 mins
Peak Mem: 92.3GB

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
