### PR TITLE
Map MySQL TIMESTAMP types to TIMESTAMP WITH TIME ZONE

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.md
+++ b/docs/src/main/sphinx/connector/mysql.md
@@ -205,10 +205,10 @@ this table:
     - ``TIME(n)``
     -
   * - ``DATETIME(n)``
-    - ``DATETIME(n)``
+    - ``TIMESTAMP(n)``
     -
   * - ``TIMESTAMP(n)``
-    - ``TIMESTAMP(n)``
+    - ``TIMESTAMP(n) WITH TIME ZONE``
     -
 ```
 
@@ -267,6 +267,9 @@ this table:
     - ``TIME(n)``
     -
   * - ``TIMESTAMP(n)``
+    - ``DATETIME(n)``
+    -
+  * - ``TIMESTAMP(n) WITH TIME ZONE``
     - ``TIMESTAMP(n)``
     -
 ```

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -76,11 +76,11 @@ public class MySqlClientModule
         connectionProperties.setProperty("tinyInt1isBit", "false");
         connectionProperties.setProperty("rewriteBatchedStatements", "true");
 
-        // Try to make MySQL timestamps work (See https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-time-instants.html)
-        // without relying on server time zone (which may be configured to be totally unusable).
-        // TODO (https://github.com/trinodb/trino/issues/15668) rethink how timestamps are mapped. Also, probably worth adding tests
-        //  with MySQL server with a non-UTC system zone.
-        connectionProperties.setProperty("connectionTimeZone", "UTC");
+        // connectionTimeZone = LOCAL means the JDBC driver uses the JVM zone as the session zone
+        // forceConnectionTimeZoneToSession = true means that the server side connection zone is changed to match local JVM zone
+        // https://dev.mysql.com/doc/connector-j/8.1/en/connector-j-time-instants.html (Solution 2b)
+        connectionProperties.setProperty("connectionTimeZone", "LOCAL");
+        connectionProperties.setProperty("forceConnectionTimeZoneToSession", "true");
 
         if (mySqlConfig.isAutoReconnect()) {
             connectionProperties.setProperty("autoReconnect", String.valueOf(mySqlConfig.isAutoReconnect()));

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -119,9 +119,19 @@ public abstract class BaseMySqlConnectorTest
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getTrinoTypeName();
-        if (typeName.equals("timestamp(3) with time zone") ||
-                typeName.equals("timestamp(6) with time zone")) {
-            return Optional.of(dataMappingTestSetup.asUnsupported());
+
+        // MySQL TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.
+        if (typeName.equals("timestamp(3) with time zone")) {
+            if (dataMappingTestSetup.getSampleValueLiteral().contains("1969")) {
+                return Optional.of(new DataMappingTestSetup("timestamp(3) with time zone", "TIMESTAMP '1970-01-01 15:03:00.123 +01:00'", "TIMESTAMP '1970-01-31 17:03:00.456 +01:00'"));
+            }
+            return Optional.of(new DataMappingTestSetup("timestamp(3) with time zone", "TIMESTAMP '2020-02-12 15:03:00 +01:00'", "TIMESTAMP '2038-01-19 03:14:07.000 UTC'"));
+        }
+        else if (typeName.equals("timestamp(6) with time zone")) {
+            if (dataMappingTestSetup.getSampleValueLiteral().contains("1969")) {
+                return Optional.of(new DataMappingTestSetup("timestamp(6) with time zone", "TIMESTAMP '1970-01-01 15:03:00.123456 +01:00'", "TIMESTAMP '1970-01-31 17:03:00.123456 +01:00'"));
+            }
+            return Optional.of(new DataMappingTestSetup("timestamp(6) with time zone", "TIMESTAMP '2020-02-12 15:03:00 +01:00'", "TIMESTAMP '2038-01-19 03:14:07.000 UTC'"));
         }
 
         if (typeName.equals("timestamp")) {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMySqlServer.java
@@ -23,9 +23,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.ZoneId;
 
 import static io.trino.testing.containers.TestContainers.startOrReuse;
 import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
 public class TestingMySqlServer
@@ -42,15 +44,26 @@ public class TestingMySqlServer
         this(false);
     }
 
+    public TestingMySqlServer(ZoneId zoneId)
+    {
+        this(DEFAULT_IMAGE, false, zoneId);
+    }
+
     public TestingMySqlServer(boolean globalTransactionEnable)
     {
-        this(DEFAULT_IMAGE, globalTransactionEnable);
+        this(DEFAULT_IMAGE, globalTransactionEnable, UTC);
     }
 
     public TestingMySqlServer(String dockerImageName, boolean globalTransactionEnable)
     {
+        this(dockerImageName, globalTransactionEnable, UTC);
+    }
+
+    public TestingMySqlServer(String dockerImageName, boolean globalTransactionEnable, ZoneId zoneId)
+    {
         MySQLContainer<?> container = new MySQLContainer<>(dockerImageName);
         container = container.withDatabaseName("tpch");
+        container.addEnv("TZ", zoneId.getId());
         if (globalTransactionEnable) {
             container = container.withCommand("--gtid-mode=ON", "--enforce-gtid-consistency=ON");
         }


### PR DESCRIPTION
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR changes the MySQL type mappings for MySQL's `TIMESTAMP` type to Trino's `TIMESTAMP WITH TIME ZONE` type. Note that MySQL `DATETIME` types are read as `TIMESTAMP` types and Trino `TIMESTAMP` types are inserted into MySQL as `DATETIME` types -- this behavior is unchanged.

In other words, for reads and writes:

|MySQL Type|Trino Type|
|-|-|
|DATETIME|TIMESTAMP|
|TIMESTAMP|TIMESTAMP WITH TIME ZONE|

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/15668

* Changed read and write mappings for MySQL `TIMESTAMP` type to map to Trino `TIMESTAMP WITH TIME ZONE`
  * The implementations were taken from the PostgreSQL connector -- I am open to any suggestions on implementation details here
* Added override of `getColumnDefinitionSql` to explicitly declare a column as `NULL` to satisfy an `Invalid default value` failure in the data mapping smoke tests when creating a table using a MySQL `TIMESTAMP` type
* Added a separate test class for the time/date/timestamp/timestamp with time zone types where the MySQL container's time zone is set to `Pacific/Apia` (and therefore the time zone of the MySQL server)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(X) Release notes are required, with the following suggested text:

```markdown
# MySQL Connector
* Changes MySQL TIMESTAMP types to map to TIMESTAMP WITH TIME ZONE
```
