### PR TITLE
Change TaskId.fullId creation to mitigate probable JDK bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         java-version:
           - 17
-          - 19
+          - 20
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v3
@@ -566,7 +566,7 @@ jobs:
                 - lib/trino-filesystem-s3
                 - lib/trino-hdfs
             - { modules: core/trino-main }
-            - { modules: core/trino-main, jdk: 19 }
+            - { modules: core/trino-main, jdk: 20 }
             - { modules: lib/trino-filesystem-s3, profile: cloud-tests }
             - { modules: plugin/trino-accumulo }
             - { modules: plugin/trino-bigquery }

--- a/core/trino-main/src/main/java/io/trino/execution/TaskId.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskId.java
@@ -25,6 +25,7 @@ import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.spi.QueryId.parseDottedId;
 import static java.lang.Integer.parseInt;
+import static java.lang.String.join;
 import static java.util.Objects.requireNonNull;
 
 public class TaskId
@@ -44,7 +45,11 @@ public class TaskId
         requireNonNull(stageId, "stageId is null");
         checkArgument(partitionId >= 0, "partitionId is negative: %s", partitionId);
         checkArgument(attemptId >= 0, "attemptId is negative: %s", attemptId);
-        this.fullId = stageId + "." + partitionId + "." + attemptId;
+
+        // There is a strange JDK bug related to the CompactStrings implementation in JDK20+ which causes some fullId values
+        // to get corrupted when this particular line is JIT-optimized. Changing implicit concatenation to a String.join call
+        // seems to mitigate this issue. See: https://github.com/trinodb/trino/issues/18272 for more details.
+        this.fullId = join(".", stageId.toString(), String.valueOf(partitionId), String.valueOf(attemptId));
     }
 
     private TaskId(String fullId)


### PR DESCRIPTION
This is suppose to mitigate #18272 when running on JDK 20 and 21-ea with `-XX:+CompactStrings` enabled (the default).
The bug report was submitted to JDK and we are waiting for triage.


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
