### PR TITLE
Fix instant file name path retrieval in Hudi Active Timeline

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/model/HudiReplaceCommitMetadata.java
@@ -13,7 +13,9 @@
  */
 package io.trino.plugin.hudi.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
@@ -21,20 +23,24 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class HudiReplaceCommitMetadata
 {
-    private Map<String, List<String>> partitionToReplaceFileIds;
-    private Boolean compacted;
+    private final Map<String, List<String>> partitionToReplaceFileIds;
+    private final boolean compacted;
 
-    // for ser/deser
-    public HudiReplaceCommitMetadata()
+    @JsonCreator
+    public HudiReplaceCommitMetadata(
+            @JsonProperty("partitionToReplaceFileIds") Map<String, List<String>> partitionToReplaceFileIds,
+            @JsonProperty("compacted") boolean compacted)
     {
-        partitionToReplaceFileIds = ImmutableMap.of();
-        compacted = false;
+        this.partitionToReplaceFileIds = ImmutableMap.copyOf(requireNonNull(partitionToReplaceFileIds, "partitionToReplaceFileIds is null"));
+        this.compacted = compacted;
     }
 
     public Map<String, List<String>> getPartitionToReplaceFileIds()
@@ -54,13 +60,14 @@ public class HudiReplaceCommitMetadata
 
         HudiReplaceCommitMetadata that = (HudiReplaceCommitMetadata) o;
 
-        return compacted.equals(that.compacted);
+        return partitionToReplaceFileIds.equals(that.partitionToReplaceFileIds) &&
+               compacted == that.compacted;
     }
 
     @Override
     public int hashCode()
     {
-        return compacted.hashCode();
+        return Objects.hash(partitionToReplaceFileIds, compacted);
     }
 
     public static <T> T fromBytes(byte[] bytes, ObjectMapper objectMapper, Class<T> clazz)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/timeline/HudiActiveTimeline.java
@@ -85,7 +85,11 @@ public class HudiActiveTimeline
 
     private Location getInstantFileNamePath(String fileName)
     {
-        return Location.of(fileName.contains(SCHEMA_COMMIT_ACTION) ? metaClient.getSchemaFolderName() : metaClient.getMetaPath().path()).appendPath(fileName);
+        Location metaPath = metaClient.getMetaPath();
+        if (fileName.contains(SCHEMA_COMMIT_ACTION)) {
+            return metaPath.appendPath(HudiTableMetaClient.SCHEMA_FOLDER_NAME).appendPath(fileName);
+        }
+        return metaPath.appendPath(fileName);
     }
 
     private Optional<byte[]> readDataFromPath(Location detailPath)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When submitting even a very simple query for certain types of Hudi tables (stored on S3) we were constantly receiving the following error:
```
SQL Error [65536]: Query failed (#20230710_093123_00000_bqjz2): No scheme for file system location: path/to/hudi/table/within/bucket/.hoodie
```

Stacktrace taken from the Trino coordinator:
```
...
Caused by: java.lang.IllegalArgumentException: No scheme for file system location: path/to/hudi/table/within/bucket/.hoodie
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218)
	at io.trino.filesystem.Location.of(Location.java:74)
	at io.trino.plugin.hudi.timeline.HudiActiveTimeline.getInstantFileNamePath(HudiActiveTimeline.java:88)
	at io.trino.plugin.hudi.timeline.HudiActiveTimeline.getInstantDetails(HudiActiveTimeline.java:71)
...
```

The issue could be reproduced for this table always, on the other hand, other tables were working just fine. We were using a simple SQL query `select * from test_catalog.test_schema.table limit 1;`, but more complex queries were also failing due to this error.

This PR proposes a solution for the problem by slightly modifying the way Trino handles the Hudi timeline internally. Albeit the solution is simple, I have also added some unit test coverage about the fix. Please let me know your thoughts about it (I needed to include a Java mock library into Maven, this might not be desirable from overall project perspective). 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

At some point during its operation, the Hudi connector tries to update ("reset") its internal state of the Hudi filesystem if "replaced instants" (files) are present on the Hudi timeline. This operation involves accessing the Hudi table's metadata folder on the object store. When this path segment is created, the corresponding `io.trino.filesystem.Location` class is created in a manner that it did not contain the scheme, just the path (see the code change below). This is forbidden in the code of that class (since it has to adhere to the format `scheme://[userInfo@]host[:port][/path]`), therefore the mentioned exception was thrown (refer to the Javadoc of the `Location` class for more information).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
- Fixed reading Hudi tables with replaced instants.
