### PR TITLE
Implement runtime adaptive partitioning for FTE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -187,6 +187,9 @@ public final class SystemSessionProperties
     public static final String FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT = "fault_tolerant_execution_max_partition_count";
     public static final String FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT = "fault_tolerant_execution_min_partition_count";
     public static final String FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT_FOR_WRITE = "fault_tolerant_execution_min_partition_count_for_write";
+    public static final String FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_ENABLED = "fault_tolerant_execution_runtime_adaptive_partitioning_enabled";
+    public static final String FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_PARTITION_COUNT = "fault_tolerant_execution_runtime_adaptive_partitioning_partition_count";
+    public static final String FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_MAX_TASK_SIZE = "fault_tolerant_execution_runtime_adaptive_partitioning_max_task_size";
     public static final String FAULT_TOLERANT_EXECUTION_MIN_SOURCE_STAGE_PROGRESS = "fault_tolerant_execution_min_source_stage_progress";
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_ESTIMATION_ENABLED = "fault_tolerant_execution_small_stage_estimation_enabled";
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_ESTIMATION_THRESHOLD = "fault_tolerant_execution_small_stage_estimation_threshold";
@@ -949,6 +952,22 @@ public final class SystemSessionProperties
                         queryManagerConfig.getFaultTolerantExecutionMinPartitionCountForWrite(),
                         value -> validateIntegerValue(value, FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT_FOR_WRITE, 1, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT, false),
                         false),
+                booleanProperty(
+                        FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_ENABLED,
+                        "Enables change of number of partitions at runtime when intermediate data size is large",
+                        queryManagerConfig.isFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled(),
+                        true),
+                integerProperty(
+                        FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_PARTITION_COUNT,
+                        "The partition count to use for runtime adaptive partitioning when enabled",
+                        queryManagerConfig.getFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(),
+                        value -> validateIntegerValue(value, FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_PARTITION_COUNT, 1, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT, false),
+                        true),
+                dataSizeProperty(
+                        FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_MAX_TASK_SIZE,
+                        "Max average task input size when deciding runtime adaptive partitioning",
+                        queryManagerConfig.getFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(),
+                        true),
                 doubleProperty(
                         FAULT_TOLERANT_EXECUTION_MIN_SOURCE_STAGE_PROGRESS,
                         "Minimal progress of source stage to consider scheduling of parent stage",
@@ -1788,6 +1807,21 @@ public final class SystemSessionProperties
     public static int getFaultTolerantExecutionMinPartitionCountForWrite(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT_FOR_WRITE, Integer.class);
+    }
+
+    public static boolean isFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_ENABLED, Boolean.class);
+    }
+
+    public static int getFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_PARTITION_COUNT, Integer.class);
+    }
+
+    public static DataSize getFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_MAX_TASK_SIZE, DataSize.class);
     }
 
     public static double getFaultTolerantExecutionMinSourceStageProgress(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -131,6 +131,11 @@ public class QueryManagerConfig
     private int faultTolerantExecutionMaxPartitionCount = 50;
     private int faultTolerantExecutionMinPartitionCount = 4;
     private int faultTolerantExecutionMinPartitionCountForWrite = 50;
+    private boolean faultTolerantExecutionRuntimeAdaptivePartitioningEnabled;
+    private int faultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount = FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT;
+    // Currently, initial setup is 5GB of task memory processing 4GB data. Given that we triple the memory in case of
+    // task OOM, max task size is set to 12GB such that tasks of stages below threshold will succeed within one retry.
+    private DataSize faultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize = DataSize.of(12, GIGABYTE);
     private boolean faultTolerantExecutionForcePreferredWritePartitioningEnabled = true;
     private double faultTolerantExecutionMinSourceStageProgress = 0.2;
 
@@ -962,6 +967,46 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionMinPartitionCountForWrite(int faultTolerantExecutionMinPartitionCountForWrite)
     {
         this.faultTolerantExecutionMinPartitionCountForWrite = faultTolerantExecutionMinPartitionCountForWrite;
+        return this;
+    }
+
+    public boolean isFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled()
+    {
+        return faultTolerantExecutionRuntimeAdaptivePartitioningEnabled;
+    }
+
+    @Config("fault-tolerant-execution-runtime-adaptive-partitioning-enabled")
+    public QueryManagerConfig setFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled(boolean faultTolerantExecutionRuntimeAdaptivePartitioningEnabled)
+    {
+        this.faultTolerantExecutionRuntimeAdaptivePartitioningEnabled = faultTolerantExecutionRuntimeAdaptivePartitioningEnabled;
+        return this;
+    }
+
+    @Min(1)
+    @Max(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT)
+    public int getFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount()
+    {
+        return faultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount;
+    }
+
+    @Config("fault-tolerant-execution-runtime-adaptive-partitioning-partition-count")
+    @ConfigDescription("The partition count to use for runtime adaptive partitioning when enabled")
+    public QueryManagerConfig setFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(int faultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount)
+    {
+        this.faultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount = faultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount;
+        return this;
+    }
+
+    public DataSize getFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize()
+    {
+        return faultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize;
+    }
+
+    @Config("fault-tolerant-execution-runtime-adaptive-partitioning-max-task-size")
+    @ConfigDescription("Max average task input size when deciding runtime adaptive partitioning")
+    public QueryManagerConfig setFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(DataSize faultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize)
+    {
+        this.faultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize = faultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -432,9 +432,10 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         public StageInfo getStageInfo()
         {
-            SubPlan plan = requireNonNull(this.plan.get(), "plan is null");
             Map<PlanFragmentId, StageInfo> stageInfos = stages.values().stream()
                     .collect(toImmutableMap(stage -> stage.getFragment().getId(), SqlStage::getStageInfo));
+            // make sure that plan is not staler than stageInfos since `getStageInfo` is called asynchronously
+            SubPlan plan = requireNonNull(this.plan.get(), "plan is null");
             Set<PlanFragmentId> reportedFragments = new HashSet<>();
             StageInfo stageInfo = getStageInfo(plan, stageInfos, reportedFragments);
             // TODO Some stages may no longer be present in the plan when adaptive re-planning is implemented

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantPartitioningScheme.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantPartitioningScheme.java
@@ -94,4 +94,13 @@ public class FaultTolerantPartitioningScheme
     {
         return partitionToNodeMap;
     }
+
+    public FaultTolerantPartitioningScheme withPartitionCount(int partitionCount)
+    {
+        return new FaultTolerantPartitioningScheme(
+                partitionCount,
+                this.bucketToPartitionMap,
+                this.splitToBucketFunction,
+                this.partitionToNodeMap);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantPartitioningSchemeFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FaultTolerantPartitioningSchemeFactory.java
@@ -60,6 +60,12 @@ public class FaultTolerantPartitioningSchemeFactory
             result = create(handle, partitionCount);
             cache.put(handle, result);
         }
+        else if (partitionCount.isPresent()) {
+            // With runtime adaptive partitioning, it's no longer guaranteed that the same handle will always map to
+            // the same partition count. Therefore, use the supplied `partitionCount` as the source of truth.
+            result = result.withPartitionCount(partitionCount.get());
+        }
+
         return result;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/HashDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/HashDistributionSplitAssigner.java
@@ -224,10 +224,7 @@ class HashDistributionSplitAssigner
 
         // adjust targetPartitionSizeInBytes based on total input bytes
         if (targetMaxTaskCount != Integer.MAX_VALUE || targetMinTaskCount != 0) {
-            long totalBytes = 0;
-            for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
-                totalBytes += mergedEstimate.getPartitionSizeInBytes(partitionId);
-            }
+            long totalBytes = mergedEstimate.getTotalSizeInBytes();
 
             if (totalBytes / targetPartitionSizeInBytes > targetMaxTaskCount) {
                 // targetMaxTaskCount is only used to adjust targetPartitionSizeInBytes to avoid excessive number

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragment.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragment.java
@@ -284,4 +284,49 @@ public class PlanFragment
                 .add("outputPartitioningScheme", outputPartitioningScheme)
                 .toString();
     }
+
+    public PlanFragment withPartitionCount(Optional<Integer> partitionCount)
+    {
+        return new PlanFragment(
+                this.id,
+                this.root,
+                this.symbols,
+                this.partitioning,
+                partitionCount,
+                this.partitionedSources,
+                this.outputPartitioningScheme,
+                this.statsAndCosts,
+                this.activeCatalogs,
+                this.jsonRepresentation);
+    }
+
+    public PlanFragment withOutputPartitioningScheme(PartitioningScheme outputPartitioningScheme)
+    {
+        return new PlanFragment(
+                this.id,
+                this.root,
+                this.symbols,
+                this.partitioning,
+                this.partitionCount,
+                this.partitionedSources,
+                outputPartitioningScheme,
+                this.statsAndCosts,
+                this.activeCatalogs,
+                this.jsonRepresentation);
+    }
+
+    public PlanFragment withRoot(PlanNode root)
+    {
+        return new PlanFragment(
+                this.id,
+                root,
+                this.symbols,
+                this.partitioning,
+                this.partitionCount,
+                this.partitionedSources,
+                this.outputPartitioningScheme,
+                this.statsAndCosts,
+                this.activeCatalogs,
+                this.jsonRepresentation);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmentIdAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmentIdAllocator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import io.trino.sql.planner.plan.PlanFragmentId;
+
+public class PlanFragmentIdAllocator
+{
+    private int nextId;
+
+    public PlanFragmentIdAllocator(int startId)
+    {
+        this.nextId = startId;
+    }
+
+    public PlanFragmentId getNextId()
+    {
+        return new PlanFragmentId(Integer.toString(nextId++));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -214,7 +214,7 @@ public class PlanFragmenter
         private final TypeProvider types;
         private final StatsAndCosts statsAndCosts;
         private final List<CatalogProperties> activeCatalogs;
-        private int nextFragmentId = ROOT_FRAGMENT_ID + 1;
+        private final PlanFragmentIdAllocator idAllocator = new PlanFragmentIdAllocator(ROOT_FRAGMENT_ID + 1);
 
         public Fragmenter(Session session, Metadata metadata, FunctionManager functionManager, TypeProvider types, StatsAndCosts statsAndCosts, List<CatalogProperties> activeCatalogs)
         {
@@ -229,11 +229,6 @@ public class PlanFragmenter
         public SubPlan buildRootFragment(PlanNode root, FragmentProperties properties)
         {
             return buildFragment(root, properties, new PlanFragmentId(String.valueOf(ROOT_FRAGMENT_ID)));
-        }
-
-        private PlanFragmentId nextFragmentId()
-        {
-            return new PlanFragmentId(String.valueOf(nextFragmentId++));
         }
 
         private SubPlan buildFragment(PlanNode root, FragmentProperties properties, PlanFragmentId fragmentId)
@@ -433,7 +428,7 @@ public class PlanFragmenter
 
         private SubPlan buildSubPlan(PlanNode node, FragmentProperties properties, RewriteContext<FragmentProperties> context)
         {
-            PlanFragmentId planFragmentId = nextFragmentId();
+            PlanFragmentId planFragmentId = idAllocator.getNextId();
             PlanNode child = context.rewrite(node, properties);
             return buildFragment(child, properties, planFragmentId);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanNodeIdAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanNodeIdAllocator.java
@@ -19,6 +19,16 @@ public class PlanNodeIdAllocator
 {
     private int nextId;
 
+    public PlanNodeIdAllocator()
+    {
+        this(0);
+    }
+
+    public PlanNodeIdAllocator(int startId)
+    {
+        this.nextId = startId;
+    }
+
     public PlanNodeId getNextId()
     {
         return new PlanNodeId(Integer.toString(nextId++));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RuntimeAdaptivePartitioningRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RuntimeAdaptivePartitioningRewriter.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.graph.Traverser;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.SimplePlanRewriter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterators.getOnlyElement;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.plan.ExchangeNode.Type.REPLICATE;
+import static io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+import static java.util.Objects.requireNonNull;
+
+public final class RuntimeAdaptivePartitioningRewriter
+{
+    private RuntimeAdaptivePartitioningRewriter() {}
+
+    public static SubPlan overridePartitionCountRecursively(
+            SubPlan subPlan,
+            int oldPartitionCount,
+            int newPartitionCount,
+            PlanFragmentIdAllocator planFragmentIdAllocator,
+            PlanNodeIdAllocator planNodeIdAllocator,
+            Set<PlanFragmentId> startedFragments)
+    {
+        PlanFragment fragment = subPlan.getFragment();
+        if (startedFragments.contains(fragment.getId())) {
+            // already started, nothing to change for subPlan and its descendants
+            return subPlan;
+        }
+
+        PartitioningScheme outputPartitioningScheme = fragment.getOutputPartitioningScheme();
+        if (outputPartitioningScheme.getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION)) {
+            // the result of the subtree will be broadcast, then no need to change partition count for the subtree
+            // as the planner will only broadcast fragment output if it sees input data is small or filter ratio is high
+            return subPlan;
+        }
+        if (producesHashPartitionedOutput(fragment)) {
+            fragment = fragment.withOutputPartitioningScheme(outputPartitioningScheme.withPartitionCount(Optional.of(newPartitionCount)));
+        }
+
+        if (consumesHashPartitionedInput(fragment)) {
+            fragment = fragment.withPartitionCount(Optional.of(newPartitionCount));
+        }
+        else {
+            // no input partitioning, then no need to insert extra exchanges to sources
+            return new SubPlan(
+                    fragment,
+                    subPlan.getChildren().stream()
+                            .map(child -> overridePartitionCountRecursively(
+                                    child,
+                                    oldPartitionCount,
+                                    newPartitionCount,
+                                    planFragmentIdAllocator,
+                                    planNodeIdAllocator,
+                                    startedFragments))
+                            .collect(toImmutableList()));
+        }
+
+        // insert extra exchanges to sources
+        ImmutableList.Builder<SubPlan> newSources = ImmutableList.builder();
+        ImmutableMap.Builder<PlanFragmentId, PlanFragmentId> runtimeAdaptivePlanFragmentIdMapping = ImmutableMap.builder();
+        for (SubPlan source : subPlan.getChildren()) {
+            PlanFragment sourceFragment = source.getFragment();
+            RemoteSourceNode sourceRemoteSourceNode = getOnlyElement(fragment.getRemoteSourceNodes().stream()
+                    .filter(remoteSourceNode -> remoteSourceNode.getSourceFragmentIds().contains(sourceFragment.getId()))
+                    .iterator());
+            requireNonNull(sourceRemoteSourceNode, "sourceRemoteSourceNode is null");
+            if (sourceRemoteSourceNode.getExchangeType() == REPLICATE) {
+                // since exchange type is REPLICATE, also no need to change partition count for the subtree as the
+                // planner will only broadcast fragment output if it sees input data is small or filter ratio is high
+                newSources.add(source);
+                continue;
+            }
+            if (!startedFragments.contains(sourceFragment.getId())) {
+                // source not started yet, then no need to insert extra exchanges to sources
+                newSources.add(overridePartitionCountRecursively(
+                        source,
+                        oldPartitionCount,
+                        newPartitionCount,
+                        planFragmentIdAllocator,
+                        planNodeIdAllocator,
+                        startedFragments));
+                runtimeAdaptivePlanFragmentIdMapping.put(sourceFragment.getId(), sourceFragment.getId());
+                continue;
+            }
+            RemoteSourceNode runtimeAdaptiveRemoteSourceNode = new RemoteSourceNode(
+                    planNodeIdAllocator.getNextId(),
+                    sourceFragment.getId(),
+                    sourceFragment.getOutputPartitioningScheme().getOutputLayout(),
+                    sourceRemoteSourceNode.getOrderingScheme(),
+                    sourceRemoteSourceNode.getExchangeType(),
+                    sourceRemoteSourceNode.getRetryPolicy());
+            PlanFragment runtimeAdaptivePlanFragment = new PlanFragment(
+                    planFragmentIdAllocator.getNextId(),
+                    runtimeAdaptiveRemoteSourceNode,
+                    sourceFragment.getSymbols(),
+                    FIXED_HASH_DISTRIBUTION,
+                    Optional.of(oldPartitionCount),
+                    ImmutableList.of(), // partitioned sources will be empty as the fragment will only read from `runtimeAdaptiveRemoteSourceNode`
+                    sourceFragment.getOutputPartitioningScheme().withPartitionCount(Optional.of(newPartitionCount)),
+                    sourceFragment.getStatsAndCosts(),
+                    sourceFragment.getActiveCatalogs(),
+                    sourceFragment.getJsonRepresentation());
+            SubPlan newSource = new SubPlan(
+                    runtimeAdaptivePlanFragment,
+                    ImmutableList.of(overridePartitionCountRecursively(
+                            source,
+                            oldPartitionCount,
+                            newPartitionCount,
+                            planFragmentIdAllocator,
+                            planNodeIdAllocator,
+                            startedFragments)));
+            newSources.add(newSource);
+            runtimeAdaptivePlanFragmentIdMapping.put(sourceFragment.getId(), runtimeAdaptivePlanFragment.getId());
+        }
+
+        return new SubPlan(
+                fragment.withRoot(rewriteWith(
+                        new UpdateRemoteSourceFragmentIdsRewriter(runtimeAdaptivePlanFragmentIdMapping.buildOrThrow()),
+                        fragment.getRoot())),
+                newSources.build());
+    }
+
+    public static boolean consumesHashPartitionedInput(PlanFragment fragment)
+    {
+        return isPartitioned(fragment.getPartitioning());
+    }
+
+    public static boolean producesHashPartitionedOutput(PlanFragment fragment)
+    {
+        return isPartitioned(fragment.getOutputPartitioningScheme().getPartitioning().getHandle());
+    }
+
+    public static int getMaxPlanFragmentId(List<SubPlan> subPlans)
+    {
+        return subPlans.stream()
+                .map(SubPlan::getFragment)
+                .map(PlanFragment::getId)
+                .mapToInt(fragmentId -> Integer.parseInt(fragmentId.toString()))
+                .max()
+                .orElseThrow();
+    }
+
+    public static int getMaxPlanId(List<SubPlan> subPlans)
+    {
+        return subPlans.stream()
+                .map(SubPlan::getFragment)
+                .map(PlanFragment::getRoot)
+                .mapToInt(root -> traverse(root)
+                        .map(PlanNode::getId)
+                        .mapToInt(planNodeId -> Integer.parseInt(planNodeId.toString()))
+                        .max()
+                        .orElseThrow())
+                .max()
+                .orElseThrow();
+    }
+
+    private static boolean isPartitioned(PartitioningHandle partitioningHandle)
+    {
+        return partitioningHandle.equals(FIXED_HASH_DISTRIBUTION) || partitioningHandle.equals(SCALED_WRITER_HASH_DISTRIBUTION);
+    }
+
+    private static Stream<PlanNode> traverse(PlanNode node)
+    {
+        Iterable<PlanNode> iterable = Traverser.forTree(PlanNode::getSources).depthFirstPreOrder(node);
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private static class UpdateRemoteSourceFragmentIdsRewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Map<PlanFragmentId, PlanFragmentId> runtimeAdaptivePlanFragmentIdMapping;
+
+        public UpdateRemoteSourceFragmentIdsRewriter(Map<PlanFragmentId, PlanFragmentId> runtimeAdaptivePlanFragmentIdMapping)
+        {
+            this.runtimeAdaptivePlanFragmentIdMapping = requireNonNull(runtimeAdaptivePlanFragmentIdMapping, "runtimeAdaptivePlanFragmentIdMapping is null");
+        }
+
+        @Override
+        public PlanNode visitRemoteSource(RemoteSourceNode node, RewriteContext<Void> context)
+        {
+            if (node.getExchangeType() == REPLICATE) {
+                return node;
+            }
+            return node.withSourceFragmentIds(node.getSourceFragmentIds().stream()
+                    .map(runtimeAdaptivePlanFragmentIdMapping::get)
+                    .collect(toImmutableList()));
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TopologicalOrderSubPlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TopologicalOrderSubPlanVisitor.java
@@ -26,7 +26,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
-public class TopologicalOrderSubPlanVisitor
+public final class TopologicalOrderSubPlanVisitor
 {
     private TopologicalOrderSubPlanVisitor() {}
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/RemoteSourceNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/RemoteSourceNode.java
@@ -117,4 +117,15 @@ public class RemoteSourceNode
         checkArgument(newChildren.isEmpty(), "newChildren is not empty");
         return this;
     }
+
+    public RemoteSourceNode withSourceFragmentIds(List<PlanFragmentId> sourceFragmentIds)
+    {
+        return new RemoteSourceNode(
+                this.getId(),
+                sourceFragmentIds,
+                this.getOutputSymbols(),
+                this.getOrderingScheme(),
+                this.getExchangeType(),
+                this.getRetryPolicy());
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -28,6 +28,7 @@ import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.execution.QueryManagerConfig.AVAILABLE_HEAP_MEMORY;
+import static io.trino.execution.QueryManagerConfig.FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -98,6 +99,9 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionMaxPartitionCount(50)
                 .setFaultTolerantExecutionMinPartitionCount(4)
                 .setFaultTolerantExecutionMinPartitionCountForWrite(50)
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled(false)
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(DataSize.of(12, GIGABYTE))
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT)
                 .setFaultTolerantExecutionForcePreferredWritePartitioningEnabled(true)
                 .setFaultTolerantExecutionMinSourceStageProgress(0.2)
                 .setFaultTolerantExecutionSmallStageEstimationEnabled(true)
@@ -170,6 +174,9 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-max-partition-count", "123")
                 .put("fault-tolerant-execution-min-partition-count", "12")
                 .put("fault-tolerant-execution-min-partition-count-for-write", "99")
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-enabled", "true")
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-partition-count", "888")
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-max-task-size", "18GB")
                 .put("experimental.fault-tolerant-execution-force-preferred-write-partitioning-enabled", "false")
                 .put("fault-tolerant-execution-min-source-stage-progress", "0.3")
                 .put("query.max-writer-task-count", "101")
@@ -239,6 +246,9 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionMaxPartitionCount(123)
                 .setFaultTolerantExecutionMinPartitionCount(12)
                 .setFaultTolerantExecutionMinPartitionCountForWrite(99)
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningEnabled(true)
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningPartitionCount(888)
+                .setFaultTolerantExecutionRuntimeAdaptivePartitioningMaxTaskSize(DataSize.of(18, GIGABYTE))
                 .setFaultTolerantExecutionForcePreferredWritePartitioningEnabled(false)
                 .setFaultTolerantExecutionMinSourceStageProgress(0.3)
                 .setFaultTolerantExecutionSmallStageEstimationEnabled(false)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
@@ -135,7 +135,7 @@ public class TestPlanFragmentPartitionCount
                 new PlanFragmentId("4"), Optional.empty(),
                 new PlanFragmentId("5"), Optional.empty());
 
-        assertThat(expectedPartitionCount).isEqualTo(actualPartitionCount.buildOrThrow());
+        assertThat(actualPartitionCount.buildOrThrow()).isEqualTo(expectedPartitionCount);
     }
 
     private SubPlan fragment(Plan plan)

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.connector.CoordinatorDynamicCatalogManager;
+import io.trino.connector.InMemoryCatalogStore;
+import io.trino.connector.LazyCatalogFactory;
+import io.trino.execution.QueryManagerConfig;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.planner.PartitioningHandle;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.PlanFragment;
+import io.trino.sql.planner.PlanFragmentIdAllocator;
+import io.trino.sql.planner.PlanFragmenter;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.SubPlan;
+import io.trino.sql.planner.plan.PlanFragmentId;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMaxPartitionCount;
+import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.consumesHashPartitionedInput;
+import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.getMaxPlanFragmentId;
+import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.getMaxPlanId;
+import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.overridePartitionCountRecursively;
+import static io.trino.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static io.trino.sql.planner.TopologicalOrderSubPlanVisitor.sortPlanInTopologicalOrder;
+import static io.trino.tpch.TpchTable.getTables;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestOverridePartitionCountRecursively
+        extends AbstractTestQueryFramework
+{
+    private static final int PARTITION_COUNT_OVERRIDE = 40;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        ImmutableMap.Builder<String, String> extraPropertiesWithRuntimeAdaptivePartitioning = ImmutableMap.builder();
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(FaultTolerantExecutionConnectorTestHelper.getExtraProperties());
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(FaultTolerantExecutionConnectorTestHelper.enforceRuntimeAdaptivePartitioningProperties());
+
+        return HiveQueryRunner.builder()
+                .setExtraProperties(extraPropertiesWithRuntimeAdaptivePartitioning.buildOrThrow())
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of("exchange.base-directories",
+                                    System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                })
+                .setInitialTables(getTables())
+                .build();
+    }
+
+    @Test
+    public void testCreateTableAs()
+    {
+        // already started: 3, 5, 6
+        // added fragments: 7, 8, 9
+        //   0                 0
+        //   |                 |
+        //   1                 1
+        //   |                 |
+        //   2                 2
+        //  / \              /  \
+        // 3*  4     =>    [7]   4
+        //    / \           |   / \
+        //   5* 6*         3* [8] [9]
+        //                     |   |
+        //                    5*   6*
+        assertOverridePartitionCountRecursively(
+                noJoinReordering(),
+                "CREATE TABLE tmp AS " +
+                "SELECT n1.* FROM nation n1 " +
+                        "RIGHT JOIN " +
+                        "(SELECT n.nationkey FROM (SELECT * FROM lineitem WHERE suppkey BETWEEN 20 and 30) l LEFT JOIN nation n on l.suppkey = n.nationkey) n2" +
+                        " ON n1.nationkey = n2.nationkey + 1",
+                ImmutableMap.<Integer, FragmentPartitioningInfo>builder()
+                        .put(0, new FragmentPartitioningInfo(COORDINATOR_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(1, new FragmentPartitioningInfo(SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(2, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.empty(), SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION, Optional.empty()))
+                        .put(3, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(4, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(5, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(6, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .buildOrThrow(),
+                ImmutableMap.<Integer, FragmentPartitioningInfo>builder()
+                        .put(0, new FragmentPartitioningInfo(COORDINATOR_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(1, new FragmentPartitioningInfo(SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(2, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(40), SCALED_WRITER_ROUND_ROBIN_DISTRIBUTION, Optional.empty()))
+                        .put(3, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(4, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(40), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(5, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(6, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.empty()))
+                        .put(7, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(5), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(8, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(5), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(9, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(5), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .buildOrThrow(),
+                ImmutableSet.of(3, 5, 6));
+    }
+
+    @Test
+    public void testSkipBroadcastSubtree()
+    {
+        // result of fragment 7 will be broadcast,
+        // so no runtime adaptive partitioning will be applied to its subtree
+        // already started: 4, 10, 11, 12
+        // added fragments: 13
+        //        0                  0
+        //        |                  |
+        //        1                  1
+        //       / \              /     \
+        //      2   7     =>     2       7
+        //     / \  |           / \      |
+        //    3  6  8          3  6      8
+        //   / \   / \        / \       / \
+        //  4* 5  9  12*    [13] 5     9  12*
+        //       / \          |       / \
+        //     10* 11*       4*     10* 11*
+        assertOverridePartitionCountRecursively(
+                noJoinReordering(),
+                "SELECT\n" +
+                        "  ps.partkey,\n" +
+                        "  sum(ps.supplycost * ps.availqty) AS value\n" +
+                        "FROM\n" +
+                        "  partsupp ps,\n" +
+                        "  supplier s,\n" +
+                        "  nation n\n" +
+                        "WHERE\n" +
+                        "  ps.suppkey = s.suppkey\n" +
+                        "  AND s.nationkey = n.nationkey\n" +
+                        "  AND n.name = 'GERMANY'\n" +
+                        "GROUP BY\n" +
+                        "  ps.partkey\n" +
+                        "HAVING\n" +
+                        "  sum(ps.supplycost * ps.availqty) > (\n" +
+                        "    SELECT sum(ps.supplycost * ps.availqty) * 0.0001\n" +
+                        "    FROM\n" +
+                        "      partsupp ps,\n" +
+                        "      supplier s,\n" +
+                        "      nation n\n" +
+                        "    WHERE\n" +
+                        "      ps.suppkey = s.suppkey\n" +
+                        "      AND s.nationkey = n.nationkey\n" +
+                        "      AND n.name = 'GERMANY'\n" +
+                        "  )\n" +
+                        "ORDER BY\n" +
+                        "  value DESC",
+                ImmutableMap.<Integer, FragmentPartitioningInfo>builder()
+                        .put(0, new FragmentPartitioningInfo(SINGLE_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(1, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(2, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(3, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(4, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(5, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(6, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(7, new FragmentPartitioningInfo(SINGLE_DISTRIBUTION, Optional.empty(), FIXED_BROADCAST_DISTRIBUTION, Optional.empty()))
+                        .put(8, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(9, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(10, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(11, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(12, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .buildOrThrow(),
+                ImmutableMap.<Integer, FragmentPartitioningInfo>builder()
+                        .put(0, new FragmentPartitioningInfo(SINGLE_DISTRIBUTION, Optional.empty(), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(1, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(40), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(2, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(40), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(3, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(40), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(4, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(5, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(6, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .put(7, new FragmentPartitioningInfo(SINGLE_DISTRIBUTION, Optional.empty(), FIXED_BROADCAST_DISTRIBUTION, Optional.empty()))
+                        .put(8, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), SINGLE_DISTRIBUTION, Optional.empty()))
+                        .put(9, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(10, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(11, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(12, new FragmentPartitioningInfo(SOURCE_DISTRIBUTION, Optional.empty(), FIXED_HASH_DISTRIBUTION, Optional.of(4)))
+                        .put(13, new FragmentPartitioningInfo(FIXED_HASH_DISTRIBUTION, Optional.of(4), FIXED_HASH_DISTRIBUTION, Optional.of(40)))
+                        .buildOrThrow(),
+                ImmutableSet.of(4, 10, 11, 12));
+    }
+
+    private void assertOverridePartitionCountRecursively(
+            Session session,
+            @Language("SQL") String sql,
+            Map<Integer, FragmentPartitioningInfo> fragmentPartitioningInfoBefore,
+            Map<Integer, FragmentPartitioningInfo> fragmentPartitioningInfoAfter,
+            Set<Integer> startedFragments)
+    {
+        SubPlan plan = getSubPlan(session, sql);
+        List<SubPlan> planInTopologicalOrder = sortPlanInTopologicalOrder(plan);
+        assertThat(planInTopologicalOrder).hasSize(fragmentPartitioningInfoBefore.size());
+        for (SubPlan subPlan : planInTopologicalOrder) {
+            PlanFragment fragment = subPlan.getFragment();
+            int fragmentIdAsInt = Integer.parseInt(fragment.getId().toString());
+            FragmentPartitioningInfo fragmentPartitioningInfo = fragmentPartitioningInfoBefore.get(fragmentIdAsInt);
+            assertEquals(fragment.getPartitionCount(), fragmentPartitioningInfo.inputPartitionCount());
+            assertEquals(fragment.getPartitioning(), fragmentPartitioningInfo.inputPartitioning());
+            assertEquals(fragment.getOutputPartitioningScheme().getPartitionCount(), fragmentPartitioningInfo.outputPartitionCount());
+            assertEquals(fragment.getOutputPartitioningScheme().getPartitioning().getHandle(), fragmentPartitioningInfo.outputPartitioning());
+        }
+
+        PlanFragmentIdAllocator planFragmentIdAllocator = new PlanFragmentIdAllocator(getMaxPlanFragmentId(planInTopologicalOrder) + 1);
+        PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator(getMaxPlanId(planInTopologicalOrder) + 1);
+        int oldPartitionCount = planInTopologicalOrder.stream()
+                .mapToInt(subPlan -> {
+                    PlanFragment fragment = subPlan.getFragment();
+                    if (consumesHashPartitionedInput(fragment)) {
+                        return fragment.getPartitionCount().orElse(getFaultTolerantExecutionMaxPartitionCount(session));
+                    }
+                    else {
+                        return 0;
+                    }
+                })
+                .max()
+                .orElseThrow();
+        assertTrue(oldPartitionCount > 0);
+
+        SubPlan newPlan = overridePartitionCountRecursively(
+                plan,
+                oldPartitionCount,
+                PARTITION_COUNT_OVERRIDE,
+                planFragmentIdAllocator,
+                planNodeIdAllocator,
+                startedFragments.stream().map(fragmentIdAsInt -> new PlanFragmentId(String.valueOf(fragmentIdAsInt))).collect(toImmutableSet()));
+        planInTopologicalOrder = sortPlanInTopologicalOrder(newPlan);
+        assertThat(planInTopologicalOrder).hasSize(fragmentPartitioningInfoAfter.size());
+        for (SubPlan subPlan : planInTopologicalOrder) {
+            PlanFragment fragment = subPlan.getFragment();
+            int fragmentIdAsInt = Integer.parseInt(fragment.getId().toString());
+            FragmentPartitioningInfo fragmentPartitioningInfo = fragmentPartitioningInfoAfter.get(fragmentIdAsInt);
+            assertEquals(fragment.getPartitionCount(), fragmentPartitioningInfo.inputPartitionCount());
+            assertEquals(fragment.getPartitioning(), fragmentPartitioningInfo.inputPartitioning());
+            assertEquals(fragment.getOutputPartitioningScheme().getPartitionCount(), fragmentPartitioningInfo.outputPartitionCount());
+            assertEquals(fragment.getOutputPartitioningScheme().getPartitioning().getHandle(), fragmentPartitioningInfo.outputPartitioning());
+        }
+    }
+
+    private SubPlan getSubPlan(Session session, @Language("SQL") String sql)
+    {
+        QueryRunner queryRunner = getDistributedQueryRunner();
+        Plan plan = queryRunner.createPlan(session, sql, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+        return transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+                .singleStatement()
+                .execute(session, transactionSession -> {
+                    // metadata.getCatalogHandle() registers the catalog for the transaction
+                    transactionSession.getCatalog().ifPresent(catalog -> queryRunner.getMetadata().getCatalogHandle(transactionSession, catalog));
+                    return new PlanFragmenter(
+                            queryRunner.getMetadata(),
+                            queryRunner.getFunctionManager(),
+                            queryRunner.getTransactionManager(),
+                            new CoordinatorDynamicCatalogManager(new InMemoryCatalogStore(), new LazyCatalogFactory(), directExecutor()),
+                            new QueryManagerConfig()).createSubPlans(transactionSession, plan, false, WarningCollector.NOOP);
+                });
+    }
+
+    private record FragmentPartitioningInfo(
+            PartitioningHandle inputPartitioning,
+            Optional<Integer> inputPartitionCount,
+            PartitioningHandle outputPartitioning,
+            Optional<Integer> outputPartitionCount)
+    {
+        FragmentPartitioningInfo {
+            requireNonNull(inputPartitioning, "inputPartitioning is null");
+            requireNonNull(inputPartitionCount, "inputPartitionCount is null");
+            requireNonNull(outputPartitioning, "outputPartitioning is null");
+            requireNonNull(outputPartitionCount, "outputPartitionCount is null");
+        }
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionAggregations.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionAggregations.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestFaultTolerantExecutionAggregations;
+import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
+import io.trino.testing.QueryRunner;
+
+import java.util.Map;
+
+import static io.trino.tpch.TpchTable.getTables;
+
+public class TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionAggregations
+        extends AbstractTestFaultTolerantExecutionAggregations
+{
+    @Override
+    protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        ImmutableMap.Builder<String, String> extraPropertiesWithRuntimeAdaptivePartitioning = ImmutableMap.builder();
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(extraProperties);
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(FaultTolerantExecutionConnectorTestHelper.enforceRuntimeAdaptivePartitioningProperties());
+
+        return HiveQueryRunner.builder()
+                .setExtraProperties(extraPropertiesWithRuntimeAdaptivePartitioning.buildOrThrow())
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of("exchange.base-directories",
+                            System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                })
+                .setInitialTables(getTables())
+                .build();
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionJoinQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionJoinQueries.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestFaultTolerantExecutionJoinQueries;
+import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.tpch.TpchTable.getTables;
+
+public class TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionJoinQueries
+        extends AbstractTestFaultTolerantExecutionJoinQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        ImmutableMap.Builder<String, String> extraPropertiesWithRuntimeAdaptivePartitioning = ImmutableMap.builder();
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(extraProperties);
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(FaultTolerantExecutionConnectorTestHelper.enforceRuntimeAdaptivePartitioningProperties());
+
+        verify(new DynamicFilterConfig().isEnableDynamicFiltering(), "this class assumes dynamic filtering is enabled by default");
+        return HiveQueryRunner.builder()
+                .setExtraProperties(extraPropertiesWithRuntimeAdaptivePartitioning.buildOrThrow())
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of("exchange.base-directories",
+                            System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                })
+                .setInitialTables(getTables())
+                .addHiveProperty("hive.dynamic-filtering.wait-timeout", "1h")
+                .build();
+    }
+
+    @Test
+    public void verifyDynamicFilteringEnabled()
+    {
+        assertQuery(
+                "SHOW SESSION LIKE 'enable_dynamic_filtering'",
+                "VALUES ('enable_dynamic_filtering', 'true', 'true', 'boolean', 'Enable dynamic filtering')");
+    }
+}

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionWindowQueries.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionWindowQueries.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.faulttolerant.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.exchange.filesystem.FileSystemExchangePlugin;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestFaultTolerantExecutionWindowQueries;
+import io.trino.testing.FaultTolerantExecutionConnectorTestHelper;
+import io.trino.testing.QueryRunner;
+
+import java.util.Map;
+
+import static io.trino.tpch.TpchTable.getTables;
+
+public class TestHiveRuntimeAdaptivePartitioningFaultTolerantExecutionWindowQueries
+        extends AbstractTestFaultTolerantExecutionWindowQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner(Map<String, String> extraProperties)
+            throws Exception
+    {
+        ImmutableMap.Builder<String, String> extraPropertiesWithRuntimeAdaptivePartitioning = ImmutableMap.builder();
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(extraProperties);
+        extraPropertiesWithRuntimeAdaptivePartitioning.putAll(FaultTolerantExecutionConnectorTestHelper.enforceRuntimeAdaptivePartitioningProperties());
+
+        return HiveQueryRunner.builder()
+                .setExtraProperties(extraPropertiesWithRuntimeAdaptivePartitioning.buildOrThrow())
+                .setAdditionalSetup(runner -> {
+                    runner.installPlugin(new FileSystemExchangePlugin());
+                    runner.loadExchangeManager("filesystem", ImmutableMap.of("exchange.base-directories",
+                            System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
+                })
+                .setInitialTables(getTables())
+                .build();
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
@@ -49,4 +49,14 @@ public final class FaultTolerantExecutionConnectorTestHelper
                 .put("query.schedule-split-batch-size", "2")
                 .buildOrThrow();
     }
+
+    public static Map<String, String> enforceRuntimeAdaptivePartitioningProperties()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-enabled", "true")
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-partition-count", "40")
+                // to ensure runtime adaptive partitioning is triggered
+                .put("fault-tolerant-execution-runtime-adaptive-partitioning-max-task-size", "1B")
+                .buildOrThrow();
+    }
 }


### PR DESCRIPTION
Having high number of partitions hurts the performance of FTE quite seriously, which presents a tradeoff between scalability and performance. This PR tries address this problem by calculating the total input size of each stage at runtime, and change the number of partitions at runtime by inserting extra shuffles to upstream stages.

With this change, users should be able to make the best of both worlds --- majority of the queries can finish with a small partition count efficiently, and those huge queries will still be able to finish with a larger partition count.

TODO:
- [x] Verify this works for all query shapes of TPC-DS and TPC-H
- [x] Extract the logic in `EventDrivenFaultTolerantQueryScheduler` to separate classes/files
- [x] Add tests to test `overridePartitionCountRecursively`
- [x] Avoid duplicate `isReadyForExecution` calls in a scheduling loop (probably won't do in this PR. Tradeoff between code organization and efficiency. Can't see an elegant way to avoid this)
- [x] Verify for TPC-DS sf10000 ETL suite