### PR TITLE
Suppress warning generated by WebUiStaticResource#getRoot

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WebUiStaticResource.java
@@ -36,7 +36,6 @@ public class WebUiStaticResource
 {
     @ResourceSecurity(PUBLIC)
     @GET
-    @Path("/")
     public Response getRoot()
     {
         return Response.seeOther(URI.create("/ui/")).build();


### PR DESCRIPTION
## Description

Remove the following warning caused by an extra `@Path` annotation.

```
pod/trino-coordinator-0: 2023-07-18T14:17:22.055Z	WARN	main	org.glassfish.jersey.internal.Errors	The following warnings have been detected: WARNING: The (sub)resource method getRoot in io.trino.server.ui.WebUiStaticResource contains empty path annotation.
```

## Additional context and related issues

For your information,
- https://docs.oracle.com/javaee/7/api/javax/ws/rs/Path.html
- https://stackoverflow.com/questions/33513654/warning-the-subresource-method-contains-empty-path-annotation

## Release notes

( x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text: