### PR TITLE
Verify table information retrieval failure based on exception class

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConnectorSmokeTest.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg.catalog.glue;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
 import com.amazonaws.services.glue.model.DeleteTableRequest;
+import com.amazonaws.services.glue.model.EntityNotFoundException;
 import com.amazonaws.services.glue.model.GetTableRequest;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
@@ -153,8 +154,7 @@ public class TestIcebergGlueCatalogConnectorSmokeTest
                 .withDatabaseName(schemaName)
                 .withName(tableName);
         assertThatThrownBy(() -> glueClient.getTable(getTableRequest))
-                .as("Table in metastore should not exist")
-                .hasMessageMatching(".*Table (.*) not found.*");
+                .isInstanceOf(EntityNotFoundException.class);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Tests related change

Previously the retrieval failure was being verified on the exception message, which made the assertion to fail when that AWS Glue API change the exception message.

### Context

AWS Glue API slightly changed the error message when getting a table which doesn't exist.

https://github.com/trinodb/trino/actions/runs/5514809101/jobs/10055380071


```
Error:    TestIcebergGlueCatalogConnectorSmokeTest>BaseIcebergConnectorSmokeTest.testRegisterTableWithTrailingSpaceInLocation:349->dropTableFromMetastore:157 [Table in metastore should not exist] 
Expecting message:
  "Entity Not Found (Service: AWSGlue; Status Code: 400; Error Code: EntityNotFoundException; Request ID: d1f68d62-e638-42d5-b7b7-08ccd1d23cf6; Proxy: null)"
to match regex:
  ".*Table (.*) not found.*"
but did not.

Throwable that failed the check:

com.amazonaws.services.glue.model.EntityNotFoundException: Entity Not Found (Service: AWSGlue; Status Code: 400; Error Code: EntityNotFoundException; Request ID: d1f68d62-e638-42d5-b7b7-08ccd1d23cf6; Proxy: null)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541)
	at com.amazonaws.services.glue.AWSGlueClient.doInvoke(AWSGlueClient.java:13784)
	at com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:13751)
	at com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:13740)
	at com.amazonaws.services.glue.AWSGlueClient.executeGetTable(AWSGlueClient.java:7946)
	at com.amazonaws.services.glue.AWSGlueClient.getTable(AWSGlueClient.java:7915)
	at io.trino.plugin.iceberg.catalog.glue.TestIcebergGlueCatalogConnectorSmokeTest.lambda$dropTableFromMetastore$2(TestIcebergGlueCatalogConnectorSmokeTest.java:155)
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
