### PR TITLE
Fix Iceberg conflict verification during write operations

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -446,6 +446,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-blackhole</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-exchange-filesystem</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -32,6 +32,7 @@ public class CommitTaskData
     private final Optional<String> partitionDataJson;
     private final FileContent content;
     private final Optional<String> referencedDataFile;
+    private final Optional<Long> referencedDataFileSize;
     private final Optional<Long> fileRecordCount;
     private final Optional<Long> deletedRowCount;
 
@@ -45,6 +46,7 @@ public class CommitTaskData
             @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
             @JsonProperty("content") FileContent content,
             @JsonProperty("referencedDataFile") Optional<String> referencedDataFile,
+            @JsonProperty("referencedDataFileSize") Optional<Long> referencedDataFileSize,
             @JsonProperty("fileRecordCount") Optional<Long> fileRecordCount,
             @JsonProperty("deletedRowCount") Optional<Long> deletedRowCount)
     {
@@ -56,6 +58,7 @@ public class CommitTaskData
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.content = requireNonNull(content, "content is null");
         this.referencedDataFile = requireNonNull(referencedDataFile, "referencedDataFile is null");
+        this.referencedDataFileSize = requireNonNull(referencedDataFileSize, "referencedDataFileSize is null");
         this.fileRecordCount = requireNonNull(fileRecordCount, "fileRecordCount is null");
         fileRecordCount.ifPresent(rowCount -> checkArgument(rowCount >= 0, "fileRecordCount cannot be negative"));
         this.deletedRowCount = requireNonNull(deletedRowCount, "deletedRowCount is null");
@@ -110,6 +113,12 @@ public class CommitTaskData
     public Optional<String> getReferencedDataFile()
     {
         return referencedDataFile;
+    }
+
+    @JsonProperty
+    public Optional<Long> getReferencedDataFileSize()
+    {
+        return referencedDataFileSize;
     }
 
     @JsonProperty

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -41,8 +41,9 @@ public class IcebergColumnHandle
     public static final String TRINO_ROW_ID_NAME = "$row_id";
 
     public static final int TRINO_MERGE_FILE_RECORD_COUNT = Integer.MIN_VALUE + 2;
-    public static final int TRINO_MERGE_PARTITION_SPEC_ID = Integer.MIN_VALUE + 3;
-    public static final int TRINO_MERGE_PARTITION_DATA = Integer.MIN_VALUE + 4;
+    public static final int TRINO_MERGE_FILE_SIZE = Integer.MIN_VALUE + 3;
+    public static final int TRINO_MERGE_PARTITION_SPEC_ID = Integer.MIN_VALUE + 4;
+    public static final int TRINO_MERGE_PARTITION_DATA = Integer.MIN_VALUE + 5;
 
     private final ColumnIdentity baseColumnIdentity;
     private final Type baseType;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2099,7 +2099,7 @@ public class IcebergMetadata
         IcebergMergeTableHandle mergeHandle = (IcebergMergeTableHandle) mergeTableHandle;
         IcebergTableHandle handle = mergeHandle.getTableHandle();
         RetryMode retryMode = mergeHandle.getInsertTableHandle().getRetryMode();
-        finishWrite(session, handle, fragments, true, retryMode);
+        finishWrite(session, handle, fragments, retryMode);
     }
 
     private static void verifyTableVersionForUpdate(IcebergTableHandle table)
@@ -2126,7 +2126,7 @@ public class IcebergMetadata
         }
     }
 
-    private void finishWrite(ConnectorSession session, IcebergTableHandle table, Collection<Slice> fragments, boolean runUpdateValidations, RetryMode retryMode)
+    private void finishWrite(ConnectorSession session, IcebergTableHandle table, Collection<Slice> fragments, RetryMode retryMode)
     {
         Table icebergTable = transaction.table();
 
@@ -2162,11 +2162,9 @@ public class IcebergMetadata
                 rowDelta.validateNoConflictingDataFiles();
             }
 
-            if (runUpdateValidations) {
-                // Ensure a row that is updated by this commit was not deleted by a separate commit
-                rowDelta.validateDeletedFiles();
-                rowDelta.validateNoConflictingDeleteFiles();
-            }
+            // Ensure a row that is updated by this commit was not deleted by a separate commit
+            rowDelta.validateDeletedFiles();
+            rowDelta.validateNoConflictingDeleteFiles();
 
             ImmutableSet.Builder<String> writtenFiles = ImmutableSet.builder();
             ImmutableSet.Builder<String> referencedDataFiles = ImmutableSet.builder();
@@ -2176,35 +2174,31 @@ public class IcebergMetadata
                         .map(field -> field.transform().getResultType(schema.findType(field.sourceId())))
                         .toArray(Type[]::new);
                 switch (task.getContent()) {
-                    case POSITION_DELETES:
+                    case POSITION_DELETES -> {
                         if (fullyDeletedFiles.containsKey(task.getReferencedDataFile().orElseThrow())) {
                             continue;
                         }
-
                         FileMetadata.Builder deleteBuilder = FileMetadata.deleteFileBuilder(partitionSpec)
                                 .withPath(task.getPath())
                                 .withFormat(task.getFileFormat().toIceberg())
                                 .ofPositionDeletes()
                                 .withFileSizeInBytes(task.getFileSizeInBytes())
                                 .withMetrics(task.getMetrics().metrics());
-
                         if (!partitionSpec.fields().isEmpty()) {
                             String partitionDataJson = task.getPartitionDataJson()
                                     .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
                             deleteBuilder.withPartition(PartitionData.fromJson(partitionDataJson, partitionColumnTypes));
                         }
-
                         rowDelta.addDeletes(deleteBuilder.build());
                         writtenFiles.add(task.getPath());
                         task.getReferencedDataFile().ifPresent(referencedDataFiles::add);
-                        break;
-                    case DATA:
+                    }
+                    case DATA -> {
                         DataFiles.Builder builder = DataFiles.builder(partitionSpec)
                                 .withPath(task.getPath())
                                 .withFormat(task.getFileFormat().toIceberg())
                                 .withFileSizeInBytes(task.getFileSizeInBytes())
                                 .withMetrics(task.getMetrics().metrics());
-
                         if (!icebergTable.spec().fields().isEmpty()) {
                             String partitionDataJson = task.getPartitionDataJson()
                                     .orElseThrow(() -> new VerifyException("No partition data for partitioned table"));
@@ -2212,9 +2206,8 @@ public class IcebergMetadata
                         }
                         rowDelta.addRows(builder.build());
                         writtenFiles.add(task.getPath());
-                        break;
-                    default:
-                        throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
+                    }
+                    default -> throw new UnsupportedOperationException("Unsupported task content: " + task.getContent());
                 }
             }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -400,6 +400,7 @@ public class IcebergPageSink
                 DATA,
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         commitTasks.add(wrappedBuffer(jsonCodec.toJsonBytes(task)));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -142,6 +142,7 @@ import static io.trino.parquet.ParquetTypeUtils.getDescriptors;
 import static io.trino.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.trino.parquet.predicate.PredicateUtils.predicateMatches;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_FILE_RECORD_COUNT;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_FILE_SIZE;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_DATA;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_SPEC_ID;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
@@ -272,6 +273,9 @@ public class IcebergPageSourceProvider
                             requiredColumns.add(new IcebergColumnHandle(identity, BIGINT, ImmutableList.of(), BIGINT, Optional.empty()));
                         }
                         else if (identity.getId() == TRINO_MERGE_FILE_RECORD_COUNT) {
+                            requiredColumns.add(new IcebergColumnHandle(identity, BIGINT, ImmutableList.of(), BIGINT, Optional.empty()));
+                        }
+                        else if (identity.getId() == TRINO_MERGE_FILE_SIZE) {
                             requiredColumns.add(new IcebergColumnHandle(identity, BIGINT, ImmutableList.of(), BIGINT, Optional.empty()));
                         }
                         else if (identity.getId() == TRINO_MERGE_PARTITION_SPEC_ID) {
@@ -614,6 +618,9 @@ public class IcebergPageSourceProvider
                 }
                 else if (column.getId() == TRINO_MERGE_FILE_RECORD_COUNT) {
                     columnAdaptations.add(ColumnAdaptation.constantColumn(nativeValueToBlock(column.getType(), fileRecordCount)));
+                }
+                else if (column.getId() == TRINO_MERGE_FILE_SIZE) {
+                    columnAdaptations.add(ColumnAdaptation.constantColumn(nativeValueToBlock(column.getType(), inputFile.length())));
                 }
                 else if (column.getId() == TRINO_MERGE_PARTITION_SPEC_ID) {
                     columnAdaptations.add(ColumnAdaptation.constantColumn(nativeValueToBlock(column.getType(), (long) partitionSpecId)));
@@ -976,6 +983,9 @@ public class IcebergPageSourceProvider
                 else if (column.getId() == TRINO_MERGE_FILE_RECORD_COUNT) {
                     pageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), fileRecordCount));
                 }
+                else if (column.getId() == TRINO_MERGE_FILE_SIZE) {
+                    pageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), inputFile.length()));
+                }
                 else if (column.getId() == TRINO_MERGE_PARTITION_SPEC_ID) {
                     pageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), (long) partitionSpecId));
                 }
@@ -1148,6 +1158,9 @@ public class IcebergPageSourceProvider
                 }
                 else if (column.getId() == TRINO_MERGE_FILE_RECORD_COUNT) {
                     constantPopulatingPageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), fileRecordCount));
+                }
+                else if (column.getId() == TRINO_MERGE_FILE_SIZE) {
+                    constantPopulatingPageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), inputFile.length()));
                 }
                 else if (column.getId() == TRINO_MERGE_PARTITION_SPEC_ID) {
                     constantPopulatingPageSourceBuilder.addConstantColumn(nativeValueToBlock(column.getType(), (long) partitionSpecId));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/IcebergPositionDeletePageSink.java
@@ -59,6 +59,7 @@ public class IcebergPositionDeletePageSink
     private final IcebergFileWriter writer;
     private final IcebergFileFormat fileFormat;
     private final long fileRecordCount;
+    private final long fileSize;
 
     private long validationCpuNanos;
     private boolean writtenData;
@@ -75,7 +76,8 @@ public class IcebergPositionDeletePageSink
             ConnectorSession session,
             IcebergFileFormat fileFormat,
             Map<String, String> storageProperties,
-            long fileRecordCount)
+            long fileRecordCount,
+            long fileSize)
     {
         this.dataFilePath = requireNonNull(dataFilePath, "dataFilePath is null");
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
@@ -83,6 +85,7 @@ public class IcebergPositionDeletePageSink
         this.partition = requireNonNull(partition, "partition is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.fileRecordCount = fileRecordCount;
+        this.fileSize = fileSize;
         // prepend query id to a file name so we can determine which files were written by which query. This is needed for opportunistic cleanup of extra files
         // which may be present for successfully completing query in presence of failure recovery mechanisms.
         String fileName = fileFormat.toIceberg().addExtension(session.getQueryId() + "-" + randomUUID());
@@ -140,6 +143,7 @@ public class IcebergPositionDeletePageSink
                     partition.map(PartitionData::toJson),
                     FileContent.POSITION_DELETES,
                     Optional.of(dataFilePath),
+                    Optional.of(fileSize),
                     Optional.of(fileRecordCount),
                     Optional.of(deletedRowCount));
             Long recordCount = task.getMetrics().recordCount();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.plugin.hive.TrinoViewHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
@@ -67,11 +68,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -87,6 +95,8 @@ import static io.trino.tpch.TpchTable.NATION;
 import static java.lang.String.format;
 import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.iceberg.FileFormat.ORC;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,6 +123,7 @@ public class TestIcebergV2
         return IcebergQueryRunner.builder()
                 .setInitialTables(NATION)
                 .setMetastoreDirectory(metastoreDir)
+                .addAdditionalCatalog(new BlackHolePlugin(), "blackhole", "blackhole")
                 .build();
     }
 
@@ -340,6 +351,98 @@ public class TestIcebergV2
     }
 
     @Test
+    public void runOptimizeDuringWriteOperations()
+            throws Exception
+    {
+        runOptimizeDuringWriteOperations(true);
+        runOptimizeDuringWriteOperations(false);
+    }
+
+    private void runOptimizeDuringWriteOperations(boolean useSmallFiles)
+            throws Exception
+    {
+        int threads = 5;
+        int deletionThreads = threads - 1;
+        int rows = 20;
+        int rowsPerThread = rows / deletionThreads;
+
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService executor = newFixedThreadPool(threads);
+
+        // Slow down the delete operations so optimize is more likely to complete
+        String blackholeTable = "blackhole_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE blackhole.default.%s (a INT, b INT) WITH (split_count = 1, pages_per_split = 1, rows_per_page = 1, page_processing_delay = '250ms')".formatted(blackholeTable));
+
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_optimize_during_write_operations",
+                "(int_col INT)")) {
+            String tableName = table.getName();
+
+            // Testing both situations where a file is fully removed by the delete operation and when a row level delete is required.
+            if (useSmallFiles) {
+                for (int i = 0; i < rows; i++) {
+                    assertUpdate(format("INSERT INTO %s VALUES %s", tableName, i), 1);
+                }
+            }
+            else {
+                String values = IntStream.range(0, rows).mapToObj(String::valueOf).collect(Collectors.joining(", "));
+                assertUpdate(format("INSERT INTO %s VALUES %s", tableName, values), rows);
+            }
+
+            List<Future<List<Boolean>>> deletionFutures = IntStream.range(0, deletionThreads)
+                    .mapToObj(threadNumber -> executor.submit(() -> {
+                        barrier.await(10, SECONDS);
+                        List<Boolean> successfulDeletes = new ArrayList<>();
+                        for (int i = 0; i < rowsPerThread; i++) {
+                            try {
+                                int rowNumber = threadNumber * rowsPerThread + i;
+                                getQueryRunner().execute(format("DELETE FROM %s WHERE int_col = %s OR ((SELECT count(*) FROM blackhole.default.%s) > 42)", tableName, rowNumber, blackholeTable));
+                                successfulDeletes.add(true);
+                            }
+                            catch (RuntimeException e) {
+                                successfulDeletes.add(false);
+                            }
+                        }
+                        return successfulDeletes;
+                    }))
+                    .collect(toImmutableList());
+
+            Future<?> optimizeFuture = executor.submit(() -> {
+                try {
+                    barrier.await(10, SECONDS);
+                    // Allow for some deletes to start before running optimize
+                    Thread.sleep(50);
+                    assertUpdate("ALTER TABLE %s EXECUTE optimize".formatted(tableName));
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+
+            List<String> expectedValues = new ArrayList<>();
+            for (int threadNumber = 0; threadNumber < deletionThreads; threadNumber++) {
+                List<Boolean> deleteOutcomes = deletionFutures.get(threadNumber).get();
+                verify(deleteOutcomes.size() == rowsPerThread);
+                for (int rowNumber = 0; rowNumber < rowsPerThread; rowNumber++) {
+                    boolean successfulDelete = deleteOutcomes.get(rowNumber);
+                    if (!successfulDelete) {
+                        expectedValues.add(String.valueOf(threadNumber * rowsPerThread + rowNumber));
+                    }
+                }
+            }
+
+            optimizeFuture.get();
+            assertThat(expectedValues.size()).isGreaterThan(0).isLessThan(rows);
+            assertQuery("SELECT * FROM " + tableName, "VALUES " + String.join(", ", expectedValues));
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(10, SECONDS);
+        }
+    }
+
+    @Test
     public void testUpgradeTableToV2FromTrino()
     {
         String tableName = "test_upgrade_table_to_v2_from_trino_" + randomNameSuffix();
@@ -433,7 +536,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey <= 2", "SELECT count(*) FROM nation WHERE regionkey <= 2");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey > 2");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
     }
 
     @Test
@@ -461,7 +564,7 @@ public class TestIcebergV2
         assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
         assertUpdate("DELETE FROM " + tableName + " WHERE regionkey % 2 = 1", "SELECT count(*) FROM nation WHERE regionkey % 2 = 1");
         assertQuery("SELECT * FROM " + tableName, "SELECT * FROM nation WHERE regionkey % 2 = 0");
-        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(1);
+        assertThat(this.loadTable(tableName).newScan().planFiles()).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
## Description

Update, delete, or merge operations which removed all rows in a data
file incorrectly committed the data file removal to the manifest
without the necessary conflict detection.

This could result in duplicate rows if the data file was removed
by a different operation, for example optimize, during the write.

## Additional context and related issues

Fixes: https://github.com/trinodb/trino/issues/18393

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* TODO
```
