### PR TITLE
Fix error reporting when window functions are used in HAVING clause.

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4001,7 +4001,7 @@ class StatementAnalyzer
             if (node.getHaving().isPresent()) {
                 Expression predicate = node.getHaving().get();
 
-                List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate));
+                List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, metadata);
                 if (!windowExpressions.isEmpty()) {
                     throw semanticException(NESTED_WINDOW, windowExpressions.get(0), "HAVING clause cannot contain window functions or row pattern measures");
                 }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -820,6 +820,9 @@ public class TestAnalyzer
         assertFails("SELECT 1 FROM (VALUES 1) HAVING count(*) OVER () > 1")
                 .hasErrorCode(NESTED_WINDOW)
                 .hasMessage("line 1:33: HAVING clause cannot contain window functions or row pattern measures");
+        assertFails("SELECT 1 FROM (VALUES 1) HAVING rank() > 1")
+                .hasErrorCode(NESTED_WINDOW)
+                .hasMessage("line 1:33: HAVING clause cannot contain window functions or row pattern measures");
 
         // row pattern measure over window
         assertFails("SELECT * FROM t1 WHERE classy OVER ( " +


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- When window functions are used with `OVER()`, we fail to detect them in `analyzeHaving()` which results in compiler failed errors instead of TrinoException.
- This pull request uses the previous changes in `extractWindowFunctions()` that were added as part of this [commit](https://github.com/trinodb/trino/commit/7b6c079850d9e6b51972c57cbc8b8190e22e81ce) to handle the same case in `HAVING` clause.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- To highlight the issue, I ran the following queries on cli
1. before the change (unwanted behaviour)

```
trino> SELECT 1 FROM (VALUES 1) HAVING rank() > 1;
Query 20230712_221743_00003_76sak failed: java.lang.RuntimeException: java.lang.IllegalArgumentException: rank():bigint is not a scalar function
```

2. after the change (wanted behaviour)

```
trino> SELECT 1 FROM (VALUES 1) HAVING rank() > 1;
Query 20230712_221751_00004_76sak failed: line 1:33: HAVING clause cannot contain window functions or row pattern measures
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(x) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix error reporting when window functions are used in HAVING clause.
```
