### PR TITLE
Fix HiveType.getRetainedSizeInBytes for caching removal

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveType.java
@@ -310,7 +310,6 @@ public final class HiveType
 
     public long getRetainedSizeInBytes()
     {
-        // typeInfo is not accounted for as the instances are cached (by TypeInfoFactory) and shared
-        return INSTANCE_SIZE + hiveTypeName.getEstimatedSizeInBytes();
+        return INSTANCE_SIZE + hiveTypeName.getEstimatedSizeInBytes() + typeInfo.getRetainedSizeInBytes();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/CharTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/CharTypeInfo.java
@@ -14,11 +14,13 @@
 package io.trino.plugin.hive.type;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.CHAR_TYPE_NAME;
 
 public final class CharTypeInfo
         extends BaseCharTypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(CharTypeInfo.class);
     public static final int MAX_CHAR_LENGTH = 255;
 
     public CharTypeInfo(int length)
@@ -38,5 +40,11 @@ public final class CharTypeInfo
     public int hashCode()
     {
         return getLength();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + getDeclaredFieldsRetainedSizeInBytes();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/DecimalTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/DecimalTypeInfo.java
@@ -16,12 +16,14 @@ package io.trino.plugin.hive.type;
 import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.DECIMAL_TYPE_NAME;
 
 // based on org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo
 public final class DecimalTypeInfo
         extends PrimitiveTypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(DecimalTypeInfo.class);
     public static final int MAX_PRECISION = 38;
     public static final int MAX_SCALE = 38;
 
@@ -70,5 +72,11 @@ public final class DecimalTypeInfo
     public static String decimalTypeName(int precision, int scale)
     {
         return DECIMAL_TYPE_NAME + "(" + precision + "," + scale + ")";
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + getDeclaredFieldsRetainedSizeInBytes();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/ListTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/ListTypeInfo.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.type;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_TYPE_NAME;
 import static java.util.Objects.requireNonNull;
 
@@ -20,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 public final class ListTypeInfo
         extends TypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(UnionTypeInfo.class);
+
     private final TypeInfo elementTypeInfo;
 
     ListTypeInfo(TypeInfo elementTypeInfo)
@@ -55,5 +58,11 @@ public final class ListTypeInfo
     public int hashCode()
     {
         return elementTypeInfo.hashCode();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + elementTypeInfo.getRetainedSizeInBytes();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/MapTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/MapTypeInfo.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.type;
 
 import java.util.Objects;
 
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.MAP_TYPE_NAME;
 import static java.util.Objects.requireNonNull;
 
@@ -22,6 +23,8 @@ import static java.util.Objects.requireNonNull;
 public final class MapTypeInfo
         extends TypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(UnionTypeInfo.class);
+
     private final TypeInfo keyTypeInfo;
     private final TypeInfo valueTypeInfo;
 
@@ -65,5 +68,11 @@ public final class MapTypeInfo
     public int hashCode()
     {
         return Objects.hash(keyTypeInfo, valueTypeInfo);
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + keyTypeInfo.getRetainedSizeInBytes() + valueTypeInfo.getRetainedSizeInBytes();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/PrimitiveTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/PrimitiveTypeInfo.java
@@ -13,6 +13,9 @@
  */
 package io.trino.plugin.hive.type;
 
+import static com.google.common.base.Verify.verify;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.type.TypeInfoUtils.getTypeEntryFromTypeName;
 import static java.util.Objects.requireNonNull;
 
@@ -21,6 +24,8 @@ public sealed class PrimitiveTypeInfo
         extends TypeInfo
         permits BaseCharTypeInfo, DecimalTypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(PrimitiveTypeInfo.class);
+
     protected final String typeName;
     private final PrimitiveCategory primitiveCategory;
 
@@ -61,5 +66,17 @@ public sealed class PrimitiveTypeInfo
     public int hashCode()
     {
         return typeName.hashCode();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        verify(getClass() == PrimitiveTypeInfo.class, "Method must be overridden in %s", getClass());
+        return INSTANCE_SIZE + getDeclaredFieldsRetainedSizeInBytes();
+    }
+
+    protected long getDeclaredFieldsRetainedSizeInBytes()
+    {
+        return estimatedSizeOf(typeName);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/StructTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/StructTypeInfo.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.type;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SizeOf;
 
 import java.util.Iterator;
 import java.util.List;
@@ -21,6 +22,8 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.STRUCT_TYPE_NAME;
 import static java.util.Objects.requireNonNull;
 
@@ -28,6 +31,8 @@ import static java.util.Objects.requireNonNull;
 public final class StructTypeInfo
         extends TypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(StructTypeInfo.class);
+
     private final List<String> names;
     private final List<TypeInfo> typeInfos;
 
@@ -96,5 +101,13 @@ public final class StructTypeInfo
     public int hashCode()
     {
         return Objects.hash(names, typeInfos);
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                estimatedSizeOf(names, SizeOf::estimatedSizeOf) +
+                estimatedSizeOf(typeInfos, TypeInfo::getRetainedSizeInBytes);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/TypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/TypeInfo.java
@@ -34,4 +34,6 @@ public abstract sealed class TypeInfo
 
     @Override
     public abstract int hashCode();
+
+    public abstract long getRetainedSizeInBytes();
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/UnionTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/UnionTypeInfo.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.UNION_TYPE_NAME;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -25,6 +27,8 @@ import static java.util.stream.Collectors.joining;
 public final class UnionTypeInfo
         extends TypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(UnionTypeInfo.class);
+
     private final List<TypeInfo> objectTypeInfos;
 
     UnionTypeInfo(List<TypeInfo> objectTypeInfos)
@@ -62,5 +66,11 @@ public final class UnionTypeInfo
     public int hashCode()
     {
         return objectTypeInfos.hashCode();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + estimatedSizeOf(objectTypeInfos, TypeInfo::getRetainedSizeInBytes);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/VarcharTypeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/type/VarcharTypeInfo.java
@@ -14,12 +14,14 @@
 package io.trino.plugin.hive.type;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.plugin.hive.util.SerdeConstants.VARCHAR_TYPE_NAME;
 
 // based on org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo
 public final class VarcharTypeInfo
         extends BaseCharTypeInfo
 {
+    private static final int INSTANCE_SIZE = instanceSize(VarcharTypeInfo.class);
     public static final int MAX_VARCHAR_LENGTH = 65535;
 
     public VarcharTypeInfo(int length)
@@ -39,5 +41,11 @@ public final class VarcharTypeInfo
     public int hashCode()
     {
         return getLength();
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE + getDeclaredFieldsRetainedSizeInBytes();
     }
 }


### PR DESCRIPTION
The method used to ignore the type info field, since type infos used to be cached. Our copy of `TypeInfoFactory` does not cache, however.
