### PR TITLE
mysql, mariadb: remove database url check

### DIFF
--- a/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/main/java/io/trino/plugin/mariadb/MariaDbJdbcConfig.java
@@ -15,10 +15,7 @@ package io.trino.plugin.mariadb;
 
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import jakarta.validation.constraints.AssertTrue;
-import org.mariadb.jdbc.Configuration;
 import org.mariadb.jdbc.Driver;
-
-import java.sql.SQLException;
 
 public class MariaDbJdbcConfig
         extends BaseJdbcConfig
@@ -28,20 +25,5 @@ public class MariaDbJdbcConfig
     {
         Driver driver = new Driver();
         return driver.acceptsURL(getConnectionUrl());
-    }
-
-    @AssertTrue(message = "Database (catalog) must not be specified in JDBC URL for MariaDB connector")
-    public boolean isUrlWithoutDatabase()
-    {
-        try {
-            Configuration conf = Configuration.parse(getConnectionUrl());
-            if (conf == null) {
-                return false;
-            }
-            return conf.database() == null;
-        }
-        catch (SQLException e) {
-            return false;
-        }
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbJdbcConfig.java
@@ -35,19 +35,4 @@ public class TestMariaDbJdbcConfig
         config.setConnectionUrl(url);
         return config.isUrlValid();
     }
-
-    @Test
-    public void testIsUrlWithoutDatabase()
-    {
-        assertTrue(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306"));
-        assertTrue(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306/"));
-        assertFalse(isUrlWithoutDatabase("jdbc:mariadb://example.net:3306/somedatabase"));
-    }
-
-    private static boolean isUrlWithoutDatabase(String url)
-    {
-        MariaDbJdbcConfig config = new MariaDbJdbcConfig();
-        config.setConnectionUrl(url);
-        return config.isUrlWithoutDatabase();
-    }
 }

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
@@ -13,16 +13,11 @@
  */
 package io.trino.plugin.mysql;
 
-import com.mysql.cj.conf.ConnectionUrlParser;
-import com.mysql.cj.exceptions.CJException;
 import com.mysql.cj.jdbc.Driver;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import jakarta.validation.constraints.AssertTrue;
 
 import java.sql.SQLException;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.mysql.cj.conf.ConnectionUrlParser.parseConnectionString;
 
 public class MySqlJdbcConfig
         extends BaseJdbcConfig
@@ -35,18 +30,6 @@ public class MySqlJdbcConfig
         }
         catch (SQLException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    @AssertTrue(message = "Database (catalog) must not be specified in JDBC URL for MySQL connector")
-    public boolean isUrlWithoutDatabase()
-    {
-        try {
-            ConnectionUrlParser parser = parseConnectionString(getConnectionUrl());
-            return isNullOrEmpty(parser.getPath());
-        }
-        catch (CJException ignore) {
-            return false;
         }
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlJdbcConfig.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlJdbcConfig.java
@@ -21,17 +21,18 @@ import static org.testng.Assert.assertTrue;
 public class TestMySqlJdbcConfig
 {
     @Test
-    public void testIsUrlWithoutDatabase()
+    public void testIsUrlValid()
     {
-        assertTrue(isUrlWithoutDatabase("jdbc:mysql://example.net:3306"));
-        assertTrue(isUrlWithoutDatabase("jdbc:mysql://example.net:3306/"));
-        assertFalse(isUrlWithoutDatabase("jdbc:mysql://example.net:3306/somedatabase"));
+        assertTrue(isUrlValid("jdbc:mysql://example.net:3306"));
+        assertTrue(isUrlValid("jdbc:mysql://example.net:3306/"));
+        assertFalse(isUrlValid("jdbc:notmysql://example.net:3306"));
+        assertFalse(isUrlValid("jdbc:notmysql://example.net:3306/"));
     }
 
-    private static boolean isUrlWithoutDatabase(String url)
+    private static boolean isUrlValid(String url)
     {
         MySqlJdbcConfig config = new MySqlJdbcConfig();
         config.setConnectionUrl(url);
-        return config.isUrlWithoutDatabase();
+        return config.isUrlValid();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trino MySQL and MariaDB URLs currently restrict users from specifying a database as part of the JDBC URL.

With this check in-place, ProxySQL users cannot create multiple connection profiles which refer to databases residing on different servers. ProxySQL is able to look at the database name in order to determine which server is appropriate for the request.

This PR removes the check, so that ProxySQL can be used with Trino in this configuration.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This check could presumably have been to avoid the assumption that the database URL will be incorporated by default into the schema. For example, given a MySQL connection URL of `jdbc:mysql://example.com:3306/schema1` given inside `db1.properties`, users might have assumed they could refer to tables such as `db1.table1` rather than the fully-qualified schema, `db1.schema1.table1`.

This PR also adds a test for `testIsUrlValid()` for the MySQL connector, which was previously missing.

As far as I can tell, allowing the database suffix to be specified does no harm. Trino users will still need to refer to a fully qualified catalog and schema.

Closes: #18279


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# Allow users to specify a default schema in MySQL and MariaDB connectors
* Previously, users configuring a default schema within a MySQL or MariaDB user were presented with an error. This change prevented Trino from working with certain ProxySQL configurations, which use the schema name to decide which database server to send queries to.
* This change has no effect on Trino's interpretation of the available schemas. (Catalog and schema names still need to be fully qualified.)
```
