### PR TITLE
Switch error code to TABLE_NOT_FOUND if all columns filtered out

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4279,8 +4279,12 @@ class StatementAnalyzer
                             .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, allColumns, "Unable to resolve reference %s", prefix));
                     if (identifierChainBasis.getBasisType() == TABLE) {
                         RelationType relationType = identifierChainBasis.getRelationType().orElseThrow();
-                        List<Field> fields = filterInaccessibleFields(relationType.resolveVisibleFieldsWithRelationPrefix(Optional.of(prefix)));
+                        List<Field> requestedFields = relationType.resolveVisibleFieldsWithRelationPrefix(Optional.of(prefix));
+                        List<Field> fields = filterInaccessibleFields(requestedFields);
                         if (fields.isEmpty()) {
+                            if (!requestedFields.isEmpty()) {
+                                throw semanticException(TABLE_NOT_FOUND, allColumns, "Relation not found or not allowed");
+                            }
                             throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed from relation that has no columns");
                         }
                         boolean local = scope.isLocalScope(identifierChainBasis.getScope().orElseThrow());
@@ -4305,10 +4309,14 @@ class StatementAnalyzer
                     throw semanticException(NOT_SUPPORTED, allColumns, "Column aliases not supported");
                 }
 
-                List<Field> fields = filterInaccessibleFields((List<Field>) scope.getRelationType().getVisibleFields());
+                List<Field> requestedFields = (List<Field>) scope.getRelationType().getVisibleFields();
+                List<Field> fields = filterInaccessibleFields(requestedFields);
                 if (fields.isEmpty()) {
                     if (node.getFrom().isEmpty()) {
                         throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed in queries without FROM clause");
+                    }
+                    if (!requestedFields.isEmpty()) {
+                        throw semanticException(TABLE_NOT_FOUND, allColumns, "Relation not found or not allowed");
                     }
                     throw semanticException(COLUMN_NOT_FOUND, allColumns, "SELECT * not allowed from relation that has no columns");
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a minor change that modifies the error message when all columns in a select query get filtered out to be of `TABLE_NOT_FOUND` error code instead of `COLUMN_NOT_FOUND`. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Switch error code to `TABLE_NOT_FOUND` if all columns filtered out from access control
```
