### PR TITLE
Throw meaningful exception when intending to update statistics for missing partition

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -590,6 +590,9 @@ public class ThriftHiveMetastore
     public void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
     {
         List<Partition> partitions = getPartitionsByNames(table.getDbName(), table.getTableName(), ImmutableList.of(partitionName));
+        if (partitions.isEmpty()) {
+            throw new TrinoException(HIVE_METASTORE_ERROR, "No partition found for name: " + partitionName);
+        }
         if (partitions.size() != 1) {
             throw new TrinoException(HIVE_METASTORE_ERROR, "Metastore returned multiple partitions for name: " + partitionName);
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -1910,6 +1910,65 @@ public abstract class BaseTestHiveOnDataLake
         };
     }
 
+    @Test
+    public void testDropStatsPartitionedTable()
+    {
+        String tableName = "test_hive_drop_stats_partitioned_table_" + randomNameSuffix();
+        assertUpdate(("CREATE TABLE %s (" +
+                "  data integer," +
+                "  p_varchar varchar," +
+                "  p_integer integer" +
+                ") " +
+                "WITH (" +
+                "  partitioned_by=ARRAY['p_varchar', 'p_integer']" +
+                ")").formatted(getFullyQualifiedTestTableName(tableName)));
+
+        // Drop stats for partition which does not exist
+        assertThatThrownBy(() -> query(format("CALL system.drop_stats('%s', '%s', ARRAY[ARRAY['partnotfound', '999']])", HIVE_TEST_SCHEMA, tableName)))
+                .hasMessage("No partition found for name: p_varchar=partnotfound/p_integer=999");
+
+        assertUpdate("INSERT INTO " + getFullyQualifiedTestTableName(tableName) + " VALUES (1, 'part1', 10) , (2, 'part2', 10), (12, 'part2', 20)", 3);
+
+        // Run analyze on the entire table
+        assertUpdate("ANALYZE " + getFullyQualifiedTestTableName(tableName), 3);
+
+        assertQuery("SHOW STATS FOR " + getFullyQualifiedTestTableName(tableName),
+                """
+                        VALUES
+                            ('data', null, 1.0, 0.0, null, 1, 12),
+                            ('p_varchar', 15.0, 2.0, 0.0, null, null, null),
+                            ('p_integer', null, 2.0, 0.0, null, 10, 20),
+                            (null, null, null, null, 3.0, null, null)
+                        """);
+
+        assertUpdate(format("CALL system.drop_stats('%s', '%s', ARRAY[ARRAY['part1', '10']])", HIVE_TEST_SCHEMA, tableName));
+
+        assertQuery("SHOW STATS FOR " + getFullyQualifiedTestTableName(tableName),
+                """
+                        VALUES
+                            ('data', null, 1.0, 0.0, null, 2, 12),
+                            ('p_varchar', 15.0, 2.0, 0.0, null, null, null),
+                            ('p_integer', null, 2.0, 0.0, null, 10, 20),
+                            (null, null, null, null, 3.0, null, null)
+                        """);
+
+        assertUpdate("DELETE FROM " + getFullyQualifiedTestTableName(tableName) + " WHERE p_varchar ='part1' and p_integer = 10");
+
+        // Drop stats for partition which does not exist
+        assertThatThrownBy(() -> query(format("CALL system.drop_stats('%s', '%s', ARRAY[ARRAY['part1', '10']])", HIVE_TEST_SCHEMA, tableName)))
+                .hasMessage("No partition found for name: p_varchar=part1/p_integer=10");
+
+        assertQuery("SHOW STATS FOR " + getFullyQualifiedTestTableName(tableName),
+                """
+                        VALUES
+                            ('data', null, 1.0, 0.0, null, 2, 12),
+                            ('p_varchar', 10.0, 1.0, 0.0, null, null, null),
+                            ('p_integer', null, 2.0, 0.0, null, 10, 20),
+                            (null, null, null, null, 2.0, null, null)
+                        """);
+        assertUpdate("DROP TABLE " + getFullyQualifiedTestTableName(tableName));
+    }
+
     private void renamePartitionResourcesOutsideTrino(String tableName, String partitionColumn, String regionKey)
     {
         String partitionName = format("%s=%s", partitionColumn, regionKey);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Avoid providing misleading failure cause to the user when trying to drop the statistics for a partition which doesn't exist

```
Caused by: io.trino.spi.TrinoException: Metastore returned multiple partitions for name: p_varchar=partnotfound/p_integer=999
	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.updatePartitionStatistics(ThriftHiveMetastore.java:598)
	at io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore.lambda$updatePartitionStatistics$1(BridgingHiveMetastore.java:136)
	at com.google.common.collect.SingletonImmutableBiMap.forEach(SingletonImmutableBiMap.java:68)
	at io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore.updatePartitionStatistics(BridgingHiveMetastore.java:136)
	at io.trino.plugin.hive.metastore.HiveMetastore.updatePartitionStatistics(HiveMetastore.java:58)
	at io.trino.plugin.hive.metastore.ForwardingHiveMetastore.updatePartitionStatistics(ForwardingHiveMetastore.java:100)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.updatePartitionStatistics(CachingHiveMetastore.java:720)
	at io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.updatePartitionStatistics(CachingHiveMetastore.java:720)
	at io.trino.plugin.hive.HiveMetastoreClosure.updatePartitionStatistics(HiveMetastoreClosure.java:141)
	at io.trino.plugin.hive.procedure.DropStatsProcedure.lambda$doDropStats$1(DropStatsProcedure.java:125)
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
