### PR TITLE
Use correct value for `partition_values` argument in `drop_stats` sample

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -763,7 +763,7 @@ Drop stats for a partition of the ``page_views`` table::
     CALL system.drop_stats(
         schema_name => 'web',
         table_name => 'page_views',
-        partition_values => ARRAY['2016-08-09', 'US']);
+        partition_values => ARRAY[ARRAY['2016-08-09', 'US']]);
 
 .. _hive-procedures:
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Correct the sample call for `drop_stats`

The table `example.web.page_views` has a composed partition key, reason why we need `ARRAY[ARRAY[varchar, varchar]]` type for `partition_values` parameter in the `drop_stats` call.

https://github.com/trinodb/trino/blob/e1114ff98cfea94f8e8ca2db0d3a5279bd3b1349/docs/src/main/sphinx/connector/hive.rst?plain=1#L682-L694

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
