### PR TITLE
[WIP] Expanded Support for Reading Short Decimal Column Reader with Extended TypeLength

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ShortDecimalColumnReader.java
@@ -33,6 +33,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 
@@ -46,7 +47,9 @@ public class ShortDecimalColumnReader
         super(field);
         this.parquetDecimalType = requireNonNull(parquetDecimalType, "parquetDecimalType is null");
         int typeLength = field.getDescriptor().getPrimitiveType().getTypeLength();
-        checkArgument(typeLength <= 16, "Type length %s should be <= 16 for short decimal column %s", typeLength, field.getDescriptor());
+        checkArgument(!(field.getDescriptor().getPrimitiveType().getPrimitiveTypeName() == FIXED_LEN_BYTE_ARRAY && typeLength > 16),
+                String.format("For the short decimal column %s, the type length %s should be at most %s",
+                        field.getDescriptor(), typeLength, 16));
     }
 
     @Override


### PR DESCRIPTION


<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
### The code changes fixes errors that occur when reading short decimal columns with TypeLength greater than 16 from the ShortColumnDecimalReader, regardless of the primitive type used.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
##The initial implementation of the CheckArgument included limitations specific to the [Fixed_len_byte_array](https://github.com/trinodb/trino/commit/8d233977fdc2d4106d9e72f38b5e52e07c780387) primitive type, the changes made in another [commit](https://github.com/trinodb/trino/commit/f02343c3c18689d7cbd26d0ce31497bd33d347b3#) underline the significance of refraining from assuming fixed_len_byte_array.




## Issues
 (https://github.com/trinodb/trino/issues/18271)

