### PR TITLE
Skip header or footer line(s) only for the corresponding split of the file

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReader.java
@@ -28,7 +28,7 @@ public interface LineReader
     long getReadTimeNanos();
 
     /**
-     * Read a line into the buffer. If there are no more lines in the steam, this reader is closed.
+     * Read a line into the buffer. If there are no more lines in the stream, this reader is closed.
      *
      * @return true if a line was read; otherwise, there no more lines and false is returned
      */

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -77,11 +77,12 @@ public class TextLineReaderFactory
             LineReader lineReader = new TextLineReader(inputStream, fileBufferSize, start, length);
 
             //  Only skip header rows when the split is at the beginning of the file
-            if (headerCount > 0) {
+            if (headerCount > 0 && start == 0) {
                 skipHeader(lineReader, headerCount);
             }
 
-            if (footerCount > 0) {
+            //  Only skip footer rows when the split is at the end of the file
+            if (footerCount > 0 && (start + length == inputFile.length())) {
                 lineReader = new FooterAwareLineReader(lineReader, footerCount, this::createLineBuffer);
             }
             return lineReader;

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.text;
+
+import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.memory.MemoryInputFile;
+import io.trino.hive.formats.line.LineBuffer;
+import io.trino.hive.formats.line.LineReader;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static io.trino.testing.DataProviders.cartesianProduct;
+import static io.trino.testing.DataProviders.trueFalse;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTextLineReaderFactory
+{
+    @Test(dataProvider = "testSkipHeaderFooterDataProvider")
+    public void testSkipHeaderFooter(boolean header, boolean footer)
+            throws Exception
+    {
+        TextLineReaderFactory lineReaderFactory = new TextLineReaderFactory(1024, 1024, 8096);
+        StringBuilder contentBuilder = new StringBuilder();
+        if (header) {
+            contentBuilder.append("header\n");
+        }
+        int linesCount = 100;
+        IntStream.rangeClosed(1, linesCount).forEach(index -> contentBuilder.append("line" + index + "\n"));
+        if (footer) {
+            contentBuilder.append("footer\n");
+        }
+
+        byte[] content = contentBuilder.toString().getBytes(UTF_8);
+        TrinoInputFile inputFile = getMemoryInputFile(content);
+
+        LineReader readerSplit1 = lineReaderFactory.createLineReader(inputFile, 0, content.length / 3, header ? 1 : 0, footer ? 1 : 0);
+        LineReader readerSplit2 = lineReaderFactory.createLineReader(inputFile, content.length / 3, content.length / 3, header ? 1 : 0, footer ? 1 : 0);
+        LineReader readerSplit3 = lineReaderFactory.createLineReader(inputFile, content.length / 3 + content.length / 3, content.length - (content.length / 3 + content.length / 3), header ? 1 : 0, footer ? 1 : 0);
+
+        int linesRead = 0;
+        for (LineReader reader : List.of(readerSplit1, readerSplit2, readerSplit3)) {
+            LineBuffer lineBuffer = lineReaderFactory.createLineBuffer();
+            while (reader.readLine(lineBuffer)) {
+                linesRead++;
+            }
+        }
+
+        assertThat(linesRead).isEqualTo(linesCount);
+    }
+
+    @DataProvider
+    public Object[][] testSkipHeaderFooterDataProvider()
+    {
+        return cartesianProduct(trueFalse(), trueFalse());
+    }
+
+    private static TrinoInputFile getMemoryInputFile(byte[] bytes)
+    {
+        return new MemoryInputFile(Location.of("memory:///test"), Slices.wrappedBuffer(bytes));
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The _native_ text reader (`csv.native-reader.enabled=true` in `hive.properties`)  can be configured to skip header or footer lines (e.g. for CSV files).



Skip the line corresponding to the header only in the first split of the file.
Skip the line(s) corresponding to the footer only in the last split of the file.



Before this change, if a plain CSV large file was being split in several smaller splits , each of the split was skipping the header lines.
See also the handling performed by the hive line reader

https://github.com/trinodb/trino/blob/435470e254c6e7e61f206c0f53c89396570517d3/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java#L278-L281





The _standard_ line reader has also a similar deficiency for skipping too many footer lines, but this will be addressed in a follow-up PR.
https://github.com/trinodb/trino/blob/435470e254c6e7e61f206c0f53c89396570517d3/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java#L283-L286

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix missing data when reading large text files with a header/footer. ({issue}`18255`)
```
