### PR TITLE
Support predicate pushdown on char and decimal type in mongodb

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -50,6 +50,7 @@ import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.RowFieldName;
@@ -90,6 +91,7 @@ import static io.trino.plugin.mongodb.ptf.Query.parseFilter;
 import static io.trino.spi.HostAddress.fromParts;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
@@ -667,6 +669,11 @@ public class MongoSession
 
         if (type instanceof ObjectIdType) {
             return Optional.of(new ObjectId(((Slice) trinoNativeValue).getBytes()));
+        }
+
+        if (type instanceof CharType charType) {
+            Slice slice = padSpaces(((Slice) trinoNativeValue), charType);
+            return Optional.of(slice.toStringUtf8());
         }
 
         if (type instanceof VarcharType) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -51,6 +51,9 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.NamedTypeSignature;
 import io.trino.spi.type.RowFieldName;
@@ -62,6 +65,7 @@ import io.trino.spi.type.TypeSignatureParameter;
 import io.trino.spi.type.VarcharType;
 import org.bson.Document;
 import org.bson.types.Binary;
+import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
 import java.time.Instant;
@@ -665,6 +669,13 @@ public class MongoSession
 
         if (type == BIGINT) {
             return Optional.of(trinoNativeValue);
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(Decimal128.parse(Decimals.toString((long) trinoNativeValue, decimalType.getScale())));
+            }
+            return Optional.of(Decimal128.parse(Decimals.toString((Int128) trinoNativeValue, decimalType.getScale())));
         }
 
         if (type instanceof ObjectIdType) {

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
+import io.trino.spi.type.CharType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -52,6 +53,9 @@ public final class TypeUtils
 
     public static boolean isPushdownSupportedType(Type type)
     {
-        return type instanceof VarcharType || type instanceof ObjectIdType || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
+        return type instanceof CharType
+                || type instanceof VarcharType
+                || type instanceof ObjectIdType
+                || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -55,6 +56,7 @@ public final class TypeUtils
     {
         return type instanceof CharType
                 || type instanceof VarcharType
+                || type instanceof DecimalType
                 || type instanceof ObjectIdType
                 || PUSHDOWN_SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -327,8 +327,12 @@ public class TestMongoConnectorTest
     public void testPredicatePushdown(String value)
     {
         try (TestTable table = new TestTable(getQueryRunner()::execute, "test_predicate_pushdown", "AS SELECT %s col".formatted(value))) {
-            assertThat(query("SELECT * FROM " + table.getName() + " WHERE col = " + value + ""))
-                    .isFullyPushedDown();
+            testPredicatePushdown(table.getName(), "col = " + value);
+            testPredicatePushdown(table.getName(), "col != " + value);
+            testPredicatePushdown(table.getName(), "col < " + value);
+            testPredicatePushdown(table.getName(), "col > " + value);
+            testPredicatePushdown(table.getName(), "col <= " + value);
+            testPredicatePushdown(table.getName(), "col >= " + value);
         }
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -341,6 +341,8 @@ public class TestMongoConnectorTest
                 {"smallint '2'"},
                 {"integer '3'"},
                 {"bigint '4'"},
+                {"decimal '3.14'"},
+                {"decimal '1234567890.123456789'"},
                 {"'test'"},
                 {"char 'test'"},
                 {"objectid('6216f0c6c432d45190f25e7c')"},
@@ -382,6 +384,43 @@ public class TestMongoConnectorTest
                     .matches("VALUES 7, 8, 9")
                     .isFullyPushedDown();
         }
+    }
+
+    @Test
+    public void testHighPrecisionDecimalPredicate()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_high_precision_decimal_predicate",
+                "(col DECIMAL(34, 0))",
+                Arrays.asList("decimal '3141592653589793238462643383279502'", null))) {
+            // Filter clause with 38 precision decimal value
+            String predicateValue = "decimal '31415926535897932384626433832795028841'";
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE col = " + predicateValue))
+                    // With EQUAL operator when column type precision is less than the predicate value's precision,
+                    // PushPredicateIntoTableScan#pushFilterIntoTableScan returns ValuesNode. So It is not possible to verify isFullyPushedDown.
+                    .returnsEmptyResult();
+            testPredicatePushdown(table.getName(), "col != " + predicateValue);
+            testPredicatePushdown(table.getName(), "col < " + predicateValue);
+            testPredicatePushdown(table.getName(), "col > " + predicateValue);
+            testPredicatePushdown(table.getName(), "col <= " + predicateValue);
+            testPredicatePushdown(table.getName(), "col >= " + predicateValue);
+
+            // Filter clause with 34 precision decimal value
+            predicateValue = "decimal '3141592653589793238462643383279502'";
+            testPredicatePushdown(table.getName(), "col = " + predicateValue);
+            testPredicatePushdown(table.getName(), "col != " + predicateValue);
+            testPredicatePushdown(table.getName(), "col < " + predicateValue);
+            testPredicatePushdown(table.getName(), "col > " + predicateValue);
+            testPredicatePushdown(table.getName(), "col <= " + predicateValue);
+            testPredicatePushdown(table.getName(), "col >= " + predicateValue);
+        }
+    }
+
+    private void testPredicatePushdown(String tableName, String whereClause)
+    {
+        assertThat(query("SELECT * FROM " + tableName + " WHERE " + whereClause))
+                .isFullyPushedDown();
     }
 
     @Test

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -342,12 +342,46 @@ public class TestMongoConnectorTest
                 {"integer '3'"},
                 {"bigint '4'"},
                 {"'test'"},
+                {"char 'test'"},
                 {"objectid('6216f0c6c432d45190f25e7c')"},
                 {"date '1970-01-01'"},
                 {"time '00:00:00.000'"},
                 {"timestamp '1970-01-01 00:00:00.000'"},
                 {"timestamp '1970-01-01 00:00:00.000 UTC'"},
         };
+    }
+
+    @Test
+    public void testPredicatePushdownCharWithPaddedSpace()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_predicate_pushdown_char_with_padded_space",
+                "(k, v) AS VALUES" +
+                        "   (-1, CAST(NULL AS char(3))), " +
+                        "   (0, CAST('' AS char(3)))," +
+                        "   (1, CAST(' ' AS char(3))), " +
+                        "   (2, CAST('  ' AS char(3))), " +
+                        "   (3, CAST('   ' AS char(3)))," +
+                        "   (4, CAST('x' AS char(3)))," +
+                        "   (5, CAST('x ' AS char(3)))," +
+                        "   (6, CAST('x  ' AS char(3)))," +
+                        "   (7, CAST('\0' AS char(3)))," +
+                        "   (8, CAST('\0 ' AS char(3)))," +
+                        "   (9, CAST('\0  ' AS char(3)))")) {
+            assertThat(query("SELECT k FROM " + table.getName() + " WHERE v = ''"))
+                    // The value is included because both sides of the comparison are coerced to char(3)
+                    .matches("VALUES 0, 1, 2, 3")
+                    .isFullyPushedDown();
+            assertThat(query("SELECT k FROM " + table.getName() + " WHERE v = 'x '"))
+                    // The value is included because both sides of the comparison are coerced to char(3)
+                    .matches("VALUES 4, 5, 6")
+                    .isFullyPushedDown();
+            assertThat(query("SELECT k FROM " + table.getName() + " WHERE v = '\0  '"))
+                    // The value is included because both sides of the comparison are coerced to char(3)
+                    .matches("VALUES 7, 8, 9")
+                    .isFullyPushedDown();
+        }
     }
 
     @Test


### PR DESCRIPTION
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Mongo
* Support predicate pushdown on `char` and `decimal` type. ({issue}`18382`)
```
