### PR TITLE
Disable task level writer scaling from TableExecute

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergOptimize.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergOptimize.java
@@ -75,6 +75,8 @@ public class TestIcebergOptimize
         // TODO Drop Spark dependency once that the setting 'read.split.target-size' can be set through Trino
         onSpark().executeQuery("ALTER TABLE " + sparkTableName + " SET TBLPROPERTIES ('read.split.target-size'='100')");
 
+        // For optimize we need to set task_writer_count to 1, otherwise it will create more than one file.
+        onTrino().executeQuery("SET SESSION task_writer_count = 1");
         onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE OPTIMIZE");
 
         List<String> updatedFiles = getActiveFiles(TRINO_CATALOG, TEST_SCHEMA_NAME, baseTableName);


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Currently, task writer scaling can lead to file sizes which are not controlled via OPTIMIZE command thus making it unreliable.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Fix `OPTIMIZE` to avoid creating files smaller than `file_size_threshold` due to task writer scaling. ({issue}`18388`)
```
