### PR TITLE
Add missing test case to TestBlockAndPositionNullConvention

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestBlockAndPositionNullConvention.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestBlockAndPositionNullConvention.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.scalar;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.spi.block.ValueBlock;
@@ -83,6 +84,10 @@ public class TestBlockAndPositionNullConvention
         assertThat(assertions.function("test_block_position", "true"))
                 .isEqualTo(true);
         assertThat(FunctionWithBlockAndPositionConvention.hitBlockPositionBoolean.get()).isTrue();
+
+        assertThat(assertions.function("test_block_position", "ROW(1234)"))
+                .isEqualTo(ImmutableList.of(1234));
+        assertThat(FunctionWithBlockAndPositionConvention.hitBlockPositionObject.get()).isTrue();
     }
 
     @ScalarFunction("test_block_position")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Looks like it got lost during the refactoring in commit 98c5243898e7068b264b2fef26021b6249eff7c9. Originally it used `null` for a generic object type, but perhaps a "real" object like row is better here.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This was detected by the write-only object inspection in IDEA: the `hitBlockPositionObject` was reported as never read from.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
