### PR TITLE
Support `CASCADE` option for `DROP SCHEMA` statement in Hive

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -249,9 +249,6 @@ public abstract class BaseHiveConnectorTest
             case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
 
-            case SUPPORTS_DROP_SCHEMA_CASCADE:
-                return false;
-
             case SUPPORTS_ADD_FIELD:
             case SUPPORTS_DROP_FIELD:
             case SUPPORTS_RENAME_FIELD:


### PR DESCRIPTION
## Description

Relates to #17649

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Support `CASCADE` option for `DROP SCHEMA` statement. ({issue}`18320`)
```
