### PR TITLE
Add dynamic filter before splits

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -498,8 +498,8 @@ public class SqlTask
             }
             // taskExecution can still be null if the creation was skipped
             if (taskExecution != null) {
-                taskExecution.addSplitAssignments(splitAssignments);
                 taskExecution.getTaskContext().addDynamicFilter(dynamicFilterDomains);
+                taskExecution.addSplitAssignments(splitAssignments);
             }
 
             // update speculative flag


### PR DESCRIPTION
This allows for newly created drivers
to get the most recent DFs.