### PR TITLE
Support complex connector expression filter pushdown in mongodb

### DIFF
--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -55,6 +55,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
         </dependency>
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -45,6 +45,7 @@ public class MongoClientConfig
     private String requiredReplicaSetName;
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
+    private boolean complexExpressionPushdownEnabled;
 
     @NotNull
     public String getSchemaCollection()
@@ -249,6 +250,18 @@ public class MongoClientConfig
     public MongoClientConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
     {
         this.projectionPushDownEnabled = projectionPushDownEnabled;
+        return this;
+    }
+
+    public boolean isComplexExpressionPushdownEnabled()
+    {
+        return complexExpressionPushdownEnabled;
+    }
+
+    @Config("mongodb.complex-expression-pushdown.enabled")
+    public MongoClientConfig setComplexExpressionPushdownEnabled(boolean complexExpressionPushdownEnabled)
+    {
+        this.complexExpressionPushdownEnabled = complexExpressionPushdownEnabled;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
+import io.trino.spi.type.TypeManager;
 
 import java.util.List;
 import java.util.Set;
@@ -45,6 +46,7 @@ public class MongoConnector
     private final MongoSplitManager splitManager;
     private final MongoPageSourceProvider pageSourceProvider;
     private final MongoPageSinkProvider pageSinkProvider;
+    private final TypeManager typeManager;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -56,6 +58,7 @@ public class MongoConnector
             MongoSplitManager splitManager,
             MongoPageSourceProvider pageSourceProvider,
             MongoPageSinkProvider pageSinkProvider,
+            TypeManager typeManager,
             Set<ConnectorTableFunction> connectorTableFunctions,
             Set<SessionPropertiesProvider> sessionPropertiesProviders)
     {
@@ -63,6 +66,7 @@ public class MongoConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.connectorTableFunctions = ImmutableSet.copyOf(requireNonNull(connectorTableFunctions, "connectorTableFunctions is null"));
         this.sessionProperties = sessionPropertiesProviders.stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
@@ -74,7 +78,7 @@ public class MongoConnector
     {
         checkConnectorSupports(READ_UNCOMMITTED, isolationLevel);
         MongoTransactionHandle transaction = new MongoTransactionHandle();
-        transactions.put(transaction, new MongoMetadata(mongoSession));
+        transactions.put(transaction, new MongoMetadata(mongoSession, typeManager));
         return transaction;
     }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -50,6 +50,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.RowFieldName;
@@ -90,6 +91,7 @@ import static io.trino.plugin.mongodb.ptf.Query.parseFilter;
 import static io.trino.spi.HostAddress.fromParts;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -667,6 +669,11 @@ public class MongoSession
 
         if (type instanceof ObjectIdType) {
             return Optional.of(new ObjectId(((Slice) trinoNativeValue).getBytes()));
+        }
+
+        if (type instanceof CharType charType) {
+            Slice slice = padSpaces(((Slice) trinoNativeValue), charType);
+            return Optional.of(slice.toStringUtf8());
         }
 
         if (type instanceof VarcharType) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -51,6 +51,9 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.RowFieldName;
@@ -62,6 +65,7 @@ import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarcharType;
 import org.bson.Document;
 import org.bson.types.Binary;
+import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
 import java.time.Instant;
@@ -665,6 +669,13 @@ public class MongoSession
 
         if (type == BIGINT) {
             return Optional.of(trinoNativeValue);
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(Decimal128.parse(Decimals.toString((long) trinoNativeValue, decimalType.getScale())));
+            }
+            return Optional.of(Decimal128.parse(Decimals.toString((Int128) trinoNativeValue, decimalType.getScale())));
         }
 
         if (type instanceof ObjectIdType) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -27,6 +27,7 @@ public final class MongoSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+    private static final String COMPLEX_EXPRESSION_PUSHDOWN_ENABLED = "complex_expression_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -38,6 +39,11 @@ public final class MongoSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         mongoConfig.isProjectionPushdownEnabled(),
+                        false))
+                .add(booleanProperty(
+                        COMPLEX_EXPRESSION_PUSHDOWN_ENABLED,
+                        "Allow complex expression pushdown into connectors",
+                        mongoConfig.isComplexExpressionPushdownEnabled(),
                         false))
                 .build();
     }
@@ -51,5 +57,10 @@ public final class MongoSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isComplexExpressionPushdown(ConnectorSession session)
+    {
+        return session.getProperty(COMPLEX_EXPRESSION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -15,12 +15,14 @@ package io.trino.plugin.mongodb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -36,12 +38,13 @@ public class MongoTableHandle
     private final RemoteTableName remoteTableName;
     private final Optional<String> filter;
     private final TupleDomain<ColumnHandle> constraint;
+    private final List<String> constraintExpressions;
     private final Set<MongoColumnHandle> projectedColumns;
     private final OptionalInt limit;
 
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableList.of(), ImmutableSet.of(), OptionalInt.empty());
     }
 
     @JsonCreator
@@ -50,6 +53,7 @@ public class MongoTableHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("filter") Optional<String> filter,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("constraintExpressions") List<String> constraintExpressions,
             @JsonProperty("projectedColumns") Set<MongoColumnHandle> projectedColumns,
             @JsonProperty("limit") OptionalInt limit)
     {
@@ -57,6 +61,7 @@ public class MongoTableHandle
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.filter = requireNonNull(filter, "filter is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.constraintExpressions = requireNonNull(constraintExpressions, "constraintExpressions is null");
         this.projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         this.limit = requireNonNull(limit, "limit is null");
     }
@@ -86,6 +91,12 @@ public class MongoTableHandle
     }
 
     @JsonProperty
+    public List<String> getConstraintExpressions()
+    {
+        return constraintExpressions;
+    }
+
+    @JsonProperty
     public Set<MongoColumnHandle> getProjectedColumns()
     {
         return projectedColumns;
@@ -104,6 +115,7 @@ public class MongoTableHandle
                 remoteTableName,
                 filter,
                 constraint,
+                constraintExpressions,
                 projectedColumns,
                 limit);
     }
@@ -111,7 +123,7 @@ public class MongoTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, filter, constraint, projectedColumns, limit);
+        return Objects.hash(schemaTableName, filter, constraint, constraintExpressions, projectedColumns, limit);
     }
 
     @Override
@@ -128,6 +140,7 @@ public class MongoTableHandle
                 Objects.equals(this.remoteTableName, other.remoteTableName) &&
                 Objects.equals(this.filter, other.filter) &&
                 Objects.equals(this.constraint, other.constraint) &&
+                Objects.equals(this.constraintExpressions, other.constraintExpressions) &&
                 Objects.equals(this.projectedColumns, other.projectedColumns) &&
                 Objects.equals(this.limit, other.limit);
     }
@@ -140,6 +153,7 @@ public class MongoTableHandle
                 .add("remoteTableName", remoteTableName)
                 .add("filter", filter)
                 .add("constraint", constraint)
+                .add("constraintExpressions", constraintExpressions)
                 .add("projectedColumns", projectedColumns)
                 .add("limit", limit)
                 .toString();

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -52,6 +53,9 @@ public final class TypeUtils
 
     public static boolean isPushdownSupportedType(Type type)
     {
-        return type instanceof VarcharType || type instanceof ObjectIdType || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof CharType
+                || type instanceof VarcharType
+                || type instanceof ObjectIdType
+                || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -55,6 +56,7 @@ public final class TypeUtils
     {
         return type instanceof CharType
                 || type instanceof VarcharType
+                || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+public class ExpressionUtils
+{
+    private ExpressionUtils() {}
+
+    public static Document toDecimal(Object value)
+    {
+        return documentOf("$toDecimal", value);
+    }
+
+    public static Document toDate(Object value)
+    {
+        return documentOf("$toDate", value);
+    }
+
+    public static Document toObjectId(Object value)
+    {
+        return documentOf("$toObjectId", value);
+    }
+
+    public static Document documentOf(String key, Object value)
+    {
+        return new Document(key, value);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionUtils.java
@@ -34,6 +34,14 @@ public class ExpressionUtils
         return documentOf("$toObjectId", value);
     }
 
+    public static Document toString(Object value)
+    {
+        Document convertValue = documentOf("input", value)
+                .append("to", "string")
+                .append("onError", null);
+        return documentOf("$convert", convertValue);
+    }
+
     public static Document documentOf(String key, Object value)
     {
         return new Document(key, value);

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/JsonObjectExpressionBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/JsonObjectExpressionBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+import java.util.List;
+
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
+
+public class JsonObjectExpressionBuilder
+{
+    private final String jsonVariable;
+    private final List<String> jsonPath;
+
+    public JsonObjectExpressionBuilder(String jsonVariable, List<String> jsonPath)
+    {
+        this.jsonVariable = requireNonNull(jsonVariable, "jsonVariable is null");
+        this.jsonPath = requireNonNull(jsonPath, "jsonPath is null");
+    }
+
+    public Document build()
+    {
+        return buildExpression(jsonVariable, jsonPath, 0);
+    }
+
+    private static Document buildExpression(String variable, List<String> jsonPath, int variableNumber)
+    {
+        StringBuilder variableBuilder = new StringBuilder(variable);
+        for (int i = 0; i < jsonPath.size(); i++) {
+            String path = jsonPath.get(i);
+            if (isInteger(path)) {
+                String letVariable = newVariable(variableNumber);
+                Document inExpr = inExpression(letVariable, jsonPath.subList(i + 1, jsonPath.size()), variableNumber + 1);
+                return letExpression(letVariable, variableBuilder.toString(), Integer.parseInt(path), inExpr);
+            }
+            else {
+                variableBuilder.append(".").append(path);
+            }
+        }
+        return ExpressionUtils.toString(variableBuilder.toString());
+    }
+
+    private static Document inExpression(String letVariable, List<String> path, int variableNumber)
+    {
+        return buildExpression("$$" + letVariable, path, variableNumber);
+    }
+
+    private static Document letExpression(String letVariable, String variable, int index, Document inExpression)
+    {
+        Document letValue = documentOf("vars", documentOf(letVariable, arrayObjectConditionExpression(variable, index)))
+                .append("in", inExpression);
+        return documentOf("$let", letValue);
+    }
+
+    private static Document arrayObjectConditionExpression(String variable, int index)
+    {
+        return documentOf("$cond", asList(arrayCheck(variable), arrayElemAt(variable, index), objectElement(variable, index)));
+    }
+
+    private static Document arrayCheck(String variable)
+    {
+        Document type = documentOf("$type", variable);
+        return documentOf("$eq", asList(type, "array"));
+    }
+
+    private static Document arrayElemAt(String variable, int index)
+    {
+        return documentOf("$arrayElemAt", asList(variable, index));
+    }
+
+    private static String objectElement(String variable, int index)
+    {
+        return "%s.%d".formatted(variable, index);
+    }
+
+    private static String newVariable(int variableNumber)
+    {
+        return "var_%05d".formatted(variableNumber);
+    }
+
+    private static boolean isInteger(String value)
+    {
+        try {
+            Integer.parseInt(value);
+            return true;
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+
+public class MongoConnectorExpressionRewriterBuilder
+{
+    public static MongoConnectorExpressionRewriterBuilder newBuilder()
+    {
+        return new MongoConnectorExpressionRewriterBuilder();
+    }
+
+    private final ImmutableSet.Builder<ConnectorExpressionRule<?, MongoExpression>> rules = ImmutableSet.builder();
+
+    private MongoConnectorExpressionRewriterBuilder() {}
+
+    public MongoConnectorExpressionRewriterBuilder addDefaultRules()
+    {
+        add(new RewriteVariable());
+        add(new RewriteBooleanConstant());
+        add(new RewriteVarcharConstant());
+        add(new RewriteExactNumericConstant());
+        add(new RewriteObjectIdConstant());
+        add(new RewriteTimeConstant());
+        add(new RewriteDateConstant());
+        add(new RewriteTimestampConstant());
+        add(new RewriteTimestampWithTimeZoneConstant());
+        add(new RewriteAnd());
+        add(new RewriteOr());
+        add(new RewriteComparison());
+        add(new RewriteIn());
+        add(new RewriteNot());
+        add(new RewriteIsNull());
+
+        return this;
+    }
+
+    public MongoConnectorExpressionRewriterBuilder add(ConnectorExpressionRule<?, MongoExpression> rule)
+    {
+        rules.add(rule);
+        return this;
+    }
+
+    public ConnectorExpressionRewriter<MongoExpression> build()
+    {
+        return new ConnectorExpressionRewriter<>(rules.build());
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -49,6 +49,8 @@ public class MongoConnectorExpressionRewriterBuilder
         add(new RewriteIsNull());
         add(new RewriteJsonPath(typeManager.getType(new TypeSignature("JsonPath"))));
         add(new RewriteJsonExtractScalar());
+        add(new RewriteFromIso8601Date());
+        add(new RewriteFromIso8601Timestamp());
 
         return this;
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoConnectorExpressionRewriterBuilder.java
@@ -16,6 +16,8 @@ package io.trino.plugin.mongodb.expression;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.TypeSignature;
 
 public class MongoConnectorExpressionRewriterBuilder
 {
@@ -28,7 +30,7 @@ public class MongoConnectorExpressionRewriterBuilder
 
     private MongoConnectorExpressionRewriterBuilder() {}
 
-    public MongoConnectorExpressionRewriterBuilder addDefaultRules()
+    public MongoConnectorExpressionRewriterBuilder addDefaultRules(TypeManager typeManager)
     {
         add(new RewriteVariable());
         add(new RewriteBooleanConstant());
@@ -45,6 +47,8 @@ public class MongoConnectorExpressionRewriterBuilder
         add(new RewriteIn());
         add(new RewriteNot());
         add(new RewriteIsNull());
+        add(new RewriteJsonPath(typeManager.getType(new TypeSignature("JsonPath"))));
+        add(new RewriteJsonExtractScalar());
 
         return this;
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpression.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import org.bson.Document;
+
+import java.util.Optional;
+
+public record MongoExpression(Object expression)
+{
+    public Optional<Document> expressionDocument()
+    {
+        if (expression instanceof Document document) {
+            return Optional.of(document);
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+
+public class RewriteAnd
+        extends RewriteLogicalExpression
+{
+    public RewriteAnd()
+    {
+        super(AND_FUNCTION_NAME, "$and");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteBooleanConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteBooleanConstant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteBooleanConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(BooleanType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        return Optional.of(new MongoExpression(constant.getValue()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.plugin.mongodb.expression.RewriteComparison.ComparisonOperator.LESS_THAN;
+import static io.trino.plugin.mongodb.expression.RewriteComparison.ComparisonOperator.LESS_THAN_OR_EQUAL;
+import static io.trino.plugin.mongodb.expression.RewriteComparison.ComparisonOperator.NOT_EQUAL;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class RewriteComparison
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> LEFT = newCapture();
+    private static final Capture<ConnectorExpression> RIGHT = newCapture();
+
+    public enum ComparisonOperator
+    {
+        EQUAL(EQUAL_OPERATOR_FUNCTION_NAME, "$eq"),
+        NOT_EQUAL(NOT_EQUAL_OPERATOR_FUNCTION_NAME, "$ne"),
+        LESS_THAN(LESS_THAN_OPERATOR_FUNCTION_NAME, "$lt"),
+        LESS_THAN_OR_EQUAL(LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$lte"),
+        GREATER_THAN(GREATER_THAN_OPERATOR_FUNCTION_NAME, "$gt"),
+        GREATER_THAN_OR_EQUAL(GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$gte"),
+        /**/;
+
+        private final FunctionName functionName;
+        private final String operator;
+
+        private static final Map<FunctionName, ComparisonOperator> OPERATOR_BY_FUNCTION_NAME = Stream.of(values())
+                .collect(toImmutableMap(ComparisonOperator::getFunctionName, identity()));
+
+        ComparisonOperator(FunctionName functionName, String operator)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+            this.operator = requireNonNull(operator, "operator is null");
+        }
+
+        private FunctionName getFunctionName()
+        {
+            return functionName;
+        }
+
+        private String getOperator()
+        {
+            return operator;
+        }
+
+        private static ComparisonOperator forFunctionName(FunctionName functionName)
+        {
+            return verifyNotNull(OPERATOR_BY_FUNCTION_NAME.get(functionName), "Function name not recognized: %s", functionName);
+        }
+    }
+
+    private final Pattern<Call> pattern;
+
+    public RewriteComparison()
+    {
+        Set<FunctionName> functionNames = Arrays.stream(ComparisonOperator.values())
+                .map(ComparisonOperator::getFunctionName)
+                .collect(toImmutableSet());
+
+        pattern = call()
+                .with(functionName().matching(functionNames::contains))
+                .with(type().equalTo(BOOLEAN))
+                .with(argumentCount().equalTo(2))
+                .with(argument(0).matching(expression().capturedAs(LEFT)))
+                .with(argument(1).matching(expression().capturedAs(RIGHT)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> left = context.defaultRewrite(captures.get(LEFT));
+        if (left.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<MongoExpression> right = context.defaultRewrite(captures.get(RIGHT));
+        if (right.isEmpty()) {
+            return Optional.empty();
+        }
+        verify(call.getFunctionName().getCatalogSchema().isEmpty()); // filtered out by the pattern
+        Object leftValue = left.get().expression();
+        Object rightValue = right.get().expression();
+
+        ComparisonOperator operator = ComparisonOperator.forFunctionName(call.getFunctionName());
+        if (operator == NOT_EQUAL || operator == LESS_THAN || operator == LESS_THAN_OR_EQUAL) {
+            // With aggregate operators when the field which is compared does not exist in document or has null value,
+            // $lt, $lte, $ne operators returns those documents as well, to special handling for those cases
+            // https://www.mongodb.com/community/forums/t/why-aggregate-operators-behave-differently-than-projection-operators/237219
+            return Optional.of(new MongoExpression(
+                    documentOf("$and", ImmutableList.of(
+                            documentOf(operator.getOperator(), Arrays.asList(leftValue, rightValue)),
+                            documentOf("$gt", Arrays.asList(leftValue, null)),
+                            documentOf("$gt", Arrays.asList(rightValue, null))))));
+        }
+        return Optional.of(new MongoExpression(documentOf(operator.getOperator(), Arrays.asList(leftValue, rightValue))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteConstant.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import java.util.Optional;
+
+public abstract class RewriteConstant
+{
+    protected Optional<MongoExpression> handleNullValue()
+    {
+        return Optional.of(new MongoExpression(null));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteDateConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteDateConstant.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.DateType;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+
+public class RewriteDateConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(DateType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Object value = constant.getValue();
+        if (value == null) {
+            return handleNullValue();
+        }
+
+        long days = (long) value;
+        return Optional.of(new MongoExpression(toDate(LocalDate.ofEpochDay(days).toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDecimal;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+
+public class RewriteExactNumericConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type ->
+            type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type instanceof DecimalType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Type type = constant.getType();
+        Object value = constant.getValue();
+        if (value == null) {
+            return handleNullValue();
+        }
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            return Optional.of(new MongoExpression(constant.getValue()));
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(new MongoExpression(toDecimal(Decimals.toString((long) value, decimalType.getScale()))));
+            }
+            return Optional.of(new MongoExpression(toDecimal(Decimals.toString((Int128) value, decimalType.getScale()))));
+        }
+        // TODO support REAL and DOUBLE
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Conversion.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Conversion.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+
+public class RewriteFromIso8601Conversion
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+
+    private final Pattern<Call> pattern;
+
+    public RewriteFromIso8601Conversion(FunctionName functionName, Predicate<? super Type> typeMatchingPredicate)
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(functionName))
+                .with(type().matching(typeMatchingPredicate))
+                .with(argumentCount().equalTo(1))
+                .with(argument(0).matching(expression().capturedAs(VALUE)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        return value.map(mongoExpression -> new MongoExpression(toDate(mongoExpression.expression())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Date.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Date.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.DateType;
+
+public class RewriteFromIso8601Date
+        extends RewriteFromIso8601Conversion
+{
+    public RewriteFromIso8601Date()
+    {
+        super(new FunctionName("from_iso8601_date"), DateType.class::isInstance);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Timestamp.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteFromIso8601Timestamp.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+
+public class RewriteFromIso8601Timestamp
+        extends RewriteFromIso8601Conversion
+{
+    public RewriteFromIso8601Timestamp()
+    {
+        super(new FunctionName("from_iso8601_timestamp"), type -> type instanceof TimestampWithTimeZoneType timestampType && timestampType.isShort());
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteIn
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<List<ConnectorExpression>> EXPRESSIONS = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(IN_PREDICATE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(expression().capturedAs(VALUE)))
+            .with(argument(1).matching(call().with(functionName().equalTo(ARRAY_CONSTRUCTOR_FUNCTION_NAME)).with(arguments().capturedAs(EXPRESSIONS))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ConnectorExpression> expressions = captures.get(EXPRESSIONS);
+
+        // IN elements could be null, so use mutable list
+        List<Object> rewrittenValues = new ArrayList<>(expressions.size());
+        for (ConnectorExpression expression : expressions) {
+            Optional<MongoExpression> rewritten = context.defaultRewrite(expression);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            rewrittenValues.add(rewritten.get().expression());
+        }
+        verify(!rewrittenValues.isEmpty(), "values is empty");
+
+        return Optional.of(new MongoExpression(documentOf("$in", Arrays.asList(value.get().expression(), rewrittenValues))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+
+public class RewriteIsNull
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteIsNull()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(IS_NULL_FUNCTION_NAME))
+                .with(type().matching(BooleanType.class::isInstance))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        ConnectorExpression argumentValue = getOnlyElement(call.getArguments());
+        Optional<MongoExpression> rewritten = context.defaultRewrite(argumentValue);
+        if (rewritten.isEmpty()) {
+            return Optional.empty();
+        }
+        Object value = rewritten.get().expression();
+        return Optional.of(new MongoExpression(
+                documentOf("$or", ImmutableList.of(
+                        documentOf("$eq", Arrays.asList(value, null)),
+                        documentOf("$eq", Arrays.asList(value, documentOf("$undefined", true)))))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonExtractScalar.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonExtractScalar.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.type.VarcharType;
+import org.bson.Document;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteJsonExtractScalar
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<ConnectorExpression> JSON_PATH = newCapture();
+
+    private final Pattern<Call> pattern;
+
+    public RewriteJsonExtractScalar()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(new FunctionName("json_extract_scalar")))
+                .with(type().matching(VarcharType.class::isInstance))
+                .with(argumentCount().equalTo(2))
+                .with(argument(0).matching(expression().capturedAs(VALUE)))
+                // this only captures cases where the JSON_PATH is a literal and no CAST is involved
+                .with(argument(1).matching(expression().capturedAs(JSON_PATH)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Optional<MongoExpression> value = context.defaultRewrite(captures.get(VALUE));
+        if (value.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<MongoExpression> jsonPath = context.defaultRewrite(captures.get(JSON_PATH));
+        if (jsonPath.isEmpty()) {
+            return Optional.empty();
+        }
+        String jsonPathString = (String) jsonPath.get().expression();
+
+        if (jsonPathString.endsWith("[\"$date\"]")) {
+            // { "dateCreated": { "$date": "2003-03-26" } }
+            // $date field will be accessible with parent object name
+            jsonPathString = jsonPathString.replace("[\"$date\"]", "");
+        }
+
+        String jsonColName = (String) value.get().expression();
+        List<String> jsonPathSplits = Arrays.stream(jsonPathString.split("\\."))
+                .toList();
+
+        Document jsonObjectExpression = new JsonObjectExpressionBuilder(jsonColName, jsonPathSplits)
+                .build();
+
+        return Optional.of(new MongoExpression(jsonObjectExpression));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonPath.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteJsonPath.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+
+public class RewriteJsonPath
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private final Pattern<Constant> pattern;
+
+    public RewriteJsonPath(Type jsonPathType)
+    {
+        this.pattern = constant().with(type().matching(jsonPathType.getClass()::isInstance));
+    }
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        if (constant.getValue() == null) {
+            return Optional.empty();
+        }
+        String jsonPath = constant.getValue().toString();
+        if (jsonPath == null) {
+            return Optional.empty();
+        }
+        if (jsonPath.startsWith("$.")) {
+            jsonPath = jsonPath.substring("$.".length());
+        }
+        return Optional.of(new MongoExpression(jsonPath));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+
+class RewriteLogicalExpression
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+    private final String operator;
+
+    RewriteLogicalExpression(FunctionName functionName, String operator)
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(requireNonNull(functionName, "functionName is null")))
+                .with(type().equalTo(BOOLEAN));
+        this.operator = requireNonNull(operator, "operator is null");
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        verify(!arguments.isEmpty(), "no arguments");
+        ImmutableList.Builder<Object> terms = ImmutableList.builder();
+        for (ConnectorExpression argument : arguments) {
+            verify(argument.getType() == BOOLEAN, "Unexpected type of argument: %s", argument.getType());
+            Optional<MongoExpression> rewritten = context.defaultRewrite(argument);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            terms.add(rewritten.get().expression());
+        }
+        return Optional.of(new MongoExpression(documentOf(operator, terms.build())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.type.BooleanType;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+
+public class RewriteNot
+        implements ConnectorExpressionRule<Call, MongoExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteNot()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(NOT_FUNCTION_NAME))
+                .with(type().matching(BooleanType.class::isInstance))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Call call, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        ConnectorExpression argumentValue = getOnlyElement(call.getArguments());
+
+        Optional<MongoExpression> rewritten = context.defaultRewrite(argumentValue);
+        if (rewritten.isEmpty()) {
+            return Optional.empty();
+        }
+        Object value = rewritten.get().expression();
+        return Optional.of(new MongoExpression(documentOf("$not", Arrays.asList(value))));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteObjectIdConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteObjectIdConstant.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.ObjectIdType;
+import io.trino.spi.expression.Constant;
+import org.bson.types.ObjectId;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toObjectId;
+
+public class RewriteObjectIdConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(ObjectIdType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Slice slice = (Slice) constant.getValue();
+        if (slice == null) {
+            return handleNullValue();
+        }
+
+        return Optional.of(new MongoExpression(toObjectId(new ObjectId((slice).getBytes()).toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+
+public class RewriteOr
+        extends RewriteLogicalExpression
+{
+    public RewriteOr()
+    {
+        super(OR_FUNCTION_NAME, "$or");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimeConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimeConstant.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.TimeType;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.Timestamps.roundDiv;
+
+public class RewriteTimeConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(TimeType.class::isInstance));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Object value = constant.getValue();
+        if (value == null) {
+            return handleNullValue();
+        }
+
+        long picos = (long) value;
+        Instant instant = Instant.ofEpochSecond(0, LocalTime.ofNanoOfDay(roundDiv(picos, PICOSECONDS_PER_NANOSECOND)).toNanoOfDay());
+        return Optional.of(new MongoExpression(toDate(instant.toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimestampConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimestampConstant.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.TimestampType;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.time.ZoneOffset.UTC;
+
+public class RewriteTimestampConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type -> type instanceof TimestampType timestampType && timestampType.isShort()));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Object value = constant.getValue();
+        if (value == null) {
+            return handleNullValue();
+        }
+
+        long epochMicros = (long) value;
+        long epochSecond = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        int nanoFraction = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;
+        Instant instant = Instant.ofEpochSecond(epochSecond, nanoFraction);
+        return Optional.of(new MongoExpression(toDate(LocalDateTime.ofInstant(instant, UTC).toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimestampWithTimeZoneConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteTimestampWithTimeZoneConstant.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static java.time.ZoneOffset.UTC;
+
+public class RewriteTimestampWithTimeZoneConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type -> type instanceof TimestampWithTimeZoneType timestampType && timestampType.isShort()));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Object value = constant.getValue();
+        if (value == null) {
+            return handleNullValue();
+        }
+
+        long millisUtc = unpackMillisUtc((long) value);
+        Instant instant = Instant.ofEpochMilli(millisUtc);
+        return Optional.of(new MongoExpression(toDate(LocalDateTime.ofInstant(instant, UTC).toString())));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.spi.type.Chars.padSpaces;
+
+public class RewriteVarcharConstant
+        extends RewriteConstant
+        implements ConnectorExpressionRule<Constant, MongoExpression>
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type -> type instanceof VarcharType || type instanceof CharType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Constant constant, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        Slice slice = (Slice) constant.getValue();
+        Type type = constant.getType();
+        if (slice == null) {
+            return handleNullValue();
+        }
+        if (type instanceof CharType charType) {
+            slice = padSpaces(slice, charType);
+        }
+        return Optional.of(new MongoExpression(slice.toStringUtf8()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.expression.Variable;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+
+public class RewriteVariable
+        implements ConnectorExpressionRule<Variable, MongoExpression>
+{
+    @Override
+    public Pattern<Variable> getPattern()
+    {
+        return variable();
+    }
+
+    @Override
+    public Optional<MongoExpression> rewrite(Variable variable, Captures captures, RewriteContext<MongoExpression> context)
+    {
+        MongoColumnHandle columnHandle = (MongoColumnHandle) context.getAssignment(variable.getName());
+        return Optional.of(new MongoExpression("$" + columnHandle.getQualifiedName()));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/ptf/Query.java
@@ -41,6 +41,7 @@ import io.trino.spi.function.table.Descriptor;
 import io.trino.spi.function.table.ScalarArgument;
 import io.trino.spi.function.table.ScalarArgumentSpecification;
 import io.trino.spi.function.table.TableFunctionAnalysis;
+import io.trino.spi.type.TypeManager;
 import org.bson.Document;
 import org.bson.json.JsonParseException;
 
@@ -65,10 +66,11 @@ public class Query
     private final MongoSession session;
 
     @Inject
-    public Query(MongoSession session)
+    public Query(MongoSession session, TypeManager typeManager)
     {
         requireNonNull(session, "session is null");
-        this.metadata = new MongoMetadata(session);
+        requireNonNull(typeManager, "typeManager is null");
+        this.metadata = new MongoMetadata(session, typeManager);
         this.session = session;
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
@@ -141,6 +141,19 @@ public abstract class BaseMongoConnectorSmokeTest
         }
     }
 
+    @Test
+    public void testJsonExtractScalarPredicatePushdown()
+    {
+        Session session = sessionWithComplexExpressionPushdownEnabled();
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_json_extract_predicate_pushdown",
+                "AS SELECT BIGINT '1' id, JSON '{\"name\": { \"first\": \"Monika\", \"last\": \"Geller\" }}' col")) {
+            assertThat(query(session, "SELECT id FROM " + table.getName() + " WHERE json_extract_scalar(col, '$.name.last') = 'Geller'"))
+                    .isFullyPushedDown();
+        }
+    }
+
     private Session sessionWithComplexExpressionPushdownEnabled()
     {
         return Session.builder(getSession())

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -66,6 +66,7 @@ public final class MongoQueryRunner
 
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("mongodb.connection-url", server.getConnectionString().toString());
+            connectorProperties.putIfAbsent("mongodb.complex-expression-pushdown.enabled", "true");
 
             queryRunner.installPlugin(new MongoPlugin());
             queryRunner.createCatalog("mongodb", "mongodb", connectorProperties);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -43,7 +43,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.ACKNOWLEDGED)
                 .setRequiredReplicaSetName(null)
                 .setImplicitRowFieldPrefix("_pos")
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setComplexExpressionPushdownEnabled(false));
     }
 
     @Test
@@ -67,6 +68,7 @@ public class TestMongoClientConfig
                 .put("mongodb.required-replica-set", "replica_set")
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
                 .put("mongodb.projection-pushdown-enabled", "false")
+                .put("mongodb.complex-expression-pushdown.enabled", "true")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -85,7 +87,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.UNACKNOWLEDGED)
                 .setRequiredReplicaSetName("replica_set")
                 .setImplicitRowFieldPrefix("_prefix")
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setComplexExpressionPushdownEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorExpressionRewriterBuilder.java
@@ -1,0 +1,366 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.mongodb.expression.MongoConnectorExpressionRewriterBuilder;
+import io.trino.plugin.mongodb.expression.MongoExpression;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+import org.bson.types.ObjectId;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAccessor;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.documentOf;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDate;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toDecimal;
+import static io.trino.plugin.mongodb.expression.ExpressionUtils.toObjectId;
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static java.time.temporal.ChronoField.EPOCH_DAY;
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
+import static java.time.temporal.ChronoField.MICRO_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoConnectorExpressionRewriterBuilder
+{
+    private final ConnectorSession connectorSession;
+    private final ConnectorExpressionRewriter<MongoExpression> mongoExpressionRewriter;
+
+    private TestMongoConnectorExpressionRewriterBuilder()
+    {
+        this.mongoExpressionRewriter = MongoConnectorExpressionRewriterBuilder.newBuilder()
+                .addDefaultRules()
+                .build();
+        this.connectorSession = testSessionBuilder().build().toConnectorSession();
+    }
+
+    @Test
+    public void testRewriteCharConstant()
+    {
+        Slice slice = Slices.wrappedBuffer("value".getBytes(UTF_8));
+        ConnectorExpression expression = new Constant(slice, createCharType(8));
+        assertRewrite(expression, "value   ");
+    }
+
+    @Test
+    public void testRewriteVarcharConstant()
+    {
+        ConnectorExpression expression = new Constant(Slices.wrappedBuffer("value".getBytes(UTF_8)), VARCHAR);
+        assertRewrite(expression, "value");
+    }
+
+    @Test
+    public void testRewriteExactNumericConstant()
+    {
+        ConnectorExpression tinyintValue = new Constant(1, TINYINT);
+        assertRewrite(tinyintValue, 1);
+
+        ConnectorExpression smallintValue = new Constant(15, SMALLINT);
+        assertRewrite(smallintValue, 15);
+
+        ConnectorExpression intValue = new Constant(123456, INTEGER);
+        assertRewrite(intValue, 123456);
+
+        ConnectorExpression bigintValue = new Constant(123456789, BIGINT);
+        assertRewrite(bigintValue, 123456789);
+
+        long shortDecimal = Decimals.encodeShortScaledValue(new BigDecimal("3.14"), 2);
+        ConnectorExpression shortDecimalValue = new Constant(shortDecimal, createDecimalType(3, 2));
+        assertRewrite(shortDecimalValue, toDecimal("3.14"));
+
+        Int128 longDecimal = Decimals.encodeScaledValue(new BigDecimal("1234567890.123456789"), 9);
+        ConnectorExpression longDecimalValue = new Constant(longDecimal, createDecimalType(19, 9));
+        assertRewrite(longDecimalValue, toDecimal("1234567890.123456789"));
+    }
+
+    @Test
+    public void testRewriteBooleanConstant()
+    {
+        ConnectorExpression expression = new Constant(true, BOOLEAN);
+        assertRewrite(expression, true);
+    }
+
+    @Test
+    public void testRewriteDateTimeConstant()
+    {
+        ConnectorExpression expression = new Constant(Instant.ofEpochSecond(LocalTime.of(9, 39, 5).toNanoOfDay()).toEpochMilli(), createTimeType(6));
+        assertRewrite(expression, toDate("1970-01-01T09:39:05Z"));
+
+        expression = new Constant(LocalDate.of(2022, 10, 12).toEpochDay(), DATE);
+        assertRewrite(expression, toDate("2022-10-12"));
+
+        TemporalAccessor parseResult = ISO_OFFSET_DATE_TIME.parse("2020-01-01T09:39:05Z");
+        long timestamp = TimeUnit.DAYS.toMicros(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MICRO_OF_DAY);
+        expression = new Constant(timestamp, createTimestampType(3));
+        assertRewrite(expression, toDate("2020-01-01T09:39:05"));
+
+        parseResult = ISO_OFFSET_DATE_TIME.parse("2003-01-01T05:27:35.495Z");
+        long timestampWithZone = packDateTimeWithZone(parseResult.getLong(INSTANT_SECONDS) * 1000 + parseResult.getLong(MILLI_OF_SECOND), getTimeZoneKey(ZoneId.from(parseResult).getId()));
+        expression = new Constant(timestampWithZone, createTimestampWithTimeZoneType(3));
+        assertRewrite(expression, toDate("2003-01-01T05:27:35.495"));
+    }
+
+    @Test
+    public void testRewriteObjectIdConstant()
+    {
+        ConnectorExpression expression = new Constant(Slices.wrappedBuffer(new ObjectId("6216f0c6c432d45190f25e7c").toByteArray()), OBJECT_ID);
+        assertRewrite(expression, toObjectId("6216f0c6c432d45190f25e7c"));
+    }
+
+    @Test(dataProvider = "typeProvider")
+    public void testRewriteNullConstant(Type type)
+    {
+        ConnectorExpression nullValue = new Constant(null, type);
+        assertRewrite(nullValue, null);
+    }
+
+    @DataProvider
+    public static Object[][] typeProvider()
+    {
+        return new Object[][] {
+                {BOOLEAN},
+                {TINYINT},
+                {SMALLINT},
+                {INTEGER},
+                {BIGINT},
+                {createDecimalType(9)}, // ShortDecimalType
+                {createDecimalType(34)}, // LongDecimalType
+                {createCharType(3)},
+                {VARCHAR},
+                {OBJECT_ID},
+                {createTimeType(12)},
+                {DATE},
+                {createTimestampType(6)}, // ShortTimestampType
+                {createTimestampWithTimeZoneType(3)}, // ShortTimestampWithTimeZoneType
+        };
+    }
+
+    @Test(dataProvider = "unsupportedTypeProvider")
+    public void testRewriteUnsupportedConstantType(Type type)
+    {
+        ConnectorExpression dummyConstant = new Constant(new Object(), type);
+        assertThat(mongoExpressionRewriter.rewrite(connectorSession, dummyConstant, ImmutableMap.of()))
+                .isEmpty();
+    }
+
+    @DataProvider
+    public static Object[][] unsupportedTypeProvider()
+    {
+        return new Object[][] {
+                {VARBINARY},
+                {REAL},
+                {DOUBLE},
+                {createTimeWithTimeZoneType(3)}, // ShortTimeWithTimeZoneType
+                {createTimeWithTimeZoneType(12)}, // LongTimeWithTimeZoneType
+                {createTimestampType(9)}, // LongTimestampType
+                {createTimestampWithTimeZoneType(6)}, // LongTimestampWithTimeZoneType
+        };
+    }
+
+    @Test
+    public void testRewriteVariable()
+    {
+        ConnectorExpression expression = new Variable("col", BIGINT);
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        assertRewrite(expression, "$col", assignments);
+    }
+
+    @Test
+    public void testRewriteIsNull()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression expression = new Call(BOOLEAN, IS_NULL_FUNCTION_NAME, ImmutableList.of(variable));
+        assertRewrite(
+                expression,
+                documentOf("$or", ImmutableList.of(
+                        documentOf("$eq", Arrays.asList("$col", null)),
+                        documentOf("$eq", Arrays.asList("$col", documentOf("$undefined", true))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteIsNotNull()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression notExpression = new Call(BOOLEAN, IS_NULL_FUNCTION_NAME, ImmutableList.of(variable));
+        ConnectorExpression isNotNullExpression = new Call(BOOLEAN, NOT_FUNCTION_NAME, ImmutableList.of(notExpression));
+        assertRewrite(
+                isNotNullExpression,
+                documentOf("$not", ImmutableList.of(
+                        documentOf("$or", ImmutableList.of(
+                                documentOf("$eq", Arrays.asList("$col", null)),
+                                documentOf("$eq", Arrays.asList("$col", documentOf("$undefined", true))))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteIn()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        List<ConnectorExpression> constants = ImmutableList.of(
+                new Constant(10, BIGINT),
+                new Constant(15, BIGINT));
+        ConnectorExpression arrayExpression = new Call(BOOLEAN, ARRAY_CONSTRUCTOR_FUNCTION_NAME, constants);
+        ConnectorExpression expression = new Call(BOOLEAN, IN_PREDICATE_FUNCTION_NAME, ImmutableList.of(variable, arrayExpression));
+        assertRewrite(expression, documentOf("$in", ImmutableList.of("$col", ImmutableList.of(10, 15))), assignments);
+    }
+
+    @Test
+    public void testRewriteComparison()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression expression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(expression, documentOf("$eq", ImmutableList.of("$col", 10)), assignments);
+
+        expression = new Call(BOOLEAN, NOT_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                expression,
+                documentOf("$and", ImmutableList.of(
+                        documentOf("$ne", ImmutableList.of("$col", 10)),
+                        documentOf("$gt", Arrays.asList("$col", null)),
+                        documentOf("$gt", Arrays.asList(10, null)))),
+                assignments);
+
+        expression = new Call(BOOLEAN, LESS_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                expression,
+                documentOf("$and", ImmutableList.of(
+                        documentOf("$lt", ImmutableList.of("$col", 10)),
+                        documentOf("$gt", Arrays.asList("$col", null)),
+                        documentOf("$gt", Arrays.asList(10, null)))),
+                assignments);
+
+        expression = new Call(BOOLEAN, GREATER_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(expression, documentOf("$gt", ImmutableList.of("$col", 10)), assignments);
+
+        expression = new Call(BOOLEAN, LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                expression,
+                documentOf("$and", ImmutableList.of(
+                        documentOf("$lte", ImmutableList.of("$col", 10)),
+                        documentOf("$gt", Arrays.asList("$col", null)),
+                        documentOf("$gt", Arrays.asList(10, null)))),
+                assignments);
+
+        expression = new Call(BOOLEAN, GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(expression, documentOf("$gte", ImmutableList.of("$col", 10)), assignments);
+    }
+
+    @Test
+    public void testRewriteLogicalExpression()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of(
+                "col1", createColumnHandle("col1", BIGINT),
+                "col2", createColumnHandle("col2", BIGINT));
+        ConnectorExpression variable1 = new Variable("col1", BIGINT);
+        ConnectorExpression constant1 = new Constant(10, BIGINT);
+        ConnectorExpression variable2 = new Variable("col2", BIGINT);
+        ConnectorExpression constant2 = new Constant(20, BIGINT);
+
+        ConnectorExpression leftExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable1, constant1));
+        ConnectorExpression rightExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable2, constant2));
+
+        ConnectorExpression logicalExpression = new Call(BOOLEAN, OR_FUNCTION_NAME, ImmutableList.of(leftExpression, rightExpression));
+        assertRewrite(logicalExpression, documentOf("$or", ImmutableList.of(documentOf("$eq", ImmutableList.of("$col1", 10)), documentOf("$eq", ImmutableList.of("$col2", 20)))), assignments);
+
+        logicalExpression = new Call(BOOLEAN, AND_FUNCTION_NAME, ImmutableList.of(leftExpression, rightExpression));
+        assertRewrite(logicalExpression, documentOf("$and", ImmutableList.of(documentOf("$eq", ImmutableList.of("$col1", 10)), documentOf("$eq", ImmutableList.of("$col2", 20)))), assignments);
+    }
+
+    private void assertRewrite(ConnectorExpression expression, Object expectedValue)
+    {
+        assertRewrite(expression, expectedValue, ImmutableMap.of());
+    }
+
+    private void assertRewrite(ConnectorExpression expression, Object expectedValue, Map<String, ColumnHandle> assignments)
+    {
+        Optional<MongoExpression> actualExpression = mongoExpressionRewriter.rewrite(connectorSession, expression, assignments);
+        Optional<MongoExpression> expectedExpression = Optional.of(new MongoExpression(expectedValue));
+        assertThat(actualExpression).isEqualTo(expectedExpression);
+    }
+
+    private static MongoColumnHandle createColumnHandle(String baseName, Type type, String... dereferenceNames)
+    {
+        return new MongoColumnHandle(
+                baseName,
+                ImmutableList.copyOf(dereferenceNames),
+                type,
+                false,
+                false,
+                Optional.empty());
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -342,6 +342,7 @@ public class TestMongoConnectorTest
                 {"integer '3'"},
                 {"bigint '4'"},
                 {"'test'"},
+                {"char 'test'"},
                 {"objectid('6216f0c6c432d45190f25e7c')"},
                 {"date '1970-01-01'"},
                 {"time '00:00:00.000'"},

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -122,6 +122,7 @@ public class TestMongoTableHandle
                 remoteTableName,
                 Optional.empty(),
                 TupleDomain.all(),
+                ImmutableList.of(),
                 projectedColumns,
                 OptionalInt.empty());
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


This PR covers use cases for connector expression Filter pushdown:

- Complex Filter which can not represent by TupleDomain
- `json_extract_scalar`
- `from_iso8601_timestamp`
- `from_iso8601_date`

Covered Logical operator:

- `OR`, `AND`

Covered Comparision Operator:

- `=`, `!=`, `<`, `>`, `>=`, `<=`

Other Operators:

- `IN`
- `IS NULL`
- `IS NOT NULL`

Covered Type:

- `BooleanType`
- `ObjectIdType`
- `CharType`, `VarcharType`
- `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `DecimalType`
- `TimeType`, `DateType`, `ShortTimestampType`, `ShortTimestampWithTimeZoneType`

TODO: Fix below
```
testJsonExtractScalarPredicatePushdownWithNullAndMissingField
testComplexExpressionPredicatePushdownWithMismatchedDataType
```
TODO: support for `CAST` as follow up PR

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
(X) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Mongodb
* Fix some things. ({issue}`issuenumber`)
```
