### PR TITLE
Migrate redundant connector test to smoke test in Hudi

### DIFF
--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/BaseHudiConnectorSmokeTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hudi;
+
+import io.trino.testing.BaseConnectorSmokeTest;
+import io.trino.testing.TestingConnectorBehavior;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class BaseHudiConnectorSmokeTest
+        extends BaseConnectorSmokeTest
+{
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        switch (connectorBehavior) {
+            case SUPPORTS_INSERT:
+            case SUPPORTS_DELETE:
+            case SUPPORTS_UPDATE:
+            case SUPPORTS_MERGE:
+                return false;
+
+            case SUPPORTS_CREATE_SCHEMA:
+                return false;
+
+            case SUPPORTS_CREATE_TABLE:
+            case SUPPORTS_RENAME_TABLE:
+                return false;
+
+            case SUPPORTS_CREATE_VIEW:
+            case SUPPORTS_CREATE_MATERIALIZED_VIEW:
+                return false;
+
+            case SUPPORTS_COMMENT_ON_COLUMN:
+                return false;
+
+            default:
+                return super.hasBehavior(connectorBehavior);
+        }
+    }
+
+    @Override
+    public void testShowCreateTable()
+    {
+        // Override because Hudi connector contains 'location' table property
+        String schema = getSession().getSchema().orElseThrow();
+        assertThat((String) computeScalar("SHOW CREATE TABLE region"))
+                .matches("\\QCREATE TABLE hudi." + schema + ".region (\n" +
+                        "   regionkey bigint,\n" +
+                        "   name varchar(25),\n" +
+                        "   comment varchar(152)\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   location = \\E'.*/region'\n\\Q" +
+                        ")");
+    }
+}

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteConnectorSmokeTest.java
@@ -18,10 +18,11 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hudi.HudiQueryRunner.createHudiQueryRunner;
-import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
+import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 
-public class TestHudiMergeOnReadConnectorTest
-        extends BaseHudiConnectorTest
+public class TestHudiCopyOnWriteConnectorSmokeTest
+        extends BaseHudiConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
@@ -29,7 +30,7 @@ public class TestHudiMergeOnReadConnectorTest
     {
         return createHudiQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("hudi.columns-to-hide", columnsToHide()),
-                new TpchHudiTablesInitializer(MERGE_ON_READ, REQUIRED_TPCH_TABLES));
+                ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
+                new TpchHudiTablesInitializer(COPY_ON_WRITE, REQUIRED_TPCH_TABLES));
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiCopyOnWriteMinioConnectorSmokeTest.java
@@ -19,25 +19,26 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
+import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
+import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
 
-public class TestHudiMergeOnReadMinioConnectorTest
-        extends BaseHudiMinioConnectorTest
+public class TestHudiCopyOnWriteMinioConnectorSmokeTest
+        extends BaseHudiConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomNameSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
+        HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 
         return S3HudiQueryRunner.create(
                 ImmutableMap.of(),
-                ImmutableMap.of("hudi.columns-to-hide", columnsToHide()),
-                new TpchHudiTablesInitializer(MERGE_ON_READ, REQUIRED_TPCH_TABLES),
+                ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
+                new TpchHudiTablesInitializer(COPY_ON_WRITE, REQUIRED_TPCH_TABLES),
                 hiveMinioDataLake);
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadConnectorSmokeTest.java
@@ -18,10 +18,11 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hudi.HudiQueryRunner.createHudiQueryRunner;
-import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
+import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 
-public class TestHudiCopyOnWriteConnectorTest
-        extends BaseHudiConnectorTest
+public class TestHudiMergeOnReadConnectorSmokeTest
+        extends BaseHudiConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
@@ -29,7 +30,7 @@ public class TestHudiCopyOnWriteConnectorTest
     {
         return createHudiQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("hudi.columns-to-hide", columnsToHide()),
-                new TpchHudiTablesInitializer(COPY_ON_WRITE, REQUIRED_TPCH_TABLES));
+                ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
+                new TpchHudiTablesInitializer(MERGE_ON_READ, REQUIRED_TPCH_TABLES));
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorSmokeTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiMergeOnReadMinioConnectorSmokeTest.java
@@ -19,25 +19,26 @@ import io.trino.plugin.hudi.testing.TpchHudiTablesInitializer;
 import io.trino.testing.QueryRunner;
 
 import static io.trino.plugin.hive.containers.HiveHadoop.HIVE3_IMAGE;
+import static io.trino.plugin.hudi.testing.HudiTestUtils.COLUMNS_TO_HIDE;
 import static io.trino.testing.TestingNames.randomNameSuffix;
-import static org.apache.hudi.common.model.HoodieTableType.COPY_ON_WRITE;
+import static org.apache.hudi.common.model.HoodieTableType.MERGE_ON_READ;
 
-public class TestHudiCopyOnWriteMinioConnectorTest
-        extends BaseHudiMinioConnectorTest
+public class TestHudiMergeOnReadMinioConnectorSmokeTest
+        extends BaseHudiConnectorSmokeTest
 {
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
         String bucketName = "test-hudi-connector-" + randomNameSuffix();
-        hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
+        HiveMinioDataLake hiveMinioDataLake = closeAfterClass(new HiveMinioDataLake(bucketName, HIVE3_IMAGE));
         hiveMinioDataLake.start();
         hiveMinioDataLake.getMinioClient().ensureBucketExists(bucketName);
 
         return S3HudiQueryRunner.create(
                 ImmutableMap.of(),
-                ImmutableMap.of("hudi.columns-to-hide", columnsToHide()),
-                new TpchHudiTablesInitializer(COPY_ON_WRITE, REQUIRED_TPCH_TABLES),
+                ImmutableMap.of("hudi.columns-to-hide", COLUMNS_TO_HIDE),
+                new TpchHudiTablesInitializer(MERGE_ON_READ, REQUIRED_TPCH_TABLES),
                 hiveMinioDataLake);
     }
 }

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/HudiTestUtils.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/testing/HudiTestUtils.java
@@ -11,12 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.hudi;
+package io.trino.plugin.hudi.testing;
 
-import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import com.google.common.collect.ImmutableList;
 
-public abstract class BaseHudiMinioConnectorTest
-        extends BaseHudiConnectorTest
+import static io.trino.plugin.hudi.testing.TpchHudiTablesInitializer.FIELD_UUID;
+import static org.apache.hudi.common.model.HoodieRecord.HOODIE_META_COLUMNS;
+
+public final class HudiTestUtils
 {
-    protected HiveMinioDataLake hiveMinioDataLake;
+    private HudiTestUtils() {}
+
+    public static final String COLUMNS_TO_HIDE = String.join(",", ImmutableList.<String>builder()
+            .addAll(HOODIE_META_COLUMNS)
+            .add(FIELD_UUID)
+            .build());
 }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or docs only and no release notes are required.