### PR TITLE
Mark JUnit overriding test as such

### DIFF
--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -171,7 +171,8 @@ public abstract class AbstractTestAzureFileSystem
     }
 
     @Test
-    void testPaths()
+    @Override
+    public void testPaths()
             throws IOException
     {
         // Azure file paths are always hierarchical

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -521,7 +521,7 @@ public abstract class AbstractTestTrinoFileSystem
     }
 
     @Test
-    void testPaths()
+    public void testPaths()
             throws IOException
     {
         if (isHierarchical()) {


### PR DESCRIPTION
In JUnit 5, when base and derived test classes are in different packages and use package-private method visibility, the derived class's test with same name still overrides the base class test, even though this is not a Java method override, indicated with `@Override` annotation.

