### PR TITLE
Disallow dropping last non-partition column in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1426,6 +1426,9 @@ public class DeltaLakeMetadata
         if (columns.size() == columnNames.size()) {
             throw new ColumnNotFoundException(table.schemaTableName(), dropColumnName);
         }
+        if (columnNames.size() == partitionColumns.size()) {
+            throw new TrinoException(NOT_SUPPORTED, "Dropping the last non-partition column is unsupported");
+        }
         Map<String, String> physicalColumnNameMapping = columns.stream()
                 .collect(toImmutableMap(DeltaLakeColumnMetadata::getName, DeltaLakeColumnMetadata::getPhysicalName));
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -392,6 +392,17 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot drop column from table using column mapping mode NONE");
     }
 
+    @Test
+    public void testDropLastNonPartitionColumn()
+    {
+        String tableName = "test_drop_last_non_partition_column_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + "(data int, part int) WITH (partitioned_by = ARRAY['part'], column_mapping_mode = 'name')");
+
+        assertQueryFails("ALTER TABLE " + tableName + " DROP COLUMN data", "Dropping the last non-partition column is unsupported");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
     @Override
     public void testRenameColumn()
     {


### PR DESCRIPTION
## Description

Follow-up of #18354
Filed Delta Lake issue at https://github.com/delta-io/delta/issues/1929

## Release notes

(x) This is not user-visible or docs only and no release notes are required.