### PR TITLE
Disable Hive text native readers

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFormatsConfig.java
@@ -18,19 +18,19 @@ import io.airlift.configuration.ConfigDescription;
 
 public class HiveFormatsConfig
 {
-    private boolean avroFileNativeReaderEnabled = true;
-    private boolean avroFileNativeWriterEnabled = true;
-    private boolean csvNativeReaderEnabled = true;
-    private boolean csvNativeWriterEnabled = true;
-    private boolean jsonNativeReaderEnabled = true;
-    private boolean jsonNativeWriterEnabled = true;
-    private boolean openXJsonNativeReaderEnabled = true;
-    private boolean openXJsonNativeWriterEnabled = true;
-    private boolean regexNativeReaderEnabled = true;
-    private boolean textFileNativeReaderEnabled = true;
-    private boolean textFileNativeWriterEnabled = true;
-    private boolean sequenceFileNativeReaderEnabled = true;
-    private boolean sequenceFileNativeWriterEnabled = true;
+    private boolean avroFileNativeReaderEnabled;
+    private boolean avroFileNativeWriterEnabled;
+    private boolean csvNativeReaderEnabled;
+    private boolean csvNativeWriterEnabled;
+    private boolean jsonNativeReaderEnabled;
+    private boolean jsonNativeWriterEnabled;
+    private boolean openXJsonNativeReaderEnabled;
+    private boolean openXJsonNativeWriterEnabled;
+    private boolean regexNativeReaderEnabled;
+    private boolean textFileNativeReaderEnabled;
+    private boolean textFileNativeWriterEnabled;
+    private boolean sequenceFileNativeReaderEnabled;
+    private boolean sequenceFileNativeWriterEnabled;
 
     public boolean isAvroFileNativeReaderEnabled()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFormatsConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFormatsConfig.java
@@ -28,41 +28,6 @@ public class TestHiveFormatsConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(HiveFormatsConfig.class)
-                .setAvroFileNativeReaderEnabled(true)
-                .setAvroFileNativeWriterEnabled(true)
-                .setCsvNativeReaderEnabled(true)
-                .setCsvNativeWriterEnabled(true)
-                .setJsonNativeReaderEnabled(true)
-                .setJsonNativeWriterEnabled(true)
-                .setOpenXJsonNativeReaderEnabled(true)
-                .setOpenXJsonNativeWriterEnabled(true)
-                .setRegexNativeReaderEnabled(true)
-                .setTextFileNativeReaderEnabled(true)
-                .setTextFileNativeWriterEnabled(true)
-                .setSequenceFileNativeReaderEnabled(true)
-                .setSequenceFileNativeWriterEnabled(true));
-    }
-
-    @Test
-    public void testExplicitPropertyMappings()
-    {
-        Map<String, String> properties = ImmutableMap.<String, String>builder()
-                .put("avro.native-reader.enabled", "false")
-                .put("avro.native-writer.enabled", "false")
-                .put("csv.native-reader.enabled", "false")
-                .put("csv.native-writer.enabled", "false")
-                .put("json.native-reader.enabled", "false")
-                .put("json.native-writer.enabled", "false")
-                .put("openx-json.native-reader.enabled", "false")
-                .put("openx-json.native-writer.enabled", "false")
-                .put("regex.native-reader.enabled", "false")
-                .put("text-file.native-reader.enabled", "false")
-                .put("text-file.native-writer.enabled", "false")
-                .put("sequence-file.native-reader.enabled", "false")
-                .put("sequence-file.native-writer.enabled", "false")
-                .buildOrThrow();
-
-        HiveFormatsConfig expected = new HiveFormatsConfig()
                 .setAvroFileNativeReaderEnabled(false)
                 .setAvroFileNativeWriterEnabled(false)
                 .setCsvNativeReaderEnabled(false)
@@ -75,7 +40,42 @@ public class TestHiveFormatsConfig
                 .setTextFileNativeReaderEnabled(false)
                 .setTextFileNativeWriterEnabled(false)
                 .setSequenceFileNativeReaderEnabled(false)
-                .setSequenceFileNativeWriterEnabled(false);
+                .setSequenceFileNativeWriterEnabled(false));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("avro.native-reader.enabled", "true")
+                .put("avro.native-writer.enabled", "true")
+                .put("csv.native-reader.enabled", "true")
+                .put("csv.native-writer.enabled", "true")
+                .put("json.native-reader.enabled", "true")
+                .put("json.native-writer.enabled", "true")
+                .put("openx-json.native-reader.enabled", "true")
+                .put("openx-json.native-writer.enabled", "true")
+                .put("regex.native-reader.enabled", "true")
+                .put("text-file.native-reader.enabled", "true")
+                .put("text-file.native-writer.enabled", "true")
+                .put("sequence-file.native-reader.enabled", "true")
+                .put("sequence-file.native-writer.enabled", "true")
+                .buildOrThrow();
+
+        HiveFormatsConfig expected = new HiveFormatsConfig()
+                .setAvroFileNativeReaderEnabled(true)
+                .setAvroFileNativeWriterEnabled(true)
+                .setCsvNativeReaderEnabled(true)
+                .setCsvNativeWriterEnabled(true)
+                .setJsonNativeReaderEnabled(true)
+                .setJsonNativeWriterEnabled(true)
+                .setOpenXJsonNativeReaderEnabled(true)
+                .setOpenXJsonNativeWriterEnabled(true)
+                .setRegexNativeReaderEnabled(true)
+                .setTextFileNativeReaderEnabled(true)
+                .setTextFileNativeWriterEnabled(true)
+                .setSequenceFileNativeReaderEnabled(true)
+                .setSequenceFileNativeWriterEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Disable Hive text native readers

There are some silent correctness issues related to Hive text
native readers. Once they got fixed we may want to turn them on again.
