### PR TITLE
Allow assert-thrown with more focused ::evaluate 

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestExtract.java
@@ -159,7 +159,7 @@ public abstract class AbstractTestExtract
     {
         types().forEach(type -> {
             String expression = format("EXTRACT(%s FROM CAST(NULL AS %s))", extractField, type);
-            assertThatThrownBy(() -> assertions.expression(expression).evaluate(), expression)
+            assertThatThrownBy(assertions.expression(expression)::evaluate, expression)
                     .as(expression)
                     .isInstanceOf(TrinoException.class)
                     .hasMessageMatching(format("line 1:\\d+:\\Q Cannot extract %s from %s", extractField, type));

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestRegexpFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestRegexpFunctions.java
@@ -178,7 +178,7 @@ public abstract class AbstractTestRegexpFunctions
                 .hasType(createVarcharType(7))
                 .isEqualTo("yxyxyxy");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'x'", "'\\'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'x'", "'\\'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         assertThat(assertions.function("regexp_replace", "'xxx xxx xxx'", "'x'", "'$0'"))
@@ -209,13 +209,13 @@ public abstract class AbstractTestRegexpFunctions
                 .hasType(createVarcharType(175))
                 .isEqualTo("1a");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'x'", "'$1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'x'", "'$1'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'x'", "'$a'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'x'", "'$a'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'x'", "'$'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'x'", "'$'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         assertThat(assertions.function("regexp_replace", "'wxyz'", "'(?<xyz>[xyz])'", "'${xyz}${xyz}'"))
@@ -234,13 +234,13 @@ public abstract class AbstractTestRegexpFunctions
                 .hasType(createVarcharType(39))
                 .isEqualTo("xyz");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${}'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${}'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${0}'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${0}'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${nam}'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_replace", "'xxx'", "'(?<name>x)'", "'${nam}'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         assertThat(assertions.function("regexp_replace", "VARCHAR 'x'", "'.*'", "'xxxxx'"))
@@ -598,10 +598,10 @@ public abstract class AbstractTestRegexpFunctions
                 .hasType(createVarcharType(6))
                 .isEqualTo((Object) null);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_extract", "'Hello world bye'", "'\\b[a-z]([a-z]*)'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_extract", "'Hello world bye'", "'\\b[a-z]([a-z]*)'", "-1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_extract", "'Hello world bye'", "'\\b[a-z]([a-z]*)'", "2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_extract", "'Hello world bye'", "'\\b[a-z]([a-z]*)'", "2")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -632,14 +632,14 @@ public abstract class AbstractTestRegexpFunctions
                 .hasType(new ArrayType(createVarcharType(15)))
                 .isEqualTo(Collections.<String>singletonList(null));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_extract_all", "'hello'", "'(.)'", "2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_extract_all", "'hello'", "'(.)'", "2")::evaluate)
                 .hasMessage("Pattern has 1 groups. Cannot access group 2");
 
         assertThat(assertions.function("regexp_extract_all", "'12345'", "''"))
                 .hasType(new ArrayType(createVarcharType(5)))
                 .isEqualTo(ImmutableList.of("", "", "", "", "", ""));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_extract_all", "'12345'", "'('").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_extract_all", "'12345'", "'('")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -911,13 +911,13 @@ public abstract class AbstractTestRegexpFunctions
         assertThat(assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "999"))
                 .isEqualTo(-1);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "-1", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "-1", "0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "1", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "1", "0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "1", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("regexp_position", "'有朋$%X自9远方9来'", "'来'", "1", "-1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // sql in document

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayCombinationsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayCombinationsFunction.java
@@ -124,13 +124,13 @@ public class TestArrayCombinationsFunction
     @Test
     public void testLimits()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("combinations", "sequence(1, 40)", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("combinations", "sequence(1, 40)", "-1")::evaluate)
                 .hasMessage("combination size must not be negative: -1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("combinations", "sequence(1, 40)", "10").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("combinations", "sequence(1, 40)", "10")::evaluate)
                 .hasMessage("combination size must not exceed 5: 10");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("combinations", "sequence(1, 100)", "5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("combinations", "sequence(1, 100)", "5")::evaluate)
                 .hasMessage("combinations exceed max size");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayFunctions.java
@@ -59,7 +59,7 @@ public class TestArrayFunctions
                 .binding("c", "3"))
                 .matches("ARRAY[1, 2, 3]");
 
-        assertThatThrownBy(() -> assertions.expression("array[" + Joiner.on(", ").join(nCopies(255, "rand()")) + "]").evaluate())
+        assertThatThrownBy(assertions.expression("array[" + Joiner.on(", ").join(nCopies(255, "rand()")) + "]")::evaluate)
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Too many arguments for array constructor");
     }
@@ -74,7 +74,7 @@ public class TestArrayFunctions
         assertThat(assertions.function("concat", "ARRAY[1]", "ARRAY[2]", "ARRAY[3]"))
                 .matches("ARRAY[1, 2, 3]");
 
-        assertThatThrownBy(() -> assertions.expression("CONCAT(" + Joiner.on(", ").join(nCopies(128, "array[1]")) + ")").evaluate())
+        assertThatThrownBy(assertions.expression("CONCAT(" + Joiner.on(", ").join(nCopies(128, "array[1]")) + ")")::evaluate)
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("line 1:12: Too many arguments for function call concat()");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayNgramsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayNgramsFunction.java
@@ -160,7 +160,7 @@ public class TestArrayNgramsFunction
                 .isEqualTo(ImmutableList.of(
                         ImmutableList.of("", "")));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ngrams", "ARRAY['foo','bar']", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ngrams", "ARRAY['foo','bar']", "0")::evaluate)
                 .hasMessage("N must be positive");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayReduceFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayReduceFunction.java
@@ -142,7 +142,7 @@ public class TestArrayReduceFunction
                 .isEqualTo(123456789066666L);
 
         // TODO: Support coercion of return type of lambda
-        assertTrinoExceptionThrownBy(() -> assertions.expression("reduce(ARRAY [1, NULL, 2], 0, (s, x) -> CAST (s + x AS TINYINT), s -> s)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("reduce(ARRAY [1, NULL, 2], 0, (s, x) -> CAST (s + x AS TINYINT), s -> s)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayTrimFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayTrimFunction.java
@@ -75,9 +75,9 @@ public class TestArrayTrimFunction
                 .hasType(new ArrayType(new ArrayType(INTEGER)))
                 .isEqualTo(ImmutableList.of(ImmutableList.of(1, 2, 3)));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("trim_array", "ARRAY[1, 2, 3, 4]", "5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("trim_array", "ARRAY[1, 2, 3, 4]", "5")::evaluate)
                 .hasMessage("size must not exceed array cardinality 4: 5");
-        assertTrinoExceptionThrownBy(() -> assertions.function("trim_array", "ARRAY[1, 2, 3, 4]", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("trim_array", "ARRAY[1, 2, 3, 4]", "-1")::evaluate)
                 .hasMessage("size must not be negative: -1");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestBitwiseFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestBitwiseFunctions.java
@@ -87,10 +87,10 @@ public class TestBitwiseFunctions
         assertThat(assertions.function("bit_count", Long.toString(Integer.MIN_VALUE), "32"))
                 .isEqualTo(1L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", Long.toString(Integer.MAX_VALUE + 1L), "32").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", Long.toString(Integer.MAX_VALUE + 1L), "32")::evaluate)
                 .hasMessage("Number must be representable with the bits specified. 2147483648 cannot be represented with 32 bits");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", Long.toString(Integer.MIN_VALUE - 1L), "32").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", Long.toString(Integer.MIN_VALUE - 1L), "32")::evaluate)
                 .hasMessage("Number must be representable with the bits specified. -2147483649 cannot be represented with 32 bits");
 
         assertThat(assertions.function("bit_count", "1152921504598458367", "62"))
@@ -105,19 +105,19 @@ public class TestBitwiseFunctions
         assertThat(assertions.function("bit_count", "-1", "26"))
                 .isEqualTo(26L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", "1152921504598458367", "60").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", "1152921504598458367", "60")::evaluate)
                 .hasMessage("Number must be representable with the bits specified. 1152921504598458367 cannot be represented with 60 bits");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", "33554132", "25").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", "33554132", "25")::evaluate)
                 .hasMessage("Number must be representable with the bits specified. 33554132 cannot be represented with 25 bits");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", "0", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", "0", "-1")::evaluate)
                 .hasMessage("Bits specified in bit_count must be between 2 and 64, got -1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", "0", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", "0", "1")::evaluate)
                 .hasMessage("Bits specified in bit_count must be between 2 and 64, got 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bit_count", "0", "65").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bit_count", "0", "65")::evaluate)
                 .hasMessage("Bits specified in bit_count must be between 2 and 64, got 65");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestConcatWsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestConcatWsFunction.java
@@ -177,14 +177,14 @@ public class TestConcatWsFunction
     @Test
     public void testBadArray()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", "','", "ARRAY[1, 15]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat_ws", "','", "ARRAY[1, 15]")::evaluate)
                 .hasMessageContaining("Unexpected parameters");
     }
 
     @Test
     public void testBadArguments()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", "','", "1", "15").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat_ws", "','", "1", "15")::evaluate)
                 .hasMessageContaining("Unexpected parameters");
     }
 
@@ -198,14 +198,14 @@ public class TestConcatWsFunction
         for (int i = 1; i <= argumentsLimit; i++) {
             inputValues[i] = ("'" + i + "'");
         }
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", inputValues).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat_ws", inputValues)::evaluate)
                 .hasMessage("line 1:8: Too many arguments for function call concat_ws()");
     }
 
     @Test
     public void testLowArguments()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat_ws", "','").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat_ws", "','")::evaluate)
                 .hasMessage("There must be two or more arguments");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
@@ -98,28 +98,28 @@ public class TestDataSizeFunctions
         assertThat(assertions.function("parse_data_size", "'69175290276410818560EB'"))
                 .isEqualTo(decimal("79753679747094952374228423616820674560", DECIMAL));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "''")::evaluate)
                 .hasMessage("Invalid data size: ''");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'0'")::evaluate)
                 .hasMessage("Invalid data size: '0'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'10KB'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'10KB'")::evaluate)
                 .hasMessage("Invalid data size: '10KB'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'KB'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'KB'")::evaluate)
                 .hasMessage("Invalid data size: 'KB'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'-1B'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'-1B'")::evaluate)
                 .hasMessage("Invalid data size: '-1B'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'12345K'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'12345K'")::evaluate)
                 .hasMessage("Invalid data size: '12345K'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'A12345B'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'A12345B'")::evaluate)
                 .hasMessage("Invalid data size: 'A12345B'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_data_size", "'99999999999999YB'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_data_size", "'99999999999999YB'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -204,13 +204,13 @@ public class TestDateTimeFunctions
                 .matches("TIMESTAMP '2001-01-22 15:14:05.000 +01:10'");
 
         // test invalid minute offsets
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_unixtime", "0", "1", "10000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "0", "1", "10000")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_unixtime", "0", "10000", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "0", "10000", "0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_unixtime", "0", "-100", "100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "0", "-100", "100")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -786,22 +786,22 @@ public class TestDateTimeFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%D'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%D'")::evaluate)
                 .hasMessage("%D not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%U'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%U'")::evaluate)
                 .hasMessage("%U not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%u'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%u'")::evaluate)
                 .hasMessage("%u not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%V'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%V'")::evaluate)
                 .hasMessage("%V not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%w'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%w'")::evaluate)
                 .hasMessage("%w not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_format", "DATE '2001-01-09'", "'%X'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_format", "DATE '2001-01-09'", "'%X'")::evaluate)
                 .hasMessage("%X not supported in date format string");
     }
 
@@ -865,28 +865,28 @@ public class TestDateTimeFunctions
         assertThat(assertions.function("date_parse", "'31-MAY-69 04.59.59.999000 AM'", "'%d-%b-%y %l.%i.%s.%f %p'"))
                 .matches("TIMESTAMP '2069-05-31 04:59:59.999'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%D'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%D'")::evaluate)
                 .hasMessage("%D not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%U'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%U'")::evaluate)
                 .hasMessage("%U not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%u'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%u'")::evaluate)
                 .hasMessage("%u not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%V'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%V'")::evaluate)
                 .hasMessage("%V not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%w'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%w'")::evaluate)
                 .hasMessage("%w not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "''", "'%X'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "''", "'%X'")::evaluate)
                 .hasMessage("%X not supported in date format string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "'3.0123456789'", "'%s.%f'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "'3.0123456789'", "'%s.%f'")::evaluate)
                 .hasMessage("Invalid format: \"3.0123456789\" is malformed at \"9\"");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("date_parse", "'1970-01-01'", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("date_parse", "'1970-01-01'", "''")::evaluate)
                 .hasMessage("Both printing and parsing not supported");
     }
 
@@ -1063,13 +1063,13 @@ public class TestDateTimeFunctions
                 .isEqualTo(new SqlIntervalDayTime(1234, 13, 36, 28, 800));
 
         // invalid function calls
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_duration", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_duration", "''")::evaluate)
                 .hasMessage("duration is empty");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_duration", "'1f'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_duration", "'1f'")::evaluate)
                 .hasMessage("Unknown time unit: f");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("parse_duration", "'abc'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("parse_duration", "'abc'")::evaluate)
                 .hasMessage("duration is not a valid data duration string: abc");
     }
 
@@ -1119,7 +1119,7 @@ public class TestDateTimeFunctions
         assertThat(assertions.function("with_timezone", "TIMESTAMP '2001-12-01 03:04:05.321'", "'America/Los_Angeles'"))
                 .matches("TIMESTAMP '2001-12-01 03:04:05.321 America/Los_Angeles'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("with_timezone", "TIMESTAMP '2001-08-22 03:04:05.321'", "'invalidzoneid'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("with_timezone", "TIMESTAMP '2001-08-22 03:04:05.321'", "'invalidzoneid'")::evaluate)
                 .hasMessage("'invalidzoneid' is not a valid time zone");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestFailureFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestFailureFunction.java
@@ -48,7 +48,7 @@ public class TestFailureFunction
     public void testFailure()
     {
         String failure = JsonCodec.jsonCodec(FailureInfo.class).toJson(Failures.toFailure(new RuntimeException("fail me")).toFailureInfo());
-        assertTrinoExceptionThrownBy(() -> assertions.function("fail", "json_parse('" + failure + "')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("fail", "json_parse('" + failure + "')")::evaluate)
                 .hasErrorCode(GENERIC_USER_ERROR)
                 .hasMessage("fail me");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatFunction.java
@@ -146,38 +146,38 @@ public class TestFormatFunction
         assertThat(format("%s", "cast('test' AS char(5))"))
                 .isEqualTo("test ");
 
-        assertTrinoExceptionThrownBy(() -> format("%.4d", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%.4d", "8")::evaluate)
                 .hasMessage("Invalid format string: %.4d (IllegalFormatPrecision: 4)");
 
-        assertTrinoExceptionThrownBy(() -> format("%-02d", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%-02d", "8")::evaluate)
                 .hasMessage("Invalid format string: %-02d (IllegalFormatFlags: Flags = '-0')");
 
-        assertTrinoExceptionThrownBy(() -> format("%--2d", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%--2d", "8")::evaluate)
                 .hasMessage("Invalid format string: %--2d (DuplicateFormatFlags: Flags = '-')");
 
-        assertTrinoExceptionThrownBy(() -> format("%+s", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%+s", "8")::evaluate)
                 .hasMessage("Invalid format string: %+s (FormatFlagsConversionMismatch: Conversion = s, Flags = +)");
 
-        assertTrinoExceptionThrownBy(() -> format("%-s", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%-s", "8")::evaluate)
                 .hasMessage("Invalid format string: %-s (MissingFormatWidth: %-s)");
 
-        assertTrinoExceptionThrownBy(() -> format("%5n", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%5n", "8")::evaluate)
                 .hasMessage("Invalid format string: %5n (IllegalFormatWidth: 5)");
 
-        assertTrinoExceptionThrownBy(() -> format("%s %d", "8").evaluate())
+        assertTrinoExceptionThrownBy(format("%s %d", "8")::evaluate)
                 .hasMessage("Invalid format string: %s %d (MissingFormatArgument: Format specifier '%d')");
 
-        assertTrinoExceptionThrownBy(() -> format("%d", "decimal '8'").evaluate())
+        assertTrinoExceptionThrownBy(format("%d", "decimal '8'")::evaluate)
                 .hasMessage("Invalid format string: %d (IllegalFormatConversion: d != java.math.BigDecimal)");
 
-        assertTrinoExceptionThrownBy(() -> format("%tT", "current_time").evaluate())
+        assertTrinoExceptionThrownBy(format("%tT", "current_time")::evaluate)
                 .hasMessage("Invalid format string: %tT (IllegalFormatConversion: T != java.lang.String)");
 
-        assertTrinoExceptionThrownBy(() -> format("%s", "array[8]").evaluate())
+        assertTrinoExceptionThrownBy(format("%s", "array[8]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED)
                 .hasMessage("line 1:20: Type not supported for formatting: array(integer)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("format", "5", "8").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("format", "5", "8")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:17: Type of first argument to format() must be VARCHAR (actual: integer)");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
@@ -379,131 +379,131 @@ public class TestIpAddressFunctions
                 .isNull(BOOLEAN);
 
         // Invalid argument
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'64:ff9b::10.0.0.0/64'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'64:ff9b::10.0.0.0/64'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("IP address version should be the same");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'0.0.0.0/0'", "IPADDRESS '64:ff9b::10.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'0.0.0.0/0'", "IPADDRESS '64:ff9b::10.0.0.0'")::evaluate)
                 .hasMessage("IP address version should be the same");
 
         // Invalid prefix length
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'0.0.0.0/-1'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'0.0.0.0/-1'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid prefix length");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'64:ff9b::10.0.0.0/-1'", "IPADDRESS '64:ff9b::10.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'64:ff9b::10.0.0.0/-1'", "IPADDRESS '64:ff9b::10.0.0.0'")::evaluate)
                 .hasMessage("Invalid prefix length");
 
         // Invalid CIDR format
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'0.0.0.1/0'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'0.0.0.1/0'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'1.0.0.0/1'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'1.0.0.0/1'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'128.1.1.1/1'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'128.1.1.1/1'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'129.0.0.0/1'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'129.0.0.0/1'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'192.1.1.1/2'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'192.1.1.1/2'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'193.0.0.0/2'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'193.0.0.0/2'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'224.1.1.1/3'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'224.1.1.1/3'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'225.0.0.0/3'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'225.0.0.0/3'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'240.1.1.1/4'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'240.1.1.1/4'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'241.0.0.0/4'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'241.0.0.0/4'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'248.1.1.1/5'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'248.1.1.1/5'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'249.0.0.0/5'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'249.0.0.0/5'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'252.1.1.1/6'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'252.1.1.1/6'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'253.0.0.0/6'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'253.0.0.0/6'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'254.1.1.1/7'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'254.1.1.1/7'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.0.0.0/7'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.0.0.0/7'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.1.1.1/8'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.1.1.1/8'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.0.1.1/9'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.0.1.1/9'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.129.0.0/9'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.129.0.0/9'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.0.1.1/10'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.0.1.1/10'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.193.0.0/10'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.193.0.0/10'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.0.1.1/11'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.0.1.1/11'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.225.0.0/11'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.225.0.0/11'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.240.1.1/12'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.240.1.1/12'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.241.0.0/12'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.241.0.0/12'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.248.1.1/13'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.248.1.1/13'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.249.1.1/13'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.249.1.1/13'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.252.1.1/14'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.252.1.1/14'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.253.0.0/14'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.253.0.0/14'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.254.1.1/15'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.254.1.1/15'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.1.1/15'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.1.1/15'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.0.1/16'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.0.1/16'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.1.0/16'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.1.0/16'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.0.1/17'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.0.1/17'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.129.0/17'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.129.0/17'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.0.1/18'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.0.1/18'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.193.0/18'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.193.0/18'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.0.1/19'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.0.1/19'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.225.0/19'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.225.0/19'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.240.1/20'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.240.1/20'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.241.0/20'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.241.0/20'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.248.1/21'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.248.1/21'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.249.1/21'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.249.1/21'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.252.1/22'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.252.1/22'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.253.0/22'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.253.0/22'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.254.1/23'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.254.1/23'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.255.1/23'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.255.1/23'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'255.255.255.1/24'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'255.255.255.1/24'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'10.0.0.1/33'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'10.0.0.1/33'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Prefix length exceeds address length");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'64:ff9b::10.0.0.0/129'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'64:ff9b::10.0.0.0/129'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Prefix length exceeds address length");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'2620:109:c006:104::/250'", "IPADDRESS '2620:109:c006:104::'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'2620:109:c006:104::/250'", "IPADDRESS '2620:109:c006:104::'")::evaluate)
                 .hasMessage("Prefix length exceeds address length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'x.x.x.x'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'x.x.x.x'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'x:x:x:10.0.0.0'", "IPADDRESS '64:ff9b::10.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'x:x:x:10.0.0.0'", "IPADDRESS '64:ff9b::10.0.0.0'")::evaluate)
                 .hasMessage("Invalid CIDR");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'x.x.x.x/1'", "IPADDRESS '0.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'x.x.x.x/1'", "IPADDRESS '0.0.0.0'")::evaluate)
                 .hasMessage("Invalid network IP address");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'x:x:x:10.0.0.0/1'", "IPADDRESS '64:ff9b::10.0.0.0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'x:x:x:10.0.0.0/1'", "IPADDRESS '64:ff9b::10.0.0.0'")::evaluate)
                 .hasMessage("Invalid network IP address");
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "'2001:0DB8:0:CD3/60'", "IPADDRESS '2001:0DB8::CD30:0:0:0:0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "'2001:0DB8:0:CD3/60'", "IPADDRESS '2001:0DB8::CD30:0:0:0:0'")::evaluate)
                 .hasMessage("Invalid network IP address");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonFunctions.java
@@ -89,16 +89,16 @@ public class TestJsonFunctions
         assertThat(assertions.function("is_json_scalar", "'{\"a\": 1, \"b\": 2}'"))
                 .isEqualTo(false);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("is_json_scalar", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("is_json_scalar", "''")::evaluate)
                 .hasMessage("Invalid JSON value: ");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("is_json_scalar", "'[1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("is_json_scalar", "'[1'")::evaluate)
                 .hasMessage("Invalid JSON value: [1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("is_json_scalar", "'1 trailing'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("is_json_scalar", "'1 trailing'")::evaluate)
                 .hasMessage("Invalid JSON value: 1 trailing");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("is_json_scalar", "'[1, 2] trailing'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("is_json_scalar", "'[1, 2] trailing'")::evaluate)
                 .hasMessage("Invalid JSON value: [1, 2] trailing");
     }
 
@@ -663,28 +663,28 @@ public class TestJsonFunctions
     @Test
     public void testInvalidJsonParse()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON 'INVALID'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON 'INVALID'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'INVALID'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'INVALID'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'\"x\": 1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'\"x\": 1'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'{}{'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'{}{'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'{} \"a\"'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'{} \"a\"'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'{}{abc'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'{}{abc'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "'{}abc'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "'{}abc'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_parse", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_parse", "''")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -747,19 +747,19 @@ public class TestJsonFunctions
         assertThat(assertions.function("json_size", "JSON '[1,2,3]'", "null"))
                 .isNull(BIGINT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_size", "'{\"\":\"\"}'", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_size", "'{\"\":\"\"}'", "''")::evaluate)
                 .hasMessage("Invalid JSON path: ''");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_size", "'{\"\":\"\"}'", "CHAR ' '").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_size", "'{\"\":\"\"}'", "CHAR ' '")::evaluate)
                 .hasMessage("Invalid JSON path: ' '");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_size", "'{\"\":\"\"}'", "'.'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_size", "'{\"\":\"\"}'", "'.'")::evaluate)
                 .hasMessage("Invalid JSON path: '.'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_size", "'{\"\":\"\"}'", "'null'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_size", "'{\"\":\"\"}'", "'null'")::evaluate)
                 .hasMessage("Invalid JSON path: 'null'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("json_size", "'{\"\":\"\"}'", "'null'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("json_size", "'{\"\":\"\"}'", "'null'")::evaluate)
                 .hasMessage("Invalid JSON path: 'null'");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestJsonInputFunctions.java
@@ -77,7 +77,7 @@ public class TestJsonInputFunctions
                 .isEqualTo(JSON_OBJECT);
 
         // with unsuppressed input conversion error
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varchar_to_json\"('" + ERROR_INPUT + "', true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varchar_to_json\"('" + ERROR_INPUT + "', true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -100,7 +100,7 @@ public class TestJsonInputFunctions
 
         // wrong input encoding
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf8_to_json\"(" + toVarbinary(INPUT, UTF_16LE) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf8_to_json\"(" + toVarbinary(INPUT, UTF_16LE) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -112,7 +112,7 @@ public class TestJsonInputFunctions
         // correct encoding, incorrect input
 
         // with unsuppressed input conversion error
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf8_to_json\"(" + toVarbinary(ERROR_INPUT, UTF_8) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf8_to_json\"(" + toVarbinary(ERROR_INPUT, UTF_8) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -132,11 +132,11 @@ public class TestJsonInputFunctions
         // wrong input encoding
         String varbinaryLiteral = toVarbinary(INPUT, UTF_16BE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf16_to_json\"(" + varbinaryLiteral + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf16_to_json\"(" + varbinaryLiteral + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf16_to_json\"(" + toVarbinary(INPUT, UTF_8) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf16_to_json\"(" + toVarbinary(INPUT, UTF_8) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -148,7 +148,7 @@ public class TestJsonInputFunctions
         // correct encoding, incorrect input
 
         // with unsuppressed input conversion error
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf16_to_json\"(" + toVarbinary(ERROR_INPUT, UTF_16LE) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf16_to_json\"(" + toVarbinary(ERROR_INPUT, UTF_16LE) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -167,11 +167,11 @@ public class TestJsonInputFunctions
 
         // wrong input encoding
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, Charset.forName("UTF-32BE")) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, Charset.forName("UTF-32BE")) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, UTF_8) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(INPUT, UTF_8) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 
@@ -183,7 +183,7 @@ public class TestJsonInputFunctions
         // correct encoding, incorrect input
 
         // with unsuppressed input conversion error
-        assertTrinoExceptionThrownBy(() -> assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, Charset.forName("UTF-32LE")) + ", true)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("\"$varbinary_utf32_to_json\"(" + toVarbinary(ERROR_INPUT, Charset.forName("UTF-32LE")) + ", true)")::evaluate)
                 .hasErrorCode(JSON_INPUT_CONVERSION_ERROR)
                 .hasMessage("conversion to JSON failed: ");
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestLambdaExpression.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestLambdaExpression.java
@@ -296,22 +296,22 @@ public class TestLambdaExpression
     @Test
     public void testFunctionParameter()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.expression("count(x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("count(x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>) for function count. Expected: count(), count(t) T");
-        assertTrinoExceptionThrownBy(() -> assertions.expression("max(x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("max(x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>) for function max. Expected: max(t) T:orderable, max(e, bigint) E:orderable");
-        assertTrinoExceptionThrownBy(() -> assertions.expression("sqrt(x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("sqrt(x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>) for function sqrt. Expected: sqrt(double)");
-        assertTrinoExceptionThrownBy(() -> assertions.expression("sqrt(x -> x, 123, x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("sqrt(x -> x, 123, x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>, integer, <function>) for function sqrt. Expected: sqrt(double)");
-        assertTrinoExceptionThrownBy(() -> assertions.expression("pow(x -> x, 123)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("pow(x -> x, 123)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>, integer) for function pow. Expected: pow(double, double)");
-        assertTrinoExceptionThrownBy(() -> assertions.expression("pow(123, x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("pow(123, x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (integer, <function>) for function pow. Expected: pow(double, double)");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestLuhnCheckFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestLuhnCheckFunction.java
@@ -58,16 +58,16 @@ public class TestLuhnCheckFunction
         assertThat(assertions.function("luhn_check", "NULL"))
                 .isNull(BOOLEAN);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("luhn_check", "'abcd424242424242'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("luhn_check", "'abcd424242424242'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         assertThat(assertions.function("luhn_check", "'123456789'"))
                 .isEqualTo(false);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("luhn_check", "'\u4EA0\u4EFF\u4EA112345'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("luhn_check", "'\u4EA0\u4EFF\u4EA112345'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("luhn_check", "'4242\u4FE124242424242'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("luhn_check", "'4242\u4FE124242424242'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -128,16 +128,16 @@ public class TestMathFunctions
         assertThat(assertions.function("abs", "REAL '-754.1985'"))
                 .isEqualTo(754.1985f);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("abs", "TINYINT '%s'".formatted(Byte.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("abs", "TINYINT '%s'".formatted(Byte.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("abs", "SMALLINT '%s'".formatted(Short.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("abs", "SMALLINT '%s'".formatted(Short.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("abs", "INTEGER '%s'".formatted(Integer.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("abs", "INTEGER '%s'".formatted(Integer.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("abs", "-9223372036854775807 - if(rand() < 10, 1, 1)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("abs", "-9223372036854775807 - if(rand() < 10, 1, 1)")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.function("abs", "DECIMAL '123.45'"))
@@ -1171,7 +1171,7 @@ public class TestMathFunctions
         assertThat(assertions.function("mod", "CAST(NULL as DECIMAL(1,0))", "DECIMAL '5.0'"))
                 .isNull(createDecimalType(2, 1));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("mod", "DECIMAL '5.0'", "DECIMAL '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("mod", "DECIMAL '5.0'", "DECIMAL '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -1421,58 +1421,58 @@ public class TestMathFunctions
         assertThat(assertions.expression("random(-3000000000, 5000000000)"))
                 .hasType(BIGINT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rand", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rand", "-1")::evaluate)
                 .hasMessage("bound must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rand", "-3000000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rand", "-3000000000")::evaluate)
                 .hasMessage("bound must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "TINYINT '5'", "TINYINT '3'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "TINYINT '5'", "TINYINT '3'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "TINYINT '5'", "TINYINT '5'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "TINYINT '5'", "TINYINT '5'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "TINYINT '-5'", "TINYINT '-10'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "TINYINT '-5'", "TINYINT '-10'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "TINYINT '-5'", "TINYINT '-5'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "TINYINT '-5'", "TINYINT '-5'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "SMALLINT '30000'", "SMALLINT '10000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "SMALLINT '30000'", "SMALLINT '10000'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "SMALLINT '30000'", "SMALLINT '30000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "SMALLINT '30000'", "SMALLINT '30000'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "SMALLINT '-30000'", "SMALLINT '-31000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "SMALLINT '-30000'", "SMALLINT '-31000'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "SMALLINT '-30000'", "SMALLINT '-30000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "SMALLINT '-30000'", "SMALLINT '-30000'")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "1000", "500").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "1000", "500")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "500", "500").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "500", "500")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "-500", "-600").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "-500", "-600")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "-500", "-500").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "-500", "-500")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "3000000000", "1000000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "3000000000", "1000000000")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "3000000000", "3000000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "3000000000", "3000000000")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "-3000000000", "-4000000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "-3000000000", "-4000000000")::evaluate)
                 .hasMessage("start value must be less than stop value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("random", "-3000000000", "-3000000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("random", "-3000000000", "-3000000000")::evaluate)
                 .hasMessage("start value must be less than stop value");
     }
 
@@ -1906,43 +1906,43 @@ public class TestMathFunctions
         assertThat(assertions.function("round", "-9223372036854775807", "-18"))
                 .isEqualTo(-9000000000000000000L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "TINYINT '127'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "TINYINT '127'", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "TINYINT '-128'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "TINYINT '-128'", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "SMALLINT '32767'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "SMALLINT '32767'", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "SMALLINT '32767'", "-3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "SMALLINT '32767'", "-3")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "SMALLINT '-32768'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "SMALLINT '-32768'", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "SMALLINT '-32768'", "-3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "SMALLINT '-32768'", "-3")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "2147483647", "-100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "2147483647", "-100")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "2147483647", "-2147483648").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "2147483647", "-2147483648")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "9223372036854775807", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "9223372036854775807", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "9223372036854775807", "-3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "9223372036854775807", "-3")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "9223372036854775807", "-19").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "9223372036854775807", "-19")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "-9223372036854775807", "-20").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "-9223372036854775807", "-20")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "-9223372036854775807", "-2147483648").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "-9223372036854775807", "-2147483648")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         // ROUND short DECIMAL -> short DECIMAL
@@ -2295,10 +2295,10 @@ public class TestMathFunctions
         assertThat(assertions.function("round", "DECIMAL '9999999999999999999999999999999999999.9'", "1"))
                 .isEqualTo(decimal("9999999999999999999999999999999999999.9", createDecimalType(38, 1)));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "DECIMAL '9999999999999999999999999999999999999.9'", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "DECIMAL '9999999999999999999999999999999999999.9'", "0")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("round", "DECIMAL '9999999999999999999999999999999999999.9'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("round", "DECIMAL '9999999999999999999999999999999999999.9'", "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThat(assertions.function("round", "DECIMAL  '1329123201320737513'", "-3"))
@@ -2745,7 +2745,7 @@ public class TestMathFunctions
         assertThat(assertions.function("greatest", nCopies(127, "1E0")))
                 .hasType(DOUBLE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("greatest", nCopies(128, "rand()")).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("greatest", nCopies(128, "rand()"))::evaluate)
                 .hasErrorCode(TOO_MANY_ARGUMENTS)
                 .hasMessage("line 1:8: Too many arguments for function call greatest()");
 
@@ -3260,7 +3260,7 @@ public class TestMathFunctions
         assertThat(assertions.function("to_base", "NULL", "NULL"))
                 .isNull(createVarcharType(64));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_base", "255", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_base", "255", "1")::evaluate)
                 .hasMessage("Radix must be between 2 and 36");
     }
 
@@ -3291,22 +3291,22 @@ public class TestMathFunctions
         assertThat(assertions.function("from_base", "NULL", "NULL"))
                 .isNull(BIGINT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'Z'", "37").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'Z'", "37")::evaluate)
                 .hasMessage("Radix must be between 2 and 36");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'Z'", "35").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'Z'", "35")::evaluate)
                 .hasMessage("Not a valid base-35 number: Z");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'9223372036854775808'", "10").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'9223372036854775808'", "10")::evaluate)
                 .hasMessage("Not a valid base-10 number: 9223372036854775808");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'Z'", "37").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'Z'", "37")::evaluate)
                 .hasMessage("Radix must be between 2 and 36");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'Z'", "35").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'Z'", "35")::evaluate)
                 .hasMessage("Not a valid base-35 number: Z");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base", "'9223372036854775808'", "10").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base", "'9223372036854775808'", "10")::evaluate)
                 .hasMessage("Not a valid base-10 number: 9223372036854775808");
     }
 
@@ -3339,39 +3339,39 @@ public class TestMathFunctions
                 .isEqualTo(5L);
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "0", "4", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "0", "4", "0")::evaluate)
                 .hasMessage("bucketCount must be greater than 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "0", "4", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "0", "4", "-1")::evaluate)
                 .hasMessage("bucketCount must be greater than 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "nan()", "0", "4", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "nan()", "0", "4", "3")::evaluate)
                 .hasMessage("operand must not be NaN");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "-1", "-1", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "-1", "-1", "3")::evaluate)
                 .hasMessage("bounds cannot equal each other");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "nan()", "-1", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "nan()", "-1", "3")::evaluate)
                 .hasMessage("first bound must be finite");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "-1", "nan()", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "-1", "nan()", "3")::evaluate)
                 .hasMessage("second bound must be finite");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "infinity()", "-1", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "infinity()", "-1", "3")::evaluate)
                 .hasMessage("first bound must be finite");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "-1", "infinity()", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "-1", "infinity()", "3")::evaluate)
                 .hasMessage("second bound must be finite");
     }
 
     @Test
     public void testWidthBucketOverflowAscending()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "infinity()", "0", "4", Long.toString(Long.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "infinity()", "0", "4", Long.toString(Long.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Bucket for value Infinity is out of range");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "CAST(infinity() as REAL)", "0", "4", Long.toString(Long.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "CAST(infinity() as REAL)", "0", "4", Long.toString(Long.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Bucket for value Infinity is out of range");
     }
@@ -3379,11 +3379,11 @@ public class TestMathFunctions
     @Test
     public void testWidthBucketOverflowDescending()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "infinity()", "4", "0", Long.toString(Long.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "infinity()", "4", "0", Long.toString(Long.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Bucket for value Infinity is out of range");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "CAST(infinity() as REAL)", "4", "0", Long.toString(Long.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "CAST(infinity() as REAL)", "4", "0", Long.toString(Long.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("Bucket for value Infinity is out of range");
     }
@@ -3408,23 +3408,23 @@ public class TestMathFunctions
                 .isEqualTo(0L);
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "array[]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "array[]")::evaluate)
                 .hasMessage("Bins cannot be an empty array");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "nan()", "array[1.0E0, 2.0E0, 3.0E0]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "nan()", "array[1.0E0, 2.0E0, 3.0E0]")::evaluate)
                 .hasMessage("Operand cannot be NaN");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.14E0", "array[0.0E0, infinity()]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.14E0", "array[0.0E0, infinity()]")::evaluate)
                 .hasMessage("Bin value must be finite, got Infinity");
 
         // fail if we aren't sorted
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.0E0]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.0E0]")::evaluate)
                 .hasMessage("Bin values are not sorted in ascending order");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.0E0, -1.0E0]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.0E0, -1.0E0]")::evaluate)
                 .hasMessage("Bin values are not sorted in ascending order");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.3E0, 0.0E0, -1.0E0]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("width_bucket", "3.145E0", "array[1.0E0, 0.3E0, 0.0E0, -1.0E0]")::evaluate)
                 .hasMessage("Bin values are not sorted in ascending order");
 
         // this is a case that we can't catch because we are using binary search to bisect the bins array
@@ -3463,13 +3463,13 @@ public class TestMathFunctions
         assertThat(assertions.function("inverse_normal_cdf", "0.5", "0.25", "0.65"))
                 .isEqualTo(0.59633011660189195);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_normal_cdf", "4", "48", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_normal_cdf", "4", "48", "0")::evaluate)
                 .hasMessage("p must be 0 > p > 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_normal_cdf", "4", "48", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_normal_cdf", "4", "48", "1")::evaluate)
                 .hasMessage("p must be 0 > p > 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_normal_cdf", "4", "0", "0.4").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_normal_cdf", "4", "0", "0.4")::evaluate)
                 .hasMessage("sd must be > 0");
     }
 
@@ -3506,10 +3506,10 @@ public class TestMathFunctions
         assertThat(assertions.function("normal_cdf", "0", "1", "nan()"))
                 .isEqualTo(Double.NaN);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("normal_cdf", "0", "0", "0.1985").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("normal_cdf", "0", "0", "0.1985")::evaluate)
                 .hasMessage("standardDeviation must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("normal_cdf", "0", "nan()", "0.1985").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("normal_cdf", "0", "nan()", "0.1985")::evaluate)
                 .hasMessage("standardDeviation must be > 0");
     }
 
@@ -3528,16 +3528,16 @@ public class TestMathFunctions
         assertThat(assertions.function("inverse_beta_cdf", "3", "3.6", "0.95"))
                 .isEqualTo(0.7600272463100223);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_beta_cdf", "0", "3", "0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_beta_cdf", "0", "3", "0.5")::evaluate)
                 .hasMessage("a, b must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_beta_cdf", "3", "0", "0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_beta_cdf", "3", "0", "0.5")::evaluate)
                 .hasMessage("a, b must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_beta_cdf", "3", "5", "-0.1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_beta_cdf", "3", "5", "-0.1")::evaluate)
                 .hasMessage("p must be 0 >= p >= 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("inverse_beta_cdf", "3", "5", "1.1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("inverse_beta_cdf", "3", "5", "1.1")::evaluate)
                 .hasMessage("p must be 0 >= p >= 1");
     }
 
@@ -3556,47 +3556,47 @@ public class TestMathFunctions
         assertThat(assertions.function("beta_cdf", "3", "3.6", "0.9"))
                 .isEqualTo(0.9972502881611551);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("beta_cdf", "0", "3", "0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("beta_cdf", "0", "3", "0.5")::evaluate)
                 .hasMessage("a, b must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("beta_cdf", "3", "0", "0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("beta_cdf", "3", "0", "0.5")::evaluate)
                 .hasMessage("a, b must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("beta_cdf", "3", "5", "-0.1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("beta_cdf", "3", "5", "-0.1")::evaluate)
                 .hasMessage("value must be 0 >= v >= 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("beta_cdf", "3", "5", "1.1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("beta_cdf", "3", "5", "1.1")::evaluate)
                 .hasMessage("value must be 0 >= v >= 1");
     }
 
     @Test
     public void testWilsonInterval()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_lower", "-1", "100", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_lower", "-1", "100", "2.575")::evaluate)
                 .hasMessage("number of successes must not be negative");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_lower", "0", "0", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_lower", "0", "0", "2.575")::evaluate)
                 .hasMessage("number of trials must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_lower", "10", "5", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_lower", "10", "5", "2.575")::evaluate)
                 .hasMessage("number of successes must not be larger than number of trials");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_lower", "0", "100", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_lower", "0", "100", "-1")::evaluate)
                 .hasMessage("z-score must not be negative");
 
         assertThat(assertions.function("wilson_interval_lower", "1250", "1310", "1.96e0"))
                 .isEqualTo(0.9414883725395894);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_upper", "-1", "100", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_upper", "-1", "100", "2.575")::evaluate)
                 .hasMessage("number of successes must not be negative");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_upper", "0", "0", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_upper", "0", "0", "2.575")::evaluate)
                 .hasMessage("number of trials must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_upper", "10", "5", "2.575").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_upper", "10", "5", "2.575")::evaluate)
                 .hasMessage("number of successes must not be larger than number of trials");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("wilson_interval_upper", "0", "100", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("wilson_interval_upper", "0", "100", "-1")::evaluate)
                 .hasMessage("z-score must not be negative");
 
         assertThat(assertions.function("wilson_interval_upper", "1250", "1310", "1.96e0"))

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -109,13 +109,13 @@ public class TestStringFunctions
                 .hasType(createVarcharType(1))
                 .isEqualTo("\0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("chr", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("chr", "-1")::evaluate)
                 .hasMessage("Not a valid Unicode code point: -1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("chr", "1234567").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("chr", "1234567")::evaluate)
                 .hasMessage("Not a valid Unicode code point: 1234567");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("chr", "8589934592").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("chr", "8589934592")::evaluate)
                 .hasMessage("Not a valid Unicode code point: 8589934592");
     }
 
@@ -138,20 +138,20 @@ public class TestStringFunctions
                 .hasType(INTEGER)
                 .isEqualTo(33804);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("codepoint", "'hello'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("codepoint", "'hello'")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("codepoint", "'\u666E\u5217\u65AF\u6258'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("codepoint", "'\u666E\u5217\u65AF\u6258'")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("codepoint", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("codepoint", "''")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
     @Test
     public void testConcat()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat", "''")::evaluate)
                 .hasMessage("There must be two or more concatenation arguments");
 
         assertThat(assertions.function("concat", "'hello'", "' world'"))
@@ -200,7 +200,7 @@ public class TestStringFunctions
                 .hasType(VARCHAR)
                 .isEqualTo(Joiner.on("").join(nCopies(127, "x")));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("CONCAT(" + Joiner.on(", ").join(nCopies(128, "'x'")) + ")").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("CONCAT(" + Joiner.on(", ").join(nCopies(128, "'x'")) + ")")::evaluate)
                 .hasErrorCode(TOO_MANY_ARGUMENTS)
                 .hasMessage("line 1:12: Too many arguments for function call concat()");
     }
@@ -316,10 +316,10 @@ public class TestStringFunctions
                 .isEqualTo(4L);
 
         // Test for invalid utf-8 characters
-        assertTrinoExceptionThrownBy(() -> assertions.function("levenshtein_distance", "'hello world'", "utf8(from_hex('81'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("levenshtein_distance", "'hello world'", "utf8(from_hex('81'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: �");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("levenshtein_distance", "'hello wolrd'", "utf8(from_hex('3281'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("levenshtein_distance", "'hello wolrd'", "utf8(from_hex('3281'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: 2�");
 
         // Test for maximum length
@@ -329,13 +329,13 @@ public class TestStringFunctions
         assertThat(assertions.function("levenshtein_distance", "'%s'".formatted("l".repeat(100_000)), "'hello'"))
                 .isEqualTo(99998L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("levenshtein_distance", "'%s'".formatted("x".repeat(1001)), "'%s'".formatted("x".repeat(1001))).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("levenshtein_distance", "'%s'".formatted("x".repeat(1001)), "'%s'".formatted("x".repeat(1001)))::evaluate)
                 .hasMessage("The combined inputs for Levenshtein distance are too large");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("levenshtein_distance", "'hello'", "'%s'".formatted("x".repeat(500_000))).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("levenshtein_distance", "'hello'", "'%s'".formatted("x".repeat(500_000)))::evaluate)
                 .hasMessage("The combined inputs for Levenshtein distance are too large");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("levenshtein_distance", "'%s'".formatted("x".repeat(500_000)), "'hello'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("levenshtein_distance", "'%s'".formatted("x".repeat(500_000)), "'hello'")::evaluate)
                 .hasMessage("The combined inputs for Levenshtein distance are too large");
     }
 
@@ -377,22 +377,22 @@ public class TestStringFunctions
                 .isEqualTo(1L);
 
         // Test for invalid arguments
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "'hello'", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "'hello'", "''")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "''", "'hello'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "''", "'hello'")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "'hello'", "'o'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "'hello'", "'o'")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "'h'", "'hello'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "'h'", "'hello'")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "'hello na\u00EFve world'", "'hello na:ive world'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "'hello na\u00EFve world'", "'hello na:ive world'")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("hamming_distance", "'\u4FE1\u5FF5,\u7231,\u5E0C\u671B'", "'\u4FE1\u5FF5\u5E0C\u671B'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("hamming_distance", "'\u4FE1\u5FF5,\u7231,\u5E0C\u671B'", "'\u4FE1\u5FF5\u5E0C\u671B'")::evaluate)
                 .hasMessage("The input strings to hamming_distance function must have the same length");
     }
 
@@ -664,10 +664,10 @@ public class TestStringFunctions
         assertThat(assertions.function("strpos", "NULL", "NULL"))
                 .isNull(BIGINT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'", "0")::evaluate)
                 .hasMessage("'instance' must be a positive or negative number.");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("strpos", "''", "''", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("strpos", "''", "''", "0")::evaluate)
                 .hasMessage("'instance' must be a positive or negative number.");
 
         assertThat(assertions.function("strpos", "'abc/xyz/foo/bar'", "'/'"))
@@ -1170,16 +1170,16 @@ public class TestStringFunctions
                 .hasType(new ArrayType(createVarcharType(5)))
                 .isEqualTo(ImmutableList.of("a", "b", "."));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split", "'a.b.c'", "''", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split", "'a.b.c'", "''", "1")::evaluate)
                 .hasMessage("The delimiter may not be the empty string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split", "'a.b.c'", "'.'", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split", "'a.b.c'", "'.'", "0")::evaluate)
                 .hasMessage("Limit must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split", "'a.b.c'", "'.'", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split", "'a.b.c'", "'.'", "-1")::evaluate)
                 .hasMessage("Limit must be positive");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split", "'a.b.c'", "'.'", "2147483648").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split", "'a.b.c'", "'.'", "2147483648")::evaluate)
                 .hasMessage("Limit is too large");
     }
 
@@ -1222,27 +1222,27 @@ public class TestStringFunctions
                 .isEqualTo(ImmutableMap.of("", "\u4EC1"));
 
         // Entry delimiter and key-value delimiter must not be the same.
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "''", "'\u4EFF'", "'\u4EFF'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "''", "'\u4EFF'", "'\u4EFF'")::evaluate)
                 .hasMessage("entryDelimiter and keyValueDelimiter must not be the same");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'a=123,b=.4,c='", "'='", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'a=123,b=.4,c='", "'='", "'='")::evaluate)
                 .hasMessage("entryDelimiter and keyValueDelimiter must not be the same");
 
         // Duplicate keys are not allowed to exist.
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'a=123,a=.4'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'a=123,a=.4'", "','", "'='")::evaluate)
                 .hasMessage("Duplicate keys (a) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'\u4EA0\u4EFF\u4EA1\u4E00\u4EA0\u4EFF\u4EB1'", "'\u4E00'", "'\u4EFF'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'\u4EA0\u4EFF\u4EA1\u4E00\u4EA0\u4EFF\u4EB1'", "'\u4E00'", "'\u4EFF'")::evaluate)
                 .hasMessage("Duplicate keys (\u4EA0) are not allowed");
 
         // Key-value delimiter must appear exactly once in each entry.
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'key'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'key'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: 'key'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'key==value'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'key==value'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: 'key==value'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_map", "'key=va=lue'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_map", "'key=va=lue'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: 'key=va=lue'");
     }
 
@@ -1296,20 +1296,20 @@ public class TestStringFunctions
                 .isEqualTo(ImmutableMap.of("\u4EA0", ImmutableList.of("\u4EA1", "\u4EB1")));
 
         // Entry delimiter and key-value delimiter must not be the same.
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_multimap", "''", "'\u4EFF'", "'\u4EFF'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_multimap", "''", "'\u4EFF'", "'\u4EFF'")::evaluate)
                 .hasMessage("entryDelimiter and keyValueDelimiter must not be the same");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_multimap", "'a=123,b=.4,c='", "'='", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_multimap", "'a=123,b=.4,c='", "'='", "'='")::evaluate)
                 .hasMessage("entryDelimiter and keyValueDelimiter must not be the same");
 
         // Key-value delimiter must appear exactly once in each entry.
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_multimap", "'key'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_multimap", "'key'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: key");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_multimap", "'key==value'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_multimap", "'key==value'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: key==value");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_to_multimap", "'key=va=lue'", "','", "'='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_to_multimap", "'key=va=lue'", "','", "'='")::evaluate)
                 .hasMessage("Key-value delimiter must appear exactly once in each entry. Bad input: key=va=lue");
     }
 
@@ -1454,20 +1454,20 @@ public class TestStringFunctions
         assertThat(assertions.function("split_part", "'\u8B49\u8BC1\u8A3C'", "'\u8BC1'", "3"))
                 .isNull(createVarcharType(3));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_part", "'abc'", "''", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_part", "'abc'", "''", "0")::evaluate)
                 .hasMessage("Index must be greater than zero");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_part", "'abc'", "''", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_part", "'abc'", "''", "-1")::evaluate)
                 .hasMessage("Index must be greater than zero");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_part", "utf8(from_hex('CE'))", "''", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_part", "utf8(from_hex('CE'))", "''", "1")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding");
     }
 
     @Test
     public void testSplitPartInvalid()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("split_part", "'abc-@-def-@-ghi'", "'-@-'", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("split_part", "'abc-@-def-@-ghi'", "'-@-'", "0")::evaluate)
                 .hasMessage("Index must be greater than zero");
     }
 
@@ -1712,10 +1712,10 @@ public class TestStringFunctions
         assertThat(assertions.expression("CAST(LTRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)"))
                 .isEqualTo(varbinary(0x81, ' '));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ltrim", "'hello world'", "utf8(from_hex('81'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ltrim", "'hello world'", "utf8(from_hex('81'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: �");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ltrim", "'hello wolrd'", "utf8(from_hex('3281'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ltrim", "'hello wolrd'", "utf8(from_hex('3281'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: 2�");
     }
 
@@ -1858,10 +1858,10 @@ public class TestStringFunctions
         assertThat(assertions.expression("CAST(RTRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)"))
                 .isEqualTo(varbinary(' ', 0x81));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rtrim", "'hello world'", "utf8(from_hex('81'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rtrim", "'hello world'", "utf8(from_hex('81'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: �");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rtrim", "'hello world'", "utf8(from_hex('3281'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rtrim", "'hello world'", "utf8(from_hex('3281'))")::evaluate)
                 .hasMessage("Invalid UTF-8 encoding in characters: 2�");
     }
 
@@ -2083,15 +2083,15 @@ public class TestStringFunctions
                 .isEqualTo("\u4FE1\u5FF5 \u7231 ");
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("lpad", "'abc'", "3", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("lpad", "'abc'", "3", "''")::evaluate)
                 .hasMessage("Padding string must not be empty");
 
         // invalid target lengths
         long maxSize = Integer.MAX_VALUE;
-        assertTrinoExceptionThrownBy(() -> assertions.function("lpad", "'abc'", "-1", "'foo'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("lpad", "'abc'", "-1", "'foo'")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + maxSize + "]");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("lpad", "'abc'", Long.toString(maxSize + 1), "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("lpad", "'abc'", Long.toString(maxSize + 1), "''")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + maxSize + "]");
     }
 
@@ -2152,15 +2152,15 @@ public class TestStringFunctions
                 .isEqualTo("\u4FE1\u5FF5 \u7231 ");
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("rpad", "'abc'", "3", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rpad", "'abc'", "3", "''")::evaluate)
                 .hasMessage("Padding string must not be empty");
 
         // invalid target lengths
         long maxSize = Integer.MAX_VALUE;
-        assertTrinoExceptionThrownBy(() -> assertions.function("rpad", "'abc'", "-1", "'foo'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rpad", "'abc'", "-1", "'foo'")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + maxSize + "]");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rpad", "'abc'", Long.toString(maxSize + 1), "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rpad", "'abc'", Long.toString(maxSize + 1), "''")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + maxSize + "]");
     }
 
@@ -2261,10 +2261,10 @@ public class TestStringFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("X");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_utf8", "to_utf8('hello')", "'foo'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_utf8", "to_utf8('hello')", "'foo'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_utf8", "to_utf8('hello')", "1114112").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_utf8", "to_utf8('hello')", "1114112")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -2299,7 +2299,7 @@ public class TestStringFunctions
                 .hasType(createCharType(17))
                 .isEqualTo("hello na\u00EFve world");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("concat", "cast('ab ' as char(40000))", "cast('' as char(40000))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("concat", "cast('ab ' as char(40000))", "cast('' as char(40000))")::evaluate)
                 .hasErrorCode(TYPE_NOT_FOUND)
                 .hasMessage("line 1:8: Unknown type: char(80000)");
 
@@ -2425,7 +2425,7 @@ public class TestStringFunctions
                 .hasType(createVarcharType(4))
                 .isEqualTo("J500");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("soundex", "'jąmes'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("soundex", "'jąmes'")::evaluate)
                 .hasMessage("The character is not mapped: Ą (index=195)");
 
         assertThat(assertions.function("soundex", "'x123'"))

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestTryFunction.java
@@ -115,7 +115,7 @@ public class TestTryFunction
                 .isNull(BIGINT);
 
         // Exceptions that should not be suppressed
-        assertTrinoExceptionThrownBy(() -> assertions.expression("try(throw_error())").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("try(throw_error())")::evaluate)
                 .hasErrorCode(GENERIC_INTERNAL_ERROR);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestTypeOfFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestTypeOfFunction.java
@@ -105,7 +105,7 @@ public class TestTypeOfFunction
     @Test
     public void testLambda()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.expression("typeof(x -> x)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("typeof(x -> x)")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND)
                 .hasMessage("line 1:12: Unexpected parameters (<function>) for function typeof. Expected: typeof(t) T");
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestVarbinaryFunctions.java
@@ -87,7 +87,7 @@ public class TestVarbinaryFunctions
     @Test
     public void testConcat()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("CONCAT", "X''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("CONCAT", "X''")::evaluate)
                 .hasMessage("There must be two or more concatenation arguments");
 
         assertThat(assertions.expression("CAST('foo' AS VARBINARY) || CAST ('bar' AS VARBINARY)"))
@@ -324,16 +324,16 @@ public class TestVarbinaryFunctions
         assertThat(assertions.function("from_base32", "CAST(NULL AS VARBINARY)"))
                 .isNull(VARBINARY);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base32", "'1='").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base32", "'1='")::evaluate)
                 .hasMessage("Invalid input length 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base32", "'M1======'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base32", "'M1======'")::evaluate)
                 .hasMessage("Unrecognized character: 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base32", "CAST('1=' AS VARBINARY)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base32", "CAST('1=' AS VARBINARY)")::evaluate)
                 .hasMessage("Invalid input length 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_base32", "CAST('M1======' AS VARBINARY)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_base32", "CAST('M1======' AS VARBINARY)")::evaluate)
                 .hasMessage("Unrecognized character: 1");
     }
 
@@ -386,30 +386,30 @@ public class TestVarbinaryFunctions
                 .isEqualTo(base16().encode(ALL_BYTES));
 
         // '0' - 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'f/'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'f/'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // '9' + 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'f:'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'f:'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // 'A' - 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'f@'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'f@'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // 'F' + 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'fG'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'fG'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // 'a' - 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'f`'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'f`'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         // 'f' + 1
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'fg'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'fg'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_hex", "'fff'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_hex", "'fff'")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -444,13 +444,13 @@ public class TestVarbinaryFunctions
         assertThat(assertions.function("from_big_endian_64", "from_hex('8000000000000001')"))
                 .isEqualTo(-9223372036854775807L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_64", "from_hex('')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_64", "from_hex('')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_64", "from_hex('1111')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_64", "from_hex('1111')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_64", "from_hex('000000000000000011')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_64", "from_hex('000000000000000011')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -489,13 +489,13 @@ public class TestVarbinaryFunctions
                 .hasType(INTEGER)
                 .isEqualTo(-2147483647);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_32", "from_hex('')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_32", "from_hex('')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_32", "from_hex('1111')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_32", "from_hex('1111')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_big_endian_32", "from_hex('000000000000000011')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_big_endian_32", "from_hex('000000000000000011')")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -580,7 +580,7 @@ public class TestVarbinaryFunctions
                 .hasType(REAL)
                 .isEqualTo(-1.4E-45f);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_ieee754_32", "from_hex('0000')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_ieee754_32", "from_hex('0000')")::evaluate)
                 .hasMessage("Input floating-point value must be exactly 4 bytes long");
     }
 
@@ -661,7 +661,7 @@ public class TestVarbinaryFunctions
                 .hasType(DOUBLE)
                 .isEqualTo(-4.9E-324);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_ieee754_64", "from_hex('00000000')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_ieee754_64", "from_hex('00000000')")::evaluate)
                 .hasMessage("Input floating-point value must be exactly 8 bytes long");
     }
 
@@ -684,10 +684,10 @@ public class TestVarbinaryFunctions
         assertThat(assertions.function("lpad", "x'1234'", "1", "x'4524'"))
                 .isEqualTo(sqlVarbinaryFromHex("12"));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("lpad", "x'2312'", "-1", "x'4524'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("lpad", "x'2312'", "-1", "x'4524'")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + Integer.MAX_VALUE + "]");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("lpad", "x'2312'", "1", "x''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("lpad", "x'2312'", "1", "x''")::evaluate)
                 .hasMessage("Padding bytes must not be empty");
     }
 
@@ -710,10 +710,10 @@ public class TestVarbinaryFunctions
         assertThat(assertions.function("rpad", "x'1234'", "1", "x'4524'"))
                 .isEqualTo(sqlVarbinaryFromHex("12"));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rpad", "x'1234'", "-1", "x'4524'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rpad", "x'1234'", "-1", "x'4524'")::evaluate)
                 .hasMessage("Target length must be in the range [0.." + Integer.MAX_VALUE + "]");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("rpad", "x'1234'", "1", "x''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("rpad", "x'1234'", "1", "x''")::evaluate)
                 .hasMessage("Padding bytes must not be empty");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestWordStemFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestWordStemFunction.java
@@ -121,7 +121,7 @@ public class TestWordStemFunction
                 .hasType(createVarcharType(6))
                 .isEqualTo("bastã");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("word_stem", "'test'", "'xx'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("word_stem", "'test'", "'xx'")::evaluate)
                 .hasMessage("Unknown stemmer language: xx");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalDayTime.java
@@ -135,19 +135,19 @@ public class TestIntervalDayTime
         assertThat(assertions.expression("INTERVAL '32' SECOND"))
                 .isEqualTo(interval(0, 0, 0, 32, 0));
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '12X' DAY").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '12X' DAY")::evaluate)
                 .hasMessage("line 1:12: '12X' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '12 10' DAY").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '12 10' DAY")::evaluate)
                 .hasMessage("line 1:12: '12 10' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '12 X' DAY TO HOUR").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '12 X' DAY TO HOUR")::evaluate)
                 .hasMessage("line 1:12: '12 X' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '12 -10' DAY TO HOUR").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '12 -10' DAY TO HOUR")::evaluate)
                 .hasMessage("line 1:12: '12 -10' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '--12 -10' DAY TO HOUR").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '--12 -10' DAY TO HOUR")::evaluate)
                 .hasMessage("line 1:12: '--12 -10' is not a valid INTERVAL literal");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalYearMonth.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/interval/TestIntervalYearMonth.java
@@ -63,19 +63,19 @@ public class TestIntervalYearMonth
         assertThat(assertions.expression("INTERVAL '32767-32767' YEAR TO MONTH"))
                 .isEqualTo(interval(32767, 32767));
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '124X' YEAR").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '124X' YEAR")::evaluate)
                 .hasMessage("line 1:12: '124X' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '124-30' YEAR").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '124-30' YEAR")::evaluate)
                 .hasMessage("line 1:12: '124-30' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '124-X' YEAR TO MONTH").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '124-X' YEAR TO MONTH")::evaluate)
                 .hasMessage("line 1:12: '124-X' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '124--30' YEAR TO MONTH").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '124--30' YEAR TO MONTH")::evaluate)
                 .hasMessage("line 1:12: '124--30' is not a valid INTERVAL literal");
 
-        assertThatThrownBy(() -> assertions.expression("INTERVAL '--124--30' YEAR TO MONTH").evaluate())
+        assertThatThrownBy(assertions.expression("INTERVAL '--124--30' YEAR TO MONTH")::evaluate)
                 .hasMessage("line 1:12: '--124--30' is not a valid INTERVAL literal");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestExtract.java
@@ -135,7 +135,7 @@ public class TestExtract
     @Test
     public void testMillisecond()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestTime.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/time/TestTime.java
@@ -107,19 +107,19 @@ public class TestTime
                 .hasType(createTimeType(12))
                 .isEqualTo(time(12, 12, 34, 56, 123_456_789_123L));
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:34:56.1234567891234'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:34:56.1234567891234'")::evaluate)
                 .hasMessage("line 1:12: TIME precision must be in range [0, 12]: 13");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '25:00:00'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '25:00:00'")::evaluate)
                 .hasMessage("line 1:12: '25:00:00' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:65:00'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:65:00'")::evaluate)
                 .hasMessage("line 1:12: '12:65:00' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:65'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:65'")::evaluate)
                 .hasMessage("line 1:12: '12:00:65' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME 'xxx'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME 'xxx'")::evaluate)
                 .hasMessage("line 1:12: 'xxx' is not a valid TIME literal");
     }
 
@@ -1464,31 +1464,31 @@ public class TestTime
         assertThat(assertions.expression("CAST('23:59:59.999999999999' AS TIME(11))")).matches("TIME '00:00:00.00000000000'");
 
         // > 12 digits of precision
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(0))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(0))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(1))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(1))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(2))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(2))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(3))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(3))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(4))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(4))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(5))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(5))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(6))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(6))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(7))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(7))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(8))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(8))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(9))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(9))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(10))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(10))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(11))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(11))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
-        assertThatThrownBy(() -> assertions.expression("CAST('12:34:56.1111111111111' AS TIME(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('12:34:56.1111111111111' AS TIME(12))")::evaluate)
                 .hasMessage("Value cannot be cast to time: 12:34:56.1111111111111");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestExtract.java
@@ -324,7 +324,7 @@ public class TestExtract
     @Test
     public void testMillisecond()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
 
@@ -478,7 +478,7 @@ public class TestExtract
     @Test
     public void testWeekOfYear()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: WEEK_OF_YEAR");
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestHumanReadableSeconds.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestHumanReadableSeconds.java
@@ -103,11 +103,11 @@ public class TestHumanReadableSeconds
                 .isNull(VARCHAR);
 
         // check for NaN
-        assertTrinoExceptionThrownBy(() -> assertions.function("human_readable_seconds", "0.0E0 / 0.0E0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("human_readable_seconds", "0.0E0 / 0.0E0")::evaluate)
                 .hasMessage("Invalid argument found: NaN");
 
         // check for infinity
-        assertTrinoExceptionThrownBy(() -> assertions.function("human_readable_seconds", "1.0E0 / 0.0E0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("human_readable_seconds", "1.0E0 / 0.0E0")::evaluate)
                 .hasMessage("Invalid argument found: Infinity");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamp/TestTimestamp.java
@@ -143,13 +143,13 @@ public class TestTimestamp
                 .hasType(createTimestampType(12))
                 .isEqualTo(timestamp(12, 2020, 5, 1, 12, 34, 56, 123_456_789_012L));
 
-        assertThatThrownBy(() -> assertions.expression("TIMESTAMP '2020-05-01 12:34:56.1234567890123'").evaluate())
+        assertThatThrownBy(assertions.expression("TIMESTAMP '2020-05-01 12:34:56.1234567890123'")::evaluate)
                 .hasMessage("line 1:12: TIMESTAMP precision must be in range [0, 12]: 13");
 
-        assertThatThrownBy(() -> assertions.expression("TIMESTAMP '2020-13-01'").evaluate())
+        assertThatThrownBy(assertions.expression("TIMESTAMP '2020-13-01'")::evaluate)
                 .hasMessage("line 1:12: '2020-13-01' is not a valid TIMESTAMP literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIMESTAMP 'xxx'").evaluate())
+        assertThatThrownBy(assertions.expression("TIMESTAMP 'xxx'")::evaluate)
                 .hasMessage("line 1:12: 'xxx' is not a valid TIMESTAMP literal");
 
         // negative epoch
@@ -1473,9 +1473,9 @@ public class TestTimestamp
         assertThat(assertions.expression("CAST(TIMESTAMP '-12001-05-01 12:34:56' AS TIMESTAMP(0) WITH TIME ZONE)")).matches("TIMESTAMP '-12001-05-01 12:34:56 Pacific/Apia'");
 
         // Overflow
-        assertThatThrownBy(() -> assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Out of range for timestamp with time zone: 3819379822496000");
-        assertThatThrownBy(() -> assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST(TIMESTAMP '-123001-05-01 12:34:56' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Out of range for timestamp with time zone: -3943693439888000");
     }
 
@@ -1678,85 +1678,85 @@ public class TestTimestamp
         assertThat(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 +01:23' AS TIMESTAMP(12))"))
                 .matches("TIMESTAMP '2020-05-10 12:34:56.111111111111'");
 
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(0))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(0))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(1))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(1))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(2))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(2))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(3))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(3))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(4))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(4))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(5))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(5))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(6))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(6))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(7))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(7))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(8))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(8))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(9))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(9))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(10))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(10))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(11))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(11))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 12:34:56.111111111111 xxx' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 12:34:56.111111111111 xxx");
 
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(0))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(0))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(1))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(1))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(2))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(2))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(3))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(3))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(4))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(4))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(5))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(5))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(6))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(6))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(7))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(7))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(8))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(8))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(9))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(9))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(10))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(10))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(11))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(11))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10 xxx' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10 xxx");
 
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(0))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(0))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(1))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(1))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(2))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(2))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(3))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(3))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(4))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(4))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(5))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(5))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(6))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(6))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(7))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(7))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(8))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(8))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(9))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(9))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(10))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(10))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(11))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(11))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
-        assertThatThrownBy(() -> assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2020-05-10T12:34:56' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2020-05-10T12:34:56");
     }
 
@@ -2792,30 +2792,30 @@ public class TestTimestamp
     @Test
     public void testCastInvalidTimestamp()
     {
-        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('ABC' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: ABC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61");
 
-        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('ABC' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: ABC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-00 00:00:00' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-00-01 00:00:00' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 25:00:00' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:61:00' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:61' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestExtract.java
@@ -295,7 +295,7 @@ public class TestExtract
     @Test
     public void testMillisecond()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
 
@@ -600,7 +600,7 @@ public class TestExtract
     @Test
     public void testWeekOfYear()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(WEEK_OF_YEAR FROM TIMESTAMP '2020-05-10 12:34:56 Asia/Kathmandu')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: WEEK_OF_YEAR");
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -113,10 +113,10 @@ public class TestTimestampWithTimeZone
                 .hasType(createTimestampWithTimeZoneType(12))
                 .isEqualTo(timestampWithTimeZone(12, 2020, 5, 1, 12, 34, 56, 123_456_789_012L, getTimeZoneKey("Asia/Kathmandu")));
 
-        assertThatThrownBy(() -> assertions.expression("TIMESTAMP '2020-05-01 12:34:56.1234567890123 Asia/Kathmandu'").evaluate())
+        assertThatThrownBy(assertions.expression("TIMESTAMP '2020-05-01 12:34:56.1234567890123 Asia/Kathmandu'")::evaluate)
                 .hasMessage("line 1:12: TIMESTAMP WITH TIME ZONE precision must be in range [0, 12]: 13");
 
-        assertThatThrownBy(() -> assertions.expression("TIMESTAMP '2020-13-01 Asia/Kathmandu'").evaluate())
+        assertThatThrownBy(assertions.expression("TIMESTAMP '2020-13-01 Asia/Kathmandu'")::evaluate)
                 .hasMessage("line 1:12: '2020-13-01 Asia/Kathmandu' is not a valid TIMESTAMP literal");
 
         // negative epoch
@@ -423,20 +423,20 @@ public class TestTimestampWithTimeZone
                 .isEqualTo(timestampWithTimeZone(0, 2001, 1, 2, 0, 0, 0, 0, getTimeZoneKey("Europe/Berlin")));
 
         // Overflow
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '123001-01-02 03:04:05.321 Europe/Berlin'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '123001-01-02 03:04:05.321 Europe/Berlin'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '123001-01-02 03:04:05.321 Europe/Berlin' is not a valid TIMESTAMP literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '+123001-01-02 03:04:05.321 Europe/Berlin'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '+123001-01-02 03:04:05.321 Europe/Berlin'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '+123001-01-02 03:04:05.321 Europe/Berlin' is not a valid TIMESTAMP literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '-123001-01-02 03:04:05.321 Europe/Berlin'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '-123001-01-02 03:04:05.321 Europe/Berlin'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '-123001-01-02 03:04:05.321 Europe/Berlin' is not a valid TIMESTAMP literal");
 
         // missing space after day
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TIMESTAMP '2020-13-01-12'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TIMESTAMP '2020-13-01-12'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2020-13-01-12' is not a valid TIMESTAMP literal");
     }
@@ -2608,34 +2608,34 @@ public class TestTimestampWithTimeZone
     @Test
     public void testCastInvalidTimestamp()
     {
-        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('ABC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: ABC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:00 ABC");
 
-        assertThatThrownBy(() -> assertions.expression("CAST('ABC' AS TIMESTAMP(12))").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('ABC' AS TIMESTAMP(12))")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: ABC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-00 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-00 00:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-00-01 00:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-00-01 00:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 25:00:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 25:00:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:61:00 UTC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:61:00 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:61 UTC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:61 UTC");
-        assertThatThrownBy(() -> assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP(12) WITH TIME ZONE)").evaluate())
+        assertThatThrownBy(assertions.expression("CAST('2022-01-01 00:00:00 ABC' AS TIMESTAMP(12) WITH TIME ZONE)")::evaluate)
                 .hasMessage("Value cannot be cast to timestamp: 2022-01-01 00:00:00 ABC");
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestExtract.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestExtract.java
@@ -135,7 +135,7 @@ public class TestExtract
     @Test
     public void testMillisecond()
     {
-        assertThatThrownBy(() -> assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56+08:35')").evaluate())
+        assertThatThrownBy(assertions.expression("EXTRACT(MILLISECOND FROM TIME '12:34:56+08:35')")::evaluate)
                 .isInstanceOf(ParsingException.class)
                 .hasMessage("line 1:12: Invalid EXTRACT field: MILLISECOND");
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timetz/TestTimeWithTimeZone.java
@@ -260,34 +260,34 @@ public class TestTimeWithTimeZone
                 .hasType(createTimeWithTimeZoneType(12))
                 .isEqualTo(timeWithTimeZone(12, 12, 34, 56, 123_456_789_123L, -14 * 60));
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:34:56.1234567891234+08:35'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:34:56.1234567891234+08:35'")::evaluate)
                 .hasMessage("line 1:12: TIME WITH TIME ZONE precision must be in range [0, 12]: 13");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '25:00:00+08:35'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '25:00:00+08:35'")::evaluate)
                 .hasMessage("line 1:12: '25:00:00+08:35' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:65:00+08:35'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:65:00+08:35'")::evaluate)
                 .hasMessage("line 1:12: '12:65:00+08:35' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:65+08:35'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:65+08:35'")::evaluate)
                 .hasMessage("line 1:12: '12:00:65+08:35' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00+15:00'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00+15:00'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00+15:00' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00-15:00'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00-15:00'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00-15:00' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00+14:01'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00+14:01'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00+14:01' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00-14:01'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00-14:01'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00-14:01' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00+13:60'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00+13:60'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00+13:60' is not a valid TIME literal");
 
-        assertThatThrownBy(() -> assertions.expression("TIME '12:00:00-13:60'").evaluate())
+        assertThatThrownBy(assertions.expression("TIME '12:00:00-13:60'")::evaluate)
                 .hasMessage("line 1:12: '12:00:00-13:60' is not a valid TIME literal");
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -702,7 +702,7 @@ public class QueryAssertions
                     .withRepresentation(ExpressionAssert.TYPE_RENDERER);
         }
 
-        record Result(Type type, Object value) {}
+        public record Result(Type type, Object value) {}
     }
 
     public static class ExpressionAssert

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -639,54 +639,53 @@ public class QueryAssertions
             if (bindings.isEmpty()) {
                 return run("VALUES ROW(%s)".formatted(expression));
             }
-            else {
-                List<Map.Entry<String, String>> entries = ImmutableList.copyOf(bindings.entrySet());
 
-                List<String> columns = entries.stream()
-                        .map(Map.Entry::getKey)
-                        .collect(toList());
+            List<Map.Entry<String, String>> entries = ImmutableList.copyOf(bindings.entrySet());
 
-                List<String> values = entries.stream()
-                        .map(Map.Entry::getValue)
-                        .collect(toList());
+            List<String> columns = entries.stream()
+                    .map(Map.Entry::getKey)
+                    .collect(toList());
 
-                // Evaluate the expression using two modes:
-                //  1. Avoid constant folding -> exercises the compiler and evaluation engine
-                //  2. Force constant folding -> exercises the interpreter
+            List<String> values = entries.stream()
+                    .map(Map.Entry::getValue)
+                    .collect(toList());
 
-                Result full = run("""
-                        SELECT %s
-                        FROM (
-                            VALUES ROW(%s)
-                        ) t(%s)
-                        WHERE rand() >= 0
-                        """
-                        .formatted(
-                                expression,
-                                Joiner.on(",").join(values),
-                                Joiner.on(",").join(columns)));
+            // Evaluate the expression using two modes:
+            //  1. Avoid constant folding -> exercises the compiler and evaluation engine
+            //  2. Force constant folding -> exercises the interpreter
 
-                Result withConstantFolding = run("""
-                        SELECT %s
-                        FROM (
-                            VALUES ROW(%s)
-                        ) t(%s)
-                        """
-                        .formatted(
-                                expression,
-                                Joiner.on(",").join(values),
-                                Joiner.on(",").join(columns)));
+            Result full = run("""
+                    SELECT %s
+                    FROM (
+                        VALUES ROW(%s)
+                    ) t(%s)
+                    WHERE rand() >= 0
+                    """
+                    .formatted(
+                            expression,
+                            Joiner.on(",").join(values),
+                            Joiner.on(",").join(columns)));
 
-                if (!full.type().equals(withConstantFolding.type())) {
-                    fail("Mismatched types between interpreter and evaluation engine: %s vs %s".formatted(full.type(), withConstantFolding.type()));
-                }
+            Result withConstantFolding = run("""
+                    SELECT %s
+                    FROM (
+                        VALUES ROW(%s)
+                    ) t(%s)
+                    """
+                    .formatted(
+                            expression,
+                            Joiner.on(",").join(values),
+                            Joiner.on(",").join(columns)));
 
-                if (!Objects.equals(full.value(), withConstantFolding.value())) {
-                    fail("Mismatched results between interpreter and evaluation engine: %s vs %s".formatted(full.value(), withConstantFolding.value()));
-                }
-
-                return new Result(full.type(), full.value);
+            if (!full.type().equals(withConstantFolding.type())) {
+                fail("Mismatched types between interpreter and evaluation engine: %s vs %s".formatted(full.type(), withConstantFolding.type()));
             }
+
+            if (!Objects.equals(full.value(), withConstantFolding.value())) {
+                fail("Mismatched results between interpreter and evaluation engine: %s vs %s".formatted(full.value(), withConstantFolding.value()));
+            }
+
+            return new Result(full.type(), full.value);
         }
 
         private Result run(String query)

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -1153,10 +1153,10 @@ public class TestArrayOperators
         assertThat(assertions.function("contains", "array[TIMESTAMP '2020-05-10 12:34:56.123456789', TIMESTAMP '1111-05-10 12:34:56.123456789']", "TIMESTAMP '1111-05-10 12:34:56.123456789'"))
                 .isEqualTo(true);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "array[ARRAY[1.1, 2.2], ARRAY[3.3, 4.3]]", "ARRAY[1.1, null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "array[ARRAY[1.1, 2.2], ARRAY[3.3, 4.3]]", "ARRAY[1.1, null]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("contains", "array[ARRAY[1.1, null], ARRAY[3.3, 4.3]]", "ARRAY[1.1, null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("contains", "array[ARRAY[1.1, null], ARRAY[3.3, 4.3]]", "ARRAY[1.1, null]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
     }
 
@@ -1278,13 +1278,13 @@ public class TestArrayOperators
                 .hasType(VARCHAR)
                 .isEqualTo("1.0E0x2.1E0x3.3E0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_join", "ARRAY[ARRAY[1], ARRAY[2]]", "'-'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_join", "ARRAY[ARRAY[1], ARRAY[2]]", "'-'")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_join", "ARRAY[MAP(ARRAY[1], ARRAY[2])]", "'-'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_join", "ARRAY[MAP(ARRAY[1], ARRAY[2])]", "'-'")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_join", "ARRAY[CAST(row(1, 2) AS row(col0 bigint, col1 bigint))]", "'-'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_join", "ARRAY[CAST(row(1, 2) AS row(col0 bigint, col1 bigint))]", "'-'")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
     }
 
@@ -1831,10 +1831,10 @@ public class TestArrayOperators
         assertThat(assertions.function("array_position", "ARRAY[TIMESTAMP '2020-05-10 12:34:56.123456789', TIMESTAMP '1111-05-10 12:34:56.123456789']", "TIMESTAMP '1111-05-10 12:34:56.123456789'"))
                 .isEqualTo(2L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_position", "ARRAY[ARRAY[null]]", "ARRAY[1]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_position", "ARRAY[ARRAY[null]]", "ARRAY[1]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_position", "ARRAY[ARRAY[null]]", "ARRAY[null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_position", "ARRAY[ARRAY[null]]", "ARRAY[null]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
     }
 
@@ -1995,10 +1995,10 @@ public class TestArrayOperators
     @Test
     public void testElementAt()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("element_at", "ARRAY[]", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("element_at", "ARRAY[]", "0")::evaluate)
                 .hasMessage("SQL array indices start at 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("element_at", "ARRAY[1, 2, 3]", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("element_at", "ARRAY[1, 2, 3]", "0")::evaluate)
                 .hasMessage("SQL array indices start at 1");
 
         assertThat(assertions.function("element_at", "ARRAY[]", "1"))
@@ -2292,7 +2292,7 @@ public class TestArrayOperators
                 .isEqualTo(asList(-1, 0, 1, null, null));
 
         // invalid functions
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_sort", "ARRAY[color('red'), color('blue')]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_sort", "ARRAY[color('red'), color('blue')]")::evaluate)
                 .hasErrorCode(FUNCTION_NOT_FOUND);
 
         assertTrinoExceptionThrownBy(() -> assertions.expression("array_sort(a, (x, y) -> y - x)")
@@ -2518,10 +2518,10 @@ public class TestArrayOperators
         assertThat(assertions.function("slice", "ARRAY[2.330, 1.900, 2.330]", "1", "2"))
                 .matches("ARRAY[2.330, 1.900]");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("slice", "ARRAY[1, 2, 3, 4]", "1", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "1", "-1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("slice", "ARRAY[1, 2, 3, 4]", "0", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("slice", "ARRAY[1, 2, 3, 4]", "0", "1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -4067,13 +4067,13 @@ public class TestArrayOperators
                         decimal("9876543210.9876543210", createDecimalType(22, 10)),
                         decimal("123123123456.6549876543", createDecimalType(22, 10))));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_remove", "ARRAY[ARRAY[CAST(null AS BIGINT)]]", "ARRAY[CAST(1 AS BIGINT)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_remove", "ARRAY[ARRAY[CAST(null AS BIGINT)]]", "ARRAY[CAST(1 AS BIGINT)]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_remove", "ARRAY[ARRAY[CAST(null AS BIGINT)]]", "ARRAY[CAST(null AS BIGINT)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_remove", "ARRAY[ARRAY[CAST(null AS BIGINT)]]", "ARRAY[CAST(null AS BIGINT)]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("array_remove", "ARRAY[ARRAY[CAST(1 AS BIGINT)]]", "ARRAY[CAST(null AS BIGINT)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("array_remove", "ARRAY[ARRAY[CAST(1 AS BIGINT)]]", "ARRAY[CAST(null AS BIGINT)]")::evaluate)
                 .hasErrorCode(NOT_SUPPORTED);
     }
 
@@ -4152,16 +4152,16 @@ public class TestArrayOperators
                 .isEqualTo(ImmutableList.of());
 
         // illegal inputs
-        assertTrinoExceptionThrownBy(() -> assertions.function("repeat", "2", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "2", "-1")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("repeat", "1", "1000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "1", "1000000")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("repeat", "'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongvarchar'", "9999").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongvarchar'", "9999")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("repeat", "array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]", "9999").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("repeat", "array[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]", "9999")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -4335,50 +4335,50 @@ public class TestArrayOperators
                 .isEqualTo(ImmutableList.of(-100L, 0L));
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "2", "-1", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "2", "-1", "1")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-1", "-10", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-1", "-10", "1")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "1", "1000000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "1", "1000000")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2000-04-14'", "DATE '2030-04-12'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2000-04-14'", "DATE '2030-04-12'")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
         // long overflow
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "9223372036854775807", "-9223372036854775808", "-100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "9223372036854775807", "-9223372036854775808", "-100")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "9223372036854775807", "-9223372036854775808", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "9223372036854775807", "-9223372036854775808", "-1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-9223372036854775808", "9223372036854775807", "100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-9223372036854775808", "9223372036854775807", "100")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-9223372036854775808", "9223372036854775807", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-9223372036854775808", "9223372036854775807", "1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-9223372036854775808", "0", "100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-9223372036854775808", "0", "100")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-9223372036854775808", "0", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-9223372036854775808", "0", "1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "9223372036854775807", "0", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "9223372036854775807", "0", "-1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "0", "9223372036854775807", "1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "0", "9223372036854775807", "1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "0", "-9223372036854775808", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "0", "-9223372036854775808", "-1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "-5000", "5000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "-5000", "5000")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "5000", "-5000", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "5000", "-5000", "-1")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
     }
 
@@ -4416,25 +4416,25 @@ public class TestArrayOperators
                 .matches("ARRAY[TIMESTAMP '2016-04-16 01:00:10',TIMESTAMP '2016-04-15 06:00:10',TIMESTAMP '2016-04-14 11:00:10']");
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2016-04-12'", "DATE '2016-04-14'", "interval '-1' day").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2016-04-12'", "DATE '2016-04-14'", "interval '-1' day")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2016-04-14'", "DATE '2016-04-12'", "interval '1' day").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2016-04-14'", "DATE '2016-04-12'", "interval '1' day")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2000-04-14'", "DATE '2030-04-12'", "interval '1' day").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2000-04-14'", "DATE '2030-04-12'", "interval '1' day")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2018-01-01'", "DATE '2018-01-04'", "interval '18' hour").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2018-01-01'", "DATE '2018-01-04'", "interval '18' hour")::evaluate)
                 .hasMessage("sequence step must be a day interval if start and end values are dates");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '2016-04-16 01:01:00'", "interval '-20' second").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '2016-04-16 01:01:00'", "interval '-20' second")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-04-16 01:10:10'", "timestamp '2016-04-16 01:01:00'", "interval '20' second").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-04-16 01:10:10'", "timestamp '2016-04-16 01:01:00'", "interval '20' second")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '2016-04-16 09:01:00'", "interval '1' second").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '2016-04-16 09:01:00'", "interval '1' second")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
     }
 
@@ -4472,22 +4472,22 @@ public class TestArrayOperators
                 .matches("ARRAY[TIMESTAMP '2016-04-16 01:01:10', TIMESTAMP '2014-04-16 01:01:10', TIMESTAMP '2012-04-16 01:01:10']");
 
         // failure modes
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2016-06-12'", "DATE '2016-04-12'", "interval '1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2016-06-12'", "DATE '2016-04-12'", "interval '1' month")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2016-04-12'", "DATE '2016-06-12'", "interval '-1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2016-04-12'", "DATE '2016-06-12'", "interval '-1' month")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "DATE '2000-04-12'", "DATE '3000-06-12'", "interval '1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "DATE '2000-04-12'", "DATE '3000-06-12'", "interval '1' month")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-05-16 01:00:10'", "timestamp '2016-04-16 01:01:00'", "interval '1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-05-16 01:00:10'", "timestamp '2016-04-16 01:01:00'", "interval '1' month")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-04-16 01:10:10'", "timestamp '2016-05-16 01:01:00'", "interval '-1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-04-16 01:10:10'", "timestamp '2016-05-16 01:01:00'", "interval '-1' month")::evaluate)
                 .hasMessage("sequence stop value should be greater than or equal to start value if step is greater than zero otherwise stop should be less than or equal to start");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '3000-04-16 09:01:00'", "interval '1' month").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("sequence", "timestamp '2016-04-16 01:00:10'", "timestamp '3000-04-16 09:01:00'", "interval '1' month")::evaluate)
                 .hasMessage("result of sequence function must not have more than 10000 entries");
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
@@ -482,7 +482,7 @@ public class TestBigintOperators
     @Test
     public void testOverflowAdd()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, Long.toString(Long.MAX_VALUE), "BIGINT '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, Long.toString(Long.MAX_VALUE), "BIGINT '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint addition overflow: 9223372036854775807 + 1");
     }
@@ -490,7 +490,7 @@ public class TestBigintOperators
     @Test
     public void testUnderflowSubtract()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, Long.toString(Long.MIN_VALUE), "BIGINT '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, Long.toString(Long.MIN_VALUE), "BIGINT '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint subtraction overflow: -9223372036854775808 - 1");
     }
@@ -498,11 +498,11 @@ public class TestBigintOperators
     @Test
     public void testOverflowMultiply()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, Long.toString(Long.MAX_VALUE), "2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, Long.toString(Long.MAX_VALUE), "2")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint multiplication overflow: 9223372036854775807 * 2");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, Long.toString(Long.MIN_VALUE), "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, Long.toString(Long.MIN_VALUE), "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint multiplication overflow: -9223372036854775808 * -1");
     }
@@ -510,7 +510,7 @@ public class TestBigintOperators
     @Test
     public void testOverflowDivide()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, Long.toString(Long.MIN_VALUE), "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, Long.toString(Long.MIN_VALUE), "-1")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint division overflow: -9223372036854775808 / -1");
     }
@@ -534,7 +534,7 @@ public class TestBigintOperators
     @Test
     public void testNegateOverflow()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.operator(NEGATION, Long.toString(Long.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(NEGATION, Long.toString(Long.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("bigint negation overflow: -9223372036854775808");
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestDate.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDate.java
@@ -82,11 +82,11 @@ public class TestDate
                 .isEqualTo(toDate(new DateTime(2013, 2, 2, 0, 0, 0, 0, UTC)));
 
         // three digit for month or day
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '2013-02-002'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '2013-02-002'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2013-02-002' is not a valid DATE literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '2013-002-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '2013-002-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2013-002-02' is not a valid DATE literal");
 
@@ -100,7 +100,7 @@ public class TestDate
                 .isEqualTo(toDate(new DateTime(13, 2, 2, 0, 0, 0, 0, UTC)));
 
         // invalid date
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '2013-02-29'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '2013-02-29'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2013-02-29' is not a valid DATE literal");
 
@@ -114,20 +114,20 @@ public class TestDate
                 .isEqualTo(toDate(new DateTime(2013, 2, 2, 0, 0, 0, 0, UTC)));
 
         // intra whitespace
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '2013 -02-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '2013 -02-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2013 -02-02' is not a valid DATE literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '2013- 2-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '2013- 2-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '2013- 2-02' is not a valid DATE literal");
 
         // large year
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '5881580-07-12'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '5881580-07-12'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '5881580-07-12' is not a valid DATE literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '392251590-07-12'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '392251590-07-12'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '392251590-07-12' is not a valid DATE literal");
 
@@ -145,11 +145,11 @@ public class TestDate
                 .hasType(DATE)
                 .isEqualTo(toDate(new DateTime(2013, 2, 2, 0, 0, 0, 0, UTC)));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '+ 2013-02-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '+ 2013-02-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '+ 2013-02-02' is not a valid DATE literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE ' + 2013-02-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE ' + 2013-02-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: ' + 2013-02-02' is not a valid DATE literal");
 
@@ -157,11 +157,11 @@ public class TestDate
                 .hasType(DATE)
                 .isEqualTo(toDate(new DateTime(-2013, 2, 2, 0, 0, 0, 0, UTC)));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE '- 2013-02-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE '- 2013-02-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: '- 2013-02-02' is not a valid DATE literal");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("DATE ' - 2013-02-02'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("DATE ' - 2013-02-02'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL)
                 .hasMessage("line 1:12: ' - 2013-02-02' is not a valid DATE literal");
     }
@@ -581,7 +581,7 @@ public class TestDate
         assertThat(assertions.operator(SUBTRACT, "DATE '2001-1-22'", "INTERVAL '3' day"))
                 .matches("DATE '2001-01-19'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DATE '2001-1-22'", "INTERVAL '3' hour").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DATE '2001-1-22'", "INTERVAL '3' hour")::evaluate)
                 .hasMessage("Cannot subtract hour, minutes or seconds from a date");
     }
 
@@ -606,10 +606,10 @@ public class TestDate
         assertThat(assertions.operator(ADD, "INTERVAL '3' year", "DATE '2001-1-22'"))
                 .matches("DATE '2004-01-22'");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DATE '2001-1-22'", "INTERVAL '3' hour").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DATE '2001-1-22'", "INTERVAL '3' hour")::evaluate)
                 .hasMessage("Cannot add hour, minutes or seconds to a date");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "INTERVAL '3' hour", "DATE '2001-1-22'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "INTERVAL '3' hour", "DATE '2001-1-22'")::evaluate)
                 .hasMessage("Cannot add hour, minutes or seconds to a date");
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
@@ -145,22 +145,22 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("12345678.123456789012345678901234567890", createDecimalType(38, 30)));
 
         // overflow tests
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '.1'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '.1'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '1'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '1'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '-99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '-99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         // max supported value for rescaling
@@ -170,7 +170,7 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("9999999999999999999999999999999999999.9", createDecimalType(38, 1)));
 
         // 17015000000000000000000000000000000000 on the other hand is too large and rescaled to DECIMAL(38,1) it does not fit in in 127 bits
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "DECIMAL '17015000000000000000000000000000000000'", "DECIMAL '-7015000000000000000000000000000000000.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "DECIMAL '17015000000000000000000000000000000000'", "DECIMAL '-7015000000000000000000000000000000000.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
@@ -256,19 +256,19 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("12345677.999999999999999999999999999999", createDecimalType(38, 30)));
 
         // overflow tests
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '.1'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '.1'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '-1'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '-1'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '99999999999999999999999999999999999999'", "DECIMAL '.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '99999999999999999999999999999999999999'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '-99999999999999999999999999999999999999'", "DECIMAL '99999999999999999999999999999999999999'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         // max supported value for rescaling
@@ -278,7 +278,7 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("9999999999999999999999999999999999999.9", createDecimalType(38, 1)));
 
         // 17015000000000000000000000000000000000 on the other hand is too large and rescaled to DECIMAL(38,1) it does not fit in in 127 bits
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "DECIMAL '17015000000000000000000000000000000000'", "DECIMAL '7015000000000000000000000000000000000.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "DECIMAL '17015000000000000000000000000000000000'", "DECIMAL '7015000000000000000000000000000000000.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
     }
 
@@ -408,23 +408,23 @@ public class TestDecimalOperators
                 .isEqualTo(decimal(".01524157875323883675019051998750190521", createDecimalType(38, 38)));
 
         // scale exceeds max precision
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456789'", "DECIMAL '.12345678901234567890'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '.1234567890123456789'", "DECIMAL '.12345678901234567890'")::evaluate)
                 .hasMessage("line 1:8: DECIMAL scale must be in range [0, precision (38)]: 39");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '.1'", "DECIMAL '.12345678901234567890123456789012345678'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '.1'", "DECIMAL '.12345678901234567890123456789012345678'")::evaluate)
                 .hasMessage("line 1:8: DECIMAL scale must be in range [0, precision (38)]: 39");
 
         // runtime overflow tests
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '9'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '9'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '-9'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '-9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '-9'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '-9'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         assertThatThrownBy(() -> DecimalOperators.multiplyLongShortLong(Int128.valueOf("12345678901234567890123456789012345678"), 9))
@@ -665,29 +665,29 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("0000000000000000000000000000000000.0344", createDecimalType(38, 4)));
 
         // runtime overflow
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '.1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '.12345678901234567890123456789012345678'", "DECIMAL '.1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '.12345678901234567890123456789012345678'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '12345678901234567890123456789012345678'", "DECIMAL '.12345678901234567890123456789012345678'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '.12345678901234567890123456789012345678'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '.12345678901234567890123456789012345678'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE);
 
         // division by zero tests
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0.0000000000000000000000000000000000000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0.0000000000000000000000000000000000000'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '0.0000000000000000000000000000000000000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "DECIMAL '1'", "DECIMAL '0.0000000000000000000000000000000000000'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
         assertThat(assertions.operator(DIVIDE, "CAST(1000 AS DECIMAL(38,8))", "CAST(25 AS DECIMAL(38,8))"))
@@ -926,19 +926,19 @@ public class TestDecimalOperators
                 .isEqualTo(decimal("00000000000000000000000000000000000000", createDecimalType(38)));
 
         // division by zero tests
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "DECIMAL '1'", "DECIMAL '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "DECIMAL '1'", "DECIMAL '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0.0000000000000000000000000000000000000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "DECIMAL '1.000000000000000000000000000000000000'", "DECIMAL '0.0000000000000000000000000000000000000'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "DECIMAL '1'", "DECIMAL '0.0000000000000000000000000000000000000'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "DECIMAL '1'", "DECIMAL '0.0000000000000000000000000000000000000'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "DECIMAL '1'", "CAST(0 AS DECIMAL(38,0))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "DECIMAL '1'", "CAST(0 AS DECIMAL(38,0))")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -591,7 +591,7 @@ public class TestDoubleOperators
                 .hasMessage("Value -0.0 (-0E0) cannot be represented as varchar(3)")
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("cast(0e0 / 0e0 AS varchar(2))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("cast(0e0 / 0e0 AS varchar(2))")::evaluate)
                 .hasMessage("Value NaN (NaN) cannot be represented as varchar(2)")
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
 

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -68,7 +68,7 @@ public class TestIntegerOperators
         assertThat(assertions.expression("INTEGER '17'"))
                 .isEqualTo(17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("INTEGER '" + ((long) Integer.MAX_VALUE + 1L) + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("INTEGER '" + ((long) Integer.MAX_VALUE + 1L) + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -91,7 +91,7 @@ public class TestIntegerOperators
         assertThat(assertions.expression("INTEGER '-17'"))
                 .isEqualTo(-17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("INTEGER '-" + Integer.MIN_VALUE + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("INTEGER '-" + Integer.MIN_VALUE + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -110,7 +110,7 @@ public class TestIntegerOperators
         assertThat(assertions.operator(ADD, "INTEGER '17'", "INTEGER '17'"))
                 .isEqualTo(17 + 17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("INTEGER '%s' + INTEGER '1'", Integer.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("INTEGER '%s' + INTEGER '1'", Integer.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("integer addition overflow: 2147483647 + 1");
     }
@@ -130,7 +130,7 @@ public class TestIntegerOperators
         assertThat(assertions.operator(SUBTRACT, "INTEGER '17'", "INTEGER '17'"))
                 .isEqualTo(0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("INTEGER '%s' - INTEGER '1'", Integer.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("INTEGER '%s' - INTEGER '1'", Integer.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("integer subtraction overflow: -2147483648 - 1");
     }
@@ -150,7 +150,7 @@ public class TestIntegerOperators
         assertThat(assertions.operator(MULTIPLY, "INTEGER '17'", "INTEGER '17'"))
                 .isEqualTo(17 * 17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("INTEGER '%s' * INTEGER '2'", Integer.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("INTEGER '%s' * INTEGER '2'", Integer.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("integer multiplication overflow: 2147483647 * 2");
     }
@@ -170,7 +170,7 @@ public class TestIntegerOperators
         assertThat(assertions.operator(DIVIDE, "INTEGER '17'", "INTEGER '17'"))
                 .isEqualTo(1);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTEGER '17'", "INTEGER '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTEGER '17'", "INTEGER '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -189,7 +189,7 @@ public class TestIntegerOperators
         assertThat(assertions.operator(MODULUS, "INTEGER '17'", "INTEGER '17'"))
                 .isEqualTo(0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "INTEGER '17'", "INTEGER '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "INTEGER '17'", "INTEGER '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -205,7 +205,7 @@ public class TestIntegerOperators
         assertThat(assertions.expression("-(INTEGER '" + Integer.MAX_VALUE + "')"))
                 .isEqualTo(Integer.MIN_VALUE + 1);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("-(INTEGER '%s')", Integer.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("-(INTEGER '%s')", Integer.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("integer negation overflow: -2147483648");
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTime.java
@@ -120,10 +120,10 @@ public class TestIntervalDayTime
         assertThat(assertions.operator(MULTIPLY, "2.5", "INTERVAL '1' DAY"))
                 .matches("INTERVAL '2 12:00:00.000' DAY TO SECOND");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "INTERVAL '6' SECOND", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "INTERVAL '6' SECOND", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "nan()", "INTERVAL '6' DAY").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "nan()", "INTERVAL '6' DAY")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -142,16 +142,16 @@ public class TestIntervalDayTime
         assertThat(assertions.operator(DIVIDE, "INTERVAL '4' DAY", "2.5"))
                 .matches("INTERVAL '1 14:24:00.000' DAY TO SECOND");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' SECOND", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' SECOND", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' DAY", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' DAY", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' SECOND", "0E0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' SECOND", "0E0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' DAY", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' DAY", "0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalYearMonth.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalYearMonth.java
@@ -121,10 +121,10 @@ public class TestIntervalYearMonth
         assertThat(assertions.operator(MULTIPLY, "2.5", "INTERVAL '1' YEAR"))
                 .matches("INTERVAL '2-6' YEAR TO MONTH");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "INTERVAL '6' MONTH", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "INTERVAL '6' MONTH", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "nan()", "INTERVAL '6' YEAR").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "nan()", "INTERVAL '6' YEAR")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 
@@ -143,16 +143,16 @@ public class TestIntervalYearMonth
         assertThat(assertions.operator(DIVIDE, "INTERVAL '4' YEAR", "4.8"))
                 .matches("INTERVAL '10' MONTH");
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' MONTH", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' MONTH", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' YEAR", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' YEAR", "nan()")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' MONTH", "0E0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' MONTH", "0E0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "INTERVAL '6' YEAR", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "INTERVAL '6' YEAR", "0")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonOperators.java
@@ -399,19 +399,19 @@ public class TestJsonOperators
                 .hasType(JSON)
                 .isEqualTo("{\"x\":null}");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON '{}{'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON '{}{'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON '{} \"a\"'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON '{} \"a\"'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON '{}{abc'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON '{}{abc'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON '{}abc'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON '{}abc'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("JSON ''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("JSON ''")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
@@ -153,23 +153,23 @@ public class TestMapOperators
                         sqlTimestampOf(0, 1973, 7, 8, 22, 0, 1, 0),
                         100.0));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[1]", "ARRAY[2, 4]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[1]", "ARRAY[2, 4]")::evaluate)
                 .hasMessage("Key and value arrays must be the same length");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[1, 2, 3, 2]", "ARRAY[4, 5, 6, 7]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[1, 2, 3, 2]", "ARRAY[4, 5, 6, 7]")::evaluate)
                 .hasMessage("Duplicate map keys (2) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[ARRAY[1, 2], ARRAY[1, 3], ARRAY[1, 2]]", "ARRAY[1, 2, 3]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[ARRAY[1, 2], ARRAY[1, 3], ARRAY[1, 2]]", "ARRAY[1, 2, 3]")::evaluate)
                 .hasMessage("Duplicate map keys ([1, 2]) are not allowed");
 
         assertThat(assertions.function("map", "ARRAY[ARRAY[1]]", "ARRAY[2]"))
                 .hasType(mapType(new ArrayType(INTEGER), INTEGER))
                 .isEqualTo(ImmutableMap.of(ImmutableList.of(1), 2));
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[NULL]", "ARRAY[2]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[NULL]", "ARRAY[2]")::evaluate)
                 .hasMessage("map key cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[ARRAY[NULL]]", "ARRAY[2]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[ARRAY[NULL]]", "ARRAY[2]")::evaluate)
                 .hasMessage("map key cannot be indeterminate: [null]");
     }
 
@@ -841,13 +841,13 @@ public class TestMapOperators
                 .binding("a", "map(ARRAY['puppies'], ARRAY[null])"))
                 .isNull(UNKNOWN);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[CAST(null as bigint)]", "ARRAY[1]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[CAST(null as bigint)]", "ARRAY[1]")::evaluate)
                 .hasMessage("map key cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[CAST(null as bigint)]", "ARRAY[CAST(null as bigint)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[CAST(null as bigint)]", "ARRAY[CAST(null as bigint)]")::evaluate)
                 .hasMessage("map key cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map", "ARRAY[1,null]", "ARRAY[null,2]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map", "ARRAY[1,null]", "ARRAY[null,2]")::evaluate)
                 .hasMessage("map key cannot be null");
 
         assertThat(assertions.expression("a[3]")
@@ -1661,31 +1661,31 @@ public class TestMapOperators
                 .isEqualTo(expectedNullValueMap);
 
         // invalid invocation
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[('a', 1), ('a', 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[('a', 1), ('a', 2)]")::evaluate)
                 .hasMessage("Duplicate map keys (a) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(1, 1), (1, 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(1, 1), (1, 2)]")::evaluate)
                 .hasMessage("Duplicate map keys (1) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(1.0, 1), (1.0, 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(1.0, 1), (1.0, 2)]")::evaluate)
                 .hasMessage("Duplicate map keys (1.0) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(ARRAY[1, 2], 1), (ARRAY[1, 2], 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(ARRAY[1, 2], 1), (ARRAY[1, 2], 2)]")::evaluate)
                 .hasMessage("Duplicate map keys ([1, 2]) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(MAP(ARRAY[1], ARRAY[2]), 1), (MAP(ARRAY[1], ARRAY[2]), 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(MAP(ARRAY[1], ARRAY[2]), 1), (MAP(ARRAY[1], ARRAY[2]), 2)]")::evaluate)
                 .hasMessage("Duplicate map keys ({1=2}) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(NaN(), 1), (NaN(), 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(NaN(), 1), (NaN(), 2)]")::evaluate)
                 .hasMessage("Duplicate map keys (NaN) are not allowed");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(null, 1), (null, 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(null, 1), (null, 2)]")::evaluate)
                 .hasMessage("map key cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[null]")::evaluate)
                 .hasMessage("map entry cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("map_from_entries", "ARRAY[(1, 2), null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("map_from_entries", "ARRAY[(1, 2), null]")::evaluate)
                 .hasMessage("map entry cannot be null");
     }
 
@@ -1728,13 +1728,13 @@ public class TestMapOperators
                 .isEqualTo(ImmutableMap.of(Double.NaN, ImmutableList.of(1, 2)));
 
         // invalid invocation
-        assertTrinoExceptionThrownBy(() -> assertions.function("multimap_from_entries", "ARRAY[(null, 1), (null, 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("multimap_from_entries", "ARRAY[(null, 1), (null, 2)]")::evaluate)
                 .hasMessage("map key cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("multimap_from_entries", "ARRAY[null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("multimap_from_entries", "ARRAY[null]")::evaluate)
                 .hasMessage("map entry cannot be null");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("multimap_from_entries", "ARRAY[(1, 2), null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("multimap_from_entries", "ARRAY[(1, 2), null]")::evaluate)
                 .hasMessage("map entry cannot be null");
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRowOperators.java
@@ -673,19 +673,19 @@ public class TestRowOperators
         assertComparisonCombination("row(TRUE, FALSE, TRUE, FALSE)", "row(TRUE, TRUE, TRUE, FALSE)");
         assertComparisonCombination("row(1, 2.0E0, TRUE, 'kittens', from_unixtime(1))", "row(1, 3.0E0, TRUE, 'kittens', from_unixtime(1))");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) = CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) = CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:91: Cannot apply operator: row(col0 HyperLogLog) = row(col0 HyperLogLog)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) > CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog)) > CAST(row(CAST(CAST('' as varbinary) as hyperloglog)) as row(col0 hyperloglog))")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:91: Cannot apply operator: row(col0 HyperLogLog) < row(col0 HyperLogLog)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) = CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) = CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:99: Cannot apply operator: row(col0 qdigest(double)) = row(col0 qdigest(double))");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) > CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double))) > CAST(row(CAST(CAST('' as varbinary) as qdigest(double))) as row(col0 qdigest(double)))")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:99: Cannot apply operator: row(col0 qdigest(double)) < row(col0 qdigest(double))");
 
@@ -711,11 +711,11 @@ public class TestRowOperators
                 .binding("b", "row(1, 2)"))
                 .isEqualTo(true);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) > row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) > row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))")::evaluate)
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:75: Cannot apply operator: row(boolean, array(integer), map(integer, double)) < row(boolean, array(integer), map(integer, double))");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("row(1, CAST(NULL AS INTEGER)) < row(1, 2)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("row(1, CAST(NULL AS INTEGER)) < row(1, 2)")::evaluate)
                 .hasErrorCode(StandardErrorCode.NOT_SUPPORTED);
 
         assertComparisonCombination("row(1.0E0, ARRAY [1,2,3], row(2, 2.0E0))", "row(1.0E0, ARRAY [1,3,3], row(2, 2.0E0))");

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -69,7 +69,7 @@ public class TestSmallintOperators
         assertThat(assertions.expression("SMALLINT '17'"))
                 .isEqualTo((short) 17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("SMALLINT '" + ((long) Short.MAX_VALUE + 1L) + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("SMALLINT '" + ((long) Short.MAX_VALUE + 1L) + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -92,7 +92,7 @@ public class TestSmallintOperators
         assertThat(assertions.expression("SMALLINT '-17'"))
                 .isEqualTo((short) -17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("SMALLINT '-" + Short.MIN_VALUE + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("SMALLINT '-" + Short.MIN_VALUE + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -111,7 +111,7 @@ public class TestSmallintOperators
         assertThat(assertions.operator(ADD, "SMALLINT '17'", "SMALLINT '17'"))
                 .isEqualTo((short) (17 + 17));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("SMALLINT '%s' + SMALLINT '1'", Short.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("SMALLINT '%s' + SMALLINT '1'", Short.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("smallint addition overflow: 32767 + 1");
     }
@@ -131,7 +131,7 @@ public class TestSmallintOperators
         assertThat(assertions.operator(SUBTRACT, "SMALLINT '17'", "SMALLINT '17'"))
                 .isEqualTo((short) 0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("SMALLINT '%s' - SMALLINT '1'", Short.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("SMALLINT '%s' - SMALLINT '1'", Short.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("smallint subtraction overflow: -32768 - 1");
     }
@@ -151,7 +151,7 @@ public class TestSmallintOperators
         assertThat(assertions.operator(MULTIPLY, "SMALLINT '17'", "SMALLINT '17'"))
                 .isEqualTo((short) (17 * 17));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("SMALLINT '%s' * SMALLINT '2'", Short.MAX_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("SMALLINT '%s' * SMALLINT '2'", Short.MAX_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("smallint multiplication overflow: 32767 * 2");
     }
@@ -171,7 +171,7 @@ public class TestSmallintOperators
         assertThat(assertions.operator(DIVIDE, "SMALLINT '17'", "SMALLINT '17'"))
                 .isEqualTo((short) 1);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "SMALLINT '17'", "SMALLINT '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "SMALLINT '17'", "SMALLINT '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -190,7 +190,7 @@ public class TestSmallintOperators
         assertThat(assertions.operator(MODULUS, "SMALLINT '17'", "SMALLINT '17'"))
                 .isEqualTo((short) 0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "SMALLINT '17'", "SMALLINT '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "SMALLINT '17'", "SMALLINT '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -206,7 +206,7 @@ public class TestSmallintOperators
         assertThat(assertions.expression("-(SMALLINT '" + Short.MAX_VALUE + "')"))
                 .isEqualTo((short) (Short.MIN_VALUE + 1));
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression(format("-(SMALLINT '%s')", Short.MIN_VALUE)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression(format("-(SMALLINT '%s')", Short.MIN_VALUE))::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("smallint negation overflow: -32768");
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -67,7 +67,7 @@ public class TestTinyintOperators
         assertThat(assertions.expression("TINYINT '17'"))
                 .isEqualTo((byte) 17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TINYINT '" + ((long) Byte.MAX_VALUE + 1L) + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TINYINT '" + ((long) Byte.MAX_VALUE + 1L) + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -90,7 +90,7 @@ public class TestTinyintOperators
         assertThat(assertions.expression("TINYINT '-17'"))
                 .isEqualTo((byte) -17);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("TINYINT '-" + Byte.MIN_VALUE + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("TINYINT '-" + Byte.MIN_VALUE + "'")::evaluate)
                 .hasErrorCode(INVALID_LITERAL);
     }
 
@@ -109,7 +109,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(ADD, "TINYINT '17'", "TINYINT '17'"))
                 .isEqualTo((byte) (17 + 17));
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(ADD, "TINYINT '%s'".formatted(Byte.MAX_VALUE), "TINYINT '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(ADD, "TINYINT '%s'".formatted(Byte.MAX_VALUE), "TINYINT '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("tinyint addition overflow: 127 + 1");
     }
@@ -129,7 +129,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(SUBTRACT, "TINYINT '17'", "TINYINT '17'"))
                 .isEqualTo((byte) 0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(SUBTRACT, "TINYINT '%s'".formatted(Byte.MIN_VALUE), "TINYINT '1'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(SUBTRACT, "TINYINT '%s'".formatted(Byte.MIN_VALUE), "TINYINT '1'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("tinyint subtraction overflow: -128 - 1");
     }
@@ -149,7 +149,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(MULTIPLY, "TINYINT '9'", "TINYINT '9'"))
                 .isEqualTo((byte) (9 * 9));
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MULTIPLY, "TINYINT '%s'".formatted(Byte.MAX_VALUE), "TINYINT '2'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MULTIPLY, "TINYINT '%s'".formatted(Byte.MAX_VALUE), "TINYINT '2'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("tinyint multiplication overflow: 127 * 2");
     }
@@ -169,7 +169,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(DIVIDE, "TINYINT '17'", "TINYINT '17'"))
                 .isEqualTo((byte) 1);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(DIVIDE, "TINYINT '17'", "TINYINT '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(DIVIDE, "TINYINT '17'", "TINYINT '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -188,7 +188,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(MODULUS, "TINYINT '17'", "TINYINT '17'"))
                 .isEqualTo((byte) 0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(MODULUS, "TINYINT '17'", "TINYINT '0'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(MODULUS, "TINYINT '17'", "TINYINT '0'")::evaluate)
                 .hasErrorCode(DIVISION_BY_ZERO);
     }
 
@@ -204,7 +204,7 @@ public class TestTinyintOperators
         assertThat(assertions.operator(NEGATION, "TINYINT '" + Byte.MAX_VALUE + "'"))
                 .isEqualTo((byte) (Byte.MIN_VALUE + 1));
 
-        assertTrinoExceptionThrownBy(() -> assertions.operator(NEGATION, "TINYINT '" + Byte.MIN_VALUE + "'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.operator(NEGATION, "TINYINT '" + Byte.MIN_VALUE + "'")::evaluate)
                 .hasErrorCode(NUMERIC_VALUE_OUT_OF_RANGE)
                 .hasMessage("tinyint negation overflow: -128");
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeRegisterTableProcedureTest.java
@@ -226,14 +226,14 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory and put an invalid log file to verify register_table call fails
-        String transactionLogDir = new URI(getTransactionLogDir(tableLocation)).getPath();
+        String transactionLogDir = URI.create(getTransactionLogDir(tableLocation)).getPath();
         deleteDirectoryContents(Path.of(transactionLogDir), ALLOW_INSECURE);
         new File("/" + getTransactionLogJsonEntryPath(transactionLogDir, 0).path()).createNewFile();
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*Metadata not found in transaction log for (.*)");
 
-        deleteRecursively(Path.of(new URI(tableLocation).getPath()), ALLOW_INSECURE);
+        deleteRecursively(Path.of(URI.create(tableLocation).getPath()), ALLOW_INSECURE);
         metastore.dropTable(SCHEMA, tableName, false);
     }
 
@@ -250,12 +250,12 @@ public abstract class BaseDeltaLakeRegisterTableProcedureTest
         String tableNameNew = "test_register_table_with_no_transaction_log_new_" + randomNameSuffix();
 
         // Delete files under transaction log directory to verify register_table call fails
-        deleteDirectoryContents(Path.of(new URI(getTransactionLogDir(tableLocation)).getPath()), ALLOW_INSECURE);
+        deleteDirectoryContents(Path.of(URI.create(getTransactionLogDir(tableLocation)).getPath()), ALLOW_INSECURE);
 
         assertQueryFails(format("CALL system.register_table('%s', '%s', '%s')", SCHEMA, tableNameNew, tableLocation),
                 ".*No transaction log found in location (.*)");
 
-        deleteRecursively(Path.of(new URI(tableLocation).getPath()), ALLOW_INSECURE);
+        deleteRecursively(Path.of(URI.create(tableLocation).getPath()), ALLOW_INSECURE);
         metastore.dropTable(SCHEMA, tableName, false);
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -27,7 +27,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -161,7 +160,6 @@ public class TestDeltaLakeFileOperations
 
     @Test
     public void testTableChangesFileSystemAccess()
-            throws URISyntaxException
     {
         assertUpdate("CREATE TABLE table_changes_file_system_access (page_url VARCHAR, key VARCHAR, views INTEGER) WITH (change_data_feed_enabled = true, partitioned_by=ARRAY['key'])");
         assertUpdate("INSERT INTO table_changes_file_system_access VALUES('url1', 'domain1', 1)", 1);
@@ -203,12 +201,11 @@ public class TestDeltaLakeFileOperations
     }
 
     private int countCdfFilesForKey(String partitionValue)
-            throws URISyntaxException
     {
         String path = (String) computeScalar("SELECT \"$path\" FROM table_changes_file_system_access WHERE key = '" + partitionValue + "'");
         String partitionKey = "key=" + partitionValue;
         String tableLocation = path.substring(0, path.lastIndexOf(partitionKey));
-        String partitionCdfFolder = new URI(tableLocation).getPath() + "_change_data/" + partitionKey + "/";
+        String partitionCdfFolder = URI.create(tableLocation).getPath() + "_change_data/" + partitionKey + "/";
         return toIntExact(Arrays.stream(new File(partitionCdfFolder).list()).filter(file -> !file.contains(".crc")).count());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -56,7 +56,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
@@ -263,9 +262,9 @@ public class TestDeltaLakeGlueMetastore
      * Creates a valid transaction log
      */
     private void createTransactionLog(String deltaLakeTableLocation)
-            throws URISyntaxException, IOException
+            throws IOException
     {
-        File deltaTableLogLocation = new File(new File(new URI(deltaLakeTableLocation)), "_delta_log");
+        File deltaTableLogLocation = new File(new File(URI.create(deltaLakeTableLocation)), "_delta_log");
         verify(deltaTableLogLocation.mkdirs(), "mkdirs() on '%s' failed", deltaTableLogLocation);
         String entry = Resources.toString(Resources.getResource("deltalake/person/_delta_log/00000000000000000000.json"), UTF_8);
         Files.writeString(new File(deltaTableLogLocation, "00000000000000000000.json").toPath(), entry);

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestBingTileFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestBingTileFunctions.java
@@ -106,27 +106,27 @@ public class TestBingTileFunctions
                 .isEqualTo("123030123010121");
 
         // Invalid calls: corrupt quadkeys
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "''").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "''")::evaluate)
                 .hasMessage("QuadKey must not be empty string");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "'test'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "'test'")::evaluate)
                 .hasMessage("Invalid QuadKey digit sequence: test");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "'12345'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "'12345'")::evaluate)
                 .hasMessage("Invalid QuadKey digit sequence: 12345");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "'101010101010101010101010101010100101010101001010'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "'101010101010101010101010101010100101010101001010'")::evaluate)
                 .hasMessage("QuadKey must be 23 characters or less");
 
         // Invalid calls: XY out of range
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "10", "2", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "10", "2", "3")::evaluate)
                 .hasMessage("XY coordinates for a Bing tile at zoom level 3 must be within [0, 8) range");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "2", "10", "3").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "2", "10", "3")::evaluate)
                 .hasMessage("XY coordinates for a Bing tile at zoom level 3 must be within [0, 8) range");
 
         // Invalid calls: zoom level out of range
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile", "2", "7", "37").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile", "2", "7", "37")::evaluate)
                 .hasMessage("Zoom level must be <= 23");
     }
 
@@ -151,18 +151,18 @@ public class TestBingTileFunctions
 
         // Invalid calls
         // Longitude out of range
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile_at", "30.12", "600", "15").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile_at", "30.12", "600", "15")::evaluate)
                 .hasMessage("Longitude must be between -180.0 and 180.0");
 
         // Latitude out of range
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile_at", "300.12", "60", "15").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile_at", "300.12", "60", "15")::evaluate)
                 .hasMessage("Latitude must be between -85.05112878 and 85.05112878");
 
         // Invalid zoom levels
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile_at", "30.12", "60", "0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile_at", "30.12", "60", "0")::evaluate)
                 .hasMessage("Zoom level must be > 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tile_at", "30.12", "60", "40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tile_at", "30.12", "60", "40")::evaluate)
                 .hasMessage("Zoom level must be <= 23");
     }
 
@@ -293,14 +293,14 @@ public class TestBingTileFunctions
     public void testBingTilesWithRadiusBadInput()
     {
         // Invalid radius
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tiles_around", "30.12", "60.0", "1", "-1").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tiles_around", "30.12", "60.0", "1", "-1")::evaluate)
                 .hasMessage("Radius must be >= 0");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tiles_around", "30.12", "60.0", "1", "2000").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tiles_around", "30.12", "60.0", "1", "2000")::evaluate)
                 .hasMessage("Radius must be <= 1,000 km");
 
         // Too many tiles
-        assertTrinoExceptionThrownBy(() -> assertions.function("bing_tiles_around", "30.12", "60.0", "20", "100").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("bing_tiles_around", "30.12", "60.0", "20", "100")::evaluate)
                 .hasMessage("The number of tiles covering input rectangle exceeds the limit of 1M. Number of tiles: 36699364. Radius: 100.0 km. Zoom level: 20.");
     }
 
@@ -636,7 +636,7 @@ public class TestBingTileFunctions
                 .hasMessage("Zoom level must be <= 23");
 
         // Input rectangle too large
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_to_bing_tiles", "ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)'))", "16").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_to_bing_tiles", "ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)'))", "16")::evaluate)
                 .hasMessage("The number of tiles covering input rectangle exceeds the limit of 1M. Number of tiles: 370085804. Rectangle: xMin=0.00, yMin=0.00, xMax=80.00, yMax=80.00. Zoom level: 16.");
 
         assertThat(assertions.function("cardinality", "geometry_to_bing_tiles(ST_Envelope(ST_GeometryFromText('LINESTRING (0 0, 80 80)')), 5)"))
@@ -648,14 +648,14 @@ public class TestBingTileFunctions
         try (Stream<String> lines = Files.lines(Paths.get(filePath))) {
             largeWkt = lines.collect(onlyElement());
         }
-        assertTrinoExceptionThrownBy(() -> assertions.expression("geometry_to_bing_tiles(ST_GeometryFromText('" + largeWkt + "'), 16)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("geometry_to_bing_tiles(ST_GeometryFromText('" + largeWkt + "'), 16)")::evaluate)
                 .hasMessage("The zoom level is too high or the geometry is too complex to compute a set of covering Bing tiles. Please use a lower zoom level or convert the geometry to its bounding box using the ST_Envelope function.");
 
         assertThat(assertions.expression("cardinality(geometry_to_bing_tiles(ST_Envelope(ST_GeometryFromText('" + largeWkt + "')), 16))"))
                 .isEqualTo(19939L);
 
         // Zoom level is too high
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_to_bing_tiles", "ST_GeometryFromText('POLYGON ((0 0, 0 20, 20 20, 0 0))')", "20").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_to_bing_tiles", "ST_GeometryFromText('POLYGON ((0 0, 0 20, 20 20, 0 0))')", "20")::evaluate)
                 .hasMessage("The zoom level is too high to compute a set of covering Bing tiles.");
 
         assertThat(assertions.function("cardinality", "geometry_to_bing_tiles(ST_GeometryFromText('POLYGON ((0 0, 0 20, 20 20, 0 0))'), 14)"))

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestEncodedPolylineFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestEncodedPolylineFunctions.java
@@ -92,10 +92,10 @@ public class TestEncodedPolylineFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("_p~iF~ps|U_ulLnnqC_mqNvxq`@oskPfgkJ");
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("to_encoded_polyline(ST_GeometryFromText('POINT (-120.2 38.5)'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("to_encoded_polyline(ST_GeometryFromText('POINT (-120.2 38.5)'))")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
-        assertTrinoExceptionThrownBy(() -> assertions.expression("to_encoded_polyline(ST_GeometryFromText('MULTILINESTRING ((-122.39174 37.77701))'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("to_encoded_polyline(ST_GeometryFromText('MULTILINESTRING ((-122.39174 37.77701))'))")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -156,10 +156,10 @@ public class TestGeoFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("LINESTRING (1 1, 2 2, 1 3)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_LineFromText('MULTILINESTRING EMPTY')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_LineFromText('MULTILINESTRING EMPTY')")::evaluate)
                 .hasMessage("ST_LineFromText only applies to LINE_STRING. Input type is: MULTI_LINE_STRING");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_LineFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_LineFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')")::evaluate)
                 .hasMessage("ST_LineFromText only applies to LINE_STRING. Input type is: POLYGON");
     }
 
@@ -174,7 +174,7 @@ public class TestGeoFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("POLYGON ((1 1, 4 1, 4 4, 1 4, 1 1))");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_Polygon('LINESTRING (1 1, 2 2, 1 3)')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_Polygon('LINESTRING (1 1, 2 2, 1 3)')")::evaluate)
                 .hasMessage("ST_Polygon only applies to POLYGON. Input type is: LINE_STRING");
     }
 
@@ -244,10 +244,10 @@ public class TestGeoFunctions
                 .isNull(GEOMETRY);
 
         // negative distance
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Buffer", "ST_Point(0, 0)", "-1.2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Buffer", "ST_Point(0, 0)", "-1.2")::evaluate)
                 .hasMessage("distance is negative");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Buffer", "ST_Point(0, 0)", "-infinity()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Buffer", "ST_Point(0, 0)", "-infinity()")::evaluate)
                 .hasMessage("distance is negative");
 
         // infinity() and nan() distance
@@ -255,7 +255,7 @@ public class TestGeoFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("MULTIPOLYGON EMPTY");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Buffer", "ST_Point(0, 0)", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Buffer", "ST_Point(0, 0)", "nan()")::evaluate)
                 .hasMessage("distance is NaN");
     }
 
@@ -401,7 +401,7 @@ public class TestGeoFunctions
         assertThat(assertions.function("ST_IsClosed", "ST_GeometryFromText('LINESTRING (1 1, 2 2, 1 3)')"))
                 .isEqualTo(false);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_IsClosed", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_IsClosed", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')")::evaluate)
                 .hasMessage("ST_IsClosed only applies to LINE_STRING or MULTI_LINE_STRING. Input type is: POLYGON");
     }
 
@@ -461,7 +461,7 @@ public class TestGeoFunctions
                 .isEqualTo("POLYGON ((1 0, 4 0, 4 1, 3 1, 3 3, 2 3, 2 1, 1 1, 1 0))");
 
         // Negative distance tolerance is invalid.
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "simplify_geometry(ST_GeometryFromText('POLYGON ((1 0, 1 1, 2 1, 2 3, 3 3, 3 1, 4 1, 4 0, 1 0))'), -0.5)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "simplify_geometry(ST_GeometryFromText('POLYGON ((1 0, 1 1, 2 1, 2 3, 3 3, 3 1, 4 1, 4 0, 1 0))'), -0.5)")::evaluate)
                 .hasMessage("distanceTolerance is negative");
     }
 
@@ -539,7 +539,7 @@ public class TestGeoFunctions
         assertThat(assertions.function("ST_Length", "ST_GeometryFromText('MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))')"))
                 .isEqualTo(6.0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Length", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Length", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')")::evaluate)
                 .hasMessage("ST_Length only applies to LINE_STRING or MULTI_LINE_STRING. Input type is: POLYGON");
     }
 
@@ -633,10 +633,10 @@ public class TestGeoFunctions
         assertThat(assertions.function("line_locate_point", "ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)')", "ST_GeometryFromText('POINT EMPTY')"))
                 .isNull(DOUBLE);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_locate_point", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')", "ST_Point(0.4, 1)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_locate_point", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')", "ST_Point(0.4, 1)")::evaluate)
                 .hasMessage("First argument to line_locate_point must be a LineString or a MultiLineString. Got: Polygon");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_locate_point", "ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)')", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_locate_point", "ST_GeometryFromText('LINESTRING (0 0, 0 1, 2 1)')", "ST_GeometryFromText('POLYGON ((1 1, 1 4, 4 4, 4 1))')")::evaluate)
                 .hasMessage("Second argument to line_locate_point must be a Point. Got: Polygon");
     }
 
@@ -664,13 +664,13 @@ public class TestGeoFunctions
         assertLineInterpolatePoint("LINESTRING (0 0, 1 0, 1 9)", 0.5, "POINT (1 4)");
         assertLineInterpolatePoint("LINESTRING (0 0, 1 0, 1 9)", 1.0, "POINT (1 9)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_point", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "-0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_point", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "-0.5")::evaluate)
                 .hasMessage("fraction must be between 0 and 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_point", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "2.0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_point", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "2.0")::evaluate)
                 .hasMessage("fraction must be between 0 and 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_point", "ST_GeometryFromText('POLYGON ((0 0, 1 1, 0 1, 1 0, 0 0))')", "0.2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_point", "ST_GeometryFromText('POLYGON ((0 0, 1 1, 0 1, 1 0, 0 0))')", "0.2")::evaluate)
                 .hasMessage("line_interpolate_point only applies to LINE_STRING. Input type is: POLYGON");
     }
 
@@ -686,13 +686,13 @@ public class TestGeoFunctions
         assertLineInterpolatePoints("LINESTRING (0 0, 1 1, 10 10)", 0.5, "5.000000000000001 5.000000000000001", "10 10");
         assertLineInterpolatePoints("LINESTRING (0 0, 1 1, 10 10)", 1, "10 10");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_points", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "-0.5").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_points", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "-0.5")::evaluate)
                 .hasMessage("fraction must be between 0 and 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_points", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "2.0").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_points", "ST_GeometryFromText('LINESTRING (0 0, 1 0, 1 9)')", "2.0")::evaluate)
                 .hasMessage("fraction must be between 0 and 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("line_interpolate_points", "ST_GeometryFromText('POLYGON ((0 0, 1 1, 0 1, 1 0, 0 0))')", "0.2").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("line_interpolate_points", "ST_GeometryFromText('POLYGON ((0 0, 1 1, 0 1, 1 0, 0 0))')", "0.2")::evaluate)
                 .hasMessage("line_interpolate_point only applies to LINE_STRING. Input type is: POLYGON");
     }
 
@@ -839,7 +839,7 @@ public class TestGeoFunctions
         assertThat(assertions.function("ST_NumInteriorRing", "ST_GeometryFromText('POLYGON ((0 0, 8 0, 0 8, 0 0), (1 1, 1 5, 5 1, 1 1))')"))
                 .isEqualTo(1L);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_NumInteriorRing", "ST_GeometryFromText('LINESTRING (8 4, 5 7)')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_NumInteriorRing", "ST_GeometryFromText('LINESTRING (8 4, 5 7)')")::evaluate)
                 .hasMessage("ST_NumInteriorRing only applies to POLYGON. Input type is: LINE_STRING");
     }
 
@@ -878,7 +878,7 @@ public class TestGeoFunctions
         assertThat(assertions.function("ST_IsRing", "ST_GeometryFromText('LINESTRING (0 0, 1 1, 0 2, 0 0)')"))
                 .isEqualTo(true);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_IsRing", "ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_IsRing", "ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))')")::evaluate)
                 .hasMessage("ST_IsRing only applies to LINE_STRING. Input type is: POLYGON");
     }
 
@@ -893,10 +893,10 @@ public class TestGeoFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("POINT (5 6)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_StartPoint(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_StartPoint(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))")::evaluate)
                 .hasMessage("ST_StartPoint only applies to LINE_STRING. Input type is: POLYGON");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_EndPoint(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_EndPoint(ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))'))")::evaluate)
                 .hasMessage("ST_EndPoint only applies to LINE_STRING. Input type is: POLYGON");
     }
 
@@ -985,7 +985,7 @@ public class TestGeoFunctions
         assertThat(assertions.function("ST_Y", "ST_GeometryFromText('POINT (1 2)')"))
                 .isEqualTo(2.0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Y", "ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Y", "ST_GeometryFromText('POLYGON ((2 0, 2 1, 3 1))')")::evaluate)
                 .hasMessage("ST_Y only applies to POINT. Input type is: POLYGON");
     }
 
@@ -1213,10 +1213,10 @@ public class TestGeoFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("LINESTRING (0 0, 5 0, 5 5, 0 5, 0 0)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_ExteriorRing(ST_GeometryFromText('LINESTRING (1 1, 2 2, 1 3)'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_ExteriorRing(ST_GeometryFromText('LINESTRING (1 1, 2 2, 1 3)'))")::evaluate)
                 .hasMessage("ST_ExteriorRing only applies to POLYGON. Input type is: LINE_STRING");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_AsText", "ST_ExteriorRing(ST_GeometryFromText('MULTIPOLYGON (((1 1, 2 2, 1 3, 1 1)), ((4 4, 5 5, 4 6, 4 4)))'))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_AsText", "ST_ExteriorRing(ST_GeometryFromText('MULTIPOLYGON (((1 1, 2 2, 1 3, 1 1)), ((4 4, 5 5, 4 6, 4 4)))'))")::evaluate)
                 .hasMessage("ST_ExteriorRing only applies to POLYGON. Input type is: MULTI_POLYGON");
     }
 
@@ -1582,13 +1582,13 @@ public class TestGeoFunctions
     @Test
     public void testInvalidWKT()
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineFromText", "'LINESTRING (0 0, 1)'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineFromText", "'LINESTRING (0 0, 1)'")::evaluate)
                 .hasMessage("Invalid WKT: LINESTRING (0 0, 1)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_GeometryFromText", "'POLYGON(0 0)'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_GeometryFromText", "'POLYGON(0 0)'")::evaluate)
                 .hasMessage("Invalid WKT: POLYGON(0 0)");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_Polygon", "'POLYGON(-1 1, 1 -1)'").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_Polygon", "'POLYGON(-1 1, 1 -1)'")::evaluate)
                 .hasMessage("Invalid WKT: POLYGON(-1 1, 1 -1)");
     }
 
@@ -1607,40 +1607,40 @@ public class TestGeoFunctions
         assertThat(assertions.function("great_circle_distance", "36.12", "-86.67", "36.12", "-86.67"))
                 .isEqualTo(0.0);
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "100", "20", "30", "40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "100", "20", "30", "40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "10", "20", "300", "40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "10", "20", "300", "40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "10", "200", "30", "40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "10", "200", "30", "40")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "10", "20", "30", "400").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "10", "20", "30", "400")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "nan()", "-86.67", "33.94", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "nan()", "-86.67", "33.94", "-118.40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "infinity()", "-86.67", "33.94", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "infinity()", "-86.67", "33.94", "-118.40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "nan()", "33.94", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "nan()", "33.94", "-118.40")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "infinity()", "33.94", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "infinity()", "33.94", "-118.40")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "-86.67", "nan()", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "-86.67", "nan()", "-118.40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "-86.67", "infinity()", "-118.40").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "-86.67", "infinity()", "-118.40")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "-86.67", "33.94", "nan()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "-86.67", "33.94", "nan()")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("great_circle_distance", "36.12", "-86.67", "33.94", "infinity()").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("great_circle_distance", "36.12", "-86.67", "33.94", "infinity()")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
     }
 
@@ -1673,9 +1673,9 @@ public class TestGeoFunctions
 
     private void assertInvalidInteriorRings(String wkt, String geometryType)
     {
-        assertTrinoExceptionThrownBy(() -> assertions.expression("transform(ST_InteriorRings(geometry), x -> ST_AsText(x))")
+        assertTrinoExceptionThrownBy(assertions.expression("transform(ST_InteriorRings(geometry), x -> ST_AsText(x))")
                 .binding("geometry", "ST_GeometryFromText('%s')".formatted(wkt))
-                .evaluate())
+                ::evaluate)
                 .hasMessage("ST_InteriorRings only applies to POLYGON. Input type is: %s".formatted(geometryType));
     }
 
@@ -1855,7 +1855,7 @@ public class TestGeoFunctions
                 .isEqualTo("LINESTRING (1 2, 3 4)");
 
         // Duplicate consecutive points throws exception
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1, 2), ST_Point(1, 2)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1, 2), ST_Point(1, 2)]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: consecutive duplicate points at index 2");
 
         assertThat(assertions.function("ST_LineString", "array[ST_Point(1, 2), ST_Point(3, 4), ST_Point(1, 2)]"))
@@ -1873,33 +1873,33 @@ public class TestGeoFunctions
                 .isEqualTo("LINESTRING EMPTY");
 
         // Only points can be passed
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(7,8), ST_GeometryFromText('LINESTRING (1 2, 3 4)')]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(7,8), ST_GeometryFromText('LINESTRING (1 2, 3 4)')]")::evaluate)
                 .hasMessage("ST_LineString takes only an array of valid points, LineString was passed");
 
         // Nulls points are invalid
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[NULL]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[NULL]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: null point at index 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1,2), NULL]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1,2), NULL]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: null point at index 2");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1, 2), NULL, ST_Point(3, 4)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1, 2), NULL, ST_Point(3, 4)]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: null point at index 2");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1, 2), NULL, ST_Point(3, 4), NULL]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1, 2), NULL, ST_Point(3, 4), NULL]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: null point at index 2");
 
         // Empty points are invalid
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_GeometryFromText('POINT EMPTY')]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_GeometryFromText('POINT EMPTY')]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: empty point at index 1");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY')]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY')]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: empty point at index 2");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY'), ST_Point(3,4)]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY'), ST_Point(3,4)]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: empty point at index 2");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY'), ST_Point(3,4), ST_GeometryFromText('POINT EMPTY')]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_LineString", "array[ST_Point(1,2), ST_GeometryFromText('POINT EMPTY'), ST_Point(3,4), ST_GeometryFromText('POINT EMPTY')]")::evaluate)
                 .hasMessage("Invalid input to ST_LineString: empty point at index 2");
     }
 
@@ -1926,7 +1926,7 @@ public class TestGeoFunctions
         assertInvalidMultiPoint("geometry is not a point: LineString at index 2", "POINT (7 8)", "LINESTRING (1 2, 3 4)");
 
         // Null point raises exception
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_MultiPoint", "array[null]").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_MultiPoint", "array[null]")::evaluate)
                 .hasMessage("Invalid input to ST_MultiPoint: null at index 1");
 
         assertInvalidMultiPoint("null at index 3", "POINT (1 2)", "POINT (1 2)", null);
@@ -2124,7 +2124,7 @@ public class TestGeoFunctions
         assertGeomFromBinary("LINESTRING (0 0, 0 1, 0 1, 1 1, 1 0, 0 0)");
 
         // invalid binary
-        assertTrinoExceptionThrownBy(() -> assertions.function("ST_GeomFromBinary", "from_hex('deadbeef')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("ST_GeomFromBinary", "from_hex('deadbeef')")::evaluate)
                 .hasMessage("Invalid WKB");
     }
 
@@ -2159,22 +2159,22 @@ public class TestGeoFunctions
         assertGeometryFromHadoopShape("000000000605000000000000000000F03F000000000000F03F00000000000018400000000000001840020000000A0000000000000005000000000000000000F03F000000000000F03F000000000000F03F0000000000000840000000000000084000000000000008400000000000000840000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000104000000000000000400000000000001840000000000000184000000000000018400000000000001840000000000000104000000000000000400000000000001040", "MULTIPOLYGON (((1 1, 3 1, 3 3, 1 3, 1 1)), ((2 4, 6 4, 6 6, 2 6, 2 4)))");
 
         // given hadoop shape is too short
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_from_hadoop_shape", "from_hex('1234')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_from_hadoop_shape", "from_hex('1234')")::evaluate)
                 .hasMessage("Hadoop shape input is too short");
 
         // hadoop shape type invalid
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_from_hadoop_shape", "from_hex('000000000701000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEFFF')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_from_hadoop_shape", "from_hex('000000000701000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEFFF')")::evaluate)
                 .hasMessage("Invalid Hadoop shape type: 7");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_from_hadoop_shape", "from_hex('00000000FF01000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEFFF')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_from_hadoop_shape", "from_hex('00000000FF01000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEFFF')")::evaluate)
                 .hasMessage("Invalid Hadoop shape type: -1");
 
         // esri shape invalid
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_from_hadoop_shape", "from_hex('000000000101000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEF')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_from_hadoop_shape", "from_hex('000000000101000000FFFFFFFFFFFFEFFFFFFFFFFFFFFFEF')")::evaluate)
                 .hasMessage("Invalid Hadoop shape");
 
         // shape type is invalid for given shape
-        assertTrinoExceptionThrownBy(() -> assertions.function("geometry_from_hadoop_shape", "from_hex('000000000501000000000000000000F03F0000000000000040')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("geometry_from_hadoop_shape", "from_hex('000000000501000000000000000000F03F0000000000000040')")::evaluate)
                 .hasMessage("Invalid Hadoop shape");
     }
 
@@ -2276,7 +2276,7 @@ public class TestGeoFunctions
 
     private void assertInvalidGeometryJson(String json, String message)
     {
-        assertTrinoExceptionThrownBy(() -> assertions.function("from_geojson_geometry", "'%s'".formatted(json)).evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("from_geojson_geometry", "'%s'".formatted(json))::evaluate)
                 .hasMessage(message);
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
@@ -70,7 +70,7 @@ public class TestKdbTreeCasts
                 .hasType(VARCHAR)
                 .isEqualTo("KdbTree");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("typeof", "cast('' AS KdbTree)").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("typeof", "cast('' AS KdbTree)")::evaluate)
                 .hasMessage("Invalid JSON string for KDB tree")
                 .hasErrorCode(INVALID_CAST_ARGUMENT);
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSphericalGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSphericalGeoFunctions.java
@@ -157,28 +157,28 @@ public class TestSphericalGeoFunctions
                 .matches("ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 31.9, -37.2 31.9), POLYGON ((-40.2 28.9, -37.2 28.9, -37.2 31.9, -40.2 31.9, -40.2 28.9)))')");
 
         // geometries containing invalid latitude or longitude values
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('POINT (-340.2 28.9)')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('POINT (-340.2 28.9)')")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTIPOINT ((-40.2 128.9), (-40.2 31.9))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTIPOINT ((-40.2 128.9), (-40.2 31.9))')")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('LINESTRING (-40.2 28.9, -40.2 31.9, 237.2 31.9)')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('LINESTRING (-40.2 28.9, -40.2 31.9, 237.2 31.9)')")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTILINESTRING ((-40.2 28.9, -40.2 31.9), (-40.2 131.9, -37.2 31.9))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTILINESTRING ((-40.2 28.9, -40.2 31.9), (-40.2 131.9, -37.2 31.9))')")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('POLYGON ((-40.2 28.9, -40.2 31.9, 237.2 31.9, -37.2 28.9, -40.2 28.9))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('POLYGON ((-40.2 28.9, -40.2 31.9, 237.2 31.9, -37.2 28.9, -40.2 28.9))')")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 131.9, -37.2 28.9, -40.2 28.9), (-39.2 29.9, -39.2 30.9, -38.2 30.9, -38.2 29.9, -39.2 29.9))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 131.9, -37.2 28.9, -40.2 28.9), (-39.2 29.9, -39.2 30.9, -38.2 30.9, -38.2 29.9, -39.2 29.9))')")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTIPOLYGON (((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)), ((-39.2 29.9, -39.2 30.9, 238.2 30.9, -38.2 29.9, -39.2 29.9)))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('MULTIPOLYGON (((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)), ((-39.2 29.9, -39.2 30.9, 238.2 30.9, -38.2 29.9, -39.2 29.9)))')")::evaluate)
                 .hasMessage("Longitude must be between -180 and 180");
 
-        assertTrinoExceptionThrownBy(() -> assertions.function("to_spherical_geography", "ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 131.9, -37.2 31.9), POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)))')").evaluate())
+        assertTrinoExceptionThrownBy(assertions.function("to_spherical_geography", "ST_GeometryFromText('GEOMETRYCOLLECTION (POINT (-40.2 28.9), LINESTRING (-40.2 28.9, -40.2 131.9, -37.2 31.9), POLYGON ((-40.2 28.9, -40.2 31.9, -37.2 31.9, -37.2 28.9, -40.2 28.9)))')")::evaluate)
                 .hasMessage("Latitude must be between -90 and 90");
     }
 
@@ -217,15 +217,15 @@ public class TestSphericalGeoFunctions
                 .isEqualTo((Object) null);
 
         // Invalid polygon (too few vertices)
-        assertTrinoExceptionThrownBy(() -> assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POLYGON((90 0, 0 0))')))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POLYGON((90 0, 0 0))')))")::evaluate)
                 .hasMessage("Polygon is not valid: a loop contains less then 3 vertices.");
 
         // Invalid data type (point)
-        assertTrinoExceptionThrownBy(() -> assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POINT (0 1)')))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POINT (0 1)')))")::evaluate)
                 .hasMessage("When applied to SphericalGeography inputs, ST_Area only supports POLYGON or MULTI_POLYGON. Input type is: POINT");
 
         //Invalid Polygon (duplicated point)
-        assertTrinoExceptionThrownBy(() -> assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POLYGON((0 0, 0 1, 1 1, 1 1, 1 0, 0 0))')))").evaluate())
+        assertTrinoExceptionThrownBy(assertions.expression("ST_Area(to_spherical_geography(ST_GeometryFromText('POLYGON((0 0, 0 1, 1 1, 1 1, 1 0, 0 0))')))")::evaluate)
                 .hasMessage("Polygon is not valid: it has two identical consecutive vertices");
 
         // A polygon around the North Pole

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/FileSystemTesting.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/FileSystemTesting.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.util.Progressable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -285,12 +284,7 @@ public class FileSystemTesting
         @Override
         public URI getUri()
         {
-            try {
-                return new URI("mock:///");
-            }
-            catch (URISyntaxException err) {
-                throw new IllegalArgumentException("huh?", err);
-            }
+            return URI.create("mock:///");
         }
 
         @Override

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerConfig.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListenerConfig.java
@@ -20,7 +20,6 @@ import io.airlift.units.Duration;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
-import java.net.URISyntaxException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,6 @@ public class HttpEventListenerConfig
     @ConfigDescription("URL of receiving server. Explicitly set the scheme https:// to use symmetric encryption")
     @Config("http-event-listener.connect-ingest-uri")
     public HttpEventListenerConfig setIngestUri(String ingestUri)
-            throws URISyntaxException
     {
         this.ingestUri = ingestUri;
         return this;

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -20,7 +20,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
@@ -34,10 +33,9 @@ public class TestPrometheusConnectorConfig
 {
     @Test
     public void testDefaults()
-            throws URISyntaxException
     {
         assertRecordedDefaults(recordDefaults(PrometheusConnectorConfig.class)
-                .setPrometheusURI(new URI("http://localhost:9090"))
+                .setPrometheusURI(URI.create("http://localhost:9090"))
                 .setQueryChunkSizeDuration(new Duration(1, DAYS))
                 .setMaxQueryRangeDuration(new Duration(21, DAYS))
                 .setCacheDuration(new Duration(30, SECONDS))
@@ -80,10 +78,9 @@ public class TestPrometheusConnectorConfig
 
     @Test
     public void testFailOnDurationLessThanQueryChunkConfig()
-            throws Exception
     {
         PrometheusConnectorConfig config = new PrometheusConnectorConfig();
-        config.setPrometheusURI(new URI("http://doesnotmatter.com"));
+        config.setPrometheusURI(URI.create("http://doesnotmatter.com"));
         config.setQueryChunkSizeDuration(new Duration(21, DAYS));
         config.setMaxQueryRangeDuration(new Duration(1, DAYS));
         config.setCacheDuration(new Duration(30, SECONDS));

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
@@ -34,7 +34,6 @@ import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -122,7 +121,6 @@ public class TestPrometheusSplit
 
     @Test
     public void testQueryWithTableNameNeedingURLEncodeInSplits()
-            throws URISyntaxException
     {
         Instant now = LocalDateTime.of(2019, 10, 2, 7, 26, 56, 0).toInstant(UTC);
         PrometheusConnectorConfig config = getCommonConfig(prometheusHttpServer.resolve("/prometheus-data/prom-metrics-non-standard-name.json"));
@@ -142,13 +140,12 @@ public class TestPrometheusSplit
                 config.getQueryChunkSizeDuration().toMillis() -
                 OFFSET_MILLIS * 20);
         assertEquals(queryInSplit,
-                new URI("http://doesnotmatter:9090/api/v1/query?query=up%20now[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
+                URI.create("http://doesnotmatter:9090/api/v1/query?query=up%20now[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
                         timeShouldBe).getQuery());
     }
 
     @Test
     public void testQueryDividedIntoSplitsFirstSplitHasRightTime()
-            throws URISyntaxException
     {
         Instant now = LocalDateTime.of(2019, 10, 2, 7, 26, 56, 0).toInstant(UTC);
         PrometheusConnectorConfig config = getCommonConfig(prometheusHttpServer.resolve("/prometheus-data/prometheus-metrics.json"));
@@ -168,13 +165,12 @@ public class TestPrometheusSplit
                 config.getQueryChunkSizeDuration().toMillis() -
                 OFFSET_MILLIS * 20);
         assertEquals(queryInSplit,
-                new URI("http://doesnotmatter:9090/api/v1/query?query=up[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
+                URI.create("http://doesnotmatter:9090/api/v1/query?query=up[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
                         timeShouldBe).getQuery());
     }
 
     @Test
     public void testQueryDividedIntoSplitsLastSplitHasRightTime()
-            throws URISyntaxException
     {
         Instant now = LocalDateTime.of(2019, 10, 2, 7, 26, 56, 0).toInstant(UTC);
         PrometheusConnectorConfig config = getCommonConfig(prometheusHttpServer.resolve("/prometheus-data/prometheus-metrics.json"));
@@ -192,7 +188,7 @@ public class TestPrometheusSplit
         PrometheusSplit lastSplit = (PrometheusSplit) splits.get(lastSplitIndex);
         String queryInSplit = URI.create(lastSplit.getUri()).getQuery();
         String timeShouldBe = decimalSecondString(now.toEpochMilli());
-        URI uriAsFormed = new URI("http://doesnotmatter:9090/api/v1/query?query=up[" +
+        URI uriAsFormed = URI.create("http://doesnotmatter:9090/api/v1/query?query=up[" +
                 getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" +
                 "&time=" + timeShouldBe);
         assertEquals(queryInSplit, uriAsFormed.getQuery());

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
@@ -45,7 +45,6 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -159,12 +158,11 @@ public class TestRaptorSplitManager
 
     @Test
     public void testAssignRandomNodeWhenBackupAvailable()
-            throws URISyntaxException
     {
         TestingNodeManager nodeManager = new TestingNodeManager();
         CatalogName connectorId = new CatalogName("raptor");
         NodeSupplier nodeSupplier = nodeManager::getWorkerNodes;
-        InternalNode node = new InternalNode(UUID.randomUUID().toString(), new URI("http://127.0.0.1/"), NodeVersion.UNKNOWN, false);
+        InternalNode node = new InternalNode(UUID.randomUUID().toString(), URI.create("http://127.0.0.1/"), NodeVersion.UNKNOWN, false);
         nodeManager.addNode(node);
         RaptorSplitManager raptorSplitManagerWithBackup = new RaptorSplitManager(connectorId, nodeSupplier, shardManager, true);
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksCreateTableAsSelectCompatibility.java
@@ -23,8 +23,6 @@ import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -121,7 +119,6 @@ public class TestDeltaLakeDatabricksCreateTableAsSelectCompatibility
     @Test(groups = {DELTA_LAKE_DATABRICKS, PROFILE_SPECIFIC_TESTS})
     @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
     public void testPrestoCacheInvalidatedOnCreateTable()
-            throws URISyntaxException, IOException
     {
         String tableName = "test_dl_ctas_caching_" + randomNameSuffix();
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
@@ -52,7 +52,6 @@ public class TestHiveIgnoreAbsentPartitions
 
     @Test
     public void testIgnoreAbsentPartitions()
-            throws Exception
     {
         String tableNameInDatabase = tablesState.get("test_table").getNameInDatabase();
         String tablePath = getTablePath(tableNameInDatabase, 1);
@@ -74,7 +73,6 @@ public class TestHiveIgnoreAbsentPartitions
 
     @Test
     public void testShouldThrowErrorOnUnpartitionedTableMissingData()
-            throws Exception
     {
         String tableName = "unpartitioned_absent_table_data";
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionProcedures.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionProcedures.java
@@ -22,7 +22,6 @@ import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
 import org.testng.annotations.Test;
 
-import java.net.URISyntaxException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -55,7 +54,6 @@ public class TestHivePartitionProcedures
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
     @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testUnregisterPartition()
-            throws URISyntaxException
     {
         createPartitionedTable(FIRST_TABLE);
 
@@ -202,7 +200,6 @@ public class TestHivePartitionProcedures
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
     @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testRegisterPartition()
-            throws URISyntaxException
     {
         createPartitionedTable(FIRST_TABLE);
         createPartitionedTable(SECOND_TABLE);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/util/TableLocationUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/util/TableLocationUtils.java
@@ -14,7 +14,6 @@
 package io.trino.tests.product.hive.util;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,16 +51,13 @@ public final class TableLocationUtils
     }
 
     public static String getTablePath(String tableName)
-            throws URISyntaxException
     {
         return getTablePath(tableName, 0);
     }
 
     public static String getTablePath(String tableName, int partitionColumns)
-            throws URISyntaxException
     {
         String location = getTableLocation(tableName, partitionColumns);
-        URI uri = new URI(location);
-        return uri.getPath();
+        return URI.create(location).getPath();
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkDropTableCompatibility.java
@@ -22,7 +22,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -98,14 +97,8 @@ public class TestIcebergSparkDropTableCompatibility
     private static String getPath(String uri)
     {
         if (uri.startsWith("hdfs://")) {
-            try {
-                return new URI(uri).getPath();
-            }
-            catch (URISyntaxException e) {
-                throw new RuntimeException("Invalid syntax for the URI: " + uri, e);
-            }
+            return URI.create(uri).getPath();
         }
-
         return uri;
     }
 }


### PR DESCRIPTION
Previously one could write e.g.

    assertTrinoExceptionThrownBy(assertions.function(...)::evaluate)

but it would fail at runtime due to insufficient result class visibility.

This commit unlocks that. The added benefit is that now
`assertTrinoExceptionThrownBy` / `assertThatThrowBy` encompases only the
evaluation method (by reference) instead of the setup, which may involve
providing arguments, bindings.