### PR TITLE
Rewrite partial top-n node to LimitNode or LastNNode

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
@@ -519,6 +524,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -211,6 +211,7 @@ public final class SystemSessionProperties
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
     public static final String IDLE_WRITER_MIN_DATA_SIZE_THRESHOLD = "idle_writer_min_data_size_threshold";
     public static final String CLOSE_IDLE_WRITERS_TRIGGER_DURATION = "close_idle_writers_trigger_duration";
+    public static final String ALLOW_PUSH_PARTIAL_TOP_N_TO_TABLE_SCAN = "allow_push_partial_top_n_to_table_scan";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1072,7 +1073,11 @@ public final class SystemSessionProperties
                 durationProperty(CLOSE_IDLE_WRITERS_TRIGGER_DURATION,
                         "The duration after which the writer operator tries to close the idle writers",
                         new Duration(5, SECONDS),
-                        true));
+                        true),
+                booleanProperty(ALLOW_PUSH_PARTIAL_TOP_N_TO_TABLE_SCAN,
+                        "Allow push partial sort to table scan.",
+                        false,
+                        false));
     }
 
     @Override
@@ -1204,6 +1209,11 @@ public final class SystemSessionProperties
     public static boolean isOptimizeMetadataQueries(Session session)
     {
         return session.getSystemProperty(OPTIMIZE_METADATA_QUERIES, Boolean.class);
+    }
+
+    public static boolean isPushPartialTopNIntoTableScan(Session session)
+    {
+        return session.getSystemProperty(ALLOW_PUSH_PARTIAL_TOP_N_TO_TABLE_SCAN, Boolean.class);
     }
 
     public static DataSize getQueryMaxMemory(Session session)

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -45,7 +45,6 @@ import io.trino.spi.connector.SampleType;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortItem;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -560,13 +559,11 @@ public interface Metadata
             List<SortItem> sortItems,
             Map<String, ColumnHandle> assignments);
 
-    /**
-     * Attempt to push down partial sort or top n to table scan.
-     */
     default Optional<PartialSortApplicationResult<TableHandle>> applyPartialSort(
             Session session,
             TableHandle tableHandle,
-            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -35,6 +35,7 @@ import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PartialSortApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RelationType;
@@ -44,6 +45,7 @@ import io.trino.spi.connector.SampleType;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -557,6 +559,17 @@ public interface Metadata
             long topNCount,
             List<SortItem> sortItems,
             Map<String, ColumnHandle> assignments);
+
+    /**
+     * Attempt to push down partial sort or top n to table scan.
+     */
+    default Optional<PartialSortApplicationResult<TableHandle>> applyPartialSort(
+            Session session,
+            TableHandle tableHandle,
+            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    {
+        return Optional.empty();
+    }
 
     Optional<TableFunctionApplicationResult<TableHandle>> applyTableFunction(Session session, TableFunctionHandle handle);
 

--- a/core/trino-main/src/main/java/io/trino/operator/LastNOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LastNOperator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.spi.Page;
+import io.trino.sql.planner.plan.PlanNodeId;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class LastNOperator
+        implements Operator
+{
+    public static class LastNOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final int count;
+        private boolean closed;
+
+        public LastNOperatorFactory(int operatorId, PlanNodeId planNodeId, int count)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.count = count;
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, LastNOperator.class.getSimpleName());
+            return new LastNOperator(operatorContext, count);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new LastNOperatorFactory(operatorId, planNodeId, count);
+        }
+    }
+
+    private enum State
+    {
+        NEEDS_INPUT,
+        FINISHED
+    }
+
+    private final OperatorContext operatorContext;
+    private long count;
+    private long totalPositions;
+    private State state = State.NEEDS_INPUT;
+    private long lastPageRowGroupId;
+    private final ArrayDeque<Page> outputPages;
+    private boolean canOutput;
+    private int remainingLimit;
+    private ArrayDeque<Page> currentQueue;
+    private ArrayDeque<ArrayDeque<Page>> totalQueue;
+
+    public LastNOperator(OperatorContext operatorContext, int count)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        checkArgument(count >= 0, "count must be at least zero");
+        this.count = count;
+        this.remainingLimit = count;
+        this.currentQueue = new ArrayDeque<>();
+        this.totalQueue = new ArrayDeque<>();
+        this.outputPages = new ArrayDeque<>();
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public void finish()
+    {
+        state = State.FINISHED;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return state == State.FINISHED && totalQueue == null;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return count > 0 && state != State.FINISHED;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        checkState(state == State.NEEDS_INPUT, "Operator is already finishing");
+        long currPageRowGroupId = getCurrentPageRowGroupId(page);
+        if (currPageRowGroupId != lastPageRowGroupId) {
+            totalPositions = 0;
+            if (!currentQueue.isEmpty()) {
+                totalQueue.add(reverseDeque(currentQueue));
+                int countInLastRowGroup = 0;
+                for (Page currPage : currentQueue) {
+                    countInLastRowGroup += currPage.getPositionCount();
+                }
+                count = count - countInLastRowGroup;
+                currentQueue = new ArrayDeque<>();
+            }
+        }
+        lastPageRowGroupId = currPageRowGroupId;
+        totalPositions += page.getPositionCount();
+        currentQueue.add(page);
+        while (!currentQueue.isEmpty() && totalPositions - currentQueue.peek().getPositionCount() >= count) {
+            totalPositions -= currentQueue.remove().getPositionCount();
+        }
+    }
+
+    private ArrayDeque<Page> reverseDeque(ArrayDeque<Page> deque)
+    {
+        ArrayDeque<Page> reversedDeque = new ArrayDeque<>();
+        Iterator<Page> descendingIterator = deque.descendingIterator();
+        while (descendingIterator.hasNext()) {
+            reversedDeque.add(descendingIterator.next());
+        }
+        return reversedDeque;
+    }
+
+    private long getCurrentPageRowGroupId(Page page)
+    {
+        return page.getBlock(page.getChannelCount() - 1).getLong(0, 0);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (count > 0 && state != State.FINISHED) {
+            return null;
+        }
+        if (!canOutput) {
+            if (!currentQueue.isEmpty()) {
+                totalQueue.add(reverseDeque(currentQueue));
+            }
+            ArrayDeque<Page> pages = totalQueue.stream().flatMap(Collection::stream).collect(Collectors.toCollection(ArrayDeque::new));
+            for (Page page : pages) {
+                if (page.getPositionCount() <= remainingLimit) {
+                    remainingLimit = remainingLimit - page.getPositionCount();
+                    outputPages.add(page);
+                }
+                else {
+                    Page region = page.getRegion(page.getPositionCount() - remainingLimit, remainingLimit);
+                    outputPages.add(region);
+                }
+            }
+            canOutput = true;
+        }
+        if (outputPages.isEmpty()) {
+            state = State.FINISHED;
+            totalQueue = null;
+            return null;
+        }
+        return outputPages.removeFirst();
+    }
+
+    @Override
+    public void close()
+            throws Exception
+    {
+        totalQueue = null;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/DynamicTupleFilterFactory.java
@@ -89,7 +89,7 @@ public class DynamicTupleFilterFactory
     public OperatorFactory filterWithTuple(Page tuplePage)
     {
         Supplier<PageProcessor> processor = createPageProcessor(tuplePage.getColumns(tupleFilterChannels), OptionalInt.empty());
-        return FilterAndProjectOperator.createOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, DataSize.ofBytes(0), 0);
+        return FilterAndProjectOperator.createOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, DataSize.ofBytes(0), 0, false);
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
@@ -64,9 +64,10 @@ public final class MergePages
             long minPageSizeInBytes,
             int minRowCount,
             WorkProcessor<Page> pages,
-            AggregatedMemoryContext memoryContext)
+            AggregatedMemoryContext memoryContext,
+            boolean iteratorEnd)
     {
-        return mergePages(types, minPageSizeInBytes, minRowCount, DEFAULT_MAX_PAGE_SIZE_IN_BYTES, pages, memoryContext);
+        return mergePages(types, minPageSizeInBytes, minRowCount, DEFAULT_MAX_PAGE_SIZE_IN_BYTES, pages, memoryContext, iteratorEnd);
     }
 
     public static WorkProcessor<Page> mergePages(
@@ -75,8 +76,12 @@ public final class MergePages
             int minRowCount,
             int maxPageSizeInBytes,
             WorkProcessor<Page> pages,
-            AggregatedMemoryContext memoryContext)
+            AggregatedMemoryContext memoryContext,
+            boolean iteratorEnd)
     {
+        if (iteratorEnd) {
+            return pages;
+        }
         List<Type> typeList = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         WorkProcessor.Transformation<Page, Page> mergingTransform;
         if (typeList.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -95,7 +95,7 @@ public class PageProcessor
     @VisibleForTesting
     public Iterator<Optional<Page>> process(ConnectorSession session, DriverYieldSignal yieldSignal, LocalMemoryContext memoryContext, Page page)
     {
-        WorkProcessor<Page> processor = createWorkProcessor(session, yieldSignal, memoryContext, new PageProcessorMetrics(), page);
+        WorkProcessor<Page> processor = createWorkProcessor(session, yieldSignal, memoryContext, new PageProcessorMetrics(), page, false);
         return processor.yieldingIterator();
     }
 
@@ -104,7 +104,8 @@ public class PageProcessor
             DriverYieldSignal yieldSignal,
             LocalMemoryContext memoryContext,
             PageProcessorMetrics metrics,
-            Page page)
+            Page page,
+            boolean iteratorEnd)
     {
         // limit the scope of the dictionary ids to just one page
         dictionarySourceIdFunction.reset();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -164,6 +164,7 @@ import io.trino.sql.planner.iterative.rule.PushMergeWriterUpdateIntoConnector;
 import io.trino.sql.planner.iterative.rule.PushOffsetThroughProject;
 import io.trino.sql.planner.iterative.rule.PushPartialAggregationThroughExchange;
 import io.trino.sql.planner.iterative.rule.PushPartialAggregationThroughJoin;
+import io.trino.sql.planner.iterative.rule.PushPartialTopNIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushPredicateThroughProjectIntoRowNumber;
 import io.trino.sql.planner.iterative.rule.PushPredicateThroughProjectIntoWindow;
@@ -952,6 +953,16 @@ public class PlanOptimizers
 
         // Optimizers above this don't understand local exchanges, so be careful moving this.
         builder.add(new AddLocalExchanges(plannerContext, typeAnalyzer));
+
+        // must run after AddLocalExchanges.
+        builder.add(
+                new IterativeOptimizer(
+                        plannerContext,
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.of(new PushPartialTopNIntoTableScan(plannerContext))));
+
         // UseNonPartitionedJoinLookupSource needs to run after AddLocalExchanges since it operates on ExchangeNodes added by this optimizer.
         builder.add(new IterativeOptimizer(
                 plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -41,6 +41,7 @@ import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.GroupIdNode;
 import io.trino.sql.planner.plan.IndexJoinNode;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.LastNNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.MarkDistinctNode;
 import io.trino.sql.planner.plan.MergeProcessorNode;
@@ -378,6 +379,12 @@ public class SplitSourceFactory
 
         @Override
         public Map<PlanNodeId, SplitSource> visitLimit(LimitNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitLastN(LastNNode node, Void context)
         {
             return node.getSource().accept(this, context);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialTopNIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialTopNIntoTableScan.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.PartialSortApplicationResult;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.GroupReference;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
+import io.trino.sql.planner.plan.ExchangeNode;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.LastNNode;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.planner.plan.PlanVisitor;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.sql.planner.plan.TopNNode;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.isPushPartialTopNIntoTableScan;
+import static io.trino.sql.planner.plan.Patterns.TopN.step;
+import static io.trino.sql.planner.plan.Patterns.exchange;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.lang.Math.toIntExact;
+
+/**
+ * This rule rewrites the partial TopNNode to LimitNode or LastNNode.
+ *
+ * <p>
+ * Transforms:
+ * <pre> {@code
+ *    Top[partial]
+ *      Project
+ *        Filter
+ *          TableScan
+ *        }
+ * </pre>
+ * into:
+ * <pre> {@code
+ *    Limit / LastN
+ *      Project
+ *        Filter
+ *         TableScan
+ *    }
+ *  </pre>
+ *
+ */
+public class PushPartialTopNIntoTableScan
+        implements Rule<ExchangeNode>
+{
+    private static final Capture<TopNNode> TOP_N_NODE = Capture.newCapture();
+    private final Metadata metadata;
+
+    // We need to ensure that the source node of TopN(partial) is either a Project, a Filter, or a TableScan.
+    // In addition, if there are nodes other than TableScan, Project, Filter when traversing from TopN(partial),
+    // then the optimization can not apply to the logical plan.
+    private static final Pattern<ExchangeNode> PATTERN = exchange()
+            .matching(exchange -> exchange.getScope() == ExchangeNode.Scope.REMOTE && exchange.getType() == ExchangeNode.Type.GATHER)
+            .with(source().matching(
+                    Pattern.typeOf(TopNNode.class).capturedAs(TOP_N_NODE).with(step().equalTo(TopNNode.Step.PARTIAL))
+                            .with(source().matching(
+                                    planNode -> planNode instanceof TableScanNode || planNode instanceof FilterNode || planNode instanceof ProjectNode))));
+
+    public PushPartialTopNIntoTableScan(PlannerContext plannerContext)
+    {
+        this.metadata = plannerContext.getMetadata();
+    }
+
+    @Override
+    public Pattern<ExchangeNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isPushPartialTopNIntoTableScan(session);
+    }
+
+    @Override
+    public Result apply(ExchangeNode node, Captures captures, Context context)
+    {
+        TopNNode topNNode = captures.get(TOP_N_NODE);
+        Optional<TableScanNode> tableScanNode = findTableScanNode(node, context);
+        if (tableScanNode.isEmpty()) {
+            return Result.empty();
+        }
+        Session session = context.getSession();
+        TableHandle table = tableScanNode.get().getTable();
+        Visitor visitor = new Visitor(context.getLookup());
+        Boolean accept = topNNode.accept(visitor, null);
+        if (!accept) {
+            return Result.empty();
+        }
+        Optional<PartialSortApplicationResult<TableHandle>> result = metadata.applyPartialSort(session, table, visitor.getColumnHandleSortOrderMap());
+        if (result.isEmpty() || !result.get().allSorted()) {
+            return Result.empty();
+        }
+        PartialSortApplicationResult<TableHandle> partialSortResult = result.get();
+        TableHandle newTable = partialSortResult.getHandle();
+        PlanNode source = topNNode.getSource();
+
+        // Support the following scenarios
+        // Read ASC NULL LAST, write ASC NULL LAST or DESC NULL FIRST
+        // Read ASC NULL FIRST, write ASC NULL FIRST or DESC NULL LAST
+        // Read DESC NULL LAST, write DESC NULL LAST or ASC NULL FIRST
+        // Read DESC NULL FIRST, write DESC NULL FIRST or ASC NULL LAST
+        if (partialSortResult.isSameSortDirection() && partialSortResult.isSameNullOrdering()) {
+            LimitNode limitNode = new LimitNode(
+                    topNNode.getId(),
+                    source.accept(new ReplaceTableScans(context.getLookup()), newTable),
+                    topNNode.getCount(),
+                    Optional.empty(),
+                    true,
+                    ImmutableList.of());
+            return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(limitNode)));
+        }
+        if (!partialSortResult.isSameSortDirection() && !partialSortResult.isSameNullOrdering()) {
+            LastNNode lastNNode = new LastNNode(
+                    topNNode.getId(),
+                    source.accept(new ReplaceTableScans(context.getLookup()), newTable),
+                    toIntExact(topNNode.getCount()));
+            return Result.ofPlanNode(node.replaceChildren(ImmutableList.of(lastNNode)));
+        }
+        return Result.empty();
+    }
+
+    private static class ReplaceTableScans
+            extends PlanVisitor<PlanNode, TableHandle>
+    {
+        private final Lookup lookup;
+
+        public ReplaceTableScans(Lookup lookup)
+        {
+            this.lookup = lookup;
+        }
+
+        @Override
+        public PlanNode visitGroupReference(GroupReference node, TableHandle context)
+        {
+            return lookup.resolve(node).accept(this, context);
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, TableHandle context)
+        {
+            return node.replaceChildren(Collections.singletonList(node.getSource().accept(this, context)));
+        }
+
+        @Override
+        public PlanNode visitProject(ProjectNode node, TableHandle context)
+        {
+            return node.replaceChildren(Collections.singletonList(node.getSource().accept(this, context)));
+        }
+
+        @Override
+        public PlanNode visitTableScan(TableScanNode node, TableHandle newTableHandle)
+        {
+            return new TableScanNode(
+                    node.getId(),
+                    newTableHandle,
+                    node.getOutputSymbols(),
+                    node.getAssignments(),
+                    node.getEnforcedConstraint(),
+                    node.getStatistics(),
+                    node.isUpdateTarget(),
+                    node.getUseConnectorNodePartitioning());
+        }
+
+        @Override
+        protected PlanNode visitPlan(PlanNode node, TableHandle context)
+        {
+            return node;
+        }
+    }
+
+    private static class Visitor
+            extends PlanVisitor<Boolean, Void>
+    {
+        private final Lookup lookup;
+
+        private Map<Symbol, ColumnHandle> assignments;
+
+        private final Map<ColumnHandle, SortOrder> columnHandleSortOrderMap;
+
+        private Visitor(Lookup lookup)
+        {
+            this.lookup = lookup;
+            this.assignments = new HashMap<>();
+            this.columnHandleSortOrderMap = new HashMap<>();
+        }
+
+        public Map<ColumnHandle, SortOrder> getColumnHandleSortOrderMap()
+        {
+            return columnHandleSortOrderMap;
+        }
+
+        @Override
+        public Boolean visitTopN(TopNNode node, Void context)
+        {
+            if (node.getOrderingScheme().getOrderBy().size() != 1 || !node.getSource().accept(this, context)) {
+                return false;
+            }
+            Symbol symbol = node.getOrderingScheme().getOrderBy().get(0);
+            if (!assignments.containsKey(symbol)) {
+                return false;
+            }
+            SortOrder ordering = node.getOrderingScheme().getOrdering(symbol);
+            columnHandleSortOrderMap.put(assignments.get(symbol), ordering);
+            return true;
+        }
+
+        @Override
+        public Boolean visitTableScan(TableScanNode node, Void context)
+        {
+            this.assignments = node.getAssignments();
+            return true;
+        }
+
+        @Override
+        public Boolean visitFilter(FilterNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Boolean visitProject(ProjectNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        protected Boolean visitPlan(PlanNode node, Void context)
+        {
+            return false;
+        }
+
+        @Override
+        public Boolean visitGroupReference(GroupReference node, Void context)
+        {
+            return lookup.resolve(node).accept(this, context);
+        }
+    }
+
+    private Optional<TableScanNode> findTableScanNode(ExchangeNode node, Context context)
+    {
+        return PlanNodeSearcher.searchFrom(node, context.getLookup()).where(planNode -> planNode instanceof TableScanNode).findFirst();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/LastNNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/LastNNode.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.trino.sql.planner.Symbol;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+@Immutable
+public class LastNNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final int count;
+
+    @JsonCreator
+    public LastNNode(@JsonProperty("id") PlanNodeId id,
+                     @JsonProperty("source") PlanNode source,
+                     @JsonProperty("count") int count)
+    {
+        super(id);
+        this.source = source;
+        this.count = count;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @Override
+    public List<Symbol> getOutputSymbols()
+    {
+        return source.getOutputSymbols();
+    }
+
+    @JsonProperty("count")
+    public int getCount()
+    {
+        return count;
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitLastN(this, context);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        return new LastNNode(getId(), Iterables.getOnlyElement(newChildren), count);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
@@ -71,6 +71,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = PatternRecognitionNode.class, name = "patternRecognition"),
         @JsonSubTypes.Type(value = TableFunctionNode.class, name = "tableFunction"),
         @JsonSubTypes.Type(value = TableFunctionProcessorNode.class, name = "tableFunctionProcessor"),
+        @JsonSubTypes.Type(value = LastNNode.class, name = "lastN"),
 })
 public abstract class PlanNode
 {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
@@ -44,6 +44,11 @@ public abstract class PlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
+    public R visitLastN(LastNNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitOutput(OutputNode node, C context)
     {
         return visitPlan(node, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -81,6 +81,7 @@ import io.trino.sql.planner.plan.IndexJoinNode;
 import io.trino.sql.planner.plan.IndexSourceNode;
 import io.trino.sql.planner.plan.IntersectNode;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.LastNNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.MarkDistinctNode;
 import io.trino.sql.planner.plan.MergeProcessorNode;
@@ -822,6 +823,12 @@ public class PlanPrinter
                             "inputPreSortedBy", formatSymbols(node.getPreSortedInputs())),
                     context.tag());
             return processChildren(node, new Context());
+        }
+
+        @Override
+        public Void visitLastN(LastNNode node, Context context)
+        {
+            return super.visitLastN(node, context);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -39,6 +39,7 @@ import io.trino.sql.planner.plan.IndexJoinNode;
 import io.trino.sql.planner.plan.IndexSourceNode;
 import io.trino.sql.planner.plan.IntersectNode;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.LastNNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.MarkDistinctNode;
 import io.trino.sql.planner.plan.MergeProcessorNode;
@@ -538,6 +539,14 @@ public final class ValidateDependenciesChecker
 
             checkDependencies(source.getOutputSymbols(), node.getOutputSymbols(), "Invalid node. Output column dependencies (%s) not in source plan output (%s)", node.getOutputSymbols(), source.getOutputSymbols());
 
+            return null;
+        }
+
+        @Override
+        public Void visitLastN(LastNNode node, Set<Symbol> boundSymbols)
+        {
+            PlanNode source = node.getSource();
+            source.accept(this, boundSymbols); // visit child
             return null;
         }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -48,6 +48,7 @@ import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PartialSortApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
@@ -60,6 +61,7 @@ import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1239,6 +1241,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("applyTopN", handle);
         try (var ignored = scopedSpan(span)) {
             return delegate.applyTopN(session, handle, topNCount, sortItems, assignments);
+        }
+    }
+
+    @Override
+    public Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(ConnectorSession session, ConnectorTableHandle tableHandle, Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    {
+        Span span = startSpan("applyPartialSort", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -61,7 +61,6 @@ import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1245,11 +1244,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
-    public Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(ConnectorSession session, ConnectorTableHandle tableHandle, Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    public Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
     {
         Span span = startSpan("applyPartialSort", tableHandle);
         try (var ignored = scopedSpan(span)) {
-            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
+            return delegate.applyPartialSort(session, tableHandle, sortItems, assignments);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -73,7 +73,6 @@ import io.trino.spi.connector.SampleType;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortItem;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1024,11 +1023,15 @@ public class TracingMetadata
     }
 
     @Override
-    public Optional<PartialSortApplicationResult<TableHandle>> applyPartialSort(Session session, TableHandle tableHandle, Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    public Optional<PartialSortApplicationResult<TableHandle>> applyPartialSort(
+            Session session,
+            TableHandle tableHandle,
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
     {
         Span span = startSpan("applyPartialSort", tableHandle);
         try (var ignored = scopedSpan(span)) {
-            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
+            return delegate.applyPartialSort(session, tableHandle, sortItems, assignments);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -63,6 +63,7 @@ import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PartialSortApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RelationType;
@@ -72,6 +73,7 @@ import io.trino.spi.connector.SampleType;
 import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1018,6 +1020,15 @@ public class TracingMetadata
         Span span = startSpan("applyTopN", handle);
         try (var ignored = scopedSpan(span)) {
             return delegate.applyTopN(session, handle, topNCount, sortItems, assignments);
+        }
+    }
+
+    @Override
+    public Optional<PartialSortApplicationResult<TableHandle>> applyPartialSort(Session session, TableHandle tableHandle, Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    {
+        Span span = startSpan("applyPartialSort", tableHandle);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/RowPagesBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/RowPagesBuilder.java
@@ -17,10 +17,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.LongArrayBlock;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.Type;
 import io.trino.type.TypeTestUtils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,6 +79,22 @@ public class RowPagesBuilder
 
         pageBreak();
         Page page = SequencePageBuilder.createSequencePage(types, length, initialValues);
+        pages.add(page);
+        return this;
+    }
+
+    public RowPagesBuilder addSequencePageWithRowGroupId(int length, long rowGroupId, int... initialValues)
+    {
+        checkArgument(length > 0, "length must be at least 1");
+        checkArgument(rowGroupId >= 0, "length must be at least 0");
+        requireNonNull(initialValues, "initialValues is null");
+        checkArgument(initialValues.length == types.size(), "Expected %s initialValues, but got %s", types.size(), initialValues.length);
+
+        pageBreak();
+        Page page = SequencePageBuilder.createSequencePage(types, length, initialValues);
+        long[] values = new long[page.getPositionCount()];
+        Arrays.fill(values, rowGroupId);
+        page = page.appendColumn(new LongArrayBlock(page.getPositionCount(), Optional.empty(), values));
         pages.add(page);
         return this;
     }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -176,7 +176,8 @@ public class BenchmarkScanFilterAndProjectOperator
                     DynamicFilter.EMPTY,
                     types,
                     FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
-                    FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT);
+                    FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT,
+                    false);
         }
 
         public TaskContext createTaskContext()

--- a/core/trino-main/src/test/java/io/trino/operator/TestFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFilterAndProjectOperator.java
@@ -104,7 +104,8 @@ public class TestFilterAndProjectOperator
                 processor,
                 ImmutableList.of(VARCHAR, BIGINT),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), VARCHAR, BIGINT)
                 .row("0", 5L)
@@ -148,7 +149,8 @@ public class TestFilterAndProjectOperator
                 processor,
                 ImmutableList.of(BIGINT),
                 DataSize.of(64, KILOBYTE),
-                2);
+                2,
+                false);
 
         List<Page> expected = rowPagesBuilder(BIGINT)
                 .row(10L)

--- a/core/trino-main/src/test/java/io/trino/operator/TestLastNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestLastNOperator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.LastNOperator.LastNOperatorFactory;
+import io.trino.spi.Page;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.RowPagesBuilder.rowPagesBuilder;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
+@Test(singleThreaded = true)
+public class TestLastNOperator
+{
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+    private DriverContext driverContext;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed(getClass().getSimpleName() + "-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed(getClass().getSimpleName() + "-scheduledExecutor-%s"));
+        driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testPageWithRowGroupId()
+    {
+        List<Page> input = rowPagesBuilder(BIGINT)
+                .addSequencePageWithRowGroupId(2, 1, 6)
+                .addSequencePageWithRowGroupId(2, 2, 4)
+                .addSequencePageWithRowGroupId(3, 3, 1)
+                .build();
+        OperatorFactory operatorFactory = new LastNOperatorFactory(0, new PlanNodeId("test"), 2);
+
+        List<Page> expected = rowPagesBuilder(BIGINT).addSequencePageWithRowGroupId(2, 1, 6).build();
+
+        OperatorAssertion.assertOperatorEquals(operatorFactory, ImmutableList.of(BIGINT, BIGINT), driverContext, input, expected);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestScanFilterAndProjectOperator.java
@@ -133,7 +133,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -175,7 +176,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.of(64, KILOBYTE),
-                2);
+                2,
+                false);
 
         SourceOperator operator = factory.createOperator(newDriverContext());
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -220,7 +222,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -254,7 +257,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(VARCHAR),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -305,7 +309,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
@@ -370,7 +375,8 @@ public class TestScanFilterAndProjectOperator
                 DynamicFilter.EMPTY,
                 ImmutableList.of(BIGINT),
                 DataSize.ofBytes(0),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestMergePages.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestMergePages.java
@@ -51,7 +51,8 @@ public class TestMergePages
                 Integer.MAX_VALUE,
                 Integer.MAX_VALUE,
                 pagesSource(page),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
         assertFinishes(mergePages);
@@ -68,7 +69,8 @@ public class TestMergePages
                 page.getPositionCount(),
                 Integer.MAX_VALUE,
                 pagesSource(page),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
         assertFinishes(mergePages);
@@ -90,7 +92,8 @@ public class TestMergePages
                 page.getPositionCount() * 2,
                 Integer.MAX_VALUE,
                 pagesSource(page),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         assertThat(mergePages.process()).isTrue();
         assertThat(mergePages.isFinished()).isFalse();
@@ -115,7 +118,8 @@ public class TestMergePages
                 page.getPositionCount() + 1,
                 Integer.MAX_VALUE,
                 pagesSource(splits.get(0), splits.get(1)),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, page));
         assertFinishes(mergePages);
@@ -133,7 +137,8 @@ public class TestMergePages
                 bigPage.getPositionCount(),
                 Integer.MAX_VALUE,
                 pagesSource(smallPage, bigPage),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, smallPage));
         validateResult(mergePages, actualPage -> assertPageEquals(TYPES, actualPage, bigPage));
@@ -154,7 +159,8 @@ public class TestMergePages
                 page.getPositionCount() / 2 + 1,
                 toIntExact(page.getSizeInBytes()),
                 pagesSource(splits.get(0), splits.get(1), splits.get(0), splits.get(1)),
-                newSimpleAggregatedMemoryContext());
+                newSimpleAggregatedMemoryContext(),
+                false);
 
         validateResult(mergePages, actualPage -> assertPageEquals(types, actualPage, page));
         validateResult(mergePages, actualPage -> assertPageEquals(types, actualPage, page));

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1643,12 +1643,23 @@ public interface ConnectorMetadata
     }
 
     /**
-     * If the file is ordered, attempt to push down sort or topN to connector.
+     * Attempt to push down the partial sort into the table scan.
+     * <p>
+     * Connectors can indicate whether they don't support partial sort pushdown or that the action had no effect
+     * by returning {@link Optional#empty()}. Connectors should expect this method may be called multiple times.
+     * </p>
+     * <b>Note</b>: it's critical for connectors to return {@link Optional#empty()} if calling this method has no effect for that
+     * invocation, even if the connector generally supports partial sort pushdown. Doing otherwise can cause the optimizer
+     * to loop indefinitely.
+     * <p>
+     * If the connector can handle partial sort pushdown then it should return a non-empty result with "partial sort guaranteed"
+     * flag set to true.
      */
     default Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
-            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1643,6 +1643,17 @@ public interface ConnectorMetadata
     }
 
     /**
+     * If the file is ordered, attempt to push down sort or topN to connector.
+     */
+    default Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    {
+        return Optional.empty();
+    }
+
+    /**
      * Attempt to push down the table function invocation into the connector.
      * <p>
      * Connectors can indicate whether they don't support table function invocation pushdown or that the action had no

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/PartialSortApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/PartialSortApplicationResult.java
@@ -18,14 +18,14 @@ public class PartialSortApplicationResult<T>
     private final T handle;
     private final boolean sameSortDirection;
     private final boolean sameNullOrdering;
-    private final boolean allSorted;
+    private final boolean partialSortGuaranteed;
 
-    public PartialSortApplicationResult(T handle, boolean sortDirection, boolean nullOrdering, boolean allSorted)
+    public PartialSortApplicationResult(T handle, boolean sortDirection, boolean nullOrdering, boolean partialSortGuaranteed)
     {
         this.handle = handle;
         this.sameSortDirection = sortDirection;
         this.sameNullOrdering = nullOrdering;
-        this.allSorted = allSorted;
+        this.partialSortGuaranteed = partialSortGuaranteed;
     }
 
     public T getHandle()
@@ -43,8 +43,8 @@ public class PartialSortApplicationResult<T>
         return sameNullOrdering;
     }
 
-    public boolean allSorted()
+    public boolean isPartialSortGuaranteed()
     {
-        return allSorted;
+        return partialSortGuaranteed;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/PartialSortApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/PartialSortApplicationResult.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public class PartialSortApplicationResult<T>
+{
+    private final T handle;
+    private final boolean sameSortDirection;
+    private final boolean sameNullOrdering;
+    private final boolean allSorted;
+
+    public PartialSortApplicationResult(T handle, boolean sortDirection, boolean nullOrdering, boolean allSorted)
+    {
+        this.handle = handle;
+        this.sameSortDirection = sortDirection;
+        this.sameNullOrdering = nullOrdering;
+        this.allSorted = allSorted;
+    }
+
+    public T getHandle()
+    {
+        return handle;
+    }
+
+    public boolean isSameSortDirection()
+    {
+        return sameSortDirection;
+    }
+
+    public boolean isSameNullOrdering()
+    {
+        return sameNullOrdering;
+    }
+
+    public boolean allSorted()
+    {
+        return allSorted;
+    }
+}

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
@@ -314,6 +314,47 @@ public class OrcReader
                 fieldMapperFactory);
     }
 
+    public OrcRecordBackwardReader createRecordBackwardReader(
+            List<OrcColumn> readColumns,
+            List<Type> readTypes,
+            List<ProjectedLayout> readLayouts,
+            OrcPredicate predicate,
+            long offset,
+            long length,
+            DateTimeZone legacyFileTimeZone,
+            AggregatedMemoryContext memoryUsage,
+            int initialBatchSize,
+            Function<Exception, RuntimeException> exceptionTransform,
+            FieldMapperFactory fieldMapperFactory)
+            throws OrcCorruptionException
+    {
+        return new OrcRecordBackwardReader(
+                requireNonNull(readColumns, "readColumns is null"),
+                requireNonNull(readTypes, "readTypes is null"),
+                requireNonNull(readLayouts, "readLayouts is null"),
+                requireNonNull(predicate, "predicate is null"),
+                footer.getNumberOfRows(),
+                footer.getStripes(),
+                footer.getFileStats(),
+                metadata.getStripeStatsList(),
+                orcDataSource,
+                offset,
+                length,
+                footer.getTypes(),
+                decompressor,
+                footer.getRowsInRowGroup(),
+                requireNonNull(legacyFileTimeZone, "legacyFileTimeZone is null"),
+                hiveWriterVersion,
+                metadataReader,
+                options,
+                footer.getUserMetadata(),
+                memoryUsage,
+                writeValidation,
+                initialBatchSize,
+                exceptionTransform,
+                fieldMapperFactory);
+    }
+
     private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize)
             throws IOException
     {

--- a/lib/trino-orc/src/main/java/io/trino/orc/RecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/RecordReader.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.orc;
+
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.orc.metadata.ColumnMetadata;
+import io.trino.orc.metadata.OrcType;
+import io.trino.orc.metadata.StripeInformation;
+import io.trino.orc.metadata.statistics.StripeStatistics;
+import io.trino.orc.reader.ColumnReader;
+import io.trino.spi.Page;
+import io.trino.spi.type.Type;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static io.trino.orc.reader.ColumnReaders.createColumnReader;
+import static java.util.Objects.requireNonNull;
+
+public interface RecordReader
+        extends Closeable
+{
+    ColumnMetadata<OrcType> getColumnTypes();
+
+    Page nextPage()
+            throws IOException;
+
+    long getFilePosition();
+
+    long getMaxCombinedBytesPerRow();
+
+    long getTotalDataLength();
+
+    @Override
+    void close()
+            throws IOException;
+
+    Optional<Long> getStartRowPosition();
+
+    Optional<Long> getEndRowPosition();
+
+    default boolean splitContainsStripe(long splitOffset, long splitLength, StripeInformation stripe)
+    {
+        long splitEndOffset = splitOffset + splitLength;
+        return splitOffset <= stripe.getOffset() && stripe.getOffset() < splitEndOffset;
+    }
+
+    default boolean isStripeIncluded(
+            StripeInformation stripe,
+            Optional<StripeStatistics> stripeStats,
+            OrcPredicate predicate)
+    {
+        // if there are no stats, include the column
+        return stripeStats
+                .map(StripeStatistics::getColumnStatistics)
+                .map(columnStats -> predicate.matches(stripe.getNumberOfRows(), columnStats))
+                .orElse(true);
+    }
+
+    default ColumnReader[] createColumnReaders(
+            List<OrcColumn> columns,
+            List<Type> readTypes,
+            List<OrcReader.ProjectedLayout> readLayouts,
+            AggregatedMemoryContext memoryContext,
+            OrcBlockFactory blockFactory,
+            OrcReader.FieldMapperFactory fieldMapperFactory)
+            throws OrcCorruptionException
+    {
+        ColumnReader[] columnReaders = new ColumnReader[columns.size()];
+        for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+            Type readType = readTypes.get(columnIndex);
+            OrcColumn column = columns.get(columnIndex);
+            OrcReader.ProjectedLayout projectedLayout = readLayouts.get(columnIndex);
+            columnReaders[columnIndex] = createColumnReader(readType, column, projectedLayout, memoryContext, blockFactory, fieldMapperFactory);
+        }
+        return columnReaders;
+    }
+
+    class StripeInfo
+    {
+        private final StripeInformation stripe;
+        private final Optional<StripeStatistics> stats;
+
+        public StripeInfo(StripeInformation stripe, Optional<StripeStatistics> stats)
+        {
+            this.stripe = requireNonNull(stripe, "stripe is null");
+            this.stats = requireNonNull(stats, "stats is null");
+        }
+
+        public StripeInformation getStripe()
+        {
+            return stripe;
+        }
+
+        public Optional<StripeStatistics> getStats()
+        {
+            return stats;
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -48,6 +48,7 @@ import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PartialSortApplicationResult;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
@@ -60,6 +61,7 @@ import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
+import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1085,6 +1087,17 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applyTopN(session, table, topNCount, sortItems, assignments);
+        }
+    }
+
+    @Override
+    public Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -61,7 +61,6 @@ import io.trino.spi.connector.SaveMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SortItem;
-import io.trino.spi.connector.SortOrder;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.connector.TableFunctionApplicationResult;
@@ -1094,10 +1093,11 @@ public class ClassLoaderSafeConnectorMetadata
     public Optional<PartialSortApplicationResult<ConnectorTableHandle>> applyPartialSort(
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
-            Map<ColumnHandle, SortOrder> columnHandleSortOrderMap)
+            List<SortItem> sortItems,
+            Map<String, ColumnHandle> assignments)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyPartialSort(session, tableHandle, columnHandleSortOrderMap);
+            return delegate.applyPartialSort(session, tableHandle, sortItems, assignments);
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -626,7 +626,8 @@ public class TestOrcPageSourceMemoryTracking
                     DynamicFilter.EMPTY,
                     types,
                     DataSize.ofBytes(0),
-                    0);
+                    0,
+                    false);
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(TEST_CATALOG_HANDLE, TestingSplit.createLocalSplit()));
             operator.noMoreSplits();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -58,13 +58,14 @@ public class IcebergPageSource
             List<IcebergColumnHandle> requiredColumns,
             ConnectorPageSource delegate,
             Optional<ReaderProjectionsAdapter> projectionsAdapter,
-            Supplier<Optional<RowPredicate>> deletePredicate)
+            Supplier<Optional<RowPredicate>> deletePredicate,
+            boolean iteratorEnd)
     {
         // expectedColumns should contain columns which should be in the final Page
         // requiredColumns should include all expectedColumns as well as any columns needed by the DeleteFilter
         requireNonNull(expectedColumns, "expectedColumns is null");
         requireNonNull(requiredColumns, "requiredColumns is null");
-        this.expectedColumnIndexes = new int[expectedColumns.size()];
+        this.expectedColumnIndexes = new int[!iteratorEnd ? expectedColumns.size() : expectedColumns.size() + 1];
         for (int i = 0; i < expectedColumns.size(); i++) {
             IcebergColumnHandle expectedColumn = expectedColumns.get(i);
             checkArgument(expectedColumn.equals(requiredColumns.get(i)), "Expected columns must be a prefix of required columns");
@@ -83,6 +84,10 @@ public class IcebergPageSource
                     fieldIdToRowIdIndex.put(fieldId, columnIndex);
                 }
             }
+        }
+
+        if (iteratorEnd) {
+            expectedColumnIndexes[expectedColumns.size()] = expectedColumns.size();
         }
 
         this.delegate = requireNonNull(delegate, "delegate is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -127,7 +127,8 @@ public class TableChangesFunctionProcessor
                 split.fileRecordCount(),
                 split.partitionDataJson(),
                 split.fileFormat(),
-                functionHandle.nameMappingJson().map(NameMappingParser::fromJson));
+                functionHandle.nameMappingJson().map(NameMappingParser::fromJson),
+                false);
         this.delegateColumnMap = delegateColumnMap;
 
         this.changeTypeIndex = changeTypeIndex;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -169,7 +169,9 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            false,
+                            false),
                     transaction);
 
             TupleDomain<ColumnHandle> splitPruningPredicate = TupleDomain.withColumnDomains(
@@ -284,7 +286,9 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            false,
+                            false),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably
@@ -443,7 +447,9 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                             false,
                             Optional.empty(),
                             ImmutableSet.of(),
-                            Optional.of(false)),
+                            Optional.of(false),
+                            false,
+                            false),
                     transaction);
 
             // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -164,7 +164,9 @@ public class TestIcebergSplitSource
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                false,
+                false);
 
         try (IcebergSplitSource splitSource = new IcebergSplitSource(
                 fileSystemFactory,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -174,7 +174,9 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                false,
+                false);
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -258,7 +260,9 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                false,
+                false);
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = new IcebergColumnHandle(primitiveColumnIdentity(1, "a"), INTEGER, ImmutableList.of(), INTEGER, true, Optional.empty());
@@ -309,7 +313,9 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                false,
+                false);
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = new IcebergColumnHandle(primitiveColumnIdentity(0, "a"), INTEGER, ImmutableList.of(), INTEGER, true, Optional.empty());
@@ -371,7 +377,9 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.of(false));
+                Optional.of(false),
+                false,
+                false);
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = new IcebergColumnHandle(primitiveColumnIdentity(1, "just_bigint"), BIGINT, ImmutableList.of(), BIGINT, true, Optional.empty());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If Trino knows that each file has been sorted, it can rewrite the `Partial TopN` to `LimitNode` or `LastNNode`(a new logical plan node in this PR), which will significantly improve query performance. Trino can use the `sort_order_id` field in the Iceberg manifest entry to determine whether a data file has been sorted.

## Backgrounds and Core Idea
For convenience of review, I need to describe the `LastNOperator` (a new operator was introduced) in this PR and the working principle of the related code. First, as a recap, let's take a quick look at how Page was originally built from `OrcReader`. I believe Trino gods are more familiar with the implementation details, but it can help understanding the `LastNOperator` implementations later. Trino's OrcReader advances based on RowGroups then obtains the current RowGroup's input stream, and construct Pages based on this input stream. Therefore, at least during the Pages generation phase, a Page is not generated across RowGroups. In other words, a Page does not come from two different RowGroups. Additionally, the batch parameter MAX_BATCH_SIZE is set to 8192 in current codebase, so if the default RowGroup size is 10,000, at least one Page will be generated for each RowGroup.

In this PR, when OrcReader outputs a Page, it adds an additional column whose value is calculated by concatenating the existing variables `stripeSize` and `currentRowGroup`. The following code snippet is the logic for adding the last column to the Page. This code is part of a class called `OrcRecordBackwardReader`. This class mainly iterates row groups in reverse order.

```
Page page = new Page(currentBatchSize, blocks);
long[] values = new long[page.getPositionCount()];
Arrays.fill(values, (long) stripeSize << 32 | currentRowGroup);
LongArrayBlock rowGroupId = new LongArrayBlock(page.getPositionCount(), Optional.empty(), values);
page = page.appendColumn(rowGroupId);
```

It should be noted that trino will do some additional optimization on the output Page. For example, when the
physical operator includes `ScanFilterAndProjectOperator` or `FilterAndProjectOperator` instead of `TableScanOperator`. Trino optimizes the Page by merging or splitting and this PR also adapts to the both scenarios.

If the implementation of `LastNOperator` reads from the beginning of the file and retains the data from the last few Pages at the end of the file, there may still be significant IO overhead due to processing a lot of irrelevant data. Therefore, the `LastNOperator` expects the input page to be constructed from the last RowGroup of the current split and this depends on the behavior of OrcReader's output Page,so the PR introduces a class called `OrcRecordBackwardReader` to differentiate it from the existing `OrcRecordReader`.

Furthermore, the `LastNOperator` implementation takes performance issues into account. Each Page entering the operator has a unique RowGroupId block to indicate from which row group the Page comes and the block is the last block of the Page. Unlike the `LimitOperator`, which outputs any input Page downstream until remainingLimit is no longer greater than 0, the `LastNOperator` accumulates the Pages. It does not output to the downstream operator until it accumulates N elements unless the total number of rows in the source data is less than N. Therefore, the `LastNOperator` is a blocking operator, like the `OrderByOperator`, and it can precisely calculates the N elements needed to reduce the memory of the current worker process and the network pressure caused by sending data to downstream operator.

Now, let's illustrate the general implementation approach of the `LastNOperator` with an example.

Consider the following data written sequentially in a column. For convenience, I use one row to represent it, and assume the row group size is 3. This numbers will be divided into three row groups. Since the data is written sequentially, the data between row groups follows the order: data in row group 3 is smaller than that in row group 2, and data in row group 2 is smaller than that in row group 1. However, within each row group, the data is still sequential.

```
1,2,3 | 4,5,6 | 7,8,9

row group-3 [1,2,3]
row group-2 [4,5,6]
row group-1 [7,8,9]
```

The `LastNOperator` maintains a corresponding queue for each row group, and the queue saves the pages generated by the row group.  Also, the value of N is updated when encountering each new row group and the purpose is to calculate how many N is needed remaining in the new row group. For example, if we need the top 4 data. i.e. [9,8,7,6], with N being 4, then when row group-1 is processed done, N will be updated to 1, we can call it the remaining N is 1. At this point, only 1 more digit needs to be obtained from row group-2 is fine. Since in each row group, the data is still sequentialas so all pages in row group-2 must be read to find the page containing the number 6. Next, when reading row group-3, N is updated again, and when N decrease to 0, it indicates that no more data is needed. When the `LastNOperator` finally outputs, it region the pages to reduce memory and network pressure, ensuring that the data sent downstream only contains [9,8,7,6], even if don't region page at `getOutput`, it won't have much impact on memory and network because this part of the data is very small. In addition, the implementation of `addInput` in `LastNOperator`, for each current queue, the impact of memory on the worker process will also be fully considered.

After this version of the code if can be successfully merged, we will also plan to support multi-field sorting and the situation where only some part of files are sorted. Probably like below, but this PR does not have these functions.

<img width="212" alt="image" src="https://github.com/trinodb/trino/assets/6520673/648d4666-0b03-49cd-9bd3-81430d016fbd">


## Test
Testing was performed on real log queries to retrieve the latest 200 records, which is a very common business requirement. Two query scenarios were tested, one ascending and one descending. It is worth noting that the performance of these two test cases was almost identical.
The brief test idea is as follows:

### Write
The iceberg table sorting field is defined as `ORDER BY _timestamp DESC NULLS LAST`, and the iceberg table is written using the `Apache/Spark` engine.

### Read
The sorting of the query was divided into two cases, one that is exactly the same as the writing order and one that is completely opposite.

**ORDER BY _timestamp DESC NULLS LAST**: It took **1.96 seconds**, and the partial-top-n node was rewritten as `LimitNode`, corresponding to `LimitOperator`.

**ORDER BY _timestamp ASC NULLS FIRST**: It took **2.24 seconds**, and the partial-top-n node was rewritten as `LastNNode`, corresponding to the new operator added by the MR, called `LastNOperator`.

Compared to the original Trino query, the query takes **36.45 seconds**, and the test results show a performance **improvement of 16 to 18 times**.

```
SELECT
  "cid",
  "errno",
  "host_deploy_env" "host.deploy_env",
  "host_name" "host.name",
  "host_region" "host.region",
  "host_zone" "host.zone",
  "log_file" "log.file",
  "log_level" "log.level",
  "log_msg" "log.msg",
  "log_observed_time" "log.observed_time",
  "log_offset" "log.offset",
  "msg",
  "pid",
  "service_name" "service.name",
  "tag",
  "version",
  "_consumer_hostname",
  "_id",
  "log_stuid" "log.stuid",
  "upstream_code",
  "upstream_addr",
  "req_type",
  "arg_trid",
  "_timestamp" "timestamp"
FROM iceberg_log.xxx_yyy_zzz
WHERE ((("msg" LIKE '%client%') AND ("msg" IS NOT NULL)) AND (_timestamp > 1705341600000) AND (_timestamp <= 1705342800000) AND (log_date >= '20240116') AND (log_date <= '20240116') AND (log_hour >= '02') AND (log_hour <= '02'))
ORDER BY _timestamp ASC NULLS FIRST
OFFSET 0 ROWS
LIMIT 200
```

**Partition statistics**
- Size: 58.1GB
- Record Counts: 1,083,459,817
- Total File Counts: 236

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is the work of the first part of this issue https://github.com/trinodb/trino/issues/18139
