### PR TITLE
Push down DELETE for enforceable filters on Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -357,7 +357,7 @@ public abstract class AbstractDeltaLakePageSink
                 partitionName = Optional.of(partName);
             }
 
-            String fileName = session.getQueryId() + "-" + randomUUID();
+            String fileName = session.getQueryId() + "_" + randomUUID();
             filePath = filePath.appendPath(fileName);
 
             FileWriter fileWriter = createParquetFileWriter(filePath);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -282,7 +282,7 @@ public class TestDeltaLakeFileOperations
     {
         public static FileOperation create(String path, OperationType operationType)
         {
-            Pattern dataFilePattern = Pattern.compile(".*/(?<partition>key=[^/]*/)(?<queryId>\\d{8}_\\d{6}_\\d{5}_\\w{5})-(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})");
+            Pattern dataFilePattern = Pattern.compile(".*/(?<partition>key=[^/]*/)(?<queryId>\\d{8}_\\d{6}_\\d{5}_\\w{5})_(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})");
             String fileName = path.replaceFirst(".*/", "");
             if (path.matches(".*/_delta_log/_last_checkpoint")) {
                 return new FileOperation(LAST_CHECKPOINT, fileName, operationType);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSystemTables.java
@@ -78,7 +78,7 @@ public class TestDeltaLakeSystemTables
                     .matches("""
                             VALUES
                                 (BIGINT '5', VARCHAR 'OPTIMIZE', BIGINT '4', VARCHAR 'WriteSerializable', true),
-                                (BIGINT '4', VARCHAR 'MERGE', BIGINT '3', VARCHAR 'WriteSerializable', true),
+                                (BIGINT '4', VARCHAR 'DELETE', BIGINT '3', VARCHAR 'WriteSerializable', true),
                                 (BIGINT '3', VARCHAR 'MERGE', BIGINT '2', VARCHAR 'WriteSerializable', true),
                                 (BIGINT '2', VARCHAR 'WRITE', BIGINT '1', VARCHAR 'WriteSerializable', true),
                                 (BIGINT '1', VARCHAR 'WRITE', BIGINT '0', VARCHAR 'WriteSerializable', true),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
@@ -33,7 +33,7 @@ import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestDeltaLakeDatabricksDelete
+public class TestDeltaLakeDeleteCompatibility
         extends BaseTestDeltaLakeS3Storage
 {
     @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Perform DELETE only on the metadata of the Delta Lake
table when the delete filter does not touch any data
columns.

Sample queries affected by this enhancement are:

```
DELETE FROM table 
DELETE FROM table WHERE true
DELETE FROM partitioned_table WHERE part1=value1 AND part2=value2
DELETE FROM partitioned_table WHERE part2=value2
```

Fixes #18331



The operation will not be performed on the metadata layer when
there are `add` file entries in the transaction log of the table
without statistics containing number of records.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


Without `DELETE` pushdown

```
trino:default> create table delta.tiny.sforders100 as select * from tpch.sf100.orders;
CREATE TABLE: 150000000 rows

trino:default> delete from delta.tiny.sforders100 where true;
DELETE: 150000000 rows

Query 20230725_125258_00003_xfv9h, FINISHED, 1 node
http://localhost:8080/ui/query.html?20230725_125258_00003_xfv9h
Splits: 25 total, 25 done (100.00%)
CPU Time: 115.1s total,  1.3M rows/s, 11.2MB/s, 89% active
Per Node: 1.1 parallelism, 1.46M rows/s, 12.5MB/s
Parallelism: 1.1
Peak Memory: 87.3MB
1:43 [150M rows, 1.26GB] [1.46M rows/s, 12.5MB/s]
```

With `DELETE` pushdown

```
trino:default> delete from delta.tiny.sf100orders where true;
DELETE: 150000000 rows

Query 20230725_123039_00000_fk4kt, FINISHED, 1 node
http://localhost:8080/ui/query.html?20230725_123039_00000_fk4kt
Splits: 1 total, 1 done (100.00%)
CPU Time: 0.1s total,     0 rows/s,     0B/s, 83% active
Per Node: 0.1 parallelism,     0 rows/s,     0B/s
Parallelism: 0.1
Peak Memory: 112B
1.84 [0 rows, 0B] [0 rows/s, 0B/s]
```

tldr; before 103 s after 1.8 s


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Improve performance of `DELETE` statement when it deletes the whole table or the filters apply only to the partition columns. ({issue}`18332 `)
```
