### PR TITLE
Use Aircompressor in Avro library code

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -92,6 +92,12 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -105,11 +111,10 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- TODO: remove after making Avro use Aircompressor -->
         <dependency>
-            <groupId>com.github.luben</groupId>
-            <artifactId>zstd-jni</artifactId>
-            <scope>runtime</scope>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -118,11 +123,10 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- TODO: remove after making Avro use Aircompressor -->
         <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <scope>runtime</scope>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -199,6 +203,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -207,6 +224,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileReader.java
@@ -41,6 +41,11 @@ public class AvroFileReader
     private Page nextPage;
     private final OptionalLong end;
 
+    static {
+        // ensure static CodecFactory map is updated by loading CompressionKind class
+        AvroCompressionKind.values();
+    }
+
     public AvroFileReader(
             TrinoInputFile inputFile,
             Schema schema,

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroFileWriter.java
@@ -24,7 +24,6 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.trino.hive.formats.avro.AvroTypeUtils.lowerCaseAllFieldsForWriter;
 
@@ -47,7 +46,6 @@ public class AvroFileWriter
             boolean resolveUsingLowerCaseFieldsInSchema)
             throws IOException, AvroTypeException
     {
-        verify(compressionKind.isSupportedLocally(), "compression kind must be supported locally: %s", compressionKind);
         if (resolveUsingLowerCaseFieldsInSchema) {
             pagePositionDataWriter = new AvroPagePositionDataWriter(lowerCaseAllFieldsForWriter(schema), avroTypeManager, names, types);
         }
@@ -56,7 +54,7 @@ public class AvroFileWriter
         }
         try {
             DataFileWriter<Integer> fileWriter = new DataFileWriter<>(pagePositionDataWriter)
-                    .setCodec(compressionKind.getCodecFactory());
+                    .setCodec(compressionKind.getTrinoCodecFactory());
             fileMetadata.forEach(fileWriter::setMeta);
             pagePositionFileWriter = fileWriter.create(schema, rawOutput);
         }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/SnappyAirCompressorCodec.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/SnappyAirCompressorCodec.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import io.airlift.compress.v3.snappy.SnappyCompressor;
+import io.airlift.compress.v3.snappy.SnappyDecompressor;
+import org.apache.avro.file.Codec;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.zip.CRC32;
+
+public class SnappyAirCompressorCodec
+        extends Codec
+{
+    public static final CodecFactory SNAPPY_CODEC_FACTORY = new CodecFactory()
+    {
+        @Override
+        protected Codec createInstance()
+        {
+            return new SnappyAirCompressorCodec();
+        }
+    };
+
+    private final SnappyCompressor compressor = SnappyCompressor.create();
+    private final SnappyDecompressor decompressor = SnappyDecompressor.create();
+    private final CRC32 crc32 = new CRC32();
+
+    @Override
+    public String getName()
+    {
+        return DataFileConstants.SNAPPY_CODEC;
+    }
+
+    @Override
+    public ByteBuffer compress(ByteBuffer uncompressedData)
+            throws IOException
+    {
+        if (uncompressedData.isDirect()) {
+            throw new IllegalArgumentException("Direct byte buffer not supported");
+        }
+        crc32.reset();
+        crc32.update(uncompressedData.array(), uncompressedData.arrayOffset() + uncompressedData.position(), uncompressedData.remaining());
+        ByteBuffer output = ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedData.remaining()) + 4);
+        int compressedSize = compressor.compress(
+                uncompressedData.array(), uncompressedData.arrayOffset() + uncompressedData.position(), uncompressedData.remaining(),
+                output.array(), 0, output.capacity());
+        output.position(compressedSize);
+        output.putInt((int) crc32.getValue());
+        output.flip();
+        return output;
+    }
+
+    @Override
+    public ByteBuffer decompress(ByteBuffer compressedData)
+            throws IOException
+    {
+        if (compressedData.isDirect()) {
+            throw new IllegalArgumentException("Direct byte buffer not supported");
+        }
+        int remaining = compressedData.remaining() - 4;
+        ByteBuffer output;
+        if (compressedData.limit() == compressedData.capacity() && compressedData.arrayOffset() == 0) {
+            output = ByteBuffer.allocate(decompressor.getUncompressedLength(compressedData.array(), compressedData.position()));
+        }
+        else {
+            byte[] input = new byte[remaining];
+            System.arraycopy(compressedData.array(), compressedData.arrayOffset() + compressedData.position(), input, 0, remaining);
+            output = ByteBuffer.allocate(decompressor.getUncompressedLength(input, 0));
+        }
+
+        compressedData.limit(compressedData.limit() - 4);
+        int decompressedSize = decompressor.decompress(
+                compressedData.array(), compressedData.arrayOffset() + compressedData.position(), compressedData.remaining(),
+                output.array(), 0, output.capacity());
+        output.position(decompressedSize);
+        output.flip();
+        compressedData.limit(compressedData.limit() + 4);
+        int storedCrc32 = compressedData.getInt(compressedData.limit() - 4);
+        crc32.reset();
+        crc32.update(output.array(), output.arrayOffset() + output.position(), output.remaining());
+        if (storedCrc32 != (int) crc32.getValue()) {
+            throw new IOException("Checksum failure " + storedCrc32 + " " + crc32.getValue());
+        }
+
+        return output;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SnappyAirCompressorCodec that)) {
+            return false;
+        }
+        return compressor.equals(that.compressor) && decompressor.equals(that.decompressor) && crc32.equals(that.crc32);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(compressor, decompressor, crc32);
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/ZstdAirCompressorCodec.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/ZstdAirCompressorCodec.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import io.airlift.compress.v3.zstd.ZstdCompressor;
+import io.airlift.compress.v3.zstd.ZstdDecompressor;
+import io.airlift.compress.v3.zstd.ZstdInputStream;
+import org.apache.avro.file.Codec;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import static java.lang.Math.toIntExact;
+
+public class ZstdAirCompressorCodec
+        extends Codec
+{
+    public static final CodecFactory ZSTD_CODEC_FACTORY = new CodecFactory()
+    {
+        @Override
+        protected Codec createInstance()
+        {
+            return new ZstdAirCompressorCodec();
+        }
+    };
+
+    private final ZstdCompressor compressor = ZstdCompressor.create();
+    private final ZstdDecompressor decompressor = ZstdDecompressor.create();
+
+    @Override
+    public String getName()
+    {
+        return DataFileConstants.ZSTANDARD_CODEC;
+    }
+
+    @Override
+    public ByteBuffer compress(ByteBuffer uncompressedData)
+            throws IOException
+    {
+        if (uncompressedData.isDirect()) {
+            throw new IllegalArgumentException("Direct byte buffer not supported");
+        }
+        ByteBuffer output = ByteBuffer.allocate(compressor.maxCompressedLength(uncompressedData.remaining()));
+        int compressedSize = compressor.compress(
+                uncompressedData.array(), uncompressedData.arrayOffset() + uncompressedData.position(), uncompressedData.remaining(),
+                output.array(), 0, output.capacity());
+        output.position(compressedSize);
+        output.flip();
+        return output;
+    }
+
+    @Override
+    public ByteBuffer decompress(ByteBuffer compressedData)
+            throws IOException
+    {
+        if (compressedData.isDirect()) {
+            throw new IllegalArgumentException("Direct byte buffer not supported");
+        }
+        int decompressedSize = toIntExact(decompressor.getDecompressedSize(compressedData.array(), compressedData.arrayOffset() + compressedData.position(), compressedData.remaining()));
+        if (decompressedSize < 0) {
+            return ByteBuffer.wrap(new ZstdInputStream(new ByteArrayInputStream(compressedData.array(), compressedData.arrayOffset() + compressedData.position(), compressedData.remaining())).readAllBytes());
+        }
+        else {
+            ByteBuffer output = ByteBuffer.allocate(decompressedSize);
+            decompressor.decompress(compressedData.array(), compressedData.arrayOffset() + compressedData.position(), compressedData.remaining(),
+                    output.array(), 0, output.capacity());
+            output.position(decompressedSize);
+            output.flip();
+            return output;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ZstdAirCompressorCodec that)) {
+            return false;
+        }
+        return compressor.equals(that.compressor) && decompressor.equals(that.decompressor);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(compressor, decompressor);
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAirCompressorAsAvroCodec.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAirCompressorAsAvroCodec.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.avro;
+
+import org.apache.avro.file.Codec;
+import org.apache.avro.file.CodecFactoryAccessor;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
+import static io.trino.hive.formats.avro.TestAvroBase.getLegacyCodecFactory;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class TestAirCompressorAsAvroCodec
+{
+    @ParameterizedTest
+    @EnumSource(AvroCompressionKind.class)
+    public void testAirCompressorCompatibility(AvroCompressionKind kind)
+            throws IOException
+    {
+        Supplier<byte[]> bytes = randomOriginalBytes();
+        Codec trinoCodec = CodecFactoryAccessor.createCodecInstance(kind.getTrinoCodecFactory());
+        Codec avroCodec = CodecFactoryAccessor.createCodecInstance(getLegacyCodecFactory(kind));
+
+        ByteBuffer expected = ByteBuffer.wrap(bytes.get());
+        ByteBuffer trinoDecompressedFromAvroCompressed = trinoCodec.decompress(avroCodec.compress(ByteBuffer.wrap(bytes.get())));
+        ByteBuffer avroDecompressedFromTrinoCompressed = avroCodec.decompress(trinoCodec.compress(ByteBuffer.wrap(bytes.get())));
+        ByteBuffer trinoRoundTrip = trinoCodec.decompress(trinoCodec.compress(ByteBuffer.wrap(bytes.get())));
+        ByteBuffer avroRoundTrip = avroCodec.decompress(avroCodec.compress(ByteBuffer.wrap(bytes.get())));
+
+        assertThat(trinoDecompressedFromAvroCompressed).isEqualTo(expected);
+        assertThat(avroDecompressedFromTrinoCompressed).isEqualTo(expected);
+        assertThat(trinoRoundTrip).isEqualTo(expected);
+        assertThat(avroRoundTrip).isEqualTo(expected);
+    }
+
+    private Supplier<byte[]> randomOriginalBytes()
+    {
+        byte[] b = generateRandomByteArray();
+        return () -> Arrays.copyOf(b, b.length);
+    }
+
+    private byte[] generateRandomByteArray()
+    {
+        int n = ThreadLocalRandom.current().nextInt(1000, 10000);
+        byte[] a = new byte[n];
+        ThreadLocalRandom.current().nextBytes(a);
+        return a;
+    }
+}

--- a/lib/trino-hive-formats/src/test/java/org/apache/avro/file/CodecFactoryAccessor.java
+++ b/lib/trino-hive-formats/src/test/java/org/apache/avro/file/CodecFactoryAccessor.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avro.file;
+
+public final class CodecFactoryAccessor
+{
+    private CodecFactoryAccessor() {}
+
+    public static Codec createCodecInstance(CodecFactory factory)
+    {
+        return factory.createInstance();
+    }
+}

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -392,6 +392,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-server</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive.avro;
 
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.trino.filesystem.Location;
@@ -94,9 +93,6 @@ public class AvroFileWriterFactory
         }
 
         AvroCompressionKind compressionKind = compressionCodec.getAvroCompressionKind().orElse(AvroCompressionKind.NULL);
-        if (!compressionKind.isSupportedLocally()) {
-            throw new VerifyException("Avro Compression codec %s is not supported in the environment".formatted(compressionKind));
-        }
 
         HiveTimestampPrecision hiveTimestampPrecision = getTimestampPrecision(session);
         // existing tables and partitions may have columns in a different order than the writer is providing, so build

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -92,6 +92,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-hive-formats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
         </dependency>
 
@@ -180,12 +185,6 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-hive-formats</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnector.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConnector.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.hive.formats.avro.AvroCompressionKind;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HiveTransactionHandle;
@@ -53,6 +54,11 @@ public class HudiConnector
     private final Set<SystemTable> systemTables;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> tableProperties;
+
+    static {
+        // ensure static CodecFactory map is updated by loading CompressionKind class
+        AvroCompressionKind.values();
+    }
 
     public HudiConnector(
             Injector injector,

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -325,6 +325,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-client</artifactId>
             <scope>runtime</scope>
@@ -395,6 +401,12 @@
             <!-- Docs promise that PostgreSQL driver will be on the classpath, for JDBC catalog's sake-->
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Substitute Aircompressor code for Avro Codec Factories for snappy and Zstd.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Allows us to further carve out Hadoop dependencies.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes


(X ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
