### PR TITLE
Avoid running expensive INSERT to assert on the plan and stats calculation fixes

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -109,16 +109,6 @@ public class PlanNodeSearcher
         return Optional.empty();
     }
 
-    public <T extends PlanNode> Optional<T> findSingle()
-    {
-        List<T> all = findAll();
-        return switch (all.size()) {
-            case 0 -> Optional.empty();
-            case 1 -> Optional.of(all.get(0));
-            default -> throw new IllegalStateException("Multiple nodes found");
-        };
-    }
-
     /**
      * Return a list of matching nodes ordered as in pre-order traversal of the plan tree.
      */
@@ -132,15 +122,6 @@ public class PlanNodeSearcher
     public <T extends PlanNode> T findOnlyElement()
     {
         return getOnlyElement(findAll());
-    }
-
-    public <T extends PlanNode> T findOnlyElement(T defaultValue)
-    {
-        List<T> all = findAll();
-        if (all.size() == 0) {
-            return defaultValue;
-        }
-        return getOnlyElement(all);
     }
 
     private <T extends PlanNode> void findAllRecursive(PlanNode node, ImmutableList.Builder<T> nodes)

--- a/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
@@ -609,7 +609,9 @@ public class TestFilterStatsCalculator
                                 .nullsFraction(0.0));
 
         assertExpression("'a' IN ('a', 'b')").equalTo(standardInputStatistics);
+        assertExpression("'a' IN ('a', 'b', NULL)").equalTo(standardInputStatistics);
         assertExpression("'a' IN ('b', 'c')").outputRowsCount(0);
+        assertExpression("'a' IN ('b', 'c', NULL)").outputRowsCount(0);
         assertExpression("CAST('b' AS VARCHAR(3)) IN (CAST('a' AS VARCHAR(3)), CAST('b' AS VARCHAR(3)))").equalTo(standardInputStatistics);
         assertExpression("CAST('c' AS VARCHAR(3)) IN (CAST('a' AS VARCHAR(3)), CAST('b' AS VARCHAR(3)))").outputRowsCount(0);
     }
@@ -678,6 +680,15 @@ public class TestFilterStatsCalculator
 
         // Multiple values some in some out of range
         assertExpression("x IN (DOUBLE '-42', 1.5e0, 2.5e0, 7.5e0, 314e0)")
+                .outputRowsCount(56.25)
+                .symbolStats("x", symbolStats ->
+                        symbolStats.distinctValuesCount(3.0)
+                                .lowValue(1.5)
+                                .highValue(7.5)
+                                .nullsFraction(0.0));
+
+        // Multiple values some including NULL
+        assertExpression("x IN (DOUBLE '-42', 1.5e0, 2.5e0, 7.5e0, 314e0, CAST(NULL AS double))")
                 .outputRowsCount(56.25)
                 .symbolStats("x", symbolStats ->
                         symbolStats.distinctValuesCount(3.0)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1711,12 +1711,9 @@ public abstract class BaseJdbcConnectorTest
                     "INSERT INTO " + table.getName() + " (a, b) SELECT clerk, orderkey FROM tpch.sf100.orders LIMIT " + numberOfRows,
                     WarningCollector.NOOP,
                     createPlanOptimizersStatsCollector());
-            TableWriterNode.WriterTarget target = searchFrom(plan.getRoot())
+            TableWriterNode.WriterTarget target = ((TableWriterNode) searchFrom(plan.getRoot())
                     .where(node -> node instanceof TableWriterNode)
-                    .findFirst()
-                    .map(TableWriterNode.class::cast)
-                    .map(TableWriterNode::getTarget)
-                    .orElseThrow();
+                    .findOnlyElement()).getTarget();
 
             assertThat(target.getMaxWriterTasks(getQueryRunner().getMetadata(), getSession()))
                     .hasValue(parallelism);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -5376,6 +5376,10 @@ public abstract class BaseIcebergConnectorTest
                 .returnsEmptyResult()
                 .isFullyPushedDown();
 
+        assertQuerySucceeds("SHOW STATS FOR (SELECT userid FROM " + tableName + " WHERE \"$path\" = '" + somePath + "')");
+        // EXPLAIN triggers stats calculation and also rendering
+        assertQuerySucceeds("EXPLAIN SELECT userid FROM " + tableName + " WHERE \"$path\" = '" + somePath + "'");
+
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -5462,6 +5466,10 @@ public abstract class BaseIcebergConnectorTest
             assertThat(query("SELECT col FROM " + table.getName() + " WHERE \"$file_modified_time\" IS NULL"))
                     .returnsEmptyResult()
                     .isFullyPushedDown();
+
+            assertQuerySucceeds("SHOW STATS FOR (SELECT col FROM " + table.getName() + " WHERE \"$file_modified_time\" = from_iso8601_timestamp('" + fileModifiedTime.format(ISO_OFFSET_DATE_TIME) + "'))");
+            // EXPLAIN triggers stats calculation and also rendering
+            assertQuerySucceeds("EXPLAIN SELECT col FROM " + table.getName() + " WHERE \"$file_modified_time\" = from_iso8601_timestamp('" + fileModifiedTime.format(ISO_OFFSET_DATE_TIME) + "')");
         }
     }
 


### PR DESCRIPTION
Speed up `testWriteTaskParallelismSessionProperty` for JDBC connectors.

fixes https://github.com/trinodb/trino/issues/18328
fixes https://github.com/trinodb/trino/issues/18330

```
# release notes - based on issues being closed
```
