### PR TITLE
Check type of filter expression at statement analysis

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1230,7 +1230,12 @@ public class ExpressionAnalyzer
 
             if (node.getFilter().isPresent()) {
                 Expression expression = node.getFilter().get();
-                process(expression, context);
+                Type type = process(expression, context);
+                if (!type.equals(BOOLEAN)) {
+                    if (!type.equals(UNKNOWN)) {
+                        throw semanticException(TYPE_MISMATCH, expression, "Filter expression must evaluate to a boolean: actual type %s", type);
+                    }
+                }
             }
 
             List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4033,6 +4033,12 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testNullAggregationFilter()
+    {
+        analyze("SELECT a, count(*) FILTER (WHERE NULL) FROM t1 GROUP BY a");
+    }
+
+    @Test
     public void testInvalidAggregationFilter()
     {
         assertFails("SELECT sum(x) FILTER (WHERE x > 1) OVER (PARTITION BY x) FROM (VALUES (1), (2), (2), (4)) t (x)")
@@ -4044,6 +4050,12 @@ public class TestAnalyzer
         assertFails("SELECT abs(x) FILTER (where y = 1) FROM (VALUES (1, 1, 1)) t(x, y, z) GROUP BY z")
                 .hasErrorCode(FUNCTION_NOT_AGGREGATE)
                 .hasMessage("line 1:8: Filter is only valid for aggregation functions");
+        assertFails("SELECT count(*) FILTER (WHERE 0) FROM t1")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:31: Filter expression must evaluate to a boolean: actual type integer");
+        assertFails("SELECT a, count(*) FILTER (WHERE 0) FROM t1 GROUP BY a")
+                .hasErrorCode(TYPE_MISMATCH)
+                .hasMessage("line 1:34: Filter expression must evaluate to a boolean: actual type integer");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoid INTERNAL ERROR (COMPILER_ERROR) when non boolean expression is given as FILTER predicate. With this fix, the error will be USER ERROR (TYPE_MISMATCH).

```sql
select count(*) filter(where 0) from system.runtime.queries;
```

```
io.trino.spi.TrinoException: Compiler failed. Possible reasons include: the query may have too many or too complex expressions, or the underlying tables may have too many columns
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitScanFilterAndProject(LocalExecutionPlanner.java:2110)
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:1993)
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitProject(LocalExecutionPlanner.java:906)
	at io.trino.sql.planner.plan.ProjectNode.accept(ProjectNode.java:81)
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitAggregation(LocalExecutionPlanner.java:1928)
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitAggregation(LocalExecutionPlanner.java:906)
	at io.trino.sql.planner.plan.AggregationNode.accept(AggregationNode.java:221)
	at io.trino.sql.planner.LocalExecutionPlanner.plan(LocalExecutionPlanner.java:628)
	at io.trino.sql.planner.LocalExecutionPlanner.plan(LocalExecutionPlanner.java:533)
	at io.trino.execution.SqlTaskExecutionFactory.create(SqlTaskExecutionFactory.java:84)
	at io.trino.execution.SqlTask.tryCreateSqlTaskExecution(SqlTask.java:545)
	at io.trino.execution.SqlTask.updateTask(SqlTask.java:497)
	at io.trino.execution.SqlTaskManager.doUpdateTask(SqlTaskManager.java:532)
	at io.trino.execution.SqlTaskManager.lambda$updateTask$9(SqlTaskManager.java:476)
	at io.trino.$gen.Trino_dev____20230730_104711_2.call(Unknown Source)
	at io.trino.execution.SqlTaskManager.updateTask(SqlTaskManager.java:476)
	at io.trino.server.TaskResource.createOrUpdateTask(TaskResource.java:153)
	...
Caused by: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.RuntimeException: java.lang.VerifyError: Bad type on operand stack
Exception Details:
  Location:
    io/trino/$gen/CursorProcessor_20230730_104748_39.filter(Lio/trino/spi/connector/ConnectorSession;Lio/trino/spi/connector/RecordCursor;)Z @7: pop
  Reason:
    Type long_2nd (current frame, stack[1]) is not assignable to category1 type
  Current Frame:
    bci: @7
    flags: { }
    locals: { 'io/trino/$gen/CursorProcessor_20230730_104748_39', 'io/trino/spi/connector/ConnectorSession', 'io/trino/spi/connector/RecordCursor', integer }
    stack: { long, long_2nd }
  Bytecode:
    0000000: 033e 091d 9900 0557 03ac               
  Stackmap Table:
    full_frame(@9,{Object[#2],Object[#64],Object[#23],Integer},{Long})

	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085)
	at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
	at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
	at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
	at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
	at com.google.common.cache.ForwardingLoadingCache.getUnchecked(ForwardingLoadingCache.java:54)
	at io.trino.sql.gen.ExpressionCompiler.compileCursorProcessor(ExpressionCompiler.java:85)
	at io.trino.sql.planner.LocalExecutionPlanner$Visitor.visitScanFilterAndProject(LocalExecutionPlanner.java:2075)
	... 83 more
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.