### PR TITLE
Show original characters for string literals instead of escaping

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql;
 
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.tree.AllColumns;
@@ -112,10 +111,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
-import java.util.PrimitiveIterator;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.sql.ReservedIdentifiers.reserved;
@@ -1053,35 +1050,7 @@ public final class ExpressionFormatter
 
     static String formatStringLiteral(String s)
     {
-        s = s.replace("'", "''");
-        if (CharMatcher.inRange((char) 0x20, (char) 0x7E).matchesAllOf(s)) {
-            return "'" + s + "'";
-        }
-
-        StringBuilder builder = new StringBuilder();
-        builder.append("U&'");
-        PrimitiveIterator.OfInt iterator = s.codePoints().iterator();
-        while (iterator.hasNext()) {
-            int codePoint = iterator.nextInt();
-            checkArgument(codePoint >= 0, "Invalid UTF-8 encoding in characters: %s", s);
-            if (isAsciiPrintable(codePoint)) {
-                char ch = (char) codePoint;
-                if (ch == '\\') {
-                    builder.append(ch);
-                }
-                builder.append(ch);
-            }
-            else if (codePoint <= 0xFFFF) {
-                builder.append('\\');
-                builder.append(format("%04X", codePoint));
-            }
-            else {
-                builder.append("\\+");
-                builder.append(format("%06X", codePoint));
-            }
-        }
-        builder.append("'");
-        return builder.toString();
+        return "'" + s.replace("'", "''") + "'";
     }
 
     public static String formatOrderBy(OrderBy orderBy)

--- a/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
@@ -13,8 +13,11 @@
  */
 package io.trino.sql;
 
+import io.trino.sql.tree.CharLiteral;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.IntervalLiteral;
+import io.trino.sql.tree.StringLiteral;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -28,6 +31,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestExpressionFormatter
 {
+    @Test
+    public void testStringLiteral()
+    {
+        assertFormattedExpression(
+                new StringLiteral("test"),
+                "'test'");
+    }
+
+    @Test
+    public void testCharLiteral()
+    {
+        assertFormattedExpression(
+                new CharLiteral("test"),
+                "CHAR 'test'");
+    }
+
+    @Test
+    public void testGenericLiteral()
+    {
+        assertFormattedExpression(
+                new GenericLiteral("VARCHAR", "test"),
+                "VARCHAR 'test'");
+    }
+
     @Test
     public void testIntervalLiteral()
     {

--- a/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestExpressionFormatter.java
@@ -37,6 +37,12 @@ public class TestExpressionFormatter
         assertFormattedExpression(
                 new StringLiteral("test"),
                 "'test'");
+        assertFormattedExpression(
+                new StringLiteral("攻殻機動隊"),
+                "'攻殻機動隊'");
+        assertFormattedExpression(
+                new StringLiteral("😂"),
+                "'😂'");
     }
 
     @Test
@@ -45,6 +51,12 @@ public class TestExpressionFormatter
         assertFormattedExpression(
                 new CharLiteral("test"),
                 "CHAR 'test'");
+        assertFormattedExpression(
+                new CharLiteral("攻殻機動隊"),
+                "CHAR '攻殻機動隊'");
+        assertFormattedExpression(
+                new CharLiteral("😂"),
+                "CHAR '😂'");
     }
 
     @Test
@@ -53,6 +65,12 @@ public class TestExpressionFormatter
         assertFormattedExpression(
                 new GenericLiteral("VARCHAR", "test"),
                 "VARCHAR 'test'");
+        assertFormattedExpression(
+                new GenericLiteral("VARCHAR", "攻殻機動隊"),
+                "VARCHAR '攻殻機動隊'");
+        assertFormattedExpression(
+                new GenericLiteral("VARCHAR", "😂"),
+                "VARCHAR '😂'");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -64,6 +64,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowCatalogs(Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW CATALOGS LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowCatalogs(Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW CATALOGS LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -78,6 +81,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowSchemas(Optional.empty(), Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW SCHEMAS LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowSchemas(Optional.empty(), Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW SCHEMAS LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -92,6 +98,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowTables(Optional.empty(), Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW TABLES LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowTables(Optional.empty(), Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW TABLES LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -106,6 +115,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowColumns(QualifiedName.of("a"), Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW COLUMNS FROM a LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowColumns(QualifiedName.of("a"), Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW COLUMNS FROM a LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -120,6 +132,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowFunctions(Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW FUNCTIONS LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowFunctions(Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW FUNCTIONS LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -134,6 +149,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new ShowSession(Optional.of("%$_%"), Optional.of("$"))))
                 .isEqualTo("SHOW SESSION LIKE '%$_%' ESCAPE '$'");
+        assertThat(formatSql(
+                new ShowSession(Optional.of("%機動隊"), Optional.of("😂"))))
+                .isEqualTo("SHOW SESSION LIKE '%機動隊' ESCAPE '😂'");
     }
 
     @Test
@@ -181,6 +199,16 @@ public class TestSqlFormatter
                         Optional.of("test comment"))))
                 .isEqualTo("CREATE CATALOG test USING conn\n" +
                         "COMMENT 'test comment'");
+        assertThat(formatSql(
+                new CreateCatalog(
+                        new Identifier("test"),
+                        false,
+                        new Identifier("conn"),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.of("攻殻機動隊"))))
+                .isEqualTo("CREATE CATALOG test USING conn\n" +
+                        "COMMENT '攻殻機動隊'");
     }
 
     @Test
@@ -207,6 +235,41 @@ public class TestSqlFormatter
                 .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
         assertThat(formatSql(createTable.apply("exists", "exists")))
                 .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+
+        // Create a table with table comment
+        assertThat(formatSql(
+                new CreateTable(
+                        QualifiedName.of(ImmutableList.of(new Identifier("test", false))),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),
+                                true,
+                                ImmutableList.of(),
+                                Optional.empty())),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.of("攻殻機動隊"))))
+                .isEqualTo("CREATE TABLE test (\n" +
+                        "   col VARCHAR\n" +
+                        ")\n" +
+                        "COMMENT '攻殻機動隊'");
+
+        // Create a table with column comment
+        assertThat(formatSql(
+                new CreateTable(
+                        QualifiedName.of(ImmutableList.of(new Identifier("test", false))),
+                        ImmutableList.of(new ColumnDefinition(
+                                QualifiedName.of("col"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),
+                                true,
+                                ImmutableList.of(),
+                                Optional.of("攻殻機動隊"))),
+                        FAIL,
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo("CREATE TABLE test (\n" +
+                        "   col VARCHAR COMMENT '攻殻機動隊'\n" +
+                        ")");
     }
 
     @Test
@@ -229,6 +292,20 @@ public class TestSqlFormatter
                 .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
         assertThat(formatSql(createTableAsSelect.apply("exists", "exists")))
                 .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+
+        assertThat(formatSql(
+                new CreateTableAsSelect(
+                        QualifiedName.of(ImmutableList.of(new Identifier("test", false))),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        FAIL,
+                        ImmutableList.of(),
+                        true,
+                        Optional.of(ImmutableList.of(new Identifier("col", false))),
+                        Optional.of("攻殻機動隊"))))
+                .isEqualTo("CREATE TABLE test( col )\n" +
+                        "COMMENT '攻殻機動隊' AS SELECT *\n" +
+                        "FROM\n" +
+                        "  t\n");
     }
 
     @Test
@@ -243,6 +320,18 @@ public class TestSqlFormatter
                         Optional.empty(),
                         Optional.empty())))
                 .isEqualTo("CREATE VIEW test AS\n" +
+                        "SELECT *\n" +
+                        "FROM\n" +
+                        "  t\n");
+        assertThat(formatSql(
+                new CreateView(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
+                        Optional.of("攻殻機動隊"),
+                        Optional.empty())))
+                .isEqualTo("CREATE VIEW test COMMENT '攻殻機動隊' AS\n" +
                         "SELECT *\n" +
                         "FROM\n" +
                         "  t\n");
@@ -265,6 +354,21 @@ public class TestSqlFormatter
                         "SELECT *\n" +
                         "FROM\n" +
                         "  test_base\n");
+        assertThat(formatSql(
+                new CreateMaterializedView(
+                        Optional.empty(),
+                        QualifiedName.of("test_mv"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("test_base"))),
+                        false,
+                        false,
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.of("攻殻機動隊"))))
+                .isEqualTo("CREATE MATERIALIZED VIEW test_mv\n" +
+                        "COMMENT '攻殻機動隊' AS\n" +
+                        "SELECT *\n" +
+                        "FROM\n" +
+                        "  test_base\n");
     }
 
     @Test
@@ -280,6 +384,16 @@ public class TestSqlFormatter
                                 Optional.empty()),
                         false, false)))
                 .isEqualTo("ALTER TABLE foo.t ADD COLUMN c VARCHAR");
+        assertThat(formatSql(
+                new AddColumn(
+                        QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(QualifiedName.of("c"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),
+                                true,
+                                emptyList(),
+                                Optional.of("攻殻機動隊")),
+                        false, false)))
+                .isEqualTo("ALTER TABLE foo.t ADD COLUMN c VARCHAR COMMENT '攻殻機動隊'");
     }
 
     @Test
@@ -288,6 +402,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON TABLE a IS 'test'");
+        assertThat(formatSql(
+                new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
+                .isEqualTo("COMMENT ON TABLE a IS '攻殻機動隊'");
     }
 
     @Test
@@ -296,6 +413,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON VIEW a IS 'test'");
+        assertThat(formatSql(
+                new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("攻殻機動隊"))))
+                .isEqualTo("COMMENT ON VIEW a IS '攻殻機動隊'");
     }
 
     @Test
@@ -304,6 +424,9 @@ public class TestSqlFormatter
         assertThat(formatSql(
                 new Comment(Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("test"))))
                 .isEqualTo("COMMENT ON COLUMN test.a IS 'test'");
+        assertThat(formatSql(
+                new Comment(Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("攻殻機動隊"))))
+                .isEqualTo("COMMENT ON COLUMN test.a IS '攻殻機動隊'");
     }
 
     @Test
@@ -321,5 +444,12 @@ public class TestSqlFormatter
                         new StringLiteral(new NodeLocation(1, 19), "SELECT * FROM foo WHERE col1 = 'bar'"),
                         ImmutableList.of())))
                 .isEqualTo("EXECUTE IMMEDIATE\n'SELECT * FROM foo WHERE col1 = ''bar'''");
+        assertThat(formatSql(
+                new ExecuteImmediate(
+                        new NodeLocation(1, 1),
+                        new StringLiteral(new NodeLocation(1, 19), "SELECT * FROM foo WHERE col1 = '攻殻機動隊'"),
+                        ImmutableList.of())))
+                .isEqualTo("EXECUTE IMMEDIATE\n" +
+                        "'SELECT * FROM foo WHERE col1 = ''攻殻機動隊'''");
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/TestSqlFormatter.java
@@ -14,10 +14,15 @@
 package io.trino.sql;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.ColumnDefinition;
+import io.trino.sql.tree.Comment;
+import io.trino.sql.tree.CreateCatalog;
+import io.trino.sql.tree.CreateMaterializedView;
 import io.trino.sql.tree.CreateTable;
 import io.trino.sql.tree.CreateTableAsSelect;
+import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.ExecuteImmediate;
 import io.trino.sql.tree.GenericDataType;
 import io.trino.sql.tree.Identifier;
@@ -25,6 +30,12 @@ import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
+import io.trino.sql.tree.ShowCatalogs;
+import io.trino.sql.tree.ShowColumns;
+import io.trino.sql.tree.ShowFunctions;
+import io.trino.sql.tree.ShowSchemas;
+import io.trino.sql.tree.ShowSession;
+import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.StringLiteral;
 import org.junit.jupiter.api.Test;
 
@@ -36,10 +47,95 @@ import static io.trino.sql.QueryUtil.simpleQuery;
 import static io.trino.sql.QueryUtil.table;
 import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.tree.SaveMode.FAIL;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSqlFormatter
 {
+    @Test
+    public void testShowCatalogs()
+    {
+        assertThat(formatSql(
+                new ShowCatalogs(Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW CATALOGS");
+        assertThat(formatSql(
+                new ShowCatalogs(Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW CATALOGS LIKE '%'");
+        assertThat(formatSql(
+                new ShowCatalogs(Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW CATALOGS LIKE '%$_%' ESCAPE '$'");
+    }
+
+    @Test
+    public void testShowSchemas()
+    {
+        assertThat(formatSql(
+                new ShowSchemas(Optional.empty(), Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW SCHEMAS");
+        assertThat(formatSql(
+                new ShowSchemas(Optional.empty(), Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW SCHEMAS LIKE '%'");
+        assertThat(formatSql(
+                new ShowSchemas(Optional.empty(), Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW SCHEMAS LIKE '%$_%' ESCAPE '$'");
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        assertThat(formatSql(
+                new ShowTables(Optional.empty(), Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW TABLES");
+        assertThat(formatSql(
+                new ShowTables(Optional.empty(), Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW TABLES LIKE '%'");
+        assertThat(formatSql(
+                new ShowTables(Optional.empty(), Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW TABLES LIKE '%$_%' ESCAPE '$'");
+    }
+
+    @Test
+    public void testShowColumns()
+    {
+        assertThat(formatSql(
+                new ShowColumns(QualifiedName.of("a"), Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW COLUMNS FROM a");
+        assertThat(formatSql(
+                new ShowColumns(QualifiedName.of("a"), Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW COLUMNS FROM a LIKE '%'");
+        assertThat(formatSql(
+                new ShowColumns(QualifiedName.of("a"), Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW COLUMNS FROM a LIKE '%$_%' ESCAPE '$'");
+    }
+
+    @Test
+    public void testShowFunctions()
+    {
+        assertThat(formatSql(
+                new ShowFunctions(Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW FUNCTIONS");
+        assertThat(formatSql(
+                new ShowFunctions(Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW FUNCTIONS LIKE '%'");
+        assertThat(formatSql(
+                new ShowFunctions(Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW FUNCTIONS LIKE '%$_%' ESCAPE '$'");
+    }
+
+    @Test
+    public void testShowSession()
+    {
+        assertThat(formatSql(
+                new ShowSession(Optional.empty(), Optional.empty())))
+                .isEqualTo("SHOW SESSION");
+        assertThat(formatSql(
+                new ShowSession(Optional.of("%"), Optional.empty())))
+                .isEqualTo("SHOW SESSION LIKE '%'");
+        assertThat(formatSql(
+                new ShowSession(Optional.of("%$_%"), Optional.of("$"))))
+                .isEqualTo("SHOW SESSION LIKE '%$_%' ESCAPE '$'");
+    }
+
     @Test
     public void testIdentifiers()
     {
@@ -61,6 +157,30 @@ public class TestSqlFormatter
         // Non-ANSI compliant identifier
         assertThat(formatSql(new Identifier("1", true))).isEqualTo("\"1\"");
         assertThat(formatSql(new Identifier("\"1\"", true))).isEqualTo("\"\"\"1\"\"\"");
+    }
+
+    @Test
+    public void testCreateCatalog()
+    {
+        assertThat(formatSql(
+                new CreateCatalog(
+                        new Identifier("test"),
+                        false,
+                        new Identifier("conn"),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.empty())))
+                .isEqualTo("CREATE CATALOG test USING conn");
+        assertThat(formatSql(
+                new CreateCatalog(
+                        new Identifier("test"),
+                        false,
+                        new Identifier("conn"),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        Optional.of("test comment"))))
+                .isEqualTo("CREATE CATALOG test USING conn\n" +
+                        "COMMENT 'test comment'");
     }
 
     @Test
@@ -109,6 +229,81 @@ public class TestSqlFormatter
                 .isEqualTo(String.format(createTableSql, "table_name", "column_name"));
         assertThat(formatSql(createTableAsSelect.apply("exists", "exists")))
                 .isEqualTo(String.format(createTableSql, "\"exists\"", "\"exists\""));
+    }
+
+    @Test
+    public void testCreateView()
+    {
+        assertThat(formatSql(
+                new CreateView(
+                        new NodeLocation(1, 1),
+                        QualifiedName.of("test"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("t"))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty())))
+                .isEqualTo("CREATE VIEW test AS\n" +
+                        "SELECT *\n" +
+                        "FROM\n" +
+                        "  t\n");
+    }
+
+    @Test
+    public void testCreateMaterializedView()
+    {
+        assertThat(formatSql(
+                new CreateMaterializedView(
+                        Optional.empty(),
+                        QualifiedName.of("test_mv"),
+                        simpleQuery(selectList(new AllColumns()), table(QualifiedName.of("test_base"))),
+                        false,
+                        false,
+                        Optional.empty(),
+                        ImmutableList.of(),
+                        Optional.empty())))
+                .isEqualTo("CREATE MATERIALIZED VIEW test_mv AS\n" +
+                        "SELECT *\n" +
+                        "FROM\n" +
+                        "  test_base\n");
+    }
+
+    @Test
+    public void testAddColumn()
+    {
+        assertThat(formatSql(
+                new AddColumn(
+                        QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(QualifiedName.of("c"),
+                                new GenericDataType(new NodeLocation(1, 1), new Identifier("VARCHAR", false), ImmutableList.of()),
+                                true,
+                                emptyList(),
+                                Optional.empty()),
+                        false, false)))
+                .isEqualTo("ALTER TABLE foo.t ADD COLUMN c VARCHAR");
+    }
+
+    @Test
+    public void testCommentOnTable()
+    {
+        assertThat(formatSql(
+                new Comment(Comment.Type.TABLE, QualifiedName.of("a"), Optional.of("test"))))
+                .isEqualTo("COMMENT ON TABLE a IS 'test'");
+    }
+
+    @Test
+    public void testCommentOnView()
+    {
+        assertThat(formatSql(
+                new Comment(Comment.Type.VIEW, QualifiedName.of("a"), Optional.of("test"))))
+                .isEqualTo("COMMENT ON VIEW a IS 'test'");
+    }
+
+    @Test
+    public void testCommentOnColumn()
+    {
+        assertThat(formatSql(
+                new Comment(Comment.Type.COLUMN, QualifiedName.of("test", "a"), Optional.of("test"))))
+                .isEqualTo("COMMENT ON COLUMN test.a IS 'test'");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
@@ -335,11 +335,11 @@ public class TestStatementBuilder
     public void testStringFormatter()
     {
         assertSqlFormatter("U&'hello\\6d4B\\8Bd5\\+10FFFFworld\\7F16\\7801'",
-                "U&'hello\\6D4B\\8BD5\\+10FFFFworld\\7F16\\7801'");
+                "'hello测试\uDBFF\uDFFFworld编码'");
         assertSqlFormatter("'hello world'", "'hello world'");
-        assertSqlFormatter("U&'!+10FFFF!6d4B!8Bd5ABC!6d4B!8Bd5' UESCAPE '!'", "U&'\\+10FFFF\\6D4B\\8BD5ABC\\6D4B\\8BD5'");
-        assertSqlFormatter("U&'\\+10FFFF\\6D4B\\8BD5\\0041\\0042\\0043\\6D4B\\8BD5'", "U&'\\+10FFFF\\6D4B\\8BD5ABC\\6D4B\\8BD5'");
-        assertSqlFormatter("U&'\\\\abc\\6D4B'''", "U&'\\\\abc\\6D4B'''");
+        assertSqlFormatter("U&'!+10FFFF!6d4B!8Bd5ABC!6d4B!8Bd5' UESCAPE '!'", "'\uDBFF\uDFFF测试ABC测试'");
+        assertSqlFormatter("U&'\\+10FFFF\\6D4B\\8BD5\\0041\\0042\\0043\\6D4B\\8BD5'", "'\uDBFF\uDFFF测试ABC测试'");
+        assertSqlFormatter("U&'\\\\abc\\6D4B'''", "'\\abc测'''");
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #5061

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Show original characters for string literals. ({issue}`5061`)
```
