### PR TITLE
Operate on column handle directly in checkPartitionTypesSupported and other cleanups

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -229,13 +229,6 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.method.returnTypeChanged</code>
-                                    <old>method void io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</old>
-                                    <new>method io.trino.spi.block.VariableWidthBlockBuilder io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</new>
-                                    <justification>Safe to change void return to match other method of same name with different signature</justification>
-                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Locations.java
@@ -33,35 +33,6 @@ public final class Locations
         return location + path;
     }
 
-    /**
-     * @deprecated use {@link Location#parentDirectory()} instead
-     */
-    @Deprecated
-    public static String getParent(String location)
-    {
-        validateLocation(location);
-
-        int lastIndexOfSlash = location.lastIndexOf('/');
-        if (lastIndexOfSlash > 0) {
-            String parent = location.substring(0, lastIndexOfSlash);
-            if (!parent.endsWith("/") && !parent.endsWith(":")) {
-                return parent;
-            }
-        }
-        throw new IllegalArgumentException("Location does not have parent: " + location);
-    }
-
-    /**
-     * @deprecated use {@link Location#fileName()} instead
-     */
-    @Deprecated
-    public static String getFileName(String location)
-    {
-        validateLocation(location);
-
-        return location.substring(location.lastIndexOf('/') + 1);
-    }
-
     private static void validateLocation(String location)
     {
         checkArgument(location.indexOf('?') < 0, "location contains a query string: %s", location);

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocations.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TestLocations.java
@@ -22,8 +22,6 @@ import java.util.stream.Stream;
 
 import static io.trino.filesystem.Locations.appendPath;
 import static io.trino.filesystem.Locations.areDirectoryLocationsEquivalent;
-import static io.trino.filesystem.Locations.getFileName;
-import static io.trino.filesystem.Locations.getParent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -66,90 +64,6 @@ public class TestLocations
     public void testInvalidLocationInAppendPath(String location, String exceptionMessageRegexp)
     {
         assertThatThrownBy(() -> appendPath(location, "test"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageMatching(exceptionMessageRegexp);
-    }
-
-    private static Stream<Arguments> testGetFileNameFromLocationData()
-    {
-        return Stream.of(
-                Arguments.of("", ""),
-                Arguments.of("test_file", "test_file"),
-                Arguments.of("test>file", "test>file"),
-                Arguments.of("test_dir/", ""),
-                Arguments.of("/test_file.txt", "test_file.txt"),
-                Arguments.of("test_dir/test_file.txt", "test_file.txt"),
-                Arguments.of("/test_dir/test_file.txt", "test_file.txt"),
-                Arguments.of("test_dir /test_file.txt", "test_file.txt"),
-                Arguments.of("test_dir  /test_file.txt", "test_file.txt"),
-                Arguments.of("test_<dir  /test_file.txt", "test_file.txt"),
-                Arguments.of("test_dir/test_dir2/", ""),
-                Arguments.of("s3://test_dir/test_file.txt", "test_file.txt"),
-                Arguments.of("s3://test_dir/test_dir2/test_file.txt", "test_file.txt"),
-                Arguments.of("s3://dir_with_space /test_file.txt", "test_file.txt"),
-                Arguments.of("file://test_dir/test_file", "test_file"),
-                Arguments.of("file:/test_dir/test_file", "test_file"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("testGetFileNameFromLocationData")
-    public void testGetFileNameFromLocation(String location, String fileName)
-    {
-        assertThat(getFileName(location)).isEqualTo(fileName);
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidLocations")
-    public void testGetFileNameFromInvalidLocation(String location, String exceptionMessageRegexp)
-    {
-        assertThatThrownBy(() -> getFileName(location))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageMatching(exceptionMessageRegexp);
-    }
-
-    private static Stream<Arguments> validParentData()
-    {
-        return Stream.of(
-                Arguments.of("test_dir/", "test_dir"),
-                Arguments.of("test_dir/test_file.txt", "test_dir"),
-                Arguments.of("/test_dir/test_file.txt", "/test_dir"),
-                Arguments.of("test_dir /test_file.txt", "test_dir "),
-                Arguments.of("test_dir  /test_file.txt", "test_dir  "),
-                Arguments.of("test_<dir  /test_file.txt", "test_<dir  "),
-                Arguments.of("test_dir/test_dir2/", "test_dir/test_dir2"),
-                Arguments.of("s3:/test_dir/test_file.txt", "s3:/test_dir"),
-                Arguments.of("s3://test_dir/test_file.txt", "s3://test_dir"),
-                Arguments.of("s3://test_dir/test_dir2/test_file.txt", "s3://test_dir/test_dir2"),
-                Arguments.of("s3://dir_with_space /test_file.txt", "s3://dir_with_space "),
-                Arguments.of("file://test_dir/test_file", "file://test_dir"),
-                Arguments.of("file:/test_dir/test_file", "file:/test_dir"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("validParentData")
-    public void testValidParent(String location, String parent)
-    {
-        assertThat(getParent(location)).isEqualTo(parent);
-    }
-
-    private static Stream<Arguments> invalidParentData()
-    {
-        return Stream.of(
-                Arguments.of("location?", "location contains a query string.*"),
-                Arguments.of("location#", "location contains a fragment.*"),
-                Arguments.of("", "Location does not have parent.*"),
-                Arguments.of("test_file", "Location does not have parent.*"),
-                Arguments.of("/test_file.txt", "Location does not have parent.*"),
-                Arguments.of("s3:/test_file", "Location does not have parent.*"),
-                Arguments.of("s3://test_file", "Location does not have parent.*"),
-                Arguments.of("s3:///test_file", "Location does not have parent.*"));
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidParentData")
-    public void testInvalidParent(String location, String exceptionMessageRegexp)
-    {
-        assertThatThrownBy(() -> getParent(location))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageMatching(exceptionMessageRegexp);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.Duration;
 import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.Location;
-import io.trino.filesystem.Locations;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.hdfs.HdfsContext;
@@ -866,7 +865,7 @@ public class BackgroundHiveSplitLoader
         // build mapping of file name to bucket
         ListMultimap<Integer, TrinoFileStatus> bucketFiles = ArrayListMultimap.create();
         for (TrinoFileStatus file : files) {
-            String fileName = Locations.getFileName(file.getPath());
+            String fileName = Location.of(file.getPath()).fileName();
             OptionalInt bucket = getBucketNumber(fileName);
             if (bucket.isPresent()) {
                 bucketFiles.put(bucket.getAsInt(), file);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -982,9 +982,8 @@ public class HiveMetadata
         hiveStorageFormat.validateColumns(columnHandles);
 
         Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
-        List<Column> partitionColumns = partitionedBy.stream()
+        List<HiveColumnHandle> partitionColumns = partitionedBy.stream()
                 .map(columnHandlesByName::get)
-                .map(HiveColumnHandle::toMetastoreColumn)
                 .collect(toImmutableList());
         checkPartitionTypesSupported(partitionColumns);
 
@@ -1301,11 +1300,10 @@ public class HiveMetadata
         }
     }
 
-    private void checkPartitionTypesSupported(List<Column> partitionColumns)
+    private void checkPartitionTypesSupported(List<HiveColumnHandle> partitionColumns)
     {
-        for (Column partitionColumn : partitionColumns) {
-            Type partitionType = typeManager.getType(partitionColumn.getType().getTypeSignature());
-            verifyPartitionTypeSupported(partitionColumn.getName(), partitionType);
+        for (HiveColumnHandle partitionColumn : partitionColumns) {
+            verifyPartitionTypeSupported(partitionColumn.getName(), partitionColumn.getType());
         }
     }
 
@@ -1671,9 +1669,8 @@ public class HiveMetadata
         actualStorageFormat.validateColumns(columnHandles);
 
         Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
-        List<Column> partitionColumns = partitionedBy.stream()
+        List<HiveColumnHandle> partitionColumns = partitionedBy.stream()
                 .map(columnHandlesByName::get)
-                .map(HiveColumnHandle::toMetastoreColumn)
                 .collect(toImmutableList());
         checkPartitionTypesSupported(partitionColumns);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
@@ -215,8 +215,7 @@ public final class HiveBucketing
         }
 
         HiveBucketProperty hiveBucketProperty = hiveTable.getBucketHandle().get().toTableBucketProperty();
-        List<Column> dataColumns = hiveTable.getDataColumns().stream()
-                .map(HiveColumnHandle::toMetastoreColumn)
+        List<HiveColumnHandle> dataColumns = hiveTable.getDataColumns().stream()
                 .collect(toImmutableList());
 
         Optional<Map<ColumnHandle, List<NullableValue>>> bindings = TupleDomain.extractDiscreteValues(effectivePredicate);
@@ -247,7 +246,7 @@ public final class HiveBucketing
         return Optional.of(new HiveBucketFilter(builder.build()));
     }
 
-    private static Optional<Set<Integer>> getHiveBuckets(HiveBucketProperty hiveBucketProperty, List<Column> dataColumns, Map<ColumnHandle, List<NullableValue>> bindings)
+    private static Optional<Set<Integer>> getHiveBuckets(HiveBucketProperty hiveBucketProperty, List<HiveColumnHandle> dataColumns, Map<ColumnHandle, List<NullableValue>> bindings)
     {
         if (bindings.isEmpty()) {
             return Optional.empty();
@@ -258,8 +257,8 @@ public final class HiveBucketing
 
         // Verify the bucket column types are supported
         Map<String, HiveType> hiveTypes = new HashMap<>();
-        for (Column column : dataColumns) {
-            hiveTypes.put(column.getName(), column.getType());
+        for (HiveColumnHandle column : dataColumns) {
+            hiveTypes.put(column.getName(), column.getHiveType());
         }
         for (String column : bucketColumns) {
             if (!isTypeSupportedForBucketing(hiveTypes.get(column).getTypeInfo())) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -522,10 +522,10 @@ public class TrinoGlueCatalog
 
                 try {
                     TrinoViewUtil.getView(schemaTableName,
-                            Optional.ofNullable(table.getViewOriginalText()),
-                            getTableType(table),
-                            parameters,
-                            Optional.ofNullable(table.getOwner()))
+                                    Optional.ofNullable(table.getViewOriginalText()),
+                                    getTableType(table),
+                                    parameters,
+                                    Optional.ofNullable(table.getOwner()))
                             .ifPresent(viewDefinition -> viewCache.put(schemaTableName, viewDefinition));
                 }
                 catch (RuntimeException e) {
@@ -600,10 +600,10 @@ public class TrinoGlueCatalog
                 session.getUser(),
                 createViewProperties(session, trinoVersion, TRINO_CREATED_BY_VALUE));
         Failsafe.with(RetryPolicy.builder()
-                .withMaxRetries(3)
-                .withDelay(Duration.ofMillis(100))
-                .abortIf(throwable -> !replace || throwable instanceof ViewAlreadyExistsException)
-                .build())
+                        .withMaxRetries(3)
+                        .withDelay(Duration.ofMillis(100))
+                        .abortIf(throwable -> !replace || throwable instanceof ViewAlreadyExistsException)
+                        .build())
                 .run(() -> doCreateView(session, schemaViewName, viewTableInput, replace));
     }
 


### PR DESCRIPTION
Avoid converting to metastore Column when checking for supported and unsupported types. This avoids a lookup in `TypeManager`.

Extracted from https://github.com/trinodb/trino/pull/18315