### PR TITLE
Add Glacier skipping logic to S3FileSystem

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3Context.java
@@ -13,13 +13,14 @@
  */
 package io.trino.filesystem.s3;
 
+import io.trino.filesystem.s3.S3FileSystemConfig.S3ObjectStorageClassFilter;
 import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import software.amazon.awssdk.services.s3.model.RequestPayer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId)
+record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String sseKmsKeyId, S3ObjectStorageClassFilter s3ObjectStorageClassFilter)
 {
     private static final int MIN_PART_SIZE = 5 * 1024 * 1024; // S3 requirement
 
@@ -28,6 +29,7 @@ record S3Context(int partSize, boolean requesterPays, S3SseType sseType, String 
         checkArgument(partSize >= MIN_PART_SIZE, "partSize must be at least %s bytes", MIN_PART_SIZE);
         requireNonNull(sseType, "sseType is null");
         checkArgument((sseType != S3SseType.KMS) || (sseKmsKeyId != null), "sseKmsKeyId is null for SSE-KMS");
+        requireNonNull(s3ObjectStorageClassFilter, "s3ObjectStorageClassFilter is null");
     }
 
     public RequestPayer requestPayer()

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -32,6 +32,13 @@ public class S3FileSystemConfig
         NONE, S3, KMS
     }
 
+    public enum S3ObjectStorageClassFilter
+    {
+        READ_ALL,
+        SKIP_ALL_GLACIER,
+        READ_RESTORED_GLACIER_OBJECTS
+    }
+
     private String awsAccessKey;
     private String awsSecretKey;
     private String endpoint;
@@ -49,6 +56,7 @@ public class S3FileSystemConfig
     private Integer maxConnections;
     private HostAndPort httpProxy;
     private boolean httpProxySecure;
+    private S3ObjectStorageClassFilter s3ObjectStorageClassFilter = S3ObjectStorageClassFilter.READ_ALL;
 
     public String getAwsAccessKey()
     {
@@ -264,6 +272,18 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setHttpProxySecure(boolean httpProxySecure)
     {
         this.httpProxySecure = httpProxySecure;
+        return this;
+    }
+
+    public S3ObjectStorageClassFilter getS3ObjectStorageClassFilter()
+    {
+        return s3ObjectStorageClassFilter;
+    }
+
+    @Config("s3.object-storage-class-filter")
+    public S3FileSystemConfig setS3ObjectStorageClassFilter(S3ObjectStorageClassFilter s3ObjectStorageClassFilter)
+    {
+        this.s3ObjectStorageClassFilter = s3ObjectStorageClassFilter;
         return this;
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -91,7 +91,8 @@ public final class S3FileSystemFactory
                 toIntExact(config.getStreamingPartSize().toBytes()),
                 config.isRequesterPays(),
                 config.getSseType(),
-                config.getSseKmsKeyId());
+                config.getSseKmsKeyId(),
+                config.getS3ObjectStorageClassFilter());
     }
 
     @PreDestroy

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -48,7 +48,8 @@ public class TestS3FileSystemConfig
                 .setRequesterPays(false)
                 .setMaxConnections(null)
                 .setHttpProxy(null)
-                .setHttpProxySecure(false));
+                .setHttpProxySecure(false)
+                .setS3ObjectStorageClassFilter(S3FileSystemConfig.S3ObjectStorageClassFilter.READ_ALL));
     }
 
     @Test
@@ -72,6 +73,7 @@ public class TestS3FileSystemConfig
                 .put("s3.max-connections", "42")
                 .put("s3.http-proxy", "localhost:8888")
                 .put("s3.http-proxy.secure", "true")
+                .put("s3.object-storage-class-filter", "SKIP_ALL_GLACIER")
                 .buildOrThrow();
 
         S3FileSystemConfig expected = new S3FileSystemConfig()
@@ -91,7 +93,8 @@ public class TestS3FileSystemConfig
                 .setRequesterPays(true)
                 .setMaxConnections(42)
                 .setHttpProxy(HostAndPort.fromParts("localhost", 8888))
-                .setHttpProxySecure(true);
+                .setHttpProxySecure(true)
+                .setS3ObjectStorageClassFilter(S3FileSystemConfig.S3ObjectStorageClassFilter.SKIP_ALL_GLACIER);
 
         assertFullMapping(properties, expected);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.493</dep.aws-sdk.version>
-        <dep.aws-sdk-v2.version>2.20.89</dep.aws-sdk-v2.version>
+        <dep.aws-sdk-v2.version>2.20.101</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.20</dep.drift.version>
@@ -174,7 +174,7 @@
         <dep.iceberg.version>1.3.0</dep.iceberg.version>
         <dep.protobuf.version>3.22.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <dep.netty.version>4.1.92.Final</dep.netty.version>
+        <dep.netty.version>4.1.94.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
         <dep.okio.version>3.3.0</dep.okio.version>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`TrinoS3FileSystem` contains logic/configuration for skipping Glacier objects found in S3.

This PR adds the missing functionality/configuration from `TrinoS3FileSystem` and also adds the capability to configure the filesystem to read restored Glacier objects.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Recently, S3 added the `RestoreStatus` to the result of `ListObjectsV2` - see https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-s3-restore-status-s3-glacier-objects-list-api/ for more details.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
() Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
