### PR TITLE
Migrate S3 Select to use AWS Java SDK v2

### DIFF
--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -278,6 +278,51 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>metrics-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>netty-nio-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>regions</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sdk-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
@@ -503,6 +548,15 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredNonTestScopedDependencies>
+                        <ignoredNonTestScopedDependency>com.amazonaws:aws-java-sdk-s3</ignoredNonTestScopedDependency>
+                    </ignoredNonTestScopedDependencies>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -526,6 +580,9 @@
                                 <exclude>**/TestFullParquetReader.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                             </excludes>
+                            <systemPropertyVariables>
+                                <aws.region>us-east-1</aws.region>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -580,6 +637,9 @@
                                 <include>**/TestTrinoS3FileSystemAwsS3.java</include>
                                 <include>**/TestS3SelectQueries.java</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <aws.region>us-east-1</aws.region>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AwsSdkV2ClientStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AwsSdkV2ClientStats.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.airlift.stats.CounterStat;
+import io.airlift.stats.TimeStat;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+import software.amazon.awssdk.core.internal.metrics.SdkErrorType;
+import software.amazon.awssdk.core.metrics.CoreMetric;
+import software.amazon.awssdk.http.HttpMetric;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class AwsSdkV2ClientStats
+{
+    private final CounterStat awsRequestCount = new CounterStat();
+    private final CounterStat awsRetryCount = new CounterStat();
+    private final CounterStat awsThrottleExceptions = new CounterStat();
+    private final TimeStat awsServiceCallDuration = new TimeStat(MILLISECONDS);
+    private final TimeStat awsApiCallDuration = new TimeStat(MILLISECONDS);
+    private final TimeStat awsBackoffDelayDuration = new TimeStat(MILLISECONDS);
+    private final AtomicLong awsHttpClientPoolAvailableCount = new AtomicLong();
+    private final AtomicLong awsHttpClientPoolLeasedCount = new AtomicLong();
+    private final AtomicLong awsHttpClientPoolPendingCount = new AtomicLong();
+
+    @Managed
+    @Nested
+    public CounterStat getAwsRequestCount()
+    {
+        return awsRequestCount;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getAwsRetryCount()
+    {
+        return awsRetryCount;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getAwsThrottleExceptions()
+    {
+        return awsThrottleExceptions;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAwsServiceCallDuration()
+    {
+        return awsServiceCallDuration;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAwsApiCallDuration()
+    {
+        return awsApiCallDuration;
+    }
+
+    @Managed
+    @Nested
+    public TimeStat getAwsBackoffDelayDuration()
+    {
+        return awsBackoffDelayDuration;
+    }
+
+    @Managed
+    public long getAwsHttpClientPoolAvailableCount()
+    {
+        return awsHttpClientPoolAvailableCount.get();
+    }
+
+    @Managed
+    public long getAwsHttpClientPoolLeasedCount()
+    {
+        return awsHttpClientPoolLeasedCount.get();
+    }
+
+    @Managed
+    public long getAwsHttpClientPoolPendingCount()
+    {
+        return awsHttpClientPoolPendingCount.get();
+    }
+
+    public AwsSdkV2ClientRequestMetricsPublisher newRequestMetricsPublisher()
+    {
+        return new AwsSdkV2ClientRequestMetricsPublisher(this);
+    }
+
+    public static class AwsSdkV2ClientRequestMetricsPublisher
+            implements MetricPublisher
+    {
+        private final AwsSdkV2ClientStats stats;
+
+        protected AwsSdkV2ClientRequestMetricsPublisher(AwsSdkV2ClientStats stats)
+        {
+            this.stats = requireNonNull(stats, "stats is null");
+        }
+
+        @Override
+        public void publish(MetricCollection metricCollection)
+        {
+            var requestCount = metricCollection.metricValues(CoreMetric.RETRY_COUNT)
+                    .stream()
+                    .map(i -> i + 1)
+                    .reduce(Integer::sum).orElse(0);
+            stats.awsRequestCount.update(requestCount);
+
+            var retryCount = metricCollection.metricValues(CoreMetric.RETRY_COUNT)
+                    .stream()
+                    .reduce(Integer::sum).orElse(0);
+            stats.awsRetryCount.update(retryCount);
+
+            var throttleExceptions = metricCollection
+                    .childrenWithName("ApiCallAttempt")
+                    .flatMap(mc -> mc.metricValues(CoreMetric.ERROR_TYPE).stream())
+                    .filter(s -> s.equals(SdkErrorType.THROTTLING.toString()))
+                    .count();
+            stats.awsThrottleExceptions.update(throttleExceptions);
+
+            var serviceCallDuration = metricCollection
+                    .childrenWithName("ApiCallAttempt")
+                    .flatMap(mc -> mc.metricValues(CoreMetric.SERVICE_CALL_DURATION).stream())
+                    .reduce(Duration::plus).orElse(Duration.ZERO);
+            stats.awsServiceCallDuration.add(serviceCallDuration.toMillis(), MILLISECONDS);
+
+            var apiCallDuration = metricCollection
+                    .metricValues(CoreMetric.API_CALL_DURATION)
+                    .stream().reduce(Duration::plus).orElse(Duration.ZERO);
+            stats.awsApiCallDuration.add(apiCallDuration.toMillis(), MILLISECONDS);
+
+            var backoffDelayDuration = metricCollection
+                    .childrenWithName("ApiCallAttempt")
+                    .flatMap(mc -> mc.metricValues(CoreMetric.BACKOFF_DELAY_DURATION).stream())
+                    .reduce(Duration::plus).orElse(Duration.ZERO);
+            stats.awsBackoffDelayDuration.add(backoffDelayDuration.toMillis(), MILLISECONDS);
+
+            var httpClientPoolAvailableCount = metricCollection.childrenWithName("ApiCallAttempt")
+                    .flatMap(attempt -> attempt.childrenWithName("HttpClient"))
+                    .flatMap(httpClient -> httpClient.metricValues(HttpMetric.AVAILABLE_CONCURRENCY).stream())
+                    .reduce(Integer::max).orElse(0);
+            stats.awsHttpClientPoolAvailableCount.set(httpClientPoolAvailableCount);
+
+            var httpClientPoolLeasedCount = metricCollection.childrenWithName("ApiCallAttempt")
+                    .flatMap(attempt -> attempt.childrenWithName("HttpClient"))
+                    .flatMap(httpClient -> httpClient.metricValues(HttpMetric.LEASED_CONCURRENCY).stream())
+                    .reduce(Integer::max).orElse(0);
+            stats.awsHttpClientPoolLeasedCount.set(httpClientPoolLeasedCount);
+
+            var httpClientPoolPendingCount = metricCollection.childrenWithName("ApiCallAttempt")
+                    .flatMap(attempt -> attempt.childrenWithName("HttpClient"))
+                    .flatMap(httpClient -> httpClient.metricValues(HttpMetric.PENDING_CONCURRENCY_ACQUIRES).stream())
+                    .reduce(Integer::max).orElse(0);
+            stats.awsHttpClientPoolPendingCount.set(httpClientPoolPendingCount);
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -53,6 +53,7 @@ import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
 import io.trino.plugin.hive.s3select.S3SelectRecordCursorProvider;
+import io.trino.plugin.hive.s3select.S3SelectStats;
 import io.trino.plugin.hive.s3select.TrinoS3ClientFactory;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
@@ -89,6 +90,7 @@ public class HiveModule
                 .setDefault().toInstance(ImmutableList::of);
 
         binder.bind(TrinoS3ClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(S3SelectStats.class).toInstance(new S3SelectStats());
 
         binder.bind(CachingDirectoryLister.class).in(Scopes.SINGLETON);
         newExporter(binder).export(CachingDirectoryLister.class).withGeneratedName();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectStats.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectStats.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.s3select;
+
+import com.amazonaws.AbortedException;
+import io.airlift.stats.CounterStat;
+import io.trino.plugin.hive.AwsSdkV2ClientStats;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+
+public class S3SelectStats
+{
+    private final CounterStat activeConnections = new CounterStat();
+    private final CounterStat startedUploads = new CounterStat();
+    private final CounterStat failedUploads = new CounterStat();
+    private final CounterStat successfulUploads = new CounterStat();
+    private final CounterStat metadataCalls = new CounterStat();
+    private final CounterStat listStatusCalls = new CounterStat();
+    private final CounterStat listLocatedStatusCalls = new CounterStat();
+    private final CounterStat listObjectsCalls = new CounterStat();
+    private final CounterStat otherReadErrors = new CounterStat();
+    private final CounterStat awsAbortedExceptions = new CounterStat();
+    private final CounterStat socketExceptions = new CounterStat();
+    private final CounterStat socketTimeoutExceptions = new CounterStat();
+    private final CounterStat getObjectErrors = new CounterStat();
+    private final CounterStat getMetadataErrors = new CounterStat();
+    private final CounterStat initiateMultipartUploadErrors = new CounterStat();
+    private final CounterStat getObjectRetries = new CounterStat();
+    private final CounterStat getMetadataRetries = new CounterStat();
+    private final CounterStat readRetries = new CounterStat();
+    private final CounterStat initiateMultipartUploadRetries = new CounterStat();
+
+    // see AWSRequestMetrics
+    private final AwsSdkV2ClientStats clientCoreStats = new AwsSdkV2ClientStats();
+
+    @Managed
+    @Nested
+    public CounterStat getActiveConnections()
+    {
+        return activeConnections;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getStartedUploads()
+    {
+        return startedUploads;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getFailedUploads()
+    {
+        return failedUploads;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getSuccessfulUploads()
+    {
+        return successfulUploads;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getMetadataCalls()
+    {
+        return metadataCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getListStatusCalls()
+    {
+        return listStatusCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getListLocatedStatusCalls()
+    {
+        return listLocatedStatusCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getListObjectsCalls()
+    {
+        return listObjectsCalls;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetObjectErrors()
+    {
+        return getObjectErrors;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetMetadataErrors()
+    {
+        return getMetadataErrors;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getInitiateMultipartUploadErrors()
+    {
+        return initiateMultipartUploadErrors;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getOtherReadErrors()
+    {
+        return otherReadErrors;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getSocketExceptions()
+    {
+        return socketExceptions;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getSocketTimeoutExceptions()
+    {
+        return socketTimeoutExceptions;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getAwsAbortedExceptions()
+    {
+        return awsAbortedExceptions;
+    }
+
+    @Managed
+    @Flatten
+    public AwsSdkV2ClientStats getClientCoreStats()
+    {
+        return clientCoreStats;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetObjectRetries()
+    {
+        return getObjectRetries;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getGetMetadataRetries()
+    {
+        return getMetadataRetries;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getReadRetries()
+    {
+        return readRetries;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getInitiateMultipartUploadRetries()
+    {
+        return initiateMultipartUploadRetries;
+    }
+
+    public AwsSdkV2ClientStats.AwsSdkV2ClientRequestMetricsPublisher newRequestMetricCollector()
+    {
+        return clientCoreStats.newRequestMetricsPublisher();
+    }
+
+    public void connectionOpened()
+    {
+        activeConnections.update(1);
+    }
+
+    public void connectionReleased()
+    {
+        activeConnections.update(-1);
+    }
+
+    public void uploadStarted()
+    {
+        startedUploads.update(1);
+    }
+
+    public void uploadFailed()
+    {
+        failedUploads.update(1);
+    }
+
+    public void uploadSuccessful()
+    {
+        successfulUploads.update(1);
+    }
+
+    public void newMetadataCall()
+    {
+        metadataCalls.update(1);
+    }
+
+    public void newListStatusCall()
+    {
+        listStatusCalls.update(1);
+    }
+
+    public void newListLocatedStatusCall()
+    {
+        listLocatedStatusCalls.update(1);
+    }
+
+    public void newListObjectsCall()
+    {
+        listObjectsCalls.update(1);
+    }
+
+    public void newReadError(Throwable t)
+    {
+        if (t instanceof SocketException) {
+            socketExceptions.update(1);
+        }
+        else if (t instanceof SocketTimeoutException) {
+            socketTimeoutExceptions.update(1);
+        }
+        else if (t instanceof AbortedException) {
+            awsAbortedExceptions.update(1);
+        }
+        else {
+            otherReadErrors.update(1);
+        }
+    }
+
+    public void newGetObjectError()
+    {
+        getObjectErrors.update(1);
+    }
+
+    public void newGetMetadataError()
+    {
+        getMetadataErrors.update(1);
+    }
+
+    public void newInitiateMultipartUploadError()
+    {
+        initiateMultipartUploadErrors.update(1);
+    }
+
+    public void newGetObjectRetry()
+    {
+        getObjectRetries.update(1);
+    }
+
+    public void newGetMetadataRetry()
+    {
+        getMetadataRetries.update(1);
+    }
+
+    public void newReadRetry()
+    {
+        readRetries.update(1);
+    }
+
+    public void newInitiateMultipartUploadRetry()
+    {
+        initiateMultipartUploadRetries.update(1);
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/TrinoS3ClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/TrinoS3ClientFactory.java
@@ -13,21 +13,6 @@
  */
 package io.trino.plugin.hive.s3select;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.Protocol;
-import com.amazonaws.SdkClientException;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.auth.BasicSessionCredentials;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
-import com.amazonaws.regions.DefaultAwsRegionProviderChain;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Builder;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
@@ -36,15 +21,32 @@ import io.trino.hdfs.s3.HiveS3Config;
 import io.trino.hdfs.s3.TrinoS3FileSystem;
 import io.trino.plugin.hive.HiveConfig;
 import org.apache.hadoop.conf.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.StsClientBuilder;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 import java.net.URI;
 import java.util.Optional;
 
-import static com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import static com.amazonaws.regions.Regions.US_EAST_1;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
-import static io.trino.hdfs.s3.AwsCurrentRegionHolder.getCurrentRegionFromEC2Metadata;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_CONNECT_TIMEOUT;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_CONNECT_TTL;
@@ -54,11 +56,11 @@ import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_EXTERNAL_ID;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_IAM_ROLE;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_MAX_ERROR_RETRIES;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_PIN_CLIENT_TO_CURRENT_REGION;
+import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_REGION;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_ROLE_SESSION_NAME;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SECRET_KEY;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SESSION_TOKEN;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SOCKET_TIMEOUT;
-import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SSL_ENABLED;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_STS_ENDPOINT;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_STS_REGION;
 import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_USER_AGENT_PREFIX;
@@ -80,17 +82,20 @@ public class TrinoS3ClientFactory
     private final boolean enabled;
     private final int defaultMaxConnections;
 
+    private S3SelectStats stats;
+
     @GuardedBy("this")
-    private AmazonS3 s3Client;
+    private S3AsyncClient s3Client;
 
     @Inject
-    public TrinoS3ClientFactory(HiveConfig config)
+    public TrinoS3ClientFactory(HiveConfig config, S3SelectStats stats)
     {
         this.enabled = config.isS3SelectPushdownEnabled();
         this.defaultMaxConnections = config.getS3SelectPushdownMaxConnections();
+        this.stats = stats;
     }
 
-    synchronized AmazonS3 getS3Client(Configuration config)
+    synchronized S3AsyncClient getS3Client(Configuration config)
     {
         if (s3Client == null) {
             s3Client = createS3Client(config);
@@ -98,68 +103,81 @@ public class TrinoS3ClientFactory
         return s3Client;
     }
 
-    private AmazonS3 createS3Client(Configuration config)
+    private ClientOverrideConfiguration getClientOverrideConfig(RetryPolicy retryPolicy, String userAgentPrefix)
+    {
+        return ClientOverrideConfiguration.builder()
+                .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX, userAgentPrefix)
+                .putAdvancedOption(SdkAdvancedClientOption.USER_AGENT_SUFFIX, enabled ? "Trino-select" : "Trino")
+                .addMetricPublisher(stats.newRequestMetricCollector())
+                .retryPolicy(retryPolicy).build();
+    }
+
+    private S3AsyncClient createS3Client(Configuration config)
     {
         HiveS3Config defaults = new HiveS3Config();
         String userAgentPrefix = config.get(S3_USER_AGENT_PREFIX, defaults.getS3UserAgentPrefix());
         int maxErrorRetries = config.getInt(S3_MAX_ERROR_RETRIES, defaults.getS3MaxErrorRetries());
-        boolean sslEnabled = config.getBoolean(S3_SSL_ENABLED, defaults.isS3SslEnabled());
         Duration connectTimeout = Duration.valueOf(config.get(S3_CONNECT_TIMEOUT, defaults.getS3ConnectTimeout().toString()));
         Duration socketTimeout = Duration.valueOf(config.get(S3_SOCKET_TIMEOUT, defaults.getS3SocketTimeout().toString()));
         int maxConnections = config.getInt(S3_SELECT_PUSHDOWN_MAX_CONNECTIONS, defaultMaxConnections);
 
-        ClientConfiguration clientConfiguration = new ClientConfiguration()
-                .withMaxErrorRetry(maxErrorRetries)
-                .withProtocol(sslEnabled ? Protocol.HTTPS : Protocol.HTTP)
-                .withConnectionTimeout(toIntExact(connectTimeout.toMillis()))
-                .withSocketTimeout(toIntExact(socketTimeout.toMillis()))
-                .withMaxConnections(maxConnections)
-                .withUserAgentPrefix(userAgentPrefix)
-                .withUserAgentSuffix(enabled ? "Trino-select" : "Trino");
+        NettyNioAsyncHttpClient.Builder nettyBuilder = NettyNioAsyncHttpClient.builder()
+                .maxConcurrency(maxConnections)
+                .connectionTimeout(java.time.Duration.ofMillis(toIntExact(connectTimeout.toMillis())))
+                .readTimeout(java.time.Duration.ofMillis(toIntExact(socketTimeout.toMillis())))
+                .writeTimeout(java.time.Duration.ofMillis(toIntExact(socketTimeout.toMillis())));
+
+        RetryPolicy retryPolicy = RetryPolicy.builder().numRetries(maxErrorRetries).build();
+        ClientOverrideConfiguration clientOverrideConfiguration = getClientOverrideConfig(retryPolicy, userAgentPrefix);
+        S3Configuration s3Configuration = S3Configuration.builder().pathStyleAccessEnabled(true).build();
 
         String connectTtlValue = config.get(S3_CONNECT_TTL);
         if (!isNullOrEmpty(connectTtlValue)) {
-            clientConfiguration.setConnectionTTL(Duration.valueOf(connectTtlValue).toMillis());
+            nettyBuilder.connectionTimeToLive(java.time.Duration.ofMillis(Duration.valueOf(connectTtlValue).toMillis()));
         }
 
-        AWSCredentialsProvider awsCredentialsProvider = getAwsCredentialsProvider(config);
-        AmazonS3Builder<? extends AmazonS3Builder<?, ?>, ? extends AmazonS3> clientBuilder = AmazonS3Client.builder()
-                .withCredentials(awsCredentialsProvider)
-                .withClientConfiguration(clientConfiguration)
-                .withMetricsCollector(TrinoS3FileSystem.getFileSystemStats().newRequestMetricCollector())
-                .enablePathStyleAccess();
+        AwsCredentialsProvider awsCredentialsProvider = getAwsCredentialsProvider(config);
+        S3AsyncClientBuilder clientBuilder = S3AsyncClient.builder()
+                .httpClientBuilder(nettyBuilder)
+                .credentialsProvider(awsCredentialsProvider)
+                .overrideConfiguration(clientOverrideConfiguration)
+                .serviceConfiguration(s3Configuration);
 
         boolean regionOrEndpointSet = false;
 
         String endpoint = config.get(S3_ENDPOINT);
+        String region = config.get(S3_REGION);
         boolean pinS3ClientToCurrentRegion = config.getBoolean(S3_PIN_CLIENT_TO_CURRENT_REGION, defaults.isPinS3ClientToCurrentRegion());
         verify(!pinS3ClientToCurrentRegion || endpoint == null,
                 "Invalid configuration: either endpoint can be set or S3 client can be pinned to the current region");
 
         // use local region when running inside of EC2
         if (pinS3ClientToCurrentRegion) {
-            clientBuilder.setRegion(getCurrentRegionFromEC2Metadata().getName());
             regionOrEndpointSet = true;
         }
 
         if (!isNullOrEmpty(endpoint)) {
-            clientBuilder.withEndpointConfiguration(new EndpointConfiguration(endpoint, null));
+            clientBuilder.endpointOverride(URI.create(endpoint));
+            regionOrEndpointSet = true;
+        }
+        else if (!isNullOrEmpty(region)) {
+            clientBuilder.region(Region.of(region));
             regionOrEndpointSet = true;
         }
 
         if (!regionOrEndpointSet) {
-            clientBuilder.withRegion(US_EAST_1);
-            clientBuilder.setForceGlobalBucketAccessEnabled(true);
+            clientBuilder.region(Region.US_EAST_1);
+            clientBuilder.crossRegionAccessEnabled(true);
         }
 
         return clientBuilder.build();
     }
 
-    private static AWSCredentialsProvider getAwsCredentialsProvider(Configuration conf)
+    private static AwsCredentialsProvider getAwsCredentialsProvider(Configuration conf)
     {
-        Optional<AWSCredentials> credentials = getAwsCredentials(conf);
+        Optional<AwsCredentials> credentials = getAwsCredentials(conf);
         if (credentials.isPresent()) {
-            return new AWSStaticCredentialsProvider(credentials.get());
+            return StaticCredentialsProvider.create(credentials.get());
         }
 
         String providerClass = conf.get(S3_CREDENTIALS_PROVIDER);
@@ -167,9 +185,9 @@ public class TrinoS3ClientFactory
             return getCustomAWSCredentialsProvider(conf, providerClass);
         }
 
-        AWSCredentialsProvider provider = getAwsCredentials(conf)
-                .map(value -> (AWSCredentialsProvider) new AWSStaticCredentialsProvider(value))
-                .orElseGet(DefaultAWSCredentialsProviderChain::getInstance);
+        AwsCredentialsProvider provider = getAwsCredentials(conf)
+                .map(value -> (AwsCredentialsProvider) StaticCredentialsProvider.create(value))
+                .orElseGet(DefaultCredentialsProvider::create);
 
         String iamRole = conf.get(S3_IAM_ROLE);
         if (iamRole != null) {
@@ -178,45 +196,50 @@ public class TrinoS3ClientFactory
             String s3RoleSessionName = conf.get(S3_ROLE_SESSION_NAME);
             String externalId = conf.get(S3_EXTERNAL_ID);
 
-            AWSSecurityTokenServiceClientBuilder stsClientBuilder = AWSSecurityTokenServiceClientBuilder.standard()
-                    .withCredentials(provider);
+            StsClientBuilder stsClientBuilder = StsClient.builder().credentialsProvider(provider);
 
-            String region;
+            Region region;
             if (!isNullOrEmpty(stsRegionOverride)) {
-                region = stsRegionOverride;
+                region = Region.of(stsRegionOverride);
             }
             else {
-                DefaultAwsRegionProviderChain regionProviderChain = new DefaultAwsRegionProviderChain();
+                DefaultAwsRegionProviderChain regionProviderChain = DefaultAwsRegionProviderChain.builder().build();
                 try {
                     region = regionProviderChain.getRegion();
                 }
                 catch (SdkClientException ex) {
-                    log.warn("Falling back to default AWS region %s", US_EAST_1);
-                    region = US_EAST_1.getName();
+                    log.warn("Falling back to default AWS region %s", Region.US_EAST_1.id());
+                    region = Region.US_EAST_1;
                 }
             }
 
             if (!isNullOrEmpty(stsEndpointOverride)) {
-                stsClientBuilder.withEndpointConfiguration(new EndpointConfiguration(stsEndpointOverride, region));
+                stsClientBuilder.endpointOverride(URI.create(stsEndpointOverride));
             }
             else {
-                stsClientBuilder.withRegion(region);
+                stsClientBuilder.region(region);
             }
 
-            provider = new STSAssumeRoleSessionCredentialsProvider.Builder(iamRole, s3RoleSessionName)
-                    .withExternalId(externalId)
-                    .withStsClient(stsClientBuilder.build())
+            AssumeRoleRequest roleRequest = AssumeRoleRequest.builder()
+                    .roleArn(iamRole)
+                    .roleSessionName(s3RoleSessionName)
+                    .externalId(externalId)
+                    .build();
+
+            provider = StsAssumeRoleCredentialsProvider.builder()
+                    .stsClient(stsClientBuilder.build())
+                    .refreshRequest(() -> roleRequest)
                     .build();
         }
 
         return provider;
     }
 
-    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(Configuration conf, String providerClass)
+    private static AwsCredentialsProvider getCustomAWSCredentialsProvider(Configuration conf, String providerClass)
     {
         try {
             return conf.getClassByName(providerClass)
-                    .asSubclass(AWSCredentialsProvider.class)
+                    .asSubclass(AwsCredentialsProvider.class)
                     .getConstructor(URI.class, Configuration.class)
                     .newInstance(null, conf);
         }
@@ -225,7 +248,7 @@ public class TrinoS3ClientFactory
         }
     }
 
-    private static Optional<AWSCredentials> getAwsCredentials(Configuration conf)
+    private static Optional<AwsCredentials> getAwsCredentials(Configuration conf)
     {
         String accessKey = conf.get(S3_ACCESS_KEY);
         String secretKey = conf.get(S3_SECRET_KEY);
@@ -235,9 +258,9 @@ public class TrinoS3ClientFactory
         }
         String sessionToken = conf.get(S3_SESSION_TOKEN);
         if (!isNullOrEmpty(sessionToken)) {
-            return Optional.of(new BasicSessionCredentials(accessKey, secretKey, sessionToken));
+            return Optional.of(AwsSessionCredentials.create(accessKey, secretKey, sessionToken));
         }
 
-        return Optional.of(new BasicAWSCredentials(accessKey, secretKey));
+        return Optional.of(AwsBasicCredentials.create(accessKey, secretKey));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/TrinoS3SelectClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/TrinoS3SelectClient.java
@@ -13,26 +13,37 @@
  */
 package io.trino.plugin.hive.s3select;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.SelectObjectContentEventVisitor;
-import com.amazonaws.services.s3.model.SelectObjectContentRequest;
-import com.amazonaws.services.s3.model.SelectObjectContentResult;
+import io.airlift.log.Logger;
 import org.apache.hadoop.conf.Configuration;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.EndEvent;
+import software.amazon.awssdk.services.s3.model.RecordsEvent;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentRequest;
+import software.amazon.awssdk.services.s3.model.SelectObjectContentResponseHandler;
 
+import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.util.ArrayDeque;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
-import static com.amazonaws.services.s3.model.SelectObjectContentEvent.EndEvent;
 import static java.util.Objects.requireNonNull;
 
 class TrinoS3SelectClient
         implements Closeable
 {
-    private final AmazonS3 s3Client;
+    private static final Logger log = Logger.get("TrinoS3SelectClient");
+    private final S3AsyncClient s3Client;
     private boolean requestComplete;
     private SelectObjectContentRequest selectObjectRequest;
-    private SelectObjectContentResult selectObjectContentResult;
 
     public TrinoS3SelectClient(Configuration configuration, TrinoS3ClientFactory s3ClientFactory)
     {
@@ -44,34 +55,44 @@ class TrinoS3SelectClient
     public InputStream getRecordsContent(SelectObjectContentRequest selectObjectRequest)
     {
         this.selectObjectRequest = requireNonNull(selectObjectRequest, "selectObjectRequest is null");
-        this.selectObjectContentResult = s3Client.selectObjectContent(selectObjectRequest);
-        return selectObjectContentResult.getPayload()
-                .getRecordsInputStream(
-                        new SelectObjectContentEventVisitor()
-                        {
-                            @Override
-                            public void visit(EndEvent endEvent)
-                            {
-                                requestComplete = true;
-                            }
-                        });
+        EventStreamEnumeration eventStreamEnumeration = new EventStreamEnumeration();
+        InputStream recordInputStream = new SequenceInputStream(eventStreamEnumeration);
+
+        SelectObjectContentResponseHandler.Visitor visitor = new SelectObjectContentResponseHandler.Visitor()
+        {
+            @Override
+            public void visitRecords(RecordsEvent event)
+            {
+                eventStreamEnumeration.addEvent(new S3Event(event, false));
+            }
+
+            @Override
+            public void visitEnd(EndEvent event)
+            {
+                requestComplete = true;
+                eventStreamEnumeration.addEvent(new S3Event(null, true));
+            }
+        };
+
+        s3Client.selectObjectContent(selectObjectRequest, SelectObjectContentResponseHandler.builder().subscriber(visitor).build()).join();
+        return recordInputStream;
     }
 
     @Override
     public void close()
             throws IOException
     {
-        selectObjectContentResult.close();
+       // No-Op
     }
 
     public String getKeyName()
     {
-        return selectObjectRequest.getKey();
+        return selectObjectRequest.key();
     }
 
     public String getBucketName()
     {
-        return selectObjectRequest.getBucketName();
+        return selectObjectRequest.bucket();
     }
 
     /**
@@ -81,5 +102,119 @@ class TrinoS3SelectClient
     public boolean isRequestComplete()
     {
         return requestComplete;
+    }
+
+    /**
+     * Below classes are required for compatibility between AWS Java SDK 1.x and 2.x
+     * They return an InputStream to all the incoming record events
+     */
+    static class S3Event
+    {
+        RecordsEvent event;
+        boolean isEndEvent;
+
+        public S3Event(RecordsEvent event, boolean isEndEvent)
+        {
+            this.event = event;
+            this.isEndEvent = isEndEvent;
+        }
+    }
+
+    private static class EventStreamEnumeration
+            extends LazyLoadedIterator<InputStream> implements Enumeration<InputStream>
+    {
+        private boolean initialized;
+        private final BlockingQueue<S3Event> inputStreams;
+
+        EventStreamEnumeration()
+        {
+            this.inputStreams = new LinkedBlockingQueue<>();
+        }
+
+        @Override
+        protected Optional<? extends InputStream> getNext()
+                throws InterruptedException
+        {
+            if (!initialized) {
+                initialized = true;
+                return Optional.of(new ByteArrayInputStream(new byte[0]));
+            }
+
+            S3Event s3Event = inputStreams.take();
+            if (s3Event.isEndEvent) {
+                return Optional.empty();
+            }
+            return Optional.of(s3Event.event.payload().asInputStream());
+        }
+
+        public void addEvent(S3Event event)
+        {
+            this.inputStreams.add(event);
+        }
+
+        @Override
+        public boolean hasMoreElements()
+        {
+            return super.hasNext();
+        }
+
+        @Override
+        public InputStream nextElement()
+        {
+            return super.next();
+        }
+    }
+
+    private abstract static class LazyLoadedIterator<T>
+            implements Iterator<T>
+    {
+        private final Queue<T> next = new ArrayDeque<T>();
+        private boolean isDone;
+
+        @Override
+        public boolean hasNext()
+        {
+            advanceIfNeeded();
+            return !isDone;
+        }
+
+        @Override
+        public T next()
+        {
+            advanceIfNeeded();
+
+            if (isDone) {
+                throw new NoSuchElementException();
+            }
+
+            return next.poll();
+        }
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        private void advanceIfNeeded()
+        {
+            if (!isDone && next.isEmpty()) {
+                try {
+                    Optional<? extends T> nextElement = getNext();
+                    nextElement.ifPresent(this.next::add);
+                    this.isDone = this.next.isEmpty();
+                }
+                catch (InterruptedException e) {
+                    log.error("Failed to read during S3 Select : %s", e.getMessage());
+                }
+            }
+        }
+
+        /**
+         * Load any newly-available events. This can return any number of events, in the order they should be encountered by the
+         * user of the iterator. This should return an empty collection if there are no remaining events in the stream.
+         */
+        protected abstract Optional<? extends T> getNext()
+                throws InterruptedException;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/csv/S3SelectCsvRecordReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/csv/S3SelectCsvRecordReader.java
@@ -13,16 +13,16 @@
  */
 package io.trino.plugin.hive.s3select.csv;
 
-import com.amazonaws.services.s3.model.CSVInput;
-import com.amazonaws.services.s3.model.CSVOutput;
-import com.amazonaws.services.s3.model.CompressionType;
-import com.amazonaws.services.s3.model.InputSerialization;
-import com.amazonaws.services.s3.model.OutputSerialization;
 import io.trino.plugin.hive.s3select.S3SelectLineRecordReader;
 import io.trino.plugin.hive.s3select.TrinoS3ClientFactory;
 import io.trino.plugin.hive.util.SerdeConstants;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import software.amazon.awssdk.services.s3.model.CSVInput;
+import software.amazon.awssdk.services.s3.model.CSVOutput;
+import software.amazon.awssdk.services.s3.model.CompressionType;
+import software.amazon.awssdk.services.s3.model.InputSerialization;
+import software.amazon.awssdk.services.s3.model.OutputSerialization;
 
 import java.util.Optional;
 import java.util.Properties;
@@ -65,18 +65,18 @@ public class S3SelectCsvRecordReader
         String quoteChar = schema.getProperty(QUOTE_CHAR, null);
         String escapeChar = schema.getProperty(ESCAPE_CHAR, null);
 
-        CSVInput selectObjectCSVInputSerialization = new CSVInput();
-        selectObjectCSVInputSerialization.setRecordDelimiter(getLineDelimiter());
-        selectObjectCSVInputSerialization.setFieldDelimiter(fieldDelimiter);
-        selectObjectCSVInputSerialization.setComments(COMMENTS_CHAR_STR);
-        selectObjectCSVInputSerialization.setQuoteCharacter(quoteChar);
-        selectObjectCSVInputSerialization.setQuoteEscapeCharacter(escapeChar);
+        CSVInput.Builder selectObjectCSVInputSerialization = CSVInput.builder();
+        selectObjectCSVInputSerialization.recordDelimiter(getLineDelimiter());
+        selectObjectCSVInputSerialization.fieldDelimiter(fieldDelimiter);
+        selectObjectCSVInputSerialization.comments(COMMENTS_CHAR_STR);
+        selectObjectCSVInputSerialization.quoteCharacter(quoteChar);
+        selectObjectCSVInputSerialization.quoteEscapeCharacter(escapeChar);
 
-        InputSerialization selectObjectInputSerialization = new InputSerialization();
-        selectObjectInputSerialization.setCompressionType(getCompressionType());
-        selectObjectInputSerialization.setCsv(selectObjectCSVInputSerialization);
+        InputSerialization.Builder selectObjectInputSerialization = InputSerialization.builder();
+        selectObjectInputSerialization.compressionType(getCompressionType());
+        selectObjectInputSerialization.csv(selectObjectCSVInputSerialization.build());
 
-        return selectObjectInputSerialization;
+        return selectObjectInputSerialization.build();
     }
 
     @Override
@@ -87,15 +87,15 @@ public class S3SelectCsvRecordReader
         String quoteChar = schema.getProperty(QUOTE_CHAR, null);
         String escapeChar = schema.getProperty(ESCAPE_CHAR, null);
 
-        OutputSerialization selectObjectOutputSerialization = new OutputSerialization();
-        CSVOutput selectObjectCSVOutputSerialization = new CSVOutput();
-        selectObjectCSVOutputSerialization.setRecordDelimiter(getLineDelimiter());
-        selectObjectCSVOutputSerialization.setFieldDelimiter(fieldDelimiter);
-        selectObjectCSVOutputSerialization.setQuoteCharacter(quoteChar);
-        selectObjectCSVOutputSerialization.setQuoteEscapeCharacter(escapeChar);
-        selectObjectOutputSerialization.setCsv(selectObjectCSVOutputSerialization);
+        OutputSerialization.Builder selectObjectOutputSerialization = OutputSerialization.builder();
+        CSVOutput.Builder selectObjectCSVOutputSerialization = CSVOutput.builder();
+        selectObjectCSVOutputSerialization.recordDelimiter(getLineDelimiter());
+        selectObjectCSVOutputSerialization.fieldDelimiter(fieldDelimiter);
+        selectObjectCSVOutputSerialization.quoteCharacter(quoteChar);
+        selectObjectCSVOutputSerialization.quoteEscapeCharacter(escapeChar);
+        selectObjectOutputSerialization.csv(selectObjectCSVOutputSerialization.build());
 
-        return selectObjectOutputSerialization;
+        return selectObjectOutputSerialization.build();
     }
 
     @Override
@@ -103,7 +103,7 @@ public class S3SelectCsvRecordReader
     {
         // Works for CSV if AllowQuotedRecordDelimiter is disabled.
         boolean isQuotedRecordDelimiterAllowed = Boolean.TRUE.equals(
-                buildInputSerialization().getCsv().getAllowQuotedRecordDelimiter());
+                buildInputSerialization().csv().allowQuotedRecordDelimiter());
         return CompressionType.NONE.equals(getCompressionType()) && !isQuotedRecordDelimiterAllowed;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/json/S3SelectJsonRecordReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/json/S3SelectJsonRecordReader.java
@@ -13,16 +13,16 @@
  */
 package io.trino.plugin.hive.s3select.json;
 
-import com.amazonaws.services.s3.model.CompressionType;
-import com.amazonaws.services.s3.model.InputSerialization;
-import com.amazonaws.services.s3.model.JSONInput;
-import com.amazonaws.services.s3.model.JSONOutput;
-import com.amazonaws.services.s3.model.JSONType;
-import com.amazonaws.services.s3.model.OutputSerialization;
 import io.trino.plugin.hive.s3select.S3SelectLineRecordReader;
 import io.trino.plugin.hive.s3select.TrinoS3ClientFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import software.amazon.awssdk.services.s3.model.CompressionType;
+import software.amazon.awssdk.services.s3.model.InputSerialization;
+import software.amazon.awssdk.services.s3.model.JSONInput;
+import software.amazon.awssdk.services.s3.model.JSONOutput;
+import software.amazon.awssdk.services.s3.model.JSONType;
+import software.amazon.awssdk.services.s3.model.OutputSerialization;
 
 import java.util.Properties;
 
@@ -43,25 +43,24 @@ public class S3SelectJsonRecordReader
     @Override
     public InputSerialization buildInputSerialization()
     {
-        // JSONType.LINES is the only JSON format supported by the Hive JsonSerDe.
-        JSONInput selectObjectJSONInputSerialization = new JSONInput();
-        selectObjectJSONInputSerialization.setType(JSONType.LINES);
+        JSONInput.Builder selectObjectJSONInputSerialization = JSONInput.builder();
+        selectObjectJSONInputSerialization.type(JSONType.LINES);
 
-        InputSerialization selectObjectInputSerialization = new InputSerialization();
-        selectObjectInputSerialization.setCompressionType(getCompressionType());
-        selectObjectInputSerialization.setJson(selectObjectJSONInputSerialization);
+        InputSerialization.Builder selectObjectInputSerialization = InputSerialization.builder();
+        selectObjectInputSerialization.compressionType(getCompressionType());
+        selectObjectInputSerialization.json(selectObjectJSONInputSerialization.build());
 
-        return selectObjectInputSerialization;
+        return selectObjectInputSerialization.build();
     }
 
     @Override
     public OutputSerialization buildOutputSerialization()
     {
-        OutputSerialization selectObjectOutputSerialization = new OutputSerialization();
-        JSONOutput selectObjectJSONOutputSerialization = new JSONOutput();
-        selectObjectOutputSerialization.setJson(selectObjectJSONOutputSerialization);
+        OutputSerialization.Builder selectObjectOutputSerialization = OutputSerialization.builder();
+        JSONOutput selectObjectJSONOutputSerialization = JSONOutput.builder().build();
+        selectObjectOutputSerialization.json(selectObjectJSONOutputSerialization);
 
-        return selectObjectOutputSerialization;
+        return selectObjectOutputSerialization.build();
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -55,6 +55,7 @@ import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
 import io.trino.plugin.hive.s3select.S3SelectRecordCursorProvider;
+import io.trino.plugin.hive.s3select.S3SelectStats;
 import io.trino.plugin.hive.s3select.TrinoS3ClientFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.block.Block;
@@ -217,7 +218,7 @@ public final class HiveTestUtils
 
     public static Set<HiveRecordCursorProvider> getDefaultHiveRecordCursorProviders(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)
     {
-        return ImmutableSet.of(new S3SelectRecordCursorProvider(hdfsEnvironment, new TrinoS3ClientFactory(hiveConfig)));
+        return ImmutableSet.of(new S3SelectRecordCursorProvider(hdfsEnvironment, new TrinoS3ClientFactory(hiveConfig, new S3SelectStats())));
     }
 
     public static Set<HiveFileWriterFactory> getDefaultHiveFileWriterFactories(HiveConfig hiveConfig, HdfsEnvironment hdfsEnvironment)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3select/TestS3SelectRecordCursorProvider.java
@@ -115,7 +115,7 @@ public class TestS3SelectRecordCursorProvider
     {
         S3SelectRecordCursorProvider s3SelectRecordCursorProvider = new S3SelectRecordCursorProvider(
                 new TestingHdfsEnvironment(new ArrayList<>()),
-                new TrinoS3ClientFactory(new HiveConfig()));
+                new TrinoS3ClientFactory(new HiveConfig(), new S3SelectStats()));
 
         return s3SelectRecordCursorProvider.createRecordCursor(
                 ConfigurationInstantiator.newEmptyConfiguration(),

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.493</dep.aws-sdk.version>
-        <dep.aws-sdk-v2.version>2.20.89</dep.aws-sdk-v2.version>
+        <dep.aws-sdk-v2.version>2.20.99</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.20</dep.drift.version>
@@ -174,7 +174,7 @@
         <dep.iceberg.version>1.3.0</dep.iceberg.version>
         <dep.protobuf.version>3.22.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <dep.netty.version>4.1.92.Final</dep.netty.version>
+        <dep.netty.version>4.1.94.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
         <dep.okio.version>3.3.0</dep.okio.version>
 


### PR DESCRIPTION
## Description
The PR aims to migrate AWS Java SDK usage in S3 Select to V2 from V1.

[AWS SDK v2](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html) is a rewrite of the V1 SDK, thus there is a lot of refactoring of the code.

As a part of this PR:
- Added a new metric collector (MetricsPublisher in SDKV2 terms) for S3 Select, since the V1 metrics collector is not compatible with the V2 classes. If metrics collection for S3Select is something we do not want, it can be removed as well to reduce complexity.
- Bumped up AWS SDK V2 version in root pom.xml to 2.20.99 from 2.20.89. This was required to incorporate the cross region client access feature.
- Bumped up netty version in root pom.xml to 4.1.94.Final from 4.1.92.Final to avoid RequireUpperBounds errors.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Some more context around the PR can be found on the conversation at https://github.com/trinodb/trino/pull/17522


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: