### PR TITLE
Add support for `GROUP BY AUTO` aggregation

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/sql/SqlBase.g4
@@ -300,6 +300,7 @@ groupBy
 
 groupingElement
     : groupingSet                                            #singleGroupingSet
+    | AUTO                                                   #auto
     | ROLLUP '(' (groupingSet (',' groupingSet)*)? ')'       #rollup
     | CUBE '(' (groupingSet (',' groupingSet)*)? ')'         #cube
     | GROUPING SETS '(' groupingSet (',' groupingSet)* ')'   #multipleGroupingSets
@@ -1043,6 +1044,7 @@ AS: 'AS';
 ASC: 'ASC';
 AT: 'AT';
 AUTHORIZATION: 'AUTHORIZATION';
+AUTO: 'AUTO';
 BEGIN: 'BEGIN';
 BERNOULLI: 'BERNOULLI';
 BETWEEN: 'BETWEEN';

--- a/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
+++ b/core/trino-grammar/src/test/java/io/trino/grammar/sql/TestSqlKeywords.java
@@ -40,6 +40,7 @@ public class TestSqlKeywords
                         "ASC",
                         "AT",
                         "AUTHORIZATION",
+                        "AUTO",
                         "BEGIN",
                         "BERNOULLI",
                         "BETWEEN",

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -3174,6 +3174,10 @@ public class TestAnalyzer
     {
         // TODO: validate output
         analyze("SELECT a, SUM(b) FROM t1 GROUP BY a");
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY AUTO");
+        analyze("SELECT a as x, SUM(b) FROM t1 GROUP BY AUTO");
+        analyze("SELECT a, SUM(b) FROM t1 GROUP BY ALL AUTO");
+        analyze("SELECT a as x, SUM(b) FROM t1 GROUP BY DISTINCT AUTO");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
@@ -160,4 +160,212 @@ public class TestGroupBy
                 "SELECT null GROUP BY 1, 1"))
                 .matches("VALUES null");
     }
+
+    @Test
+    void testGroupByAuto()
+    {
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES 1) t(a)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES 1");
+
+        assertThat(assertions.query(
+                """
+                SELECT *
+                FROM (VALUES 1, 2) t(a)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES 1, 2");
+
+        assertThat(assertions.query(
+                """
+                SELECT sum(a)
+                FROM (VALUES (1), (2)) t(a)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES BIGINT '3'");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a AS new_a, sum(b) AS sum_b
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a + 1, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (2, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT abs(a), sum(b)
+                FROM (VALUES (-1, 10), (-1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT sum(b), a
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (BIGINT '30', 1)");
+
+        assertThat(assertions.query(
+                """
+                SELECT sum(a)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO
+                """))
+                .matches("VALUES (BIGINT '2')");
+
+        // ALL AUTO
+        assertThat(assertions.query(
+                """
+                SELECT sum(a)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY ALL AUTO
+                """))
+                .matches("VALUES (BIGINT '2')");
+
+        // DISTINCT AUTO
+        assertThat(assertions.query(
+                """
+                SELECT sum(a)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY DISTINCT AUTO
+                """))
+                .matches("VALUES (BIGINT '2')");
+
+        // ROLLUP
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO, ROLLUP(b)
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20'), (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY ALL AUTO, ROLLUP(b)
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20'), (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY DISTINCT AUTO, ROLLUP(a)
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, b, c, sum(b)
+                FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                GROUP BY AUTO, ROLLUP(a)
+                """))
+                .matches(
+                        """
+                        SELECT a, b, c, sum(b)
+                        FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                        GROUP BY (a, b, c), ROLLUP(a)
+                        """);
+
+        // CUBE
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO, CUBE(b)
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20'), (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY ALL AUTO, CUBE(b)
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20'), (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY DISTINCT AUTO, CUBE(a)
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, b, c, sum(b)
+                FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                GROUP BY AUTO, CUBE(a)
+                """))
+                .matches(
+                        """
+                        SELECT a, b, c, sum(b)
+                        FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                        GROUP BY (a, b, c), CUBE(a)
+                        """);
+
+        // GROUPING SETS
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY AUTO, GROUPING SETS((b))
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY ALL AUTO, GROUPING SETS((b))
+                """))
+                .matches("VALUES (1, BIGINT '10'), (1, BIGINT '20')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, sum(b)
+                FROM (VALUES (1, 10), (1, 20)) t(a, b)
+                GROUP BY DISTINCT AUTO, GROUPING SETS((a))
+                """))
+                .matches("VALUES (1, BIGINT '30')");
+
+        assertThat(assertions.query(
+                """
+                SELECT a, b, c, sum(b)
+                FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                GROUP BY AUTO, GROUPING SETS((a))
+                """))
+                .matches(
+                        """
+                        SELECT a, b, c, sum(b)
+                        FROM (VALUES (1, 1, 1, 1), (1, 1, 1, 2), (2, 2, 2, 3)) t(a, b, c, d)
+                        GROUP BY (a, b, c), GROUPING SETS((a))
+                        """);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -22,6 +22,7 @@ import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.AtTimeZone;
+import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
@@ -1130,6 +1131,9 @@ public final class ExpressionFormatter
                 else {
                     result = formatGroupingSet(columns);
                 }
+            }
+            else if (groupingElement instanceof AutoGroupBy) {
+                result = "AUTO";
             }
             else if (groupingElement instanceof GroupingSets groupingSets) {
                 String type = switch (groupingSets.getType()) {

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -32,6 +32,7 @@ import io.trino.sql.tree.ArithmeticUnaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AssignmentStatement;
 import io.trino.sql.tree.AtTimeZone;
+import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
@@ -1306,6 +1307,12 @@ class AstBuilder
     public Node visitSingleGroupingSet(SqlBaseParser.SingleGroupingSetContext context)
     {
         return new SimpleGroupBy(getLocation(context), visit(context.groupingSet().expression(), Expression.class));
+    }
+
+    @Override
+    public Node visitAuto(SqlBaseParser.AutoContext context)
+    {
+        return new AutoGroupBy(getLocation(context));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -887,6 +887,11 @@ public abstract class AstVisitor<R, C>
         return visitGroupingElement(node, context);
     }
 
+    protected R visitAutoGroupBy(AutoGroupBy node, C context)
+    {
+        return visitGroupingElement(node, context);
+    }
+
     protected R visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, C context)
     {
         return visitExpression(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AutoGroupBy.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AutoGroupBy.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public final class AutoGroupBy
+        extends GroupingElement
+{
+    public AutoGroupBy(NodeLocation location)
+    {
+        super(Optional.of(location));
+    }
+
+    @Override
+    public List<Expression> getExpressions()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    protected <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitAutoGroupBy(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        return (o != null) && (getClass() == o.getClass());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this).toString();
+    }
+
+    @Override
+    public boolean shallowEquals(Node other)
+    {
+        return sameClass(this, other);
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -606,6 +606,12 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitAutoGroupBy(AutoGroupBy node, C context)
+    {
+        return null;
+    }
+
+    @Override
     protected Void visitGroupingSets(GroupingSets node, C context)
     {
         return null;

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -26,6 +26,7 @@ import io.trino.sql.tree.AnchorPattern;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
 import io.trino.sql.tree.Array;
 import io.trino.sql.tree.AtTimeZone;
+import io.trino.sql.tree.AutoGroupBy;
 import io.trino.sql.tree.BetweenPredicate;
 import io.trino.sql.tree.BinaryLiteral;
 import io.trino.sql.tree.BooleanLiteral;
@@ -1801,6 +1802,69 @@ public class TestSqlParser
                         Optional.empty(),
                         Optional.of(new GroupBy(false, ImmutableList.of(new SimpleGroupBy(ImmutableList.of())))),
                         Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertThat(statement("SELECT * FROM table1 GROUP BY AUTO"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(location(1, 1), false, ImmutableList.of(new AllColumns(location(1, 8), Optional.empty(), ImmutableList.of()))),
+                                Optional.of(new Table(location(1, 15), qualifiedName(location(1, 15), "table1"))),
+                                Optional.empty(),
+                                Optional.of(new GroupBy(location(1, 31), false, ImmutableList.of(new AutoGroupBy(location(1, 31))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertThat(statement("SELECT * FROM table1 GROUP BY ALL AUTO"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(location(1, 1), false, ImmutableList.of(new AllColumns(location(1, 8), Optional.empty(), ImmutableList.of()))),
+                                Optional.of(new Table(location(1, 15), qualifiedName(location(1, 15), "table1"))),
+                                Optional.empty(),
+                                Optional.of(new GroupBy(location(1, 31), false, ImmutableList.of(new AutoGroupBy(location(1, 35))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()));
+
+        assertThat(statement("SELECT * FROM table1 GROUP BY DISTINCT AUTO"))
+                .isEqualTo(new Query(
+                        location(1, 1),
+                        ImmutableList.of(),
+                        ImmutableList.of(),
+                        Optional.empty(),
+                        new QuerySpecification(
+                                location(1, 1),
+                                new Select(location(1, 1), false, ImmutableList.of(new AllColumns(location(1, 8), Optional.empty(), ImmutableList.of()))),
+                                Optional.of(new Table(location(1, 15), qualifiedName(location(1, 15), "table1"))),
+                                Optional.empty(),
+                                Optional.of(new GroupBy(location(1, 31), true, ImmutableList.of(new AutoGroupBy(location(1, 40))))),
+                                Optional.empty(),
+                                ImmutableList.of(),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -105,7 +105,7 @@ public class TestSqlParserErrorHandling
                 Arguments.of("SELECT a FROM a AS x TABLESAMPLE x ",
                         "line 1:34: mismatched input 'x'. Expecting: 'BERNOULLI', 'SYSTEM'"),
                 Arguments.of("SELECT a AS z FROM t GROUP BY CUBE (a), ",
-                        "line 1:41: mismatched input '<EOF>'. Expecting: '(', 'CUBE', 'GROUPING', 'ROLLUP', <expression>"),
+                        "line 1:41: mismatched input '<EOF>'. Expecting: '(', 'AUTO', 'CUBE', 'GROUPING', 'ROLLUP', <expression>"),
                 Arguments.of("SELECT a AS z FROM t WHERE x = 1 + ",
                         "line 1:36: mismatched input '<EOF>'. Expecting: <expression>"),
                 Arguments.of("SELECT a AS z FROM t WHERE a. ",

--- a/docs/src/main/sphinx/language/reserved.md
+++ b/docs/src/main/sphinx/language/reserved.md
@@ -12,6 +12,7 @@ be quoted (using double quotes) in order to be used as an identifier.
 | `ALTER`             | reserved | reserved |
 | `AND`               | reserved | reserved |
 | `AS`                | reserved | reserved |
+| `AUTO`              |          |          |
 | `BETWEEN`           | reserved | reserved |
 | `BY`                | reserved | reserved |
 | `CASE`              | reserved | reserved |

--- a/docs/src/main/sphinx/sql/select.md
+++ b/docs/src/main/sphinx/sql/select.md
@@ -60,6 +60,7 @@ and `grouping_element` is one of
 ```text
 ()
 expression
+AUTO
 GROUPING SETS ( ( column [, ...] ) [, ...] )
 CUBE ( column [, ...] )
 ROLLUP ( column [, ...] )


### PR DESCRIPTION
## Description

This syntax allows omitting column positions or names after `GROUP BY`. 
For instance, `SELECT name, count(1) FROM GROUP BY AUTO ` would be translated to `SELECT name, count(1) FROM GROUP BY name`

References in other database/query engines
* BigQuery https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_all
* Snowflake https://docs.snowflake.com/en/sql-reference/constructs/group-by#label-group-by-all-columns
* Databricks https://docs.databricks.com/sql/language-manual/sql-ref-syntax-qry-select-groupby.html
* ClickHouse https://clickhouse.com/docs/en/sql-reference/statements/select/group-by#group-by-all
* Databend https://databend.rs/doc/sql-commands/query-syntax/query-group-by#group-by-all-columns

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Add support for `GROUP BY AUTO` aggregation that implicitly groups all non-aggregated columns. ({issue}`18390`)
```
