### PR TITLE
Reject invalid URIs in URI extract functions

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestUrlFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestUrlFunctions.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
@@ -53,7 +56,9 @@ public class TestUrlFunctions
         validateUrlExtract("https://username:password@example.com", "https", "example.com", null, "", "", "");
         validateUrlExtract("mailto:test@example.com", "mailto", "", null, "", "", "");
         validateUrlExtract("foo", "", "", null, "foo", "", "");
-        validateUrlExtract("http://example.com/^", null, null, null, null, null, null);
+
+        invalidUrlExtract("http://example.com/^");
+        invalidUrlExtract("http://not uri/cannot contain whitespace");
     }
 
     @Test
@@ -96,6 +101,10 @@ public class TestUrlFunctions
 
         assertThat(assertions.expression("url_extract_parameter('foo', 'k1')"))
                 .isNull(createVarcharType(3));
+
+        assertTrinoExceptionThrownBy(() -> assertions.expression("url_extract_parameter('http://not uri/cannot contain whitespace?foo=bar', 'foo')").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Cannot parse as URI value 'http://not uri/cannot contain whitespace?foo=bar': Illegal character in authority at index 7: http://not uri/cannot contain whitespace?foo=bar");
     }
 
     @Test
@@ -144,6 +153,8 @@ public class TestUrlFunctions
 
     private void validateUrlExtract(String url, String protocol, String host, Long port, String path, String query, String fragment)
     {
+        checkArgument(!url.contains("'")); // Would require escaping in literals
+
         assertThat(assertions.function("url_extract_protocol", "'" + url + "'"))
                 .hasType(createVarcharType(url.length()))
                 .isEqualTo(protocol);
@@ -167,5 +178,34 @@ public class TestUrlFunctions
         assertThat(assertions.function("url_extract_fragment", "'" + url + "'"))
                 .hasType(createVarcharType(url.length()))
                 .isEqualTo(fragment);
+    }
+
+    private void invalidUrlExtract(String url)
+    {
+        checkArgument(!url.contains("'")); // Would require escaping in literals
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_protocol", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_host", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_port", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_path", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_query", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
+
+        assertTrinoExceptionThrownBy(() -> assertions.function("url_extract_fragment", "'" + url + "'").evaluate())
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessageStartingWith("Cannot parse as URI value '%s': ".formatted(url));
     }
 }


### PR DESCRIPTION
It's not by (any document) design to silently ignore invalid input in URI extracting functions (url_extract_fragment, url_extract_host, url_extract_parameter, url_extract_path, url_extract_port, url_extract_protocol, url_extract_query).

This commit follows least surprise principle: invalid input is explicitly rejected. Users wanting to ignore invalid input should use `try(...)` expression around the invocations.

This commit does not change docs, since now the functions behave as documented.

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General; potentially breaking change
* Fix URI extraction functions (``uri_extract_*``) not to ignore input which is not valid URI.
  Previously the functions undocumented behavior was to return ``NULL`` in such case.
```
