### PR TITLE
Disable `testFileSortingWithLargerTable` temporarily in Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -474,7 +474,8 @@ public abstract class BaseIcebergConnectorSmokeTest
         }
     }
 
-    @Test
+    // TODO https://github.com/trinodb/trino/issues/18217 Enable this test after fixing flaky issue
+    @Test(enabled = false)
     public void testFileSortingWithLargerTable()
     {
         // Using a larger table forces buffered data to be written to disk


### PR DESCRIPTION
## Description

Workaround for #18217

## Release notes

(x) This is not user-visible or docs only and no release notes are required.