### PR TITLE
Format CLI error messages

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -93,6 +93,7 @@ public class ClientOptions
     private static final String DEFAULT_VALUE = "(default: ${DEFAULT-VALUE})";
     private static final String SERVER_DEFAULT = "localhost:8080";
     private static final String SOURCE_DEFAULT = "trino-cli";
+    static final String DEBUG_OPTION_NAME = "--debug";
 
     @Parameters(paramLabel = "URL", description = "Trino server URL", arity = "0..1")
     public Optional<String> url;
@@ -207,7 +208,7 @@ public class ClientOptions
     @Option(names = {"-f", "--file"}, paramLabel = "<file>", description = "Execute statements from file and exit")
     public String file;
 
-    @Option(names = "--debug", paramLabel = "<debug>", description = "Enable debug information")
+    @Option(names = DEBUG_OPTION_NAME, paramLabel = "<debug>", description = "Enable debug information")
     public boolean debug;
 
     @Option(names = "--history-file", paramLabel = "<historyFile>", defaultValue = "${env:TRINO_HISTORY_FILE:-${sys:user.home}/.trino_history}", description = "Path to the history file " + DEFAULT_VALUE)

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -63,6 +63,7 @@ import static io.trino.cli.TerminalUtils.closeTerminal;
 import static io.trino.cli.TerminalUtils.getTerminal;
 import static io.trino.cli.TerminalUtils.isRealTerminal;
 import static io.trino.cli.TerminalUtils.terminalEncoding;
+import static io.trino.cli.Trino.formatCliErrorMessage;
 import static io.trino.client.ClientSession.stripTransactionId;
 import static io.trino.sql.parser.StatementSplitter.Statement;
 import static io.trino.sql.parser.StatementSplitter.isEmptyStatement;
@@ -420,10 +421,7 @@ public class Console
             return success;
         }
         catch (RuntimeException e) {
-            System.err.println("Error running command: " + e.getMessage());
-            if (queryRunner.isDebug()) {
-                e.printStackTrace(System.err);
-            }
+            System.err.println(formatCliErrorMessage(e, queryRunner.isDebug()));
             return false;
         }
     }


### PR DESCRIPTION
When an exception is raised either during query execution or parsing command line arguments in the CLI the output is now formatted:

<img width="1360" alt="Screenshot 2023-07-19 at 16 08 24" src="https://github.com/trinodb/trino/assets/66972/a28911c4-a8d6-4d2c-add6-d332e3543915">

<img width="1715" alt="Screenshot 2023-07-19 at 15 49 35" src="https://github.com/trinodb/trino/assets/66972/1ac9a7bf-354b-4b3c-83a3-257f52e1c9c6">

`--debug` option is taken into the account to expand exception stack trace

Release notes:
```markdown
# CLI
* Format error messages and hide stack traces behind `--debug` flag by default
```