### PR TITLE
Increase writerScalingMinDataProcessed threshold for scaling test

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -4184,7 +4184,9 @@ public abstract class BaseHiveConnectorTest
     public void testWriterTasksCountLimitPartitionedScaleWritersEnabled()
     {
         testLimitWriterTasks(2, 4, true, true, true, DataSize.of(1, MEGABYTE));
-        testLimitWriterTasks(2, 2, true, true, true, DataSize.of(32, MEGABYTE));
+        // Since we track page size for scaling writer instead of actual compressed output file size, we need to have a
+        // larger threshold for writerScalingMinDataProcessed. This way we can ensure that the writer scaling is not triggered.
+        testLimitWriterTasks(2, 2, true, true, true, DataSize.of(128, MEGABYTE));
     }
 
     private void testLimitWriterTasks(int maxWriterTasks, int expectedFilesCount, boolean scaleWritersEnabled, boolean redistributeWrites, boolean partitioned, DataSize writerScalingMinDataProcessed)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/17436

We have to increase the value from 32MB to 128MB because we have moved from tracking file size to tracking page size in writer scaling.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
