### PR TITLE
Fix TEXTFILE and RCTEXT string escape of an escape character

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/StringEncoding.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/encodings/text/StringEncoding.java
@@ -162,13 +162,18 @@ public class StringEncoding
 
     private static void unescape(byte escapeByte, SliceOutput output, Slice slice, int offset, int length)
     {
-        for (int i = 0; i < length; i++) {
+        int i = 0;
+        while (i < length) {
             byte value = slice.getByte(offset + i);
             if (value == escapeByte && i + 1 < length) {
-                // skip the escape byte
+                // write the next byte immediately to handle cases of multiple escape characters in a row
+                output.write(slice.getByte(offset + i + 1));
+                // skip the escape and the next byte
+                i += 2;
                 continue;
             }
             output.write(value);
+            i++;
         }
     }
 }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/simple/TestSimpleFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/simple/TestSimpleFormat.java
@@ -444,6 +444,9 @@ public class TestSimpleFormat
         assertString(type, "tab " + escape + "\t tab", "tab \t tab", options);
         assertString(type, "new " + escape + "\n line", "new \n line", options);
         assertString(type, "carriage " + escape + "\r return", "carriage \r return", options);
+        assertString(type, "escape " + escape + escape + " char", "escape " + escape + " char", options);
+        assertString(type, "double " + escape + escape + escape + escape + " escape", "double " + escape + escape + " escape", options);
+        assertString(type, "simple " + escape + "X char", "simple X char", options);
 
         String allControlCharacters = IntStream.range(0, 32)
                 .mapToObj(i -> i + " " + ((char) i))


### PR DESCRIPTION
Fixes #18215

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix TEXTFILE and RCTEXT handling of an escaped escape character. ({issue}`18215`)
```
