### PR TITLE
Disable buffering to disk for Azure output streams

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/azure/TrinoAzureConfigurationInitializer.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/azure/TrinoAzureConfigurationInitializer.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
+import static org.apache.hadoop.fs.azurebfs.constants.ConfigurationKeys.DATA_BLOCKS_BUFFER;
+import static org.apache.hadoop.fs.store.DataBlocks.DATA_BLOCKS_BUFFER_ARRAY;
 
 public class TrinoAzureConfigurationInitializer
         implements ConfigurationInitializer
@@ -117,6 +119,9 @@ public class TrinoAzureConfigurationInitializer
 
         // do not rely on information returned from local system about users and groups
         config.set("fs.azure.skipUserGroupMetadataDuringInitialization", "true");
+
+        // disable buffering Azure output streams to disk(default is DATA_BLOCKS_BUFFER_DISK)
+        config.set(DATA_BLOCKS_BUFFER, DATA_BLOCKS_BUFFER_ARRAY);
     }
 
     private static Optional<String> dropEmpty(Optional<String> optional)


### PR DESCRIPTION
https://github.com/apache/hadoop/commit/acffe203b8128989a1cde872dc5576c810e5a0f0 introduced logic to ABFS Output streams buffering blocks to disk (by default). This was introduced in Trino during Hadoop upgrade https://github.com/trinodb/trino/commit/343b908499683a75851125846be8eb5d0ca4512d. We want to disable this and stick with the legacy behavior of keeping the blocks in memory

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Disable azure's buffer to disk functionality for output streams (write operations).
```
