### PR TITLE
Remove redundant HashSet from Identity.Builder

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/Identity.java
@@ -226,7 +226,6 @@ public class Identity
 
         public Builder withEnabledRoles(Set<String> enabledRoles)
         {
-            enabledRoles = new HashSet<>(requireNonNull(enabledRoles, "enabledRoles is null"));
             this.enabledRoles = new HashSet<>(requireNonNull(enabledRoles, "enabledRoles is null"));
             return this;
         }


### PR DESCRIPTION
## Description
Removes a redundant `HashSet` copy from `Identity.Builder#withEnabledRoles`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
