### PR TITLE
Disallow creating Delta tables partitioned by all columns

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1078,6 +1078,9 @@ public class DeltaLakeMetadata
         if (!invalidPartitionNames.isEmpty()) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Table property 'partition_by' contained column names which do not exist: " + invalidPartitionNames);
         }
+        if (columns.size() == partitionColumnNames.size()) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Using all columns for partition columns is unsupported");
+        }
     }
 
     private void checkColumnTypes(List<ColumnMetadata> columnMetadata)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -310,6 +310,24 @@ public class TestDeltaLakeConnectorTest
     }
 
     @Test
+    public void testCreateTableWithAllPartitionColumns()
+    {
+        String tableName = "test_create_table_all_partition_columns_" + randomNameSuffix();
+        assertQueryFails(
+                "CREATE TABLE " + tableName + "(part INT) WITH (partitioned_by = ARRAY['part'])",
+                "Using all columns for partition columns is unsupported");
+    }
+
+    @Test
+    public void testCreateTableAsSelectAllPartitionColumns()
+    {
+        String tableName = "test_create_table_all_partition_columns_" + randomNameSuffix();
+        assertQueryFails(
+                "CREATE TABLE " + tableName + " WITH (partitioned_by = ARRAY['part']) AS SELECT 1 part",
+                "Using all columns for partition columns is unsupported");
+    }
+
+    @Test
     public void testCreateTableWithUnsupportedPartitionType()
     {
         String tableName = "test_create_table_unsupported_partition_types_" + randomNameSuffix();


### PR DESCRIPTION
## Description

Fixes #14001
I will send another PR for `DROP COLUMN` statement. Currently, OSS Delta Lake allows dropping the last data column https://github.com/delta-io/delta/issues/1929

## Release notes

(x) This is not user-visible or docs only and no release notes are required.