### PR TITLE
Clarify why join_pushdown_enabled is set to false by default

### DIFF
--- a/docs/src/main/sphinx/connector/join-pushdown-enabled-false.fragment
+++ b/docs/src/main/sphinx/connector/join-pushdown-enabled-false.fragment
@@ -3,6 +3,7 @@ Join pushdown
 
 The ``join-pushdown.enabled`` catalog configuration property or
 ``join_pushdown_enabled`` :ref:`catalog session property
-<session-properties-definition>` control whether the connector pushes
-down join operations. The property defaults to ``false``, and enabling join
-pushdowns may negatively impact performance for some queries.
+<session-properties-definition>` control whether the connector pushes down join
+operations. The property defaults to ``false`` to provide an effective measure
+against higher compute costs for some connectors. Enabling join pushdowns may
+negatively impact performance for some queries.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Clarified why `join_pushdown_enabled` is set to `false` by default

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
