### PR TITLE
Update dependencies

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcFlushMetadataCacheProcedure.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcFlushMetadataCacheProcedure.java
@@ -112,7 +112,7 @@ public class TestJdbcFlushMetadataCacheProcedure
         // H2 stores unquoted names as uppercase. So this query should fail
         assertThatThrownBy(() -> h2SqlExecutor.execute("SELECT * FROM tpch.\"cached_name\""))
                 .hasRootCauseMessage("Table \"cached_name\" not found (candidates are: \"CACHED_NAME\"); SQL statement:\n" +
-                        "SELECT * FROM tpch.\"cached_name\" [42103-214]");
+                        "SELECT * FROM tpch.\"cached_name\" [42103-220]");
         // H2 stores unquoted names as uppercase. So this query should succeed
         h2SqlExecutor.execute("SELECT * FROM tpch.\"CACHED_NAME\"");
 

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
-                <version>26.14.0</version>
+                <version>26.18.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
-                <version>2.1.214</version>
+                <version>2.2.220</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -643,7 +643,7 @@
             <dependency>
                 <groupId>info.picocli</groupId>
                 <artifactId>picocli</artifactId>
-                <version>4.7.3</version>
+                <version>4.7.4</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
             <dependency>
                 <groupId>dev.failsafe</groupId>
                 <artifactId>failsafe</artifactId>
-                <version>3.3.1</version>
+                <version>3.3.2</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1527,7 +1527,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.14.4</version>
+                <version>1.14.5</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.13.0</dep.antlr.version>
         <dep.airlift.version>234</dep.airlift.version>
-        <dep.arrow.version>11.0.0</dep.arrow.version>
+        <dep.arrow.version>12.0.1</dep.arrow.version>
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.493</dep.aws-sdk.version>
@@ -172,7 +172,7 @@
         <dep.casandra.version>4.14.0</dep.casandra.version>
         <dep.minio.version>8.4.5</dep.minio.version>
         <dep.iceberg.version>1.3.0</dep.iceberg.version>
-        <dep.protobuf.version>3.22.2</dep.protobuf.version>
+        <dep.protobuf.version>3.23.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
         <!-- Netty 4.1.94.Final breaks Apache Arrow -->
         <dep.netty.version>4.1.93.Final</dep.netty.version>
@@ -1593,7 +1593,19 @@
 
             <dependency>
                 <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-format</artifactId>
+                <version>${dep.arrow.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
                 <artifactId>arrow-memory-core</artifactId>
+                <version>${dep.arrow.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-memory-netty</artifactId>
                 <version>${dep.arrow.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1546,7 +1546,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.10</version>
+                <version>2.5.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.493</dep.aws-sdk.version>
-        <dep.aws-sdk-v2.version>2.20.89</dep.aws-sdk-v2.version>
+        <dep.aws-sdk-v2.version>2.20.93</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.20</dep.drift.version>
@@ -174,7 +174,8 @@
         <dep.iceberg.version>1.3.0</dep.iceberg.version>
         <dep.protobuf.version>3.22.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <dep.netty.version>4.1.92.Final</dep.netty.version>
+        <!-- Netty 4.1.94.Final breaks Apache Arrow -->
+        <dep.netty.version>4.1.93.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
         <dep.okio.version>3.3.0</dep.okio.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <dep.arrow.version>12.0.1</dep.arrow.version>
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.12.493</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.505</dep.aws-sdk.version>
         <dep.aws-sdk-v2.version>2.20.93</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
             <dependency>
                 <groupId>com.github.oshi</groupId>
                 <artifactId>oshi-core</artifactId>
-                <version>6.4.2</version>
+                <version>6.4.4</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1868,7 +1868,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.10.0</version>
+                <version>1.1.10.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.osgi</groupId>


### PR DESCRIPTION
I want to do it early in the release cycle to detect regressions as fast as possible

The only functional change is that BigQuery arrow implementation no longer requires `--add-opens` JVM flags, which is reflected in the documentation.