### PR TITLE
Remove invalid reference to Alluxio Catalog Service docs

### DIFF
--- a/docs/src/main/sphinx/release/release-332.md
+++ b/docs/src/main/sphinx/release/release-332.md
@@ -60,7 +60,7 @@
   `hive.metastore.glue.endpoint-url` configuration property. ({issue}`3239`)
 - Add experimental file system caching. This can be enabled with the `hive.cache.enabled` configuration property. ({issue}`2679`)
 - Support reading files compressed with newer versions of LZO. ({issue}`3209`)
-- Add support for {ref}`alluxio-catalog-service`. ({issue}`2116`)
+- Add support for Alluxio Catalog Service. ({issue}`2116`)
 - Remove unnecessary `hive.metastore.glue.use-instance-credentials` configuration property. ({issue}`3265`)
 - Remove unnecessary `hive.s3.use-instance-credentials` configuration property. ({issue}`3265`)
 - Add flexible {ref}`hive-s3-security-mapping`, allowing for separate credentials


### PR DESCRIPTION
This fixes a build failure introduced by https://github.com/trinodb/trino/pull/18022

## Release notes

(x) This is not user-visible or docs only and no release notes are required.
