### PR TITLE
Fix HiveMetadata.streamTableColumns not to include views

### DIFF
--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -53,6 +53,7 @@
             <plugin>
                 <groupId>io.takari.maven.plugins</groupId>
                 <artifactId>takari-lifecycle-plugin</artifactId>
+                <version>${dep.takari.version}</version>
                 <configuration>
                     <proc>none</proc>
                 </configuration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -286,7 +286,7 @@ public interface ConnectorMetadata
     }
 
     /**
-     * Gets the metadata for all columns that match the specified table prefix.
+     * Gets the metadata for all columns that match the specified table prefix. Columns of views and materialized views are not included.
      *
      * @deprecated use {@link #streamTableColumns} which handles redirected tables
      */
@@ -298,7 +298,7 @@ public interface ConnectorMetadata
 
     /**
      * Gets the metadata for all columns that match the specified table prefix. Redirected table names are included, but
-     * the column metadata for them is not.
+     * the column metadata for them is not. Views and materialized views are not included.
      */
     default Iterator<TableColumnsMetadata> streamTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHive.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHive.java
@@ -15,13 +15,16 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
+import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
 import org.apache.hadoop.net.NetUtils;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 // staging directory is shared mutable state
@@ -64,6 +67,16 @@ public class TestHive
                         "but found.*");
 
         throw new SkipException("not supported");
+    }
+
+    @Test
+    public void testHiveViewsHaveNoColumns()
+    {
+        try (Transaction transaction = newTransaction()) {
+            ConnectorMetadata metadata = transaction.getMetadata();
+            assertThat(listTableColumns(metadata, newSession(), new SchemaTablePrefix(view.getSchemaName(), view.getTableName())))
+                    .isEmpty();
+        }
     }
 
     @Test

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveBasicStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveBasicStatistics.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -82,12 +81,6 @@ public class HiveBasicStatistics
     public OptionalLong getOnDiskDataSizeInBytes()
     {
         return onDiskDataSizeInBytes;
-    }
-
-    public HiveBasicStatistics withAdjustedRowCount(long adjustment)
-    {
-        checkArgument(rowCount.isPresent(), "rowCount isn't present");
-        return new HiveBasicStatistics(fileCount, OptionalLong.of(rowCount.getAsLong() + adjustment), inMemoryDataSizeInBytes, onDiskDataSizeInBytes);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
@@ -46,6 +47,7 @@ import static java.util.Objects.requireNonNull;
 public class HiveConnector
         implements Connector
 {
+    private final Injector injector;
     private final LifeCycleManager lifeCycleManager;
     private final ConnectorSplitManager splitManager;
     private final ConnectorPageSourceProvider pageSourceProvider;
@@ -68,6 +70,7 @@ public class HiveConnector
     private final boolean singleStatementWritesOnly;
 
     public HiveConnector(
+            Injector injector,
             LifeCycleManager lifeCycleManager,
             HiveTransactionManager transactionManager,
             ConnectorSplitManager splitManager,
@@ -87,6 +90,7 @@ public class HiveConnector
             boolean singleStatementWritesOnly,
             ClassLoader classLoader)
     {
+        this.injector = requireNonNull(injector, "injector is null");
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
@@ -232,5 +236,10 @@ public class HiveConnector
     public Set<TableProcedureMetadata> getTableProcedures()
     {
         return tableProcedures;
+    }
+
+    public Injector getInjector()
+    {
+        return injector;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -165,6 +165,7 @@ public final class InternalHiveConnectorFactory
                     .map(accessControl -> new ClassLoaderSafeConnectorAccessControl(accessControl, classLoader));
 
             return new HiveConnector(
+                    injector,
                     lifeCycleManager,
                     transactionManager,
                     new ClassLoaderSafeConnectorSplitManager(splitManager, classLoader),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionStatistics.java
@@ -60,11 +60,6 @@ public class PartitionStatistics
         return columnStatistics;
     }
 
-    public PartitionStatistics withAdjustedRowCount(long adjustment)
-    {
-        return new PartitionStatistics(basicStatistics.withAdjustedRowCount(adjustment), columnStatistics);
-    }
-
     @Override
     public boolean equals(Object o)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Partition.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Partition.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static io.trino.plugin.hive.metastore.MetastoreUtil.adjustRowCount;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -55,12 +54,6 @@ public class Partition
         this.storage = requireNonNull(storage, "storage is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
-    }
-
-    @JsonIgnore
-    public Partition withAdjustedRowCount(String partitionName, long rowCountDelta)
-    {
-        return new Partition(databaseName, tableName, values, storage, columns, adjustRowCount(parameters, partitionName, rowCountDelta));
     }
 
     @JsonProperty

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2561,16 +2561,6 @@ public abstract class AbstractTestHive
     }
 
     @Test
-    public void testHiveViewsHaveNoColumns()
-    {
-        try (Transaction transaction = newTransaction()) {
-            ConnectorMetadata metadata = transaction.getMetadata();
-            assertThat(listTableColumns(metadata, newSession(), new SchemaTablePrefix(view.getSchemaName(), view.getTableName())))
-                    .isEmpty();
-        }
-    }
-
-    @Test
     public void testRenameTable()
     {
         SchemaTableName temporaryRenameTableOld = temporaryTable("rename_old");
@@ -3517,7 +3507,7 @@ public abstract class AbstractTestHive
         }
     }
 
-    private static Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorMetadata metadata, ConnectorSession session, SchemaTablePrefix prefix)
+    protected static Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorMetadata metadata, ConnectorSession session, SchemaTablePrefix prefix)
     {
         return stream(metadata.streamTableColumns(session, prefix))
                 .collect(toImmutableMap(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2565,7 +2565,8 @@ public abstract class AbstractTestHive
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            assertEquals(listTableColumns(metadata, newSession(), new SchemaTablePrefix(view.getSchemaName(), view.getTableName())), ImmutableMap.of());
+            assertThat(listTableColumns(metadata, newSession(), new SchemaTablePrefix(view.getSchemaName(), view.getTableName())))
+                    .isEmpty();
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
         <dep.arrow.version>12.0.1</dep.arrow.version>
         <dep.avro.version>1.11.1</dep.avro.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
+        <dep.takari.version>2.1.1</dep.takari.version>
         <dep.aws-sdk.version>1.12.505</dep.aws-sdk.version>
         <dep.aws-sdk-v2.version>2.20.93</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
@@ -2211,7 +2212,7 @@
                             <DynamicDependency>
                                 <groupId>io.takari.maven.plugins</groupId>
                                 <artifactId>takari-lifecycle-plugin</artifactId>
-                                <version>2.1.1</version>
+                                <version>${dep.takari.version}</version>
                                 <repositoryType>PLUGIN</repositoryType>
                             </DynamicDependency>
                             <DynamicDependency>

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViews.java
@@ -91,7 +91,7 @@ public class TestHiveViews
                 .hasMessageContaining("Failed to translate Hive view 'test_list_failing_views.failing_view'");
 
         // Queries on information_schema.columns also trigger ConnectorMetadata#getViews. Columns from failing_view are
-        // listed too since HiveMetadata#listTableColumns does not ignore views.
+        // listed too since HiveMetadata#listTableColumns does not ignore Hive views.
         assertThat(onTrino().executeQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'test_list_failing_views'"))
                 .containsOnly(
                         row("correct_view", "n_nationkey"),
@@ -141,7 +141,7 @@ public class TestHiveViews
                 .hasMessageContaining("Failed to translate Hive view 'test_list_failing_views.failing_view'");
 
         // Queries on system.jdbc.columns also trigger ConnectorMetadata#getViews. Columns from failing_view are
-        // listed too since HiveMetadata#listTableColumns does not ignore views.
+        // listed too since HiveMetadata#listTableColumns does not ignore Hive views.
         assertThat(onTrino().executeQuery("SELECT table_name, column_name FROM system.jdbc.columns WHERE table_cat = 'hive' AND table_schem = 'test_list_failing_views'"))
                 .containsOnly(
                         row("correct_view", "n_nationkey"),


### PR DESCRIPTION
In the absence of explicit documentation, the use place
    (`io.trino.metadata.MetadataManager#listTableColumns`) defines
    `streamTableColumns` contract as covering tables only.  This PR also
    supplements explicit documentation in `ConnectorMetadata`.

This relates to a logic introduced in `HiveMetadata.doGetTableMetadata`
    in aafe4797c34ecad00415691252e1a83b4207efba commit. It was practical for
    hive views and when view translation is not enabled, but was not correct
    for trino views.