### PR TITLE
Run JDBC driver compatibility test since 352 with dynamic step

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -10,9 +10,9 @@ maven_run_tests="${maven} clean test ${MAVEN_TEST:--B} -pl :trino-test-jdbc-comp
 
 current_version=$(${maven} help:evaluate -Dexpression=project.version -q -DforceStdout)
 previous_released_version=$((${current_version%-SNAPSHOT}-1))
-first_tested_version=$(git tag --contain $(git rev-list HEAD --since-as-filter='18 month ago' | tail -1) | sort | head -1)
+first_tested_version=352
 # test n-th version only
-version_step=7
+version_step=$(( (previous_released_version - first_tested_version) / 7 ))
 
 echo "Current version: ${current_version}"
 


### PR DESCRIPTION
## Description

This reverts #16701 and fixes the step instead. `tested_versions` will be like below:
```
...
 tested_versions='352
362
372
382
392
402
412
422'
...
```

## Release notes

(x) This is not user-visible or docs only and no release notes are required.