### PR TITLE
Change heading level of case insensitive matching fragment

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-case-insensitive-matching.fragment
@@ -1,5 +1,5 @@
 Case insensitive matching
-"""""""""""""""""""""""""
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When ``case-insensitive-name-matching`` is set to ``true``, Trino
 is able to query non-lowercase schemas and tables by maintaining a mapping of


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Changes the heading level of the `jdbc-case-insensitive-matching.fragment` to be a direct subheading of **Configuration**.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

*This fragment is currently nested under the `jdbc-procedures.fragment` but does not seem to be related to that section. If it's just another configuration property, and isn't a type of procedure, we should just nest it under Configuration.
* Heading was previously changed in https://github.com/trinodb/trino/pull/11967

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
