### PR TITLE
Remove uses of Slice not backed by byte[]

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PageDeserializer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PageDeserializer.java
@@ -239,6 +239,76 @@ public class PageDeserializer
         }
 
         @Override
+        public void readShorts(short[] destination, int destinationIndex, int length)
+        {
+            ReadBuffer buffer = buffers[0];
+            int shortsRemaining = length;
+            while (shortsRemaining > 0) {
+                ensureReadable(min(Long.BYTES, shortsRemaining * Short.BYTES));
+                int shortsToRead = min(shortsRemaining, buffer.available() / Short.BYTES);
+                buffer.readShorts(destination, destinationIndex, shortsToRead);
+                shortsRemaining -= shortsToRead;
+                destinationIndex += shortsToRead;
+            }
+        }
+
+        @Override
+        public void readInts(int[] destination, int destinationIndex, int length)
+        {
+            ReadBuffer buffer = buffers[0];
+            int intsRemaining = length;
+            while (intsRemaining > 0) {
+                ensureReadable(min(Long.BYTES, intsRemaining * Integer.BYTES));
+                int intsToRead = min(intsRemaining, buffer.available() / Integer.BYTES);
+                buffer.readInts(destination, destinationIndex, intsToRead);
+                intsRemaining -= intsToRead;
+                destinationIndex += intsToRead;
+            }
+        }
+
+        @Override
+        public void readLongs(long[] destination, int destinationIndex, int length)
+        {
+            ReadBuffer buffer = buffers[0];
+            int longsRemaining = length;
+            while (longsRemaining > 0) {
+                ensureReadable(min(Long.BYTES, longsRemaining * Long.BYTES));
+                int longsToRead = min(longsRemaining, buffer.available() / Long.BYTES);
+                buffer.readLongs(destination, destinationIndex, longsToRead);
+                longsRemaining -= longsToRead;
+                destinationIndex += longsToRead;
+            }
+        }
+
+        @Override
+        public void readFloats(float[] destination, int destinationIndex, int length)
+        {
+            ReadBuffer buffer = buffers[0];
+            int floatsRemaining = length;
+            while (floatsRemaining > 0) {
+                ensureReadable(min(Long.BYTES, floatsRemaining * Float.BYTES));
+                int floatsToRead = min(floatsRemaining, buffer.available() / Float.BYTES);
+                buffer.readFloats(destination, destinationIndex, floatsToRead);
+                floatsRemaining -= floatsToRead;
+                destinationIndex += floatsToRead;
+            }
+        }
+
+        @Override
+        public void readDoubles(double[] destination, int destinationIndex, int length)
+        {
+            ReadBuffer buffer = buffers[0];
+            int doublesRemaining = length;
+            while (doublesRemaining > 0) {
+                ensureReadable(min(Long.BYTES, doublesRemaining * Double.BYTES));
+                int doublesToRead = min(doublesRemaining, buffer.available() / Double.BYTES);
+                buffer.readDoubles(destination, destinationIndex, doublesToRead);
+                doublesRemaining -= doublesToRead;
+                destinationIndex += doublesToRead;
+            }
+        }
+
+        @Override
         public void readBytes(Slice destination, int destinationIndex, int length)
         {
             ReadBuffer buffer = buffers[0];
@@ -570,6 +640,36 @@ public class PageDeserializer
         {
             slice.getBytes(position, destination, destinationIndex, length);
             position += length;
+        }
+
+        public void readShorts(short[] destination, int destinationIndex, int length)
+        {
+            slice.getShorts(position, destination, destinationIndex, length);
+            position += length * Short.BYTES;
+        }
+
+        public void readInts(int[] destination, int destinationIndex, int length)
+        {
+            slice.getInts(position, destination, destinationIndex, length);
+            position += length * Integer.BYTES;
+        }
+
+        public void readLongs(long[] destination, int destinationIndex, int length)
+        {
+            slice.getLongs(position, destination, destinationIndex, length);
+            position += length * Long.BYTES;
+        }
+
+        public void readFloats(float[] destination, int destinationIndex, int length)
+        {
+            slice.getFloats(position, destination, destinationIndex, length);
+            position += length * Float.BYTES;
+        }
+
+        public void readDoubles(double[] destination, int destinationIndex, int length)
+        {
+            slice.getDoubles(position, destination, destinationIndex, length);
+            position += length * Double.BYTES;
         }
 
         public void readBytes(Slice destination, int destinationIndex, int length)

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PageSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PageSerializer.java
@@ -243,6 +243,91 @@ public class PageSerializer
             uncompressedSize += length;
         }
 
+        @Override
+        public void writeShorts(short[] source, int sourceIndex, int length)
+        {
+            WriteBuffer buffer = buffers[0];
+            int currentIndex = sourceIndex;
+            int shortsRemaining = length;
+            while (shortsRemaining > 0) {
+                ensureCapacityFor(min(Long.BYTES, shortsRemaining * Short.BYTES));
+                int bufferCapacity = buffer.remainingCapacity();
+                int shortsToCopy = min(shortsRemaining, bufferCapacity / Short.BYTES);
+                buffer.writeShorts(source, currentIndex, shortsToCopy);
+                currentIndex += shortsToCopy;
+                shortsRemaining -= shortsToCopy;
+            }
+            uncompressedSize += length * Short.BYTES;
+        }
+
+        @Override
+        public void writeInts(int[] source, int sourceIndex, int length)
+        {
+            WriteBuffer buffer = buffers[0];
+            int currentIndex = sourceIndex;
+            int intsRemaining = length;
+            while (intsRemaining > 0) {
+                ensureCapacityFor(min(Long.BYTES, intsRemaining * Integer.BYTES));
+                int bufferCapacity = buffer.remainingCapacity();
+                int intsToCopy = min(intsRemaining, bufferCapacity / Integer.BYTES);
+                buffer.writeInts(source, currentIndex, intsToCopy);
+                currentIndex += intsToCopy;
+                intsRemaining -= intsToCopy;
+            }
+            uncompressedSize += length * Integer.BYTES;
+        }
+
+        @Override
+        public void writeLongs(long[] source, int sourceIndex, int length)
+        {
+            WriteBuffer buffer = buffers[0];
+            int currentIndex = sourceIndex;
+            int longsRemaining = length;
+            while (longsRemaining > 0) {
+                ensureCapacityFor(min(Long.BYTES, longsRemaining * Long.BYTES));
+                int bufferCapacity = buffer.remainingCapacity();
+                int longsToCopy = min(longsRemaining, bufferCapacity / Long.BYTES);
+                buffer.writeLongs(source, currentIndex, longsToCopy);
+                currentIndex += longsToCopy;
+                longsRemaining -= longsToCopy;
+            }
+            uncompressedSize += length * Long.BYTES;
+        }
+
+        @Override
+        public void writeFloats(float[] source, int sourceIndex, int length)
+        {
+            WriteBuffer buffer = buffers[0];
+            int currentIndex = sourceIndex;
+            int floatsRemaining = length;
+            while (floatsRemaining > 0) {
+                ensureCapacityFor(min(Long.BYTES, floatsRemaining * Float.BYTES));
+                int bufferCapacity = buffer.remainingCapacity();
+                int floatsToCopy = min(floatsRemaining, bufferCapacity / Float.BYTES);
+                buffer.writeFloats(source, currentIndex, floatsToCopy);
+                currentIndex += floatsToCopy;
+                floatsRemaining -= floatsToCopy;
+            }
+            uncompressedSize += length * Float.BYTES;
+        }
+
+        @Override
+        public void writeDoubles(double[] source, int sourceIndex, int length)
+        {
+            WriteBuffer buffer = buffers[0];
+            int currentIndex = sourceIndex;
+            int doublesRemaining = length;
+            while (doublesRemaining > 0) {
+                ensureCapacityFor(min(Long.BYTES, doublesRemaining * Double.BYTES));
+                int bufferCapacity = buffer.remainingCapacity();
+                int doublesToCopy = min(doublesRemaining, bufferCapacity / Double.BYTES);
+                buffer.writeDoubles(source, currentIndex, doublesToCopy);
+                currentIndex += doublesToCopy;
+                doublesRemaining -= doublesToCopy;
+            }
+            uncompressedSize += length * Double.BYTES;
+        }
+
         public Slice closePage()
         {
             compress();
@@ -587,6 +672,36 @@ public class PageSerializer
         {
             slice.setBytes(position, source, sourceIndex, length);
             position += length;
+        }
+
+        public void writeShorts(short[] source, int sourceIndex, int length)
+        {
+            slice.setShorts(position, source, sourceIndex, length);
+            position += length * Short.BYTES;
+        }
+
+        public void writeInts(int[] source, int sourceIndex, int length)
+        {
+            slice.setInts(position, source, sourceIndex, length);
+            position += length * Integer.BYTES;
+        }
+
+        public void writeLongs(long[] source, int sourceIndex, int length)
+        {
+            slice.setLongs(position, source, sourceIndex, length);
+            position += length * Long.BYTES;
+        }
+
+        public void writeFloats(float[] source, int sourceIndex, int length)
+        {
+            slice.setFloats(position, source, sourceIndex, length);
+            position += length * Float.BYTES;
+        }
+
+        public void writeDoubles(double[] source, int sourceIndex, int length)
+        {
+            slice.setDoubles(position, source, sourceIndex, length);
+            position += length * Double.BYTES;
         }
 
         public void skip(int length)

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ChecksumAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ChecksumAggregationFunction.java
@@ -14,6 +14,8 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.operator.aggregation.state.NullableLongState;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -34,7 +36,6 @@ import io.trino.spi.function.TypeParameter;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -89,7 +90,9 @@ public final class ChecksumAggregationFunction
             out.appendNull();
         }
         else {
-            VARBINARY.writeSlice(out, wrappedLongArray(state.getValue()));
+            Slice value = Slices.allocate(Long.BYTES);
+            value.setLong(0, state.getValue());
+            VARBINARY.writeSlice(out, value);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogram.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/NumericHistogram.java
@@ -71,8 +71,8 @@ public class NumericHistogram
         values = new double[maxBuckets + buffer];
         weights = new double[maxBuckets + buffer];
 
-        input.readBytes(Slices.wrappedDoubleArray(values), nextIndex * SizeOf.SIZE_OF_DOUBLE);
-        input.readBytes(Slices.wrappedDoubleArray(weights), nextIndex * SizeOf.SIZE_OF_DOUBLE);
+        input.readDoubles(values, 0, nextIndex);
+        input.readDoubles(weights, 0, nextIndex);
     }
 
     public Slice serialize()
@@ -90,8 +90,8 @@ public class NumericHistogram
                 .appendByte(FORMAT_TAG)
                 .appendInt(maxBuckets)
                 .appendInt(nextIndex)
-                .appendBytes(Slices.wrappedDoubleArray(values, 0, nextIndex))
-                .appendBytes(Slices.wrappedDoubleArray(weights, 0, nextIndex))
+                .appendDoubles(values, 0, nextIndex)
+                .appendDoubles(weights, 0, nextIndex)
                 .getUnderlyingSlice();
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
@@ -39,17 +39,17 @@ public class LongDecimalWithOverflowAndLongStateSerializer
             long overflow = state.getOverflow();
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
-            long[] buffer = new long[4];
+            Slice buffer = Slices.allocate(Long.BYTES * 4);
             long high = decimal[offset];
             long low = decimal[offset + 1];
 
-            buffer[0] = low;
-            buffer[1] = high;
+            buffer.setLong(0, low);
+            buffer.setLong(Long.BYTES, high);
             // if high = 0, the count will overwrite it
             int countOffset = 1 + (high == 0 ? 0 : 1);
             // append count, overflow
-            buffer[countOffset] = count;
-            buffer[countOffset + 1] = overflow;
+            buffer.setLong(Long.BYTES * countOffset, count);
+            buffer.setLong(Long.BYTES * (countOffset + 1), overflow);
 
             // cases
             // high == 0 (countOffset = 1)
@@ -59,7 +59,7 @@ public class LongDecimalWithOverflowAndLongStateSerializer
             //    overflow == 0 & count == 1  -> bufferLength = 2
             //    overflow != 0 || count != 1 -> bufferLength = 4
             int bufferLength = countOffset + ((overflow == 0 & count == 1) ? 0 : 2);
-            VARBINARY.writeSlice(out, Slices.wrappedLongArray(buffer, 0, bufferLength));
+            VARBINARY.writeSlice(out, buffer, 0, bufferLength * Long.BYTES);
         }
         else {
             out.appendNull();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateSerializer.java
@@ -38,18 +38,18 @@ public class LongDecimalWithOverflowStateSerializer
             long overflow = state.getOverflow();
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
-            long[] buffer = new long[3];
+            Slice buffer = Slices.allocate(Long.BYTES * 3);
             long low = decimal[offset + 1];
             long high = decimal[offset];
-            buffer[0] = low;
-            buffer[1] = high;
-            buffer[2] = overflow;
+            buffer.setLong(0, low);
+            buffer.setLong(Long.BYTES, high);
+            buffer.setLong(Long.BYTES * 2, overflow);
             // if high == 0 and overflow == 0 we only write low (bufferLength = 1)
             // if high != 0 and overflow == 0 we write both low and high (bufferLength = 2)
             // if overflow != 0 we write all values (bufferLength = 3)
             int decimalsCount = 1 + (high == 0 ? 0 : 1);
             int bufferLength = overflow == 0 ? decimalsCount : 3;
-            VARBINARY.writeSlice(out, Slices.wrappedLongArray(buffer, 0, bufferLength));
+            VARBINARY.writeSlice(out, buffer, 0, bufferLength * Long.BYTES);
         }
         else {
             out.appendNull();

--- a/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.join;
 
-import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
 import io.trino.spi.Page;
 
@@ -64,7 +63,11 @@ public final class ArrayPositionLinks
                 @Override
                 public long checksum()
                 {
-                    return XxHash64.hash(Slices.wrappedIntArray(positionLinks));
+                    long hash = 0;
+                    for (int positionLink : positionLinks) {
+                        hash = XxHash64.hash(hash, positionLink);
+                    }
+                    return hash;
                 }
             };
         }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/VarbinaryFunctions.java
@@ -61,7 +61,7 @@ public final class VarbinaryFunctions
     public static Slice toBase64(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         if (slice.hasByteArray()) {
-            return Slices.wrappedBuffer(Base64.getEncoder().encode(slice.toByteBuffer()));
+            return Slices.wrappedHeapBuffer(Base64.getEncoder().encode(slice.toByteBuffer()));
         }
         return Slices.wrappedBuffer(Base64.getEncoder().encode(slice.getBytes()));
     }
@@ -74,7 +74,7 @@ public final class VarbinaryFunctions
     {
         try {
             if (slice.hasByteArray()) {
-                return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
+                return Slices.wrappedHeapBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
             }
             return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.getBytes()));
         }
@@ -90,7 +90,7 @@ public final class VarbinaryFunctions
     {
         try {
             if (slice.hasByteArray()) {
-                return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
+                return Slices.wrappedHeapBuffer(Base64.getDecoder().decode(slice.toByteBuffer()));
             }
             return Slices.wrappedBuffer(Base64.getDecoder().decode(slice.getBytes()));
         }
@@ -105,7 +105,7 @@ public final class VarbinaryFunctions
     public static Slice toBase64Url(@SqlType(StandardTypes.VARBINARY) Slice slice)
     {
         if (slice.hasByteArray()) {
-            return Slices.wrappedBuffer(Base64.getUrlEncoder().encode(slice.toByteBuffer()));
+            return Slices.wrappedHeapBuffer(Base64.getUrlEncoder().encode(slice.toByteBuffer()));
         }
         return Slices.wrappedBuffer(Base64.getUrlEncoder().encode(slice.getBytes()));
     }
@@ -118,7 +118,7 @@ public final class VarbinaryFunctions
     {
         try {
             if (slice.hasByteArray()) {
-                return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
+                return Slices.wrappedHeapBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
             }
             return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.getBytes()));
         }
@@ -134,7 +134,7 @@ public final class VarbinaryFunctions
     {
         try {
             if (slice.hasByteArray()) {
-                return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
+                return Slices.wrappedHeapBuffer(Base64.getUrlDecoder().decode(slice.toByteBuffer()));
             }
             return Slices.wrappedBuffer(Base64.getUrlDecoder().decode(slice.getBytes()));
         }

--- a/core/trino-main/src/main/java/io/trino/type/CodePointsType.java
+++ b/core/trino-main/src/main/java/io/trino/type/CodePointsType.java
@@ -54,14 +54,16 @@ public class CodePointsType
 
         Slice slice = block.getSlice(position, 0, block.getSliceLength(position));
         int[] codePoints = new int[slice.length() / Integer.BYTES];
-        slice.getBytes(0, Slices.wrappedIntArray(codePoints));
+        slice.getInts(0, codePoints);
         return codePoints;
     }
 
     @Override
     public void writeObject(BlockBuilder blockBuilder, Object value)
     {
-        Slice slice = Slices.wrappedIntArray((int[]) value);
+        int[] codePoints = (int[]) value;
+        Slice slice = Slices.allocate(codePoints.length * Integer.BYTES);
+        slice.setInts(0, codePoints);
         ((VariableWidthBlockBuilder) blockBuilder).writeEntry(slice);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
+++ b/core/trino-main/src/main/java/io/trino/type/IpAddressType.java
@@ -156,9 +156,10 @@ public class IpAddressType
     @Override
     public final Slice getSlice(Block block, int position)
     {
-        return Slices.wrappedLongArray(
-                block.getLong(position, 0),
-                block.getLong(position, SIZE_OF_LONG));
+        Slice value = Slices.allocate(INT128_BYTES);
+        value.setLong(0, block.getLong(position, 0));
+        value.setLong(SIZE_OF_LONG, block.getLong(position, SIZE_OF_LONG));
+        return value;
     }
 
     @ScalarOperator(EQUAL)

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -326,19 +326,26 @@ public final class BlockAssertions
     private static Block createRandomVarbinariesBlock(int positionCount, float nullRate)
     {
         Random random = random();
-        return createSlicesBlock(VARBINARY, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random.nextLong(), random.nextLong())));
+        return createSlicesBlock(VARBINARY, generateListWithNulls(positionCount, nullRate, () -> randomSlice(random, 16)));
     }
 
     private static Block createRandomUUIDsBlock(int positionCount, float nullRate)
     {
         Random random = random();
-        return createSlicesBlock(UUID, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random.nextLong(), random.nextLong())));
+        return createSlicesBlock(UUID, generateListWithNulls(positionCount, nullRate, () -> randomSlice(random, 16)));
     }
 
     private static Block createRandomIpAddressesBlock(int positionCount, float nullRate)
     {
         Random random = random();
-        return createSlicesBlock(IPADDRESS, generateListWithNulls(positionCount, nullRate, () -> Slices.wrappedLongArray(random.nextLong(), random.nextLong())));
+        return createSlicesBlock(IPADDRESS, generateListWithNulls(positionCount, nullRate, () -> randomSlice(random, 16)));
+    }
+
+    private static Slice randomSlice(Random random, int length)
+    {
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        return Slices.wrappedBuffer(bytes);
     }
 
     private static Block createRandomTinyintsBlock(int positionCount, float nullRate)

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -290,7 +290,7 @@ public class BenchmarkGroupByHash
         PageBuilder pageBuilder = new PageBuilder(types);
         for (int position = 0; position < positionCount; position++) {
             int rand = ThreadLocalRandom.current().nextInt(groupCount);
-            Slice value = Slices.wrappedBuffer(ByteBuffer.allocate(4).putInt(rand).flip());
+            Slice value = Slices.wrappedHeapBuffer(ByteBuffer.allocate(4).putInt(rand).flip());
             pageBuilder.declarePosition();
             for (int channel = 0; channel < channelCount; channel++) {
                 VARCHAR.writeSlice(pageBuilder.getBlockBuilder(channel), value);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestChecksumAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestChecksumAggregation.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.aggregation;
 
+import com.google.common.primitives.Longs;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.ArrayType;
@@ -24,7 +25,6 @@ import io.trino.type.BlockTypeOperators;
 import io.trino.type.BlockTypeOperators.BlockPositionXxHash64;
 import org.testng.annotations.Test;
 
-import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.trino.block.BlockAssertions.createArrayBigintBlock;
 import static io.trino.block.BlockAssertions.createBooleansBlock;
 import static io.trino.block.BlockAssertions.createDoublesBlock;
@@ -117,6 +117,6 @@ public class TestChecksumAggregation
                 result += xxHash64Operator.xxHash64(block, i) * PRIME64;
             }
         }
-        return new SqlVarbinary(wrappedLongArray(result).getBytes());
+        return new SqlVarbinary(Longs.toByteArray(Long.reverseBytes(result)));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestStateCompiler.java
@@ -16,6 +16,8 @@ package io.trino.operator.aggregation.state;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 import io.trino.array.BlockBigArray;
 import io.trino.array.BooleanBigArray;
 import io.trino.array.ByteBigArray;
@@ -43,7 +45,6 @@ import java.util.Map;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.airlift.slice.Slices.wrappedDoubleArray;
 import static io.trino.block.BlockAssertions.createLongsBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -212,7 +213,7 @@ public class TestStateCompiler
         singleState.setByte((byte) 3);
         singleState.setInt(4);
         singleState.setSlice(utf8Slice("test"));
-        singleState.setAnotherSlice(wrappedDoubleArray(1.0, 2.0, 3.0));
+        singleState.setAnotherSlice(toSlice(1.0, 2.0, 3.0));
         singleState.setYetAnotherSlice(null);
         Block array = createLongsBlock(45);
         singleState.setBlock(array);
@@ -311,7 +312,7 @@ public class TestStateCompiler
             Slice slice = utf8Slice("test");
             retainedSize += slice.getRetainedSize();
             groupedState.setSlice(slice);
-            slice = wrappedDoubleArray(1.0, 2.0, 3.0);
+            slice = toSlice(1.0, 2.0, 3.0);
             retainedSize += slice.getRetainedSize();
             groupedState.setAnotherSlice(slice);
             groupedState.setYetAnotherSlice(null);
@@ -340,7 +341,7 @@ public class TestStateCompiler
             Slice slice = utf8Slice("test");
             retainedSize += slice.getRetainedSize();
             groupedState.setSlice(slice);
-            slice = wrappedDoubleArray(1.0, 2.0, 3.0);
+            slice = toSlice(1.0, 2.0, 3.0);
             retainedSize += slice.getRetainedSize();
             groupedState.setAnotherSlice(slice);
             groupedState.setYetAnotherSlice(null);
@@ -357,6 +358,16 @@ public class TestStateCompiler
             groupedState.setAnotherBlock(map);
             assertEquals(groupedState.getEstimatedSize(), initialRetainedSize + retainedSize * 1000 + getReferenceCountMapOverhead(groupedState));
         }
+    }
+
+    private static Slice toSlice(double... values)
+    {
+        Slice slice = Slices.allocate(values.length * Double.BYTES);
+        SliceOutput output = slice.getOutput();
+        for (double value : values) {
+            output.writeDouble(value);
+        }
+        return slice;
     }
 
     public interface TestComplexState

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppender.java
@@ -179,7 +179,7 @@ public class TestPositionsAppender
                         {TestType.DOUBLE, createDoublesBlock(0D), createDoublesBlock(1D)},
                         {TestType.SMALLINT, createSmallintsBlock(0), createSmallintsBlock(1)},
                         {TestType.TINYINT, createTinyintsBlock(0), createTinyintsBlock(1)},
-                        {TestType.VARBINARY, createSlicesBlock(Slices.wrappedLongArray(0)), createSlicesBlock(Slices.wrappedLongArray(1))},
+                        {TestType.VARBINARY, createSlicesBlock(Slices.allocate(Long.BYTES)), createSlicesBlock(Slices.allocate(Long.BYTES).getOutput().appendLong(1).slice())},
                         {TestType.LONG_DECIMAL, createLongDecimalsBlock("0"), createLongDecimalsBlock("1")},
                         {TestType.ARRAY_BIGINT, createArrayBigintBlock(ImmutableList.of(ImmutableList.of(0L))), createArrayBigintBlock(ImmutableList.of(ImmutableList.of(1L)))},
                         {TestType.LONG_TIMESTAMP, createLongTimestampBlock(createTimestampType(9), new LongTimestamp(0, 0)),

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestSlicePositionsAppender.java
@@ -17,17 +17,13 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
-import io.trino.spi.block.VariableWidthBlock;
-import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
-import java.util.Optional;
 
 import static io.trino.block.BlockAssertions.assertBlockEquals;
 import static io.trino.block.BlockAssertions.createStringsBlock;
 import static io.trino.operator.output.SlicePositionsAppender.duplicateBytes;
-import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
@@ -44,25 +40,6 @@ public class TestSlicePositionsAppender
         Block actualBlock = positionsAppender.build();
 
         assertBlockEquals(VARCHAR, actualBlock, RunLengthEncodedBlock.create(value, 10));
-    }
-
-    // test append with VariableWidthBlock using Slice not backed by byte array
-    // to test special handling in SlicePositionsAppender.copyBytes
-    @Test
-    public void testAppendSliceNotBackedByByteArray()
-    {
-        PositionsAppender positionsAppender = new SlicePositionsAppender(1, DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
-        Block block = new VariableWidthBlock(3, Slices.wrappedLongArray(257, 2), new int[] {0, 1, Long.BYTES, 2 * Long.BYTES}, Optional.empty());
-        positionsAppender.append(IntArrayList.wrap(new int[] {0, 2}), block);
-
-        Block actual = positionsAppender.build();
-
-        Block expected = new VariableWidthBlock(
-                2,
-                Slices.wrappedBuffer(new byte[] {1, 2, 0, 0, 0, 0, 0, 0, 0}),
-                new int[] {0, 1, Long.BYTES + 1},
-                Optional.empty());
-        assertBlockEquals(VARCHAR, actual, expected);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/server/TestSliceSerialization.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestSliceSerialization.java
@@ -72,39 +72,7 @@ public class TestSliceSerialization
         slice.setBytes(0, bytes);
         testRoundTrip(slice);
 
-        slice = Slices.wrappedShortArray(new short[bytes.length / Short.BYTES + bytes.length % Short.BYTES]);
-        slice.setBytes(bytes.length % Short.BYTES, bytes);
-        testRoundTrip(slice.slice(bytes.length % Short.BYTES, bytes.length));
-
-        slice = Slices.wrappedIntArray(new int[bytes.length / Integer.BYTES + bytes.length % Integer.BYTES]);
-        slice.setBytes(bytes.length % Integer.BYTES, bytes);
-        testRoundTrip(slice.slice(bytes.length % Integer.BYTES, bytes.length));
-
-        slice = Slices.wrappedLongArray(new long[bytes.length / Long.BYTES + bytes.length % Long.BYTES]);
-        slice.setBytes(bytes.length % Long.BYTES, bytes);
-        testRoundTrip(slice.slice(bytes.length % Long.BYTES, bytes.length));
-
-        slice = Slices.wrappedDoubleArray(new double[bytes.length / Double.BYTES + bytes.length % Double.BYTES]);
-        slice.setBytes(bytes.length % Double.BYTES, bytes);
-        testRoundTrip(slice.slice(bytes.length % Double.BYTES, bytes.length));
-
-        slice = Slices.wrappedFloatArray(new float[bytes.length / Float.BYTES + bytes.length % Float.BYTES]);
-        slice.setBytes(bytes.length % Float.BYTES, bytes);
-        testRoundTrip(slice.slice(bytes.length % Float.BYTES, bytes.length));
-
-        slice = Slices.wrappedBooleanArray(new boolean[bytes.length]);
-        slice.setBytes(0, bytes);
-        testRoundTrip(slice);
-
-        slice = Slices.wrappedBooleanArray(new boolean[bytes.length + 3], 2, bytes.length);
-        slice.setBytes(0, bytes);
-        testRoundTrip(slice);
-
         slice = Slices.allocate(bytes.length);
-        slice.setBytes(0, bytes);
-        testRoundTrip(slice);
-
-        slice = Slices.allocateDirect(bytes.length);
         slice.setBytes(0, bytes);
         testRoundTrip(slice);
     }

--- a/core/trino-main/src/test/java/io/trino/type/TestUuidType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestUuidType.java
@@ -58,13 +58,16 @@ public class TestUuidType
     protected Object getGreaterValue(Object value)
     {
         Slice slice = (Slice) value;
-        return Slices.wrappedLongArray(slice.getLong(0), reverseBytes(reverseBytes(slice.getLong(SIZE_OF_LONG)) + 1));
+        Slice greater = Slices.allocate(2 * SIZE_OF_LONG);
+        greater.setLong(0, slice.getLong(0));
+        greater.setLong(SIZE_OF_LONG, reverseBytes(reverseBytes(slice.getLong(SIZE_OF_LONG)) + 1));
+        return greater;
     }
 
     @Override
     protected Object getNonNullValue()
     {
-        return Slices.wrappedLongArray(0, 0);
+        return Slices.allocate(2 * SIZE_OF_LONG);
     }
 
     @Test

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -229,6 +229,78 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method void io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</old>
+                                    <new>method io.trino.spi.block.VariableWidthBlockBuilder io.trino.spi.block.VariableWidthBlockBuilder::writeEntry(io.airlift.slice.Slice)</new>
+                                    <justification>Safe to change void return to match other method of same name with different signature</justification>
+                                </item>
+                                <item>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method java.lang.Object io.airlift.slice.Slice::getBase()</old>
+                                    <new>method byte[] io.airlift.slice.Slice::getBase()</new>
+                                </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method void io.airlift.slice.SliceInput::readDoubles(double[])</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceInput::readDoubles(double[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method void io.airlift.slice.SliceInput::readFloats(float[])</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceInput::readFloats(float[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method void io.airlift.slice.SliceInput::readInts(int[])</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceInput::readInts(int[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method void io.airlift.slice.SliceInput::readLongs(long[])</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceInput::readLongs(long[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.finalMethodAddedToNonFinalClass</code>
+                                    <new>method void io.airlift.slice.SliceInput::readShorts(short[])</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceInput::readShorts(short[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceOutput::writeDoubles(double[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceOutput::writeFloats(float[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceOutput::writeInts(int[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceOutput::writeLongs(long[], int, int)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.abstractMethodAdded</code>
+                                    <new>method void io.airlift.slice.SliceOutput::writeShorts(short[], int, int)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlockEncoding.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
-import io.airlift.slice.Slices;
 
 import static io.trino.spi.block.ArrayBlock.createArrayBlockInternal;
 import static io.trino.spi.block.EncoderUtil.decodeNullBits;
@@ -61,7 +60,7 @@ public class ArrayBlockEncoding
 
         int positionCount = sliceInput.readInt();
         int[] offsets = new int[positionCount + 1];
-        sliceInput.readBytes(Slices.wrappedIntArray(offsets));
+        sliceInput.readInts(offsets);
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
         return createArrayBlockInternal(0, positionCount, valueIsNull, offsets, values);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
-import io.airlift.slice.Slices;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -595,11 +594,6 @@ public class DictionaryBlock
     public Block getDictionary()
     {
         return dictionary;
-    }
-
-    Slice getIds()
-    {
-        return Slices.wrappedIntArray(ids, idsOffset, positionCount);
     }
 
     boolean isSequentialIds()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlockEncoding.java
@@ -15,7 +15,6 @@ package io.trino.spi.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
-import io.airlift.slice.Slices;
 
 import java.util.Optional;
 
@@ -49,7 +48,7 @@ public class DictionaryBlockEncoding
         blockEncodingSerde.writeBlock(sliceOutput, dictionary);
 
         // ids
-        sliceOutput.writeBytes(dictionaryBlock.getIds());
+        sliceOutput.writeInts(dictionaryBlock.getRawIds(), dictionaryBlock.getRawIdsOffset(), dictionaryBlock.getPositionCount());
     }
 
     @Override
@@ -63,7 +62,7 @@ public class DictionaryBlockEncoding
 
         // ids
         int[] ids = new int[positionCount];
-        sliceInput.readBytes(Slices.wrappedIntArray(ids));
+        sliceInput.readInts(ids);
 
         // flatten the dictionary
         return dictionaryBlock.copyPositions(ids, 0, ids.length);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
@@ -280,8 +278,13 @@ public class Fixed12Block
         return values[offset + 2];
     }
 
-    Slice getValuesSlice()
+    int getPositionOffset()
     {
-        return Slices.wrappedIntArray(values, positionOffset * 3, positionCount * 3);
+        return positionOffset;
+    }
+
+    int[] getRawValues()
+    {
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12BlockBuilder.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
@@ -304,8 +302,8 @@ public class Fixed12BlockBuilder
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    int[] getRawValues()
     {
-        return Slices.wrappedIntArray(values, 0, positionCount * 3);
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
@@ -233,8 +231,13 @@ public class Int128ArrayBlock
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    long[] getRawValues()
     {
-        return Slices.wrappedLongArray(values, positionOffset * 2, positionCount * 2);
+        return values;
+    }
+
+    int getPositionOffset()
+    {
+        return positionOffset;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockBuilder.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
@@ -288,8 +286,8 @@ public class Int128ArrayBlockBuilder
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    long[] getRawValues()
     {
-        return Slices.wrappedLongArray(values, 0, positionCount * 2);
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlockEncoding.java
@@ -13,10 +13,8 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
-import io.airlift.slice.Slices;
 
 import static io.trino.spi.block.EncoderUtil.decodeNullBits;
 import static io.trino.spi.block.EncoderUtil.encodeNullsAsBits;
@@ -41,7 +39,15 @@ public class Int128ArrayBlockEncoding
         encodeNullsAsBits(sliceOutput, block);
 
         if (!block.mayHaveNull()) {
-            sliceOutput.writeBytes(getValuesSlice(block));
+            if (block instanceof Int128ArrayBlock valueBlock) {
+                sliceOutput.writeLongs(valueBlock.getRawValues(), valueBlock.getPositionOffset() * 2, valueBlock.getPositionCount() * 2);
+            }
+            else if (block instanceof Int128ArrayBlockBuilder blockBuilder) {
+                sliceOutput.writeLongs(blockBuilder.getRawValues(), 0, blockBuilder.getPositionCount() * 2);
+            }
+            else {
+                throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
+            }
         }
         else {
             long[] valuesWithoutNull = new long[positionCount * 2];
@@ -55,7 +61,7 @@ public class Int128ArrayBlockEncoding
             }
 
             sliceOutput.writeInt(nonNullPositionCount / 2);
-            sliceOutput.writeBytes(Slices.wrappedLongArray(valuesWithoutNull, 0, nonNullPositionCount));
+            sliceOutput.writeLongs(valuesWithoutNull, 0, nonNullPositionCount);
         }
     }
 
@@ -68,11 +74,11 @@ public class Int128ArrayBlockEncoding
 
         long[] values = new long[positionCount * 2];
         if (valueIsNull == null) {
-            sliceInput.readBytes(Slices.wrappedLongArray(values));
+            sliceInput.readLongs(values);
         }
         else {
             int nonNullPositionCount = sliceInput.readInt();
-            sliceInput.readBytes(Slices.wrappedLongArray(values, 0, nonNullPositionCount * 2));
+            sliceInput.readLongs(values, 0, nonNullPositionCount * 2);
             int position = 2 * (nonNullPositionCount - 1);
             for (int i = positionCount - 1; i >= 0 && position >= 0; i--) {
                 System.arraycopy(values, position, values, 2 * i, 2);
@@ -83,17 +89,5 @@ public class Int128ArrayBlockEncoding
         }
 
         return new Int128ArrayBlock(0, positionCount, valueIsNull, values);
-    }
-
-    private Slice getValuesSlice(Block block)
-    {
-        if (block instanceof Int128ArrayBlock) {
-            return ((Int128ArrayBlock) block).getValuesSlice();
-        }
-        if (block instanceof Int128ArrayBlockBuilder) {
-            return ((Int128ArrayBlockBuilder) block).getValuesSlice();
-        }
-
-        throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.trino.spi.Experimental;
 import jakarta.annotation.Nullable;
 
@@ -226,11 +224,6 @@ public class IntArrayBlock
         sb.append("positionCount=").append(getPositionCount());
         sb.append('}');
         return sb.toString();
-    }
-
-    Slice getValuesSlice()
-    {
-        return Slices.wrappedIntArray(values, arrayOffset, positionCount);
     }
 
     @Experimental(eta = "2023-12-31")

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlockBuilder.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
@@ -279,8 +277,8 @@ public class IntArrayBlockBuilder
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    int[] getRawValues()
     {
-        return Slices.wrappedIntArray(values, 0, positionCount);
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
@@ -274,8 +272,13 @@ public class LongArrayBlock
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    long[] getRawValues()
     {
-        return Slices.wrappedLongArray(values, arrayOffset, positionCount);
+        return values;
+    }
+
+    int getRawValuesOffset()
+    {
+        return arrayOffset;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockBuilder.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
@@ -326,8 +324,8 @@ public class LongArrayBlockBuilder
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    long[] getRawValues()
     {
-        return Slices.wrappedLongArray(values, 0, positionCount);
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlockEncoding.java
@@ -13,10 +13,8 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
-import io.airlift.slice.Slices;
 
 import static io.trino.spi.block.EncoderUtil.decodeNullBits;
 import static io.trino.spi.block.EncoderUtil.encodeNullsAsBits;
@@ -43,7 +41,15 @@ public class LongArrayBlockEncoding
         encodeNullsAsBits(sliceOutput, block);
 
         if (!block.mayHaveNull()) {
-            sliceOutput.writeBytes(getValuesSlice(block));
+            if (block instanceof LongArrayBlock valueBlock) {
+                sliceOutput.writeLongs(valueBlock.getRawValues(), valueBlock.getRawValuesOffset(), valueBlock.getPositionCount());
+            }
+            else if (block instanceof LongArrayBlockBuilder blockBuilder) {
+                sliceOutput.writeLongs(blockBuilder.getRawValues(), 0, blockBuilder.getPositionCount());
+            }
+            else {
+                throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
+            }
         }
         else {
             long[] valuesWithoutNull = new long[positionCount];
@@ -56,7 +62,7 @@ public class LongArrayBlockEncoding
             }
 
             sliceOutput.writeInt(nonNullPositionCount);
-            sliceOutput.writeBytes(Slices.wrappedLongArray(valuesWithoutNull, 0, nonNullPositionCount));
+            sliceOutput.writeLongs(valuesWithoutNull, 0, nonNullPositionCount);
         }
     }
 
@@ -69,13 +75,13 @@ public class LongArrayBlockEncoding
         long[] values = new long[positionCount];
 
         if (valueIsNullPacked == null) {
-            sliceInput.readBytes(Slices.wrappedLongArray(values));
+            sliceInput.readLongs(values);
             return new LongArrayBlock(0, positionCount, null, values);
         }
         boolean[] valueIsNull = decodeNullBits(valueIsNullPacked, positionCount);
 
         int nonNullPositionCount = sliceInput.readInt();
-        sliceInput.readBytes(Slices.wrappedLongArray(values, 0, nonNullPositionCount));
+        sliceInput.readLongs(values, 0, nonNullPositionCount);
         int position = nonNullPositionCount - 1;
 
         // Handle Last (positionCount % 8) values
@@ -104,17 +110,5 @@ public class LongArrayBlockEncoding
             // Do nothing if there are only nulls
         }
         return new LongArrayBlock(0, positionCount, valueIsNull, values);
-    }
-
-    private Slice getValuesSlice(Block block)
-    {
-        if (block instanceof LongArrayBlock) {
-            return ((LongArrayBlock) block).getValuesSlice();
-        }
-        if (block instanceof LongArrayBlockBuilder) {
-            return ((LongArrayBlockBuilder) block).getValuesSlice();
-        }
-
-        throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockEncoding.java
@@ -17,7 +17,6 @@ package io.trino.spi.block;
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
 
-import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.trino.spi.block.RowBlock.createRowBlockInternal;
 
 public class RowBlockEncoding
@@ -61,14 +60,14 @@ public class RowBlockEncoding
 
         if (fieldBlockOffsets != null) {
             if (startFieldBlockOffset == 0) {
-                sliceOutput.writeBytes(wrappedIntArray(fieldBlockOffsets, offsetBase, positionCount + 1));
+                sliceOutput.writeInts(fieldBlockOffsets, offsetBase, positionCount + 1);
             }
             else {
                 int[] newFieldBlockOffsets = new int[positionCount + 1];
                 for (int position = 0; position < positionCount + 1; position++) {
                     newFieldBlockOffsets[position] = fieldBlockOffsets[offsetBase + position] - startFieldBlockOffset;
                 }
-                sliceOutput.writeBytes(wrappedIntArray(newFieldBlockOffsets));
+                sliceOutput.writeInts(newFieldBlockOffsets);
             }
         }
     }
@@ -88,7 +87,7 @@ public class RowBlockEncoding
         int[] fieldBlockOffsets = null;
         if (rowIsNull != null) {
             fieldBlockOffsets = new int[positionCount + 1];
-            sliceInput.readBytes(wrappedIntArray(fieldBlockOffsets));
+            sliceInput.readInts(fieldBlockOffsets);
         }
         return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Optional;
@@ -226,8 +224,13 @@ public class ShortArrayBlock
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    int getRawValuesOffset()
     {
-        return Slices.wrappedShortArray(values, arrayOffset, positionCount);
+        return arrayOffset;
+    }
+
+    short[] getRawValues()
+    {
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlockBuilder.java
@@ -13,8 +13,6 @@
  */
 package io.trino.spi.block;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import jakarta.annotation.Nullable;
 
 import java.util.Arrays;
@@ -279,8 +277,8 @@ public class ShortArrayBlockBuilder
         return sb.toString();
     }
 
-    Slice getValuesSlice()
+    short[] getRawValues()
     {
-        return Slices.wrappedShortArray(values, 0, positionCount);
+        return values;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleMapBlockEncoding.java
@@ -20,7 +20,6 @@ import io.trino.spi.type.MapType;
 
 import java.util.Optional;
 
-import static io.airlift.slice.Slices.wrappedIntArray;
 import static io.trino.spi.block.MapHashTables.HASH_MULTIPLIER;
 import static java.lang.String.format;
 
@@ -50,7 +49,7 @@ public class SingleMapBlockEncoding
         if (hashTable.isPresent()) {
             int hashTableLength = positionCount / 2 * HASH_MULTIPLIER;
             sliceOutput.appendInt(hashTableLength);  // hashtable length
-            sliceOutput.writeBytes(wrappedIntArray(hashTable.get(), offset / 2 * HASH_MULTIPLIER, hashTableLength));
+            sliceOutput.writeInts(hashTable.get(), offset / 2 * HASH_MULTIPLIER, hashTableLength);
         }
         else {
             // if the hashTable is null, we write the length -1
@@ -70,7 +69,7 @@ public class SingleMapBlockEncoding
         int[] hashTable = null;
         if (hashTableLength >= 0) {
             hashTable = new int[hashTableLength];
-            sliceInput.readBytes(wrappedIntArray(hashTable));
+            sliceInput.readInts(hashTable);
         }
 
         if (keyBlock.getPositionCount() != valueBlock.getPositionCount()) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlockEncoding.java
@@ -58,7 +58,7 @@ public class VariableWidthBlockEncoding
 
         sliceOutput
                 .appendInt(nonNullsCount)
-                .writeBytes(Slices.wrappedIntArray(lengths, 0, nonNullsCount));
+                .writeInts(lengths, 0, nonNullsCount);
 
         encodeNullsAsBits(sliceOutput, variableWidthBlock);
 
@@ -80,7 +80,7 @@ public class VariableWidthBlockEncoding
         int[] offsets = new int[positionCount + 1];
         // Read the lengths array into the end of the offsets array, since nonNullsCount <= positionCount
         int lengthIndex = offsets.length - nonNullsCount;
-        sliceInput.readBytes(Slices.wrappedIntArray(offsets, lengthIndex, nonNullsCount));
+        sliceInput.readInts(offsets, lengthIndex, nonNullsCount);
 
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
         // Transform lengths back to offsets

--- a/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UuidType.java
@@ -150,16 +150,18 @@ public class UuidType
     @Override
     public final Slice getSlice(Block block, int position)
     {
-        return Slices.wrappedLongArray(
-                block.getLong(position, 0),
-                block.getLong(position, SIZE_OF_LONG));
+        Slice value = Slices.allocate(INT128_BYTES);
+        value.setLong(0, block.getLong(position, 0));
+        value.setLong(SIZE_OF_LONG, block.getLong(position, SIZE_OF_LONG));
+        return value;
     }
 
     public static Slice javaUuidToTrinoUuid(UUID uuid)
     {
-        return Slices.wrappedLongArray(
-                reverseBytes(uuid.getMostSignificantBits()),
-                reverseBytes(uuid.getLeastSignificantBits()));
+        Slice value = Slices.allocate(INT128_BYTES);
+        value.setLong(0, reverseBytes(uuid.getMostSignificantBits()));
+        value.setLong(SIZE_OF_LONG, reverseBytes(uuid.getLeastSignificantBits()));
+        return value;
     }
 
     public static UUID trinoUuidToJavaUuid(Slice uuid)

--- a/lib/trino-array/src/test/java/io/trino/array/BenchmarkReferenceCountMap.java
+++ b/lib/trino-array/src/test/java/io/trino/array/BenchmarkReferenceCountMap.java
@@ -32,9 +32,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.slice.Slices.wrappedBuffer;
-import static io.airlift.slice.Slices.wrappedDoubleArray;
-import static io.airlift.slice.Slices.wrappedIntArray;
-import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.trino.jmh.Benchmarks.benchmark;
 
 @OutputTimeUnit(TimeUnit.SECONDS)
@@ -49,8 +46,8 @@ public class BenchmarkReferenceCountMap
     @State(Scope.Thread)
     public static class Data
     {
-        @Param({"int", "double", "long", "byte"})
-        private String arrayType = "int";
+        @Param("byte")
+        private String arrayType = "byte";
         private Object[] bases = new Object[NUMBER_OF_BASES];
         private Slice[] slices = new Slice[NUMBER_OF_ENTRIES];
 
@@ -59,15 +56,6 @@ public class BenchmarkReferenceCountMap
         {
             for (int i = 0; i < NUMBER_OF_BASES; i++) {
                 switch (arrayType) {
-                    case "int":
-                        bases[i] = new int[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
-                        break;
-                    case "double":
-                        bases[i] = new double[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
-                        break;
-                    case "long":
-                        bases[i] = new long[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
-                        break;
                     case "byte":
                         bases[i] = new byte[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
                         break;
@@ -79,18 +67,6 @@ public class BenchmarkReferenceCountMap
             for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
                 Object base = bases[ThreadLocalRandom.current().nextInt(NUMBER_OF_BASES)];
                 switch (arrayType) {
-                    case "int":
-                        int[] intBase = (int[]) base;
-                        slices[i] = wrappedIntArray(intBase, 0, intBase.length);
-                        break;
-                    case "double":
-                        double[] doubleBase = (double[]) base;
-                        slices[i] = wrappedDoubleArray(doubleBase, 0, doubleBase.length);
-                        break;
-                    case "long":
-                        long[] longBase = (long[]) base;
-                        slices[i] = wrappedLongArray(longBase, 0, longBase.length);
-                        break;
                     case "byte":
                         byte[] byteBase = (byte[]) base;
                         slices[i] = wrappedBuffer(byteBase, 0, byteBase.length);

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/BufferedOutputStreamSliceOutput.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/compression/BufferedOutputStreamSliceOutput.java
@@ -238,6 +238,66 @@ public class BufferedOutputStreamSliceOutput
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Short.BYTES) / Short.BYTES;
+            slice.setShorts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Short.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Integer.BYTES) / Integer.BYTES;
+            slice.setInts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Integer.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Long.BYTES) / Long.BYTES;
+            slice.setLongs(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Long.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Float.BYTES) / Float.BYTES;
+            slice.setFloats(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Float.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Double.BYTES) / Double.BYTES;
+            slice.setDoubles(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Double.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
     public void writeBytes(InputStream in, int length)
             throws IOException
     {

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
@@ -167,7 +167,7 @@ public abstract class TestAvroBase
         ALL_TYPES_GENERIC_RECORD.put("aString", A_STRING_VALUE);
         allTypeBlocks.add(new VariableWidthBlock(1, Slices.utf8Slice(A_STRING_VALUE), new int[] {0, Slices.utf8Slice(A_STRING_VALUE).length()}, Optional.empty()));
         ALL_TYPES_GENERIC_RECORD.put("aBytes", A_BYTES_VALUE);
-        allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedBuffer(A_BYTES_VALUE), new int[] {0, A_BYTES_VALUE.limit()}, Optional.empty()));
+        allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedHeapBuffer(A_BYTES_VALUE), new int[] {0, A_BYTES_VALUE.limit()}, Optional.empty()));
         ALL_TYPES_GENERIC_RECORD.put("aFixed", A_FIXED_VALUE);
         allTypeBlocks.add(new VariableWidthBlock(1, Slices.wrappedBuffer(A_FIXED_VALUE.bytes()), new int[] {0, A_FIXED_VALUE.bytes().length}, Optional.empty()));
         ALL_TYPES_GENERIC_RECORD.put("anArray", ImmutableList.of(1, 2, 3, 4));
@@ -369,7 +369,7 @@ public abstract class TestAvroBase
         assertThat(VARCHAR.getObject(p.getBlock(5), 0)).isEqualTo(Slices.utf8Slice(A_STRING_VALUE));
         // test bytes
         assertThat(p.getBlock(6)).isInstanceOf(VariableWidthBlock.class);
-        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(6), 0)).isEqualTo(Slices.wrappedBuffer(A_BYTES_VALUE));
+        assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(6), 0)).isEqualTo(Slices.wrappedHeapBuffer(A_BYTES_VALUE));
         // test fixed
         assertThat(p.getBlock(7)).isInstanceOf(VariableWidthBlock.class);
         assertThat(VarbinaryType.VARBINARY.getObject(p.getBlock(7), 0)).isEqualTo(Slices.wrappedBuffer(A_FIXED_VALUE.bytes()));

--- a/lib/trino-orc/src/main/java/io/trino/orc/LazySliceInput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/LazySliceInput.java
@@ -181,6 +181,36 @@ final class LazySliceInput
     }
 
     @Override
+    public void readShorts(short[] destination, int destinationIndex, int length)
+    {
+        getDelegate().readShorts(destination, destinationIndex, length);
+    }
+
+    @Override
+    public void readInts(int[] destination, int destinationIndex, int length)
+    {
+        getDelegate().readInts(destination, destinationIndex, length);
+    }
+
+    @Override
+    public void readLongs(long[] destination, int destinationIndex, int length)
+    {
+        getDelegate().readLongs(destination, destinationIndex, length);
+    }
+
+    @Override
+    public void readFloats(float[] destination, int destinationIndex, int length)
+    {
+        getDelegate().readFloats(destination, destinationIndex, length);
+    }
+
+    @Override
+    public void readDoubles(double[] destination, int destinationIndex, int length)
+    {
+        getDelegate().readDoubles(destination, destinationIndex, length);
+    }
+
+    @Override
     public void readBytes(Slice destination, int destinationIndex, int length)
     {
         getDelegate().readBytes(destination, destinationIndex, length);

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
@@ -275,6 +275,66 @@ public class OrcOutputBuffer
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Short.BYTES) / Short.BYTES;
+            slice.setShorts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Short.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Integer.BYTES) / Integer.BYTES;
+            slice.setInts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Integer.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Long.BYTES) / Long.BYTES;
+            slice.setLongs(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Long.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Float.BYTES) / Float.BYTES;
+            slice.setFloats(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Float.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = ensureBatchSize(length * Double.BYTES) / Double.BYTES;
+            slice.setDoubles(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Double.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
     public void writeBytes(InputStream in, int length)
             throws IOException
     {

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BloomFilter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/statistics/BloomFilter.java
@@ -14,9 +14,12 @@
 package io.trino.orc.metadata.statistics;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.airlift.slice.ByteArrays;
 import io.airlift.slice.Slice;
 import io.airlift.slice.UnsafeSlice;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -49,6 +52,8 @@ public class BloomFilter
         implements StatisticsHasher.Hashable
 {
     private static final int INSTANCE_SIZE = instanceSize(BloomFilter.class) + instanceSize(BitSet.class);
+
+    private static final VarHandle LONG_ARRAY_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     // from 64-bit linear congruential generator
     private static final long NULL_HASHCODE = 2862933555777941757L;
@@ -344,7 +349,7 @@ public class BloomFilter
             // body
             int current = 0;
             while (current < fastLimit) {
-                long k = ByteArrays.getLong(data, current);
+                long k = (long) LONG_ARRAY_HANDLE.get(data, current);
                 current += SIZE_OF_LONG;
 
                 // mix functions

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/DoubleInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/DoubleInputStream.java
@@ -59,6 +59,6 @@ public class DoubleInputStream
     public void next(long[] values, int items)
             throws IOException
     {
-        input.readFully(Slices.wrappedLongArray(values), 0, items * SIZE_OF_DOUBLE);
+        input.readFully(values, 0, items);
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/FloatInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/FloatInputStream.java
@@ -59,6 +59,6 @@ public class FloatInputStream
     public void next(int[] values, int items)
             throws IOException
     {
-        input.readFully(Slices.wrappedIntArray(values), 0, items * SIZE_OF_FLOAT);
+        input.readFully(values, 0, items);
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/OrcInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/OrcInputStream.java
@@ -13,8 +13,10 @@
  */
 package io.trino.orc.stream;
 
+import com.google.common.primitives.Ints;
 import io.airlift.slice.FixedLengthSliceInput;
 import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
 import io.trino.orc.OrcCorruptionException;
 import io.trino.orc.OrcDataSourceId;
 import jakarta.annotation.Nullable;
@@ -125,19 +127,77 @@ public final class OrcInputStream
         }
     }
 
-    public void readFully(Slice buffer, int offset, int length)
+    public void readFully(int[] values, int offset, int length)
             throws IOException
     {
+        if (current == null) {
+            throw new OrcCorruptionException(chunkLoader.getOrcDataSourceId(), "Unexpected end of stream");
+        }
+
         while (length > 0) {
-            if (current != null && current.remaining() == 0) {
+            int remaining = Ints.saturatedCast(current.remaining());
+            if (remaining < Integer.BYTES) {
+                // there might be a value split across the buffers
+                Slice slice = null;
+                if (remaining != 0) {
+                    slice = Slices.allocate(Integer.BYTES);
+                    current.readBytes(slice, 0, remaining);
+                }
+
                 advance();
-            }
-            if (current == null) {
-                throw new OrcCorruptionException(chunkLoader.getOrcDataSourceId(), "Unexpected end of stream");
+                if (current == null) {
+                    throw new OrcCorruptionException(chunkLoader.getOrcDataSourceId(), "Unexpected end of stream");
+                }
+
+                if (remaining != 0) {
+                    current.readBytes(slice, remaining, Integer.BYTES - remaining);
+                    values[offset] = slice.getInt(0);
+                    length--;
+                    offset++;
+                }
+                remaining = Ints.saturatedCast(current.remaining());
             }
 
-            int chunkSize = min(length, (int) current.remaining());
-            current.readBytes(buffer, offset, chunkSize);
+            int chunkSize = min(length, remaining / Integer.BYTES);
+            current.readInts(values, offset, chunkSize);
+            length -= chunkSize;
+            offset += chunkSize;
+        }
+    }
+
+    public void readFully(long[] values, int offset, int length)
+            throws IOException
+    {
+        if (current == null) {
+            throw new OrcCorruptionException(chunkLoader.getOrcDataSourceId(), "Unexpected end of stream");
+        }
+
+        while (length > 0) {
+            int remaining = Ints.saturatedCast(current.remaining());
+            if (remaining < Long.BYTES) {
+                // there might be a value split across the buffers
+                Slice slice = null;
+                if (remaining != 0) {
+                    slice = Slices.allocate(Long.BYTES);
+                    current.readBytes(slice, 0, remaining);
+                }
+
+                advance();
+                if (current == null) {
+                    throw new OrcCorruptionException(chunkLoader.getOrcDataSourceId(), "Unexpected end of stream");
+                }
+
+                if (remaining != 0) {
+                    current.readBytes(slice, remaining, Long.BYTES - remaining);
+                    values[offset] = slice.getLong(0);
+                    length--;
+                    offset++;
+                }
+                remaining = Ints.saturatedCast(current.remaining());
+            }
+
+            int chunkSize = min(length, remaining / Long.BYTES);
+            current.readLongs(values, offset, chunkSize);
             length -= chunkSize;
             offset += chunkSize;
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -427,8 +427,8 @@ public class TupleDomainParquetPredicate
         if (type instanceof VarcharType) {
             SortedRangeSet.Builder rangesBuilder = SortedRangeSet.builder(type, minimums.size());
             for (int i = 0; i < minimums.size(); i++) {
-                Slice min = Slices.wrappedBuffer(((Binary) minimums.get(i)).toByteBuffer());
-                Slice max = Slices.wrappedBuffer(((Binary) maximums.get(i)).toByteBuffer());
+                Slice min = Slices.wrappedHeapBuffer(((Binary) minimums.get(i)).toByteBuffer());
+                Slice max = Slices.wrappedHeapBuffer(((Binary) maximums.get(i)).toByteBuffer());
                 rangesBuilder.addRangeInclusive(min, max);
             }
             return Domain.create(rangesBuilder.build(), hasNullValue);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/SimpleSliceInputStream.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.reader;
 
+import com.google.common.primitives.Shorts;
 import io.airlift.slice.Slice;
 import io.airlift.slice.UnsafeSlice;
 
@@ -81,6 +82,24 @@ public final class SimpleSliceInputStream
     {
         slice.getBytes(offset, output, outputOffset, length);
         offset += length;
+    }
+
+    public void readShorts(short[] output, int outputOffset, int length)
+    {
+        slice.getShorts(offset, output, outputOffset, length);
+        offset += length * Shorts.BYTES;
+    }
+
+    public void readInts(int[] output, int outputOffset, int length)
+    {
+        slice.getInts(offset, output, outputOffset, length);
+        offset += length * Integer.BYTES;
+    }
+
+    public void readLongs(long[] output, int outputOffset, int length)
+    {
+        slice.getLongs(offset, output, outputOffset, length);
+        offset += length * Long.BYTES;
     }
 
     public void readBytes(Slice destination, int destinationIndex, int length)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/IntBitUnpackers.java
@@ -13,7 +13,6 @@
  */
 package io.trino.parquet.reader.decoders;
 
-import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 
 public final class IntBitUnpackers
@@ -1364,7 +1363,7 @@ public final class IntBitUnpackers
         @Override
         public void unpack(int[] output, int outputOffset, SimpleSliceInputStream input, int length)
         {
-            input.readBytes(Slices.wrappedIntArray(output, outputOffset, length), 0, length * Integer.BYTES);
+            input.readInts(output, outputOffset, length);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/LongBitUnpackers.java
@@ -13,7 +13,6 @@
  */
 package io.trino.parquet.reader.decoders;
 
-import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -4276,7 +4275,7 @@ public final class LongBitUnpackers
         @Override
         public void unpack(long[] output, int outputOffset, SimpleSliceInputStream input, int length)
         {
-            input.readBytes(Slices.wrappedLongArray(output, outputOffset, length), 0, length * Long.BYTES);
+            input.readLongs(output, outputOffset, length);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/PlainValueDecoders.java
@@ -54,7 +54,7 @@ public final class PlainValueDecoders
         @Override
         public void read(long[] values, int offset, int length)
         {
-            input.readBytes(Slices.wrappedLongArray(values), offset * Long.BYTES, length * Long.BYTES);
+            input.readLongs(values, offset, length);
         }
 
         @Override
@@ -78,7 +78,7 @@ public final class PlainValueDecoders
         @Override
         public void read(int[] values, int offset, int length)
         {
-            input.readBytes(Slices.wrappedIntArray(values), offset * Integer.BYTES, length * Integer.BYTES);
+            input.readInts(values, offset, length);
         }
 
         @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpackers.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortBitUnpackers.java
@@ -13,7 +13,6 @@
  */
 package io.trino.parquet.reader.decoders;
 
-import io.airlift.slice.Slices;
 import io.trino.parquet.reader.SimpleSliceInputStream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -871,7 +870,7 @@ public final class ShortBitUnpackers
         @Override
         public void unpack(short[] output, int outputOffset, SimpleSliceInputStream input, int length)
         {
-            input.readBytes(Slices.wrappedShortArray(output, outputOffset, length), 0, length * Short.BYTES);
+            input.readShorts(output, outputOffset, length);
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkLongDecimalColumnReader.java
@@ -80,7 +80,9 @@ public class BenchmarkLongDecimalColumnReader
     @Override
     protected void writeValue(ValuesWriter writer, long[] batch, int index)
     {
-        Slice slice = Slices.wrappedLongArray(batch, index * 2, 2);
+        Slice slice = Slices.allocate(Long.BYTES * 2);
+        slice.setLong(0, batch[index * 2]);
+        slice.setLong(SIZE_OF_LONG, batch[(index * 2) + 1]);
         writer.writeBytes(Binary.fromConstantByteArray(slice.getBytes()));
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkUuidColumnReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/BenchmarkUuidColumnReader.java
@@ -77,7 +77,9 @@ public class BenchmarkUuidColumnReader
     @Override
     protected void writeValue(ValuesWriter writer, long[] batch, int index)
     {
-        Slice slice = Slices.wrappedLongArray(batch, index * 2, 2);
+        Slice slice = Slices.allocate(Long.BYTES * 2);
+        slice.setLong(0, batch[index * 2]);
+        slice.setLong(SIZE_OF_LONG, batch[(index * 2) + 1]);
         writer.writeBytes(Binary.fromConstantByteArray(slice.getBytes()));
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetDataSource.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestParquetDataSource.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import io.trino.memory.context.AggregatedMemoryContext;
@@ -41,7 +42,7 @@ public class TestParquetDataSource
     public void testPlanReadOrdering(DataSize maxBufferSize)
             throws IOException
     {
-        Slice testingInput = Slices.wrappedIntArray(IntStream.range(0, 1000).toArray());
+        Slice testingInput = createTestingInput();
         TestingParquetDataSource dataSource = new TestingParquetDataSource(
                 testingInput,
                 new ParquetReaderOptions().withMaxBufferSize(maxBufferSize));
@@ -72,7 +73,7 @@ public class TestParquetDataSource
     public void testMemoryAccounting()
             throws IOException
     {
-        Slice testingInput = Slices.wrappedIntArray(IntStream.range(0, 1000).toArray());
+        Slice testingInput = createTestingInput();
         TestingParquetDataSource dataSource = new TestingParquetDataSource(
                 testingInput,
                 new ParquetReaderOptions().withMaxBufferSize(DataSize.ofBytes(500)));
@@ -112,7 +113,7 @@ public class TestParquetDataSource
     public void testChunkedInputStreamLazyLoading()
             throws IOException
     {
-        Slice testingInput = Slices.wrappedIntArray(IntStream.range(0, 1000).toArray());
+        Slice testingInput = createTestingInput();
         TestingParquetDataSource dataSource = new TestingParquetDataSource(
                 testingInput,
                 new ParquetReaderOptions()
@@ -137,5 +138,13 @@ public class TestParquetDataSource
 
         inputStreams.get("1").close();
         assertThat(memoryContext.getBytes()).isEqualTo(100);
+    }
+
+    private static Slice createTestingInput()
+    {
+        Slice testingInput = Slices.allocate(4000);
+        SliceOutput out = testingInput.getOutput();
+        IntStream.range(0, 1000).forEach(out::appendInt);
+        return testingInput;
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/TestFixedWidthByteArrayValueDecoders.java
@@ -14,7 +14,6 @@
 package io.trino.parquet.reader.decoders;
 
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slices;
 import io.trino.parquet.ParquetEncoding;
 import io.trino.parquet.PrimitiveField;
 import io.trino.parquet.reader.SimpleSliceInputStream;
@@ -36,7 +35,7 @@ import java.nio.ByteOrder;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.Random;
-import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
 
@@ -259,13 +258,9 @@ public final class TestFixedWidthByteArrayValueDecoders
         @Override
         public DataBuffer write(ValuesWriter valuesWriter, int dataSize)
         {
-            byte[][] bytes = new byte[dataSize][];
+            byte[][] bytes = new byte[dataSize][16];
             for (int i = 0; i < dataSize; i++) {
-                UUID uuid = UUID.randomUUID();
-                bytes[i] = Slices.wrappedLongArray(
-                                uuid.getMostSignificantBits(),
-                                uuid.getLeastSignificantBits())
-                        .getBytes();
+                ThreadLocalRandom.current().nextBytes(bytes[i]);
             }
             return writeBytes(valuesWriter, bytes);
         }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/io/ChunkedSliceOutput.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/io/ChunkedSliceOutput.java
@@ -203,6 +203,66 @@ public final class ChunkedSliceOutput
     }
 
     @Override
+    public void writeShorts(short[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = tryEnsureBatchSize(length * Short.BYTES) / Short.BYTES;
+            slice.setShorts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Short.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeInts(int[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = tryEnsureBatchSize(length * Integer.BYTES) / Integer.BYTES;
+            slice.setInts(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Integer.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeLongs(long[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = tryEnsureBatchSize(length * Long.BYTES) / Long.BYTES;
+            slice.setLongs(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Long.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeFloats(float[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = tryEnsureBatchSize(length * Float.BYTES) / Float.BYTES;
+            slice.setFloats(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Float.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
+    public void writeDoubles(double[] source, int sourceIndex, int length)
+    {
+        while (length > 0) {
+            int flushLength = tryEnsureBatchSize(length * Double.BYTES) / Double.BYTES;
+            slice.setDoubles(bufferPosition, source, sourceIndex, flushLength);
+            bufferPosition += flushLength * Double.BYTES;
+            sourceIndex += flushLength;
+            length -= flushLength;
+        }
+    }
+
+    @Override
     public void writeBytes(InputStream in, int length)
             throws IOException
     {

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -229,7 +229,7 @@ public class AvroColumnDecoder
 
         if (type instanceof VarbinaryType) {
             if (value instanceof ByteBuffer) {
-                return Slices.wrappedBuffer((ByteBuffer) value);
+                return Slices.wrappedHeapBuffer((ByteBuffer) value);
             }
             if (value instanceof GenericFixed) {
                 return Slices.wrappedBuffer(((GenericFixed) value).bytes());

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/raw/RawColumnDecoder.java
@@ -290,7 +290,7 @@ public class RawColumnDecoder
         @Override
         public Slice getSlice()
         {
-            Slice slice = Slices.wrappedBuffer(value.slice());
+            Slice slice = Slices.wrappedHeapBuffer(value.slice());
             return Varchars.truncateToLength(slice, columnType);
         }
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -220,7 +220,9 @@ public class JdbcPageSink
             throw new TrinoException(JDBC_ERROR, "Failed to insert data: " + firstNonNull(e.getMessage(), e), e);
         }
         // pass the successful page sink id
-        return completedFuture(ImmutableList.of(Slices.wrappedLongArray(pageSinkId.getId())));
+        Slice value = Slices.allocate(Long.BYTES);
+        value.setLong(0, pageSinkId.getId());
+        return completedFuture(ImmutableList.of(value));
     }
 
     @SuppressWarnings("unused")

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSink.java
@@ -89,7 +89,9 @@ public class BigQueryPageSink
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        return completedFuture(ImmutableList.of(Slices.wrappedLongArray(pageSinkId.getId())));
+        Slice value = Slices.allocate(Long.BYTES);
+        value.setLong(0, pageSinkId.getId());
+        return completedFuture(ImmutableList.of(value));
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryStorageAvroPageSource.java
@@ -226,7 +226,7 @@ public class BigQueryStorageAvroPageSource
         }
         else if (type instanceof VarbinaryType) {
             if (value instanceof ByteBuffer) {
-                type.writeSlice(output, Slices.wrappedBuffer((ByteBuffer) value));
+                type.writeSlice(output, Slices.wrappedHeapBuffer((ByteBuffer) value));
             }
             else {
                 output.appendNull();

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypeManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraTypeManager.java
@@ -78,6 +78,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.net.InetAddresses.toAddrString;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.airlift.slice.Slices.wrappedHeapBuffer;
 import static io.trino.plugin.cassandra.CassandraType.Kind.DATE;
 import static io.trino.plugin.cassandra.CassandraType.Kind.TIME;
 import static io.trino.plugin.cassandra.CassandraType.Kind.TIMESTAMP;
@@ -273,7 +274,7 @@ public class CassandraTypeManager
                 return NullableValue.of(trinoType, utf8Slice(row.getBigInteger(position).toString()));
             case BLOB:
             case CUSTOM:
-                return NullableValue.of(trinoType, wrappedBuffer(row.getBytesUnsafe(position)));
+                return NullableValue.of(trinoType, wrappedHeapBuffer(row.getBytesUnsafe(position)));
             case SET:
                 return NullableValue.of(trinoType, utf8Slice(buildArrayValueFromSetType(row, position, dataTypeSupplier.get())));
             case LIST:

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSink.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSink.java
@@ -299,7 +299,9 @@ public class FileSystemExchangeSink
                 currentBuffer = null;
             }
 
-            writeInternal(Slices.wrappedIntArray(data.length()));
+            Slice sizeSlice = Slices.allocate(Integer.BYTES);
+            sizeSlice.setInt(0, data.length());
+            writeInternal(sizeSlice);
             writeInternal(data);
 
             currentFileSize += requiredPageStorageSize;

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -91,7 +91,7 @@ import static com.esri.core.geometry.NonSimpleResult.Reason.OGCPolylineSelfTange
 import static com.esri.core.geometry.ogc.OGCGeometry.createFromEsriGeometry;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.airlift.slice.Slices.wrappedBuffer;
+import static io.airlift.slice.Slices.wrappedHeapBuffer;
 import static io.trino.geospatial.GeometryType.GEOMETRY_COLLECTION;
 import static io.trino.geospatial.GeometryType.LINE_STRING;
 import static io.trino.geospatial.GeometryType.MULTI_LINE_STRING;
@@ -387,7 +387,7 @@ public final class GeoFunctions
     @SqlType(VARBINARY)
     public static Slice stAsBinary(@SqlType(GEOMETRY_TYPE_NAME) Slice input)
     {
-        return wrappedBuffer(deserialize(input).asBinary());
+        return wrappedHeapBuffer(deserialize(input).asBinary());
     }
 
     @SqlNullable

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FilesTable.java
@@ -288,7 +288,7 @@ public class FilesTable
             if (value == null) {
                 return null;
             }
-            return Slices.wrappedBuffer(value);
+            return Slices.wrappedHeapBuffer(value);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergAvroDataConversion.java
@@ -283,7 +283,7 @@ public final class IcebergAvroDataConversion
             if (icebergType.typeId().equals(FIXED)) {
                 VARBINARY.writeSlice(builder, Slices.wrappedBuffer((byte[]) object));
             }
-            VARBINARY.writeSlice(builder, Slices.wrappedBuffer((ByteBuffer) object));
+            VARBINARY.writeSlice(builder, Slices.wrappedHeapBuffer((ByteBuffer) object));
             return;
         }
         if (type.equals(DATE)) {

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryDynamicMessageProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ConfluentSchemaRegistryDynamicMessageProvider.java
@@ -27,12 +27,12 @@ import io.trino.cache.NonEvictableLoadingCache;
 import io.trino.decoder.protobuf.DynamicMessageProvider;
 import io.trino.spi.TrinoException;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.decoder.protobuf.ProtobufErrorCode.INVALID_PROTOBUF_MESSAGE;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -62,10 +62,11 @@ public class ConfluentSchemaRegistryDynamicMessageProvider
         checkArgument(magicByte == MAGIC_BYTE, "Invalid MagicByte");
         int schemaId = buffer.getInt();
         MessageIndexes.readFrom(buffer);
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
         try {
             return DynamicMessage.parseFrom(
                     descriptorCache.getUnchecked(schemaId),
-                    wrappedBuffer(buffer).getInput());
+                    byteArrayInputStream);
         }
         catch (IOException e) {
             throw new TrinoException(INVALID_PROTOBUF_MESSAGE, "Decoding Protobuf record failed.", e);

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -206,7 +206,7 @@ public final class TypeHelper
             return row.getBoolean(field);
         }
         if (type instanceof VarbinaryType) {
-            return Slices.wrappedBuffer(row.getBinary(field));
+            return Slices.wrappedHeapBuffer(row.getBinary(field));
         }
         if (type instanceof DecimalType) {
             return Decimals.encodeScaledValue(row.getDecimal(field), ((DecimalType) type).getScale());
@@ -265,7 +265,7 @@ public final class TypeHelper
             return Slices.utf8Slice(row.getString(field));
         }
         if (type instanceof VarbinaryType) {
-            return Slices.wrappedBuffer(row.getBinary(field));
+            return Slices.wrappedHeapBuffer(row.getBinary(field));
         }
         throw new IllegalStateException("getSlice not implemented for " + type);
     }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSink.java
@@ -270,7 +270,9 @@ public class MongoPageSink
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        return completedFuture(ImmutableList.of(Slices.wrappedLongArray(pageSinkId.getId())));
+        Slice value = Slices.allocate(Long.BYTES);
+        value.setLong(0, pageSinkId.getId());
+        return completedFuture(ImmutableList.of(value));
     }
 
     @Override

--- a/plugin/trino-teradata-functions/src/main/java/io/trino/plugin/teradata/functions/TeradataStringFunctions.java
+++ b/plugin/trino-teradata-functions/src/main/java/io/trino/plugin/teradata/functions/TeradataStringFunctions.java
@@ -63,7 +63,7 @@ public final class TeradataStringFunctions
     @SqlType(StandardTypes.VARCHAR)
     public static Slice char2HexInt(@SqlType(StandardTypes.VARCHAR) Slice string)
     {
-        Slice utf16 = Slices.wrappedBuffer(UTF_16BE.encode(string.toStringUtf8()));
+        Slice utf16 = Slices.wrappedHeapBuffer(UTF_16BE.encode(string.toStringUtf8()));
         String encoded = BaseEncoding.base16().encode(utf16.getBytes());
         return Slices.utf8Slice(encoded);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,8 @@
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
+        <dep.slice.version>0.46</dep.slice.version>
+
         <dep.accumulo.version>1.10.2</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.13.0</dep.antlr.version>


### PR DESCRIPTION
## Description
Switch all code to only create Slice with a byte[].  This is the proposed direction of Slice as it will vastly simplify the Slice code, allow the conversion to VarHandles, and ensures that Slice based code will be monomorphic.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
