### PR TITLE
Fix reading concatenated GZIP streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -648,7 +648,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.24</version>
+                <version>0.25</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes #18223

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix missing data when reading concatenated GZIP compressed text files. ({issue}`18223`)
```
