### PR TITLE
Fix header footer

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/LineReader.java
@@ -28,7 +28,7 @@ public interface LineReader
     long getReadTimeNanos();
 
     /**
-     * Read a line into the buffer. If there are no more lines in the steam, this reader is closed.
+     * Read a line into the buffer. If there are no more lines in the stream, this reader is closed.
      *
      * @return true if a line was read; otherwise, there no more lines and false is returned
      */

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
@@ -21,6 +21,8 @@ import io.trino.hive.formats.line.LineReaderFactory;
 
 import java.io.IOException;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public class SequenceFileReaderFactory
         implements LineReaderFactory
 {
@@ -56,12 +58,13 @@ public class SequenceFileReaderFactory
     {
         LineReader lineReader = new SequenceFileReader(inputFile, start, length);
 
-        //  Only skip header rows when the split is at the beginning of the file
         if (headerCount > 0) {
+            checkArgument(start == 0 || headerCount == 1, "file cannot be split when there is more than one header row");
             skipHeader(lineReader, headerCount);
         }
 
         if (footerCount > 0) {
+            checkArgument(start == 0, "file cannot be split when there are footer rows");
             lineReader = new FooterAwareLineReader(lineReader, footerCount, this::createLineBuffer);
         }
         return lineReader;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/sequence/SequenceFileReaderFactory.java
@@ -60,7 +60,10 @@ public class SequenceFileReaderFactory
 
         if (headerCount > 0) {
             checkArgument(start == 0 || headerCount == 1, "file cannot be split when there is more than one header row");
-            skipHeader(lineReader, headerCount);
+            // header is only skipped at the beginning of the file
+            if (start == 0) {
+                skipHeader(lineReader, headerCount);
+            }
         }
 
         if (footerCount > 0) {

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -78,7 +78,10 @@ public class TextLineReaderFactory
 
             if (headerCount > 0) {
                 checkArgument(start == 0 || headerCount == 1, "file cannot be split when there is more than one header row");
-                skipHeader(lineReader, headerCount);
+                // header is only skipped at the beginning of the file
+                if (start == 0) {
+                    skipHeader(lineReader, headerCount);
+                }
             }
 
             if (footerCount > 0) {

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineReaderFactory.java
@@ -76,12 +76,13 @@ public class TextLineReaderFactory
 
             LineReader lineReader = new TextLineReader(inputStream, fileBufferSize, start, length);
 
-            //  Only skip header rows when the split is at the beginning of the file
             if (headerCount > 0) {
+                checkArgument(start == 0 || headerCount == 1, "file cannot be split when there is more than one header row");
                 skipHeader(lineReader, headerCount);
             }
 
             if (footerCount > 0) {
+                checkArgument(start == 0, "file cannot be split when there are footer rows");
                 lineReader = new FooterAwareLineReader(lineReader, footerCount, this::createLineBuffer);
             }
             return lineReader;

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileWriterFactory.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/sequence/TestSequenceFileWriterFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.sequence;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.memory.MemoryInputFile;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Optional;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestSequenceFileWriterFactory
+{
+    @Test
+    public void testHeaderFooterConstraints()
+            throws Exception
+    {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new SequenceFileWriter(
+                out,
+                Optional.empty(),
+                false,
+                ImmutableMap.of())
+                .close();
+        TrinoInputFile file = new MemoryInputFile(Location.of("memory:///test"), wrappedBuffer(out.toByteArray()));
+
+        SequenceFileReaderFactory readerFactory = new SequenceFileReaderFactory(1024, 8096);
+        assertThatThrownBy(() -> readerFactory.createLineReader(file, 1, 7, 2, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("file cannot be split.* header.*");
+
+        assertThatThrownBy(() -> readerFactory.createLineReader(file, 1, 7, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("file cannot be split.* footer.*");
+
+        // single header allowed in split file
+        readerFactory.createLineReader(file, 0, 7, 1, 0);
+        readerFactory.createLineReader(file, 2, 7, 1, 0);
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.line.text;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.memory.MemoryInputFile;
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestTextLineReaderFactory
+{
+    @Test
+    public void testHeaderFooterConstraints()
+            throws Exception
+    {
+        TextLineReaderFactory readerFactory = new TextLineReaderFactory(1024, 1024, 8096);
+        TrinoInputFile file = new MemoryInputFile(Location.of("memory:///test"), wrappedBuffer(new byte[10]));
+
+        assertThatThrownBy(() -> readerFactory.createLineReader(file, 1, 7, 2, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("file cannot be split.* header.*");
+
+        assertThatThrownBy(() -> readerFactory.createLineReader(file, 1, 7, 0, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("file cannot be split.* footer.*");
+
+        // single header allowed in split file
+        readerFactory.createLineReader(file, 0, 7, 1, 0);
+        readerFactory.createLineReader(file, 2, 7, 1, 0);
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/line/text/TestTextLineReaderFactory.java
@@ -16,10 +16,17 @@ package io.trino.hive.formats.line.text;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.memory.MemoryInputFile;
+import io.trino.hive.formats.line.LineBuffer;
+import io.trino.hive.formats.line.LineReader;
 import org.testng.annotations.Test;
 
-import static io.airlift.slice.Slices.wrappedBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestTextLineReaderFactory
 {
@@ -28,7 +35,7 @@ public class TestTextLineReaderFactory
             throws Exception
     {
         TextLineReaderFactory readerFactory = new TextLineReaderFactory(1024, 1024, 8096);
-        TrinoInputFile file = new MemoryInputFile(Location.of("memory:///test"), wrappedBuffer(new byte[10]));
+        TrinoInputFile file = new MemoryInputFile(Location.of("memory:///test"), utf8Slice("header\ndata"));
 
         assertThatThrownBy(() -> readerFactory.createLineReader(file, 1, 7, 2, 0))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -39,7 +46,12 @@ public class TestTextLineReaderFactory
                 .hasMessageMatching("file cannot be split.* footer.*");
 
         // single header allowed in split file
-        readerFactory.createLineReader(file, 0, 7, 1, 0);
-        readerFactory.createLineReader(file, 2, 7, 1, 0);
+        LineBuffer lineBuffer = new LineBuffer(1, 20);
+        LineReader lineReader = readerFactory.createLineReader(file, 0, 2, 1, 0);
+        assertFalse(lineReader.readLine(lineBuffer));
+
+        lineReader = readerFactory.createLineReader(file, 2, file.length() - 2, 1, 0);
+        assertTrue(lineReader.readLine(lineBuffer));
+        assertThat(new String(lineBuffer.getBuffer(), 0, lineBuffer.getLength(), StandardCharsets.UTF_8)).isEqualTo("data");
     }
 }


### PR DESCRIPTION
## Description

This is an alternative to #18255.  

This PR throws if a test or sequence file is created with a start off and multiple header rows, or any footer rows.  This should never happen because the split generator does not split files that have multiple header or any footer rows.

The main problem where the single header row is skipped for all splits of a file is fixed for both TEXTFILE and sequence file.

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix missing data when reading large text and sequence files with a single header row. ({issue}`18255`)
```


Fixes https://github.com/trinodb/trino/issues/18273