### PR TITLE
Deduplicate symbols inside GroupIdNode grouping set

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -56,6 +56,7 @@ import io.trino.sql.tree.SymbolReference;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -187,7 +188,7 @@ public class SymbolMapper
         ImmutableList.Builder<List<Symbol>> newGroupingSets = ImmutableList.builder();
 
         for (List<Symbol> groupingSet : node.getGroupingSets()) {
-            ImmutableList.Builder<Symbol> newGroupingSet = ImmutableList.builder();
+            Set<Symbol> newGroupingSet = new LinkedHashSet<>();
             for (Symbol output : groupingSet) {
                 Symbol newOutput = map(output);
                 newGroupingMappings.putIfAbsent(
@@ -195,7 +196,7 @@ public class SymbolMapper
                         map(node.getGroupingColumns().get(output)));
                 newGroupingSet.add(newOutput);
             }
-            newGroupingSets.add(newGroupingSet.build());
+            newGroupingSets.add(ImmutableList.copyOf(newGroupingSet));
         }
 
         return new GroupIdNode(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -47,9 +47,11 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.groupId;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
@@ -111,6 +113,29 @@ public class TestUnaliasSymbolReferences
                                                         ImmutableMap.of("probeColumn1", "suppkey", "probeColumn2", "nationkey")))))
                         .right(
                                 project(tableScan(buildTable, ImmutableMap.of("column", "nationkey"))))));
+    }
+
+    @Test
+    public void testGroupIdGroupingSetsDeduplicated()
+    {
+        assertOptimizedPlan(
+                new UnaliasSymbolReferences(getQueryRunner().getMetadata()),
+                (p, session, metadata) -> {
+                    Symbol symbol = p.symbol("symbol");
+                    Symbol alias1 = p.symbol("alias1");
+                    Symbol alias2 = p.symbol("alias2");
+
+                    return p.groupId(ImmutableList.of(ImmutableList.of(alias1, alias2)),
+                            ImmutableList.of(),
+                            p.symbol("groupId"),
+                            p.project(
+                                    Assignments.of(alias1, symbol.toSymbolReference(), alias2, symbol.toSymbolReference()),
+                                    p.values(symbol)));
+                },
+                groupId(
+                        ImmutableList.of(ImmutableList.of("symbol")),
+                        "groupId",
+                        project(values("symbol"))));
     }
 
     private void assertOptimizedPlan(PlanOptimizer optimizer, PlanCreator planCreator, PlanMatchPattern pattern)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Original grouping sets are deduplicated in the
`StatementAnalyzer.Visitor.analyzeGroupBy`. Optimizer rules can create GroupIdNode that contain duplicates unintentionally though, for example, before `UnaliasSymbolReferences` rule is run, but LocalExecutionPlanner.Visitor.visitGroupId expects unique symbols in each grouping-set.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
