### PR TITLE
Enable NarrowCalculation error-prone check

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/AbstractTrinoResultSet.java
@@ -2133,9 +2133,9 @@ abstract class AbstractTrinoResultSet
             fractionValue = Long.parseLong(fraction);
         }
 
-        long epochMilli = (hour * 3600 + minute * 60 + second) * MILLISECONDS_PER_SECOND + rescale(fractionValue, precision, 3);
+        long epochMilli = (hour * 3600L + minute * 60L + second) * MILLISECONDS_PER_SECOND + rescale(fractionValue, precision, 3);
 
-        epochMilli -= calculateOffsetMinutes(offsetSign, offsetHour, offsetMinute) * MILLISECONDS_PER_MINUTE;
+        epochMilli -= calculateOffsetMinutes(offsetSign, offsetHour, offsetMinute) * (long) MILLISECONDS_PER_MINUTE;
 
         return new Time(epochMilli);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClient.java
@@ -337,7 +337,7 @@ public class DirectExchangeClient
 
             successfulRequests++;
             // AVG_n = AVG_(n-1) * (n-1)/n + VALUE_n / n
-            averageBytesPerRequest = (long) (1.0 * averageBytesPerRequest * (successfulRequests - 1) / successfulRequests + responseSize / successfulRequests);
+            averageBytesPerRequest = (long) (1.0 * averageBytesPerRequest * (successfulRequests - 1) / successfulRequests + (double) responseSize / successfulRequests);
         }
 
         return true;

--- a/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
@@ -101,7 +101,7 @@ public class WindowInfo
             long totalRowsCount = indexInfos.stream()
                     .mapToLong(IndexInfo::getTotalRowsCount)
                     .sum();
-            double averageIndexPositions = totalRowsCount / indexInfos.size();
+            double averageIndexPositions = (double) totalRowsCount / indexInfos.size();
             double squaredDifferencesPositionsOfIndex = indexInfos.stream()
                     .mapToDouble(index -> Math.pow(index.getTotalRowsCount() - averageIndexPositions, 2))
                     .sum();

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeToTimestampWithTimeZoneCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/time/TimeToTimestampWithTimeZoneCast.java
@@ -93,7 +93,7 @@ public final class TimeToTimestampWithTimeZoneCast
     {
         long milliFraction = rescale(picoFraction, TimeType.MAX_PRECISION, 3);
         long epochMillis = multiplyExact(epochSeconds, MILLISECONDS_PER_SECOND) + milliFraction;
-        epochMillis -= zoneId.getRules().getOffset(session.getStart()).getTotalSeconds() * MILLISECONDS_PER_SECOND;
+        epochMillis -= zoneId.getRules().getOffset(session.getStart()).getTotalSeconds() * (long) MILLISECONDS_PER_SECOND;
         return epochMillis;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/type/DateTimes.java
+++ b/core/trino-main/src/main/java/io/trino/type/DateTimes.java
@@ -634,7 +634,7 @@ public final class DateTimes
         checkArgument(precision > MAX_SHORT_PRECISION && precision <= TimestampType.MAX_PRECISION, "Precision is out of range");
         return new LongTimestamp(
                 start.getEpochSecond() * MICROSECONDS_PER_SECOND + start.getLong(MICRO_OF_SECOND),
-                (int) round((start.getNano() % PICOSECONDS_PER_NANOSECOND) * PICOSECONDS_PER_NANOSECOND, (int) (TimestampType.MAX_PRECISION - precision)));
+                (int) round((start.getNano() % PICOSECONDS_PER_NANOSECOND) * (long) PICOSECONDS_PER_NANOSECOND, (int) (TimestampType.MAX_PRECISION - precision)));
     }
 
     public static LongTimestamp longTimestamp(long epochSecond, long fractionInPicos)
@@ -649,7 +649,7 @@ public final class DateTimes
         checkArgument(precision <= TimestampWithTimeZoneType.MAX_PRECISION, "Precision is out of range");
 
         long epochMilli = start.toEpochMilli();
-        int picosOfMilli = (int) round((start.getNano() % NANOSECONDS_PER_MILLISECOND) * PICOSECONDS_PER_NANOSECOND, (int) (TimestampWithTimeZoneType.MAX_PRECISION - precision));
+        int picosOfMilli = (int) round((start.getNano() % NANOSECONDS_PER_MILLISECOND) * (long) PICOSECONDS_PER_NANOSECOND, (int) (TimestampWithTimeZoneType.MAX_PRECISION - precision));
         if (picosOfMilli == PICOSECONDS_PER_MILLISECOND) {
             epochMilli++;
             picosOfMilli = 0;

--- a/core/trino-main/src/test/java/io/trino/block/TestBlockBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestBlockBuilder.java
@@ -69,7 +69,7 @@ public class TestBlockBuilder
             arrayBlockBuilder.buildEntry(elementBuilder -> {
                 ArrayBlockBuilder nestedArrayBuilder = (ArrayBlockBuilder) elementBuilder;
                 nestedArrayBuilder.buildEntry(valueBuilder -> BIGINT.writeLong(valueBuilder, value));
-                nestedArrayBuilder.buildEntry(valueBuilder -> BIGINT.writeLong(valueBuilder, value * 2));
+                nestedArrayBuilder.buildEntry(valueBuilder -> BIGINT.writeLong(valueBuilder, value * 2L));
             });
             pageBuilder.declarePosition();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestArbitraryDistributionSplitAssigner.java
@@ -55,7 +55,7 @@ public class TestArbitraryDistributionSplitAssigner
 {
     private static final int FUZZ_TESTING_INVOCATION_COUNT = 100;
 
-    private static final int STANDARD_SPLIT_SIZE_IN_BYTES = 1;
+    private static final long STANDARD_SPLIT_SIZE_IN_BYTES = 1;
 
     private static final PlanNodeId PARTITIONED_1 = new PlanNodeId("partitioned-1");
     private static final PlanNodeId PARTITIONED_2 = new PlanNodeId("partitioned-2");

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestIntervalDayToSecondAverageAggregation.java
@@ -32,7 +32,7 @@ public class TestIntervalDayToSecondAverageAggregation
     {
         BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
-            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 250);
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 250L);
         }
         return new Block[] {blockBuilder.build()};
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestIntervalDayToSecondSumAggregation.java
@@ -31,7 +31,7 @@ public class TestIntervalDayToSecondSumAggregation
     {
         BlockBuilder blockBuilder = INTERVAL_DAY_TIME.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
-            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 1000);
+            INTERVAL_DAY_TIME.writeLong(blockBuilder, i * 1000L);
         }
         return new Block[] {blockBuilder.build()};
     }
@@ -45,7 +45,7 @@ public class TestIntervalDayToSecondSumAggregation
 
         long sum = 0;
         for (int i = start; i < start + length; i++) {
-            sum += i * 1000;
+            sum += i * 1000L;
         }
         return new SqlIntervalDayTime(sum);
     }

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
@@ -117,8 +117,8 @@ public class TestLookupJoinPageBuilder
         assertTrue(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i * 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i * 2);
+            assertEquals(output.getBlock(0).getLong(i, 0), i * 2L);
+            assertEquals(output.getBlock(1).getLong(i, 0), i * 2L);
         }
         lookupJoinPageBuilder.reset();
 

--- a/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/unspilled/TestLookupJoinPageBuilder.java
@@ -118,8 +118,8 @@ public class TestLookupJoinPageBuilder
         assertTrue(output.getBlock(0) instanceof DictionaryBlock);
         assertEquals(output.getPositionCount(), entries / 2);
         for (int i = 0; i < entries / 2; i++) {
-            assertEquals(output.getBlock(0).getLong(i, 0), i * 2);
-            assertEquals(output.getBlock(1).getLong(i, 0), i * 2);
+            assertEquals(output.getBlock(0).getLong(i, 0), i * 2L);
+            assertEquals(output.getBlock(1).getLong(i, 0), i * 2L);
         }
         lookupJoinPageBuilder.reset();
 

--- a/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
+++ b/core/trino-main/src/test/java/io/trino/server/remotetask/TestHttpRemoteTask.java
@@ -159,8 +159,8 @@ public class TestHttpRemoteTask
     private static final Duration FAIL_TIMEOUT = new Duration(20, SECONDS);
     private static final TaskManagerConfig TASK_MANAGER_CONFIG = new TaskManagerConfig()
             // Shorten status refresh wait and info update interval so that we can have a shorter test timeout
-            .setStatusRefreshMaxWait(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 100, MILLISECONDS))
-            .setInfoUpdateInterval(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 10, MILLISECONDS));
+            .setStatusRefreshMaxWait(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 100.0, MILLISECONDS))
+            .setInfoUpdateInterval(new Duration(IDLE_TIMEOUT.roundTo(MILLISECONDS) / 10.0, MILLISECONDS));
 
     private static final boolean TRACE_HTTP = false;
 

--- a/core/trino-main/src/test/java/io/trino/spiller/TestBinaryFileSpiller.java
+++ b/core/trino-main/src/test/java/io/trino/spiller/TestBinaryFileSpiller.java
@@ -156,7 +156,7 @@ public class TestBinaryFileSpiller
         assertEquals(spillerStats.getTotalSpilledBytes() - spilledBytesBefore, spilledBytes);
         // At this point, the buffers should still be accounted for in the memory context, because
         // the spiller (FileSingleStreamSpiller) doesn't release its memory reservation until it's closed.
-        assertEquals(memoryContext.getBytes(), spills.length * FileSingleStreamSpiller.BUFFER_SIZE);
+        assertEquals(memoryContext.getBytes(), (long) spills.length * FileSingleStreamSpiller.BUFFER_SIZE);
 
         List<Iterator<Page>> actualSpills = spiller.getSpills();
         assertEquals(actualSpills.size(), spills.length);

--- a/core/trino-main/src/test/java/io/trino/util/TestLongLong2LongOpenCustomBigHashMap.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestLongLong2LongOpenCustomBigHashMap.java
@@ -78,7 +78,7 @@ public class TestLongLong2LongOpenCustomBigHashMap
                 count++;
                 assertTrue(map.replace(key1, key2, count - 1, count));
                 assertFalse(map.isEmpty());
-                assertEquals(map.size(), values.size() * values.size());
+                assertEquals(map.size(), (long) values.size() * values.size());
             }
         }
 
@@ -145,7 +145,7 @@ public class TestLongLong2LongOpenCustomBigHashMap
                 count++;
                 assertTrue(map.replace(key1, key2, count - 1, count));
                 assertFalse(map.isEmpty());
-                assertEquals(map.size(), values.size() * values.size());
+                assertEquals(map.size(), (long) values.size() * values.size());
             }
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/SqlVarbinary.java
@@ -77,13 +77,13 @@ public final class SqlVarbinary
         int lastLineBytes = bytes.length % 32;
 
         // 4 full words with 3 word separators and one line break per full line of output
-        long totalSize = fullLineCount * ((4 * OUTPUT_CHARS_PER_FULL_WORD) + (3 * WORD_SEPARATOR.length()) + 1);
+        long totalSize = (long) fullLineCount * ((4 * OUTPUT_CHARS_PER_FULL_WORD) + (3 * WORD_SEPARATOR.length()) + 1);
         if (lastLineBytes == 0) {
             totalSize--; // no final line separator
         }
         else {
             int lastLineWords = lastLineBytes / 8;
-            totalSize += (lastLineWords * (OUTPUT_CHARS_PER_FULL_WORD + WORD_SEPARATOR.length()));
+            totalSize += (long) lastLineWords * (OUTPUT_CHARS_PER_FULL_WORD + WORD_SEPARATOR.length());
             // whole words and separators on last line
             if (lastLineWords * 8 == lastLineBytes) {
                 totalSize -= WORD_SEPARATOR.length(); // last line ends on a word boundary, no separator

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestLazyBlock.java
@@ -94,7 +94,7 @@ public class TestLazyBlock
         assertEquals(actualNotifications, expectedNotifications);
 
         if (loadedBlock instanceof ArrayBlock) {
-            long expectedSize = (Integer.BYTES + Byte.BYTES) * loadedBlock.getPositionCount();
+            long expectedSize = (long) (Integer.BYTES + Byte.BYTES) * loadedBlock.getPositionCount();
             assertEquals(loadedBlock.getSizeInBytes(), expectedSize);
 
             Block elementsBlock = loadedBlock.getChildren().get(0);
@@ -107,7 +107,7 @@ public class TestLazyBlock
             return;
         }
         if (loadedBlock instanceof RowBlock) {
-            long expectedSize = (Integer.BYTES + Byte.BYTES) * loadedBlock.getPositionCount();
+            long expectedSize = (long) (Integer.BYTES + Byte.BYTES) * loadedBlock.getPositionCount();
             assertEquals(loadedBlock.getSizeInBytes(), expectedSize);
 
             for (Block fieldBlock : loadedBlock.getChildren()) {

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/BenchmarkSortedRangeSet.java
@@ -239,7 +239,7 @@ public class BenchmarkSortedRangeSet
         {
             ranges = new ArrayList<>();
 
-            int factor = 0;
+            long factor = 0;
             for (int i = 0; i < 10_000; i++) {
                 long from = ThreadLocalRandom.current().nextLong(100) + factor * 100;
                 long to = ThreadLocalRandom.current().nextLong(100) + (factor + 1) * 100;

--- a/lib/trino-array/src/test/java/io/trino/array/TestBlockBigArray.java
+++ b/lib/trino-array/src/test/java/io/trino/array/TestBlockBigArray.java
@@ -46,7 +46,7 @@ public class TestBlockBigArray
         long expectedSize = instanceSize(BlockBigArray.class)
                 + referenceCountMap.sizeOf()
                 + (new ObjectBigArray<>()).sizeOf()
-                + block.getRetainedSizeInBytes() + (arraySize - 1) * instanceSize(block.getClass());
+                + block.getRetainedSizeInBytes() + (arraySize - 1L) * instanceSize(block.getClass());
         assertThat(blockBigArray.sizeOf()).isEqualTo(expectedSize);
     }
 }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -233,7 +233,7 @@ public abstract class AbstractTestTrinoFileSystem
 
                 // read int at a time
                 for (int intPosition = 0; intPosition < 4 * MEGABYTE; intPosition++) {
-                    assertThat(inputStream.getPosition()).isEqualTo(intPosition * 4);
+                    assertThat(inputStream.getPosition()).isEqualTo(intPosition * 4L);
 
                     int size = inputStream.readNBytes(bytes, 0, bytes.length);
                     assertThat(size).isEqualTo(4);

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
@@ -88,7 +88,7 @@ public class LongInputStreamV1
             readValues();
         }
         if (repeat) {
-            result = literals[0] + (used++) * delta;
+            result = literals[0] + (used++) * (long) delta;
         }
         else {
             result = literals[used++];
@@ -111,7 +111,7 @@ public class LongInputStreamV1
             int chunkSize = min(numLiterals - used, items);
             if (repeat) {
                 for (int i = 0; i < chunkSize; i++) {
-                    values[offset + i] = literals[0] + ((used + i) * delta);
+                    values[offset + i] = literals[0] + ((used + i) * (long) delta);
                 }
             }
             else {
@@ -138,7 +138,7 @@ public class LongInputStreamV1
             int chunkSize = min(numLiterals - used, items);
             if (repeat) {
                 for (int i = 0; i < chunkSize; i++) {
-                    long literal = literals[0] + ((used + i) * delta);
+                    long literal = literals[0] + ((used + i) * (long) delta);
                     int value = (int) literal;
                     if (literal != value) {
                         throw new OrcCorruptionException(input.getOrcDataSourceId(), "Decoded value out of range for a 32bit number");
@@ -177,7 +177,7 @@ public class LongInputStreamV1
             int chunkSize = min(numLiterals - used, items);
             if (repeat) {
                 for (int i = 0; i < chunkSize; i++) {
-                    long literal = literals[0] + ((used + i) * delta);
+                    long literal = literals[0] + ((used + i) * (long) delta);
                     short value = (short) literal;
                     if (literal != value) {
                         throw new OrcCorruptionException(input.getOrcDataSourceId(), "Decoded value out of range for a 16bit number");

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV1.java
@@ -197,7 +197,7 @@ public class LongOutputStreamV1
     @Override
     public long getBufferedBytes()
     {
-        return buffer.estimateOutputDataSize() + (Long.BYTES * size);
+        return buffer.estimateOutputDataSize() + (Long.BYTES * (long) size);
     }
 
     @Override

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongOutputStreamV2.java
@@ -756,7 +756,7 @@ public class LongOutputStreamV2
     @Override
     public long getBufferedBytes()
     {
-        return buffer.estimateOutputDataSize() + (Long.BYTES * numLiterals);
+        return buffer.estimateOutputDataSize() + (Long.BYTES * (long) numLiterals);
     }
 
     @Override

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryCompressionOptimizer.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryCompressionOptimizer.java
@@ -153,7 +153,7 @@ public class TestDictionaryCompressionOptimizer
         // construct a simulator that will hit the dictionary (low) memory limit by estimating the number of rows at the memory limit, and then setting large limits around this value
         int stripeMaxBytes = megabytes(100);
         int dictionaryMaxMemoryBytesLow = dictionaryMaxMemoryBytes - (int) DICTIONARY_MEMORY_MAX_RANGE.toBytes();
-        int expectedMaxRowCount = (int) (dictionaryMaxMemoryBytesLow / bytesPerEntry / uniquePercentage);
+        int expectedMaxRowCount = (int) (1.0 * dictionaryMaxMemoryBytesLow / bytesPerEntry / uniquePercentage);
         DataSimulator simulator = new DataSimulator(0, stripeMaxBytes, expectedMaxRowCount * 2, dictionaryMaxMemoryBytes, 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
@@ -191,7 +191,7 @@ public class TestDictionaryCompressionOptimizer
 
         // construct a simulator that will flip the column to direct and then hit the bytes limit
         int stripeMaxBytes = megabytes(100);
-        int expectedRowCountAtFlip = (int) (dictionaryMaxMemoryBytes / bytesPerEntry / uniquePercentage);
+        int expectedRowCountAtFlip = (int) (1.0 * dictionaryMaxMemoryBytes / bytesPerEntry / uniquePercentage);
         int expectedMaxRowCountAtFull = stripeMaxBytes / bytesPerEntry;
         DataSimulator simulator = new DataSimulator(stripeMaxBytes / 2, stripeMaxBytes, expectedMaxRowCountAtFull * 2, dictionaryMaxMemoryBytes, 0, column);
 
@@ -239,7 +239,7 @@ public class TestDictionaryCompressionOptimizer
         // construct a simulator that will be full because of dictionary memory limit;
         // the column cannot not be converted to direct encoding because of stripe size limit
         int stripeMaxBytes = megabytes(100);
-        int expectedMaxRowCount = (int) (dictionaryMaxMemoryBytes / bytesPerEntry / uniquePercentage);
+        int expectedMaxRowCount = (int) (1.0 * dictionaryMaxMemoryBytes / bytesPerEntry / uniquePercentage);
         DataSimulator simulator = new DataSimulator(stripeMaxBytes / 2, stripeMaxBytes, expectedMaxRowCount * 2, dictionaryMaxMemoryBytes, 0, column);
 
         for (int loop = 0; loop < 3; loop++) {
@@ -573,7 +573,7 @@ public class TestDictionaryCompressionOptimizer
             }
             int dictionaryEntries = getDictionaryEntries();
             int bytesPerValue = estimateIndexBytesPerValue(dictionaryEntries);
-            return (dictionaryEntries * bytesPerEntry) + (getNonNullValueCount() * bytesPerValue);
+            return ((long) dictionaryEntries * bytesPerEntry) + (getNonNullValueCount() * bytesPerValue);
         }
 
         @Override

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcBloomFilters.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcBloomFilters.java
@@ -168,7 +168,7 @@ public class TestOrcBloomFilters
     @Test
     public void testBloomFilterPredicateValuesExisting()
     {
-        BloomFilter bloomFilter = new BloomFilter(TEST_VALUES.size() * 10, 0.01);
+        BloomFilter bloomFilter = new BloomFilter(TEST_VALUES.size() * 10L, 0.01);
 
         for (Map.Entry<Object, Type> testValue : TEST_VALUES.entrySet()) {
             Object o = testValue.getKey();
@@ -212,7 +212,7 @@ public class TestOrcBloomFilters
     @Test
     public void testBloomFilterPredicateValuesNonExisting()
     {
-        BloomFilter bloomFilter = new BloomFilter(TEST_VALUES.size() * 10, 0.01);
+        BloomFilter bloomFilter = new BloomFilter(TEST_VALUES.size() * 10L, 0.01);
 
         for (Map.Entry<Object, Type> testValue : TEST_VALUES.entrySet()) {
             boolean matched = checkInBloomFilter(bloomFilter, testValue.getKey(), testValue.getValue());

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestOrcReaderPositions.java
@@ -224,7 +224,7 @@ public class TestOrcReaderPositions
                     rowCountsInCurrentRowGroup += page.getPositionCount();
 
                     Block block = page.getBlock(0);
-                    if (MAX_BATCH_SIZE * currentStringBytes <= READER_OPTIONS.getMaxBlockSize().toBytes()) {
+                    if (MAX_BATCH_SIZE * (long) currentStringBytes <= READER_OPTIONS.getMaxBlockSize().toBytes()) {
                         // Either we are bounded by 1024 rows per batch, or it is the last batch in the row group
                         // For the first 3 row groups, the strings are of length 300, 600, and 900 respectively
                         // So the loaded data is bounded by MAX_BATCH_SIZE
@@ -374,7 +374,7 @@ public class TestOrcReaderPositions
     {
         Block block = page.getBlock(0);
         for (int i = 0; i < batchSize; i++) {
-            assertEquals(BIGINT.getLong(block, i), (rowIndex + i) * 3);
+            assertEquals(BIGINT.getLong(block, i), (rowIndex + i) * 3L);
         }
     }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -847,7 +847,7 @@ public class TestTupleDomainParquetPredicate
         checkArgument(precision > MAX_SHORT_PRECISION && precision <= TimestampType.MAX_PRECISION, "Precision is out of range");
         return new LongTimestamp(
                 start.atZone(ZoneOffset.UTC).toInstant().getEpochSecond() * MICROSECONDS_PER_SECOND + start.getLong(MICRO_OF_SECOND),
-                toIntExact(round((start.getNano() % PICOSECONDS_PER_NANOSECOND) * PICOSECONDS_PER_NANOSECOND, toIntExact(TimestampType.MAX_PRECISION - precision))));
+                toIntExact(round((start.getNano() % PICOSECONDS_PER_NANOSECOND) * (long) PICOSECONDS_PER_NANOSECOND, toIntExact(TimestampType.MAX_PRECISION - precision))));
     }
 
     private static List<ByteBuffer> toByteBufferList(Long... values)

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -84,7 +84,7 @@ public abstract class AbstractDateTimeJsonValueProvider
         }
         if (type.equals(TIME_TZ_MILLIS)) {
             int offsetMinutes = getTimeZone().getZoneId().getRules().getOffset(Instant.ofEpochMilli(millis)).getTotalSeconds() / 60;
-            return packTimeWithTimeZone((millis + (offsetMinutes * 60 * MILLISECONDS_PER_SECOND)) * NANOSECONDS_PER_MILLISECOND, offsetMinutes);
+            return packTimeWithTimeZone((millis + (offsetMinutes * 60L * MILLISECONDS_PER_SECOND)) * NANOSECONDS_PER_MILLISECOND, offsetMinutes);
         }
 
         throw new IllegalStateException("Unsupported type: " + type);

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/BingTileFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/BingTileFunctions.java
@@ -500,10 +500,10 @@ public final class BingTileFunctions
         checkArgument(leftUpperTile.getZoomLevel() > zoomLevel);
 
         int divisor = 1 << (leftUpperTile.getZoomLevel() - zoomLevel);
-        int minX = (int) Math.floor(leftUpperTile.getX() / divisor);
-        int maxX = (int) Math.floor(rightLowerTile.getX() / divisor);
-        int minY = (int) Math.floor(leftUpperTile.getY() / divisor);
-        int maxY = (int) Math.floor(rightLowerTile.getY() / divisor);
+        int minX = leftUpperTile.getX() / divisor;
+        int maxX = rightLowerTile.getX() / divisor;
+        int minY = leftUpperTile.getY() / divisor;
+        int maxY = rightLowerTile.getY() / divisor;
 
         BingTile[] tiles = new BingTile[(maxX - minX + 1) * (maxY - minY + 1)];
         int index = 0;

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
@@ -115,7 +115,7 @@ public class SpatialPartitioningStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + partitionCounts.sizeOf() + counts.sizeOf() + envelopes.sizeOf() + samples.sizeOf() + ENVELOPE_SIZE * (envelopeCount + samplesCount);
+            return INSTANCE_SIZE + partitionCounts.sizeOf() + counts.sizeOf() + envelopes.sizeOf() + samples.sizeOf() + (long) ENVELOPE_SIZE * (envelopeCount + samplesCount);
         }
 
         @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -4259,7 +4259,7 @@ public abstract class AbstractTestHive
 
                 // statistics
                 HiveBasicStatistics tableStatistics = getBasicStatisticsForTable(transaction, tableName);
-                assertEquals(tableStatistics.getRowCount().orElse(0), CREATE_TABLE_DATA.getRowCount() * (i + 1));
+                assertEquals(tableStatistics.getRowCount().orElse(0), CREATE_TABLE_DATA.getRowCount() * (i + 1L));
                 assertEquals(tableStatistics.getFileCount().getAsLong(), i + 1L);
                 assertGreaterThan(tableStatistics.getInMemoryDataSizeInBytes().getAsLong(), 0L);
                 assertGreaterThan(tableStatistics.getOnDiskDataSizeInBytes().getAsLong(), 0L);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -368,7 +368,7 @@ public class TestOrcPageSourceMemoryTracking
                 if (positionCount > MAX_BATCH_SIZE) {
                     // either the block is bounded by maxReadBytes or we just load one single large block
                     // an error margin MAX_BATCH_SIZE / step is needed given the block sizes are increasing
-                    assertTrue(page.getSizeInBytes() < maxReadBytes * (MAX_BATCH_SIZE / step) || 1 == page.getPositionCount());
+                    assertTrue(page.getSizeInBytes() < (long) maxReadBytes * (MAX_BATCH_SIZE / step) || 1 == page.getPositionCount());
                 }
             }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -1139,7 +1139,7 @@ public class TestHiveGlueMetastore
                                 OptionalLong.of(-1000 - i),
                                 OptionalLong.of(1000 + i),
                                 OptionalLong.of(i),
-                                OptionalLong.of(2 * i)));
+                                OptionalLong.of(2L * i)));
             }
 
             PartitionStatistics partitionStatistics = PartitionStatistics.builder()

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/json/format/CustomDateTimeFormatter.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/json/format/CustomDateTimeFormatter.java
@@ -84,7 +84,7 @@ public class CustomDateTimeFormatter
     {
         int offsetMinutes = value.getOffsetMinutes();
         DateTimeZone dateTimeZone = DateTimeZone.forOffsetHoursMinutes(offsetMinutes / 60, offsetMinutes % 60);
-        long picos = value.getPicos() - (offsetMinutes * 60 * PICOSECONDS_PER_SECOND);
+        long picos = value.getPicos() - (offsetMinutes * 60L * PICOSECONDS_PER_SECOND);
         return formatter.withZone(dateTimeZone).print(new DateTime(scalePicosToMillis(picos), dateTimeZone));
     }
 

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
@@ -298,7 +298,7 @@ public abstract class BasePinotConnectorSmokeTest
         for (int i = 0; i < MAX_ROWS_PER_SPLIT_FOR_SEGMENT_QUERIES + 1; i++) {
             tooManyRowsRecordsBuilder.add(new ProducerRecord<>(TOO_MANY_ROWS_TABLE, "key" + i, new GenericRecordBuilder(tooManyRowsAvroSchema)
                     .set("string_col", "string_" + i)
-                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000).toEpochMilli())
+                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000L).toEpochMilli())
                     .build()));
         }
         kafka.sendMessages(tooManyRowsRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
@@ -320,7 +320,7 @@ public abstract class BasePinotConnectorSmokeTest
         for (int i = 0; i < MAX_ROWS_PER_SPLIT_FOR_BROKER_QUERIES + 1; i++) {
             tooManyBrokerRowsRecordsBuilder.add(new ProducerRecord<>(TOO_MANY_BROKER_ROWS_TABLE, "key" + i, new GenericRecordBuilder(tooManyBrokerRowsAvroSchema)
                     .set("string_col", "string_" + i)
-                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000).toEpochMilli())
+                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000L).toEpochMilli())
                     .build()));
         }
         kafka.sendMessages(tooManyBrokerRowsRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
@@ -390,7 +390,7 @@ public abstract class BasePinotConnectorSmokeTest
             jsonTableRecordsBuilder.add(new ProducerRecord<>(JSON_TYPE_TABLE, "key" + i, new GenericRecordBuilder(jsonTableAvroSchema)
                     .set("string_col", "string_" + i)
                     .set("json_col", "{ \"name\": \"user_" + i + "\", \"id\": " + i + "}")
-                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000).toEpochMilli())
+                    .set("updatedAt", initialUpdatedAt.plusMillis(i * 1000L).toEpochMilli())
                     .build()));
         }
         kafka.sendMessages(jsonTableRecordsBuilder.build().stream(), schemaRegistryAwareProducer(kafka));
@@ -465,7 +465,7 @@ public abstract class BasePinotConnectorSmokeTest
                 GenericRow row = new GenericRow();
                 row.putValue("stringCol", "string_" + i);
                 row.putValue("longCol", (long) i);
-                row.putValue("updatedAt", startInstant.plus(1, DAYS).plusMillis(1000 * (i - 4)).toEpochMilli());
+                row.putValue("updatedAt", startInstant.plus(1, DAYS).plusMillis(1000L * (i - 4)).toEpochMilli());
                 offlineRowsBuilder.add(row);
             }
             Path segmentPath = createSegment(getClass().getClassLoader().getResourceAsStream("hybrid_offlineSpec.json"), getClass().getClassLoader().getResourceAsStream("hybrid_schema.json"), new GenericRowRecordReader(offlineRowsBuilder.build()), temporaryDirectory.toString(), 0);
@@ -478,7 +478,7 @@ public abstract class BasePinotConnectorSmokeTest
                 GenericRow row = new GenericRow();
                 row.putValue("stringCol", "string_" + i);
                 row.putValue("longCol", (long) i);
-                row.putValue("updatedAt", startInstant.minus(1, DAYS).plusMillis(1000 * (i - 7)).toEpochMilli());
+                row.putValue("updatedAt", startInstant.minus(1, DAYS).plusMillis(1000L * (i - 7)).toEpochMilli());
                 offlineRowsBuilder.add(row);
             }
             segmentPath = createSegment(getClass().getClassLoader().getResourceAsStream("hybrid_offlineSpec.json"), getClass().getClassLoader().getResourceAsStream("hybrid_schema.json"), new GenericRowRecordReader(offlineRowsBuilder.build()), temporaryDirectory.toString(), 1);
@@ -1103,7 +1103,7 @@ public abstract class BasePinotConnectorSmokeTest
         long rowCount = (long) computeScalar("SELECT COUNT(*) FROM " + MIXED_CASE_COLUMN_NAMES_TABLE);
         List<String> rows = new ArrayList<>();
         for (int i = 0; i < rowCount; i++) {
-            rows.add(format("('string_%s', '%s', '%s')", i, i, initialUpdatedAt.plusMillis(i * 1000).getEpochSecond()));
+            rows.add(format("('string_%s', '%s', '%s')", i, i, initialUpdatedAt.plusMillis(i * 1000L).getEpochSecond()));
         }
         String mixedCaseColumnNamesTableValues = rows.stream().collect(joining(",", "VALUES ", ""));
 
@@ -1154,7 +1154,7 @@ public abstract class BasePinotConnectorSmokeTest
         long rowCount = (long) computeScalar("SELECT COUNT(*) FROM " + MIXED_CASE_TABLE_NAME);
         List<String> rows = new ArrayList<>();
         for (int i = 0; i < rowCount; i++) {
-            rows.add(format("('string_%s', '%s', '%s')", i, i, initialUpdatedAt.plusMillis(i * 1000).getEpochSecond()));
+            rows.add(format("('string_%s', '%s', '%s')", i, i, initialUpdatedAt.plusMillis(i * 1000L).getEpochSecond()));
         }
 
         String mixedCaseColumnNamesTableValues = rows.stream().collect(joining(",", "VALUES ", ""));
@@ -1284,7 +1284,7 @@ public abstract class BasePinotConnectorSmokeTest
         // ingest the row from kafka.
         List<String> tooManyRowsTableValues = new ArrayList<>();
         for (int i = 0; i < MAX_ROWS_PER_SPLIT_FOR_SEGMENT_QUERIES + 1; i++) {
-            tooManyRowsTableValues.add(format("('string_%s', '%s')", i, initialUpdatedAt.plusMillis(i * 1000).getEpochSecond()));
+            tooManyRowsTableValues.add(format("('string_%s', '%s')", i, initialUpdatedAt.plusMillis(i * 1000L).getEpochSecond()));
         }
 
         // Explicit limit is necessary otherwise pinot returns 10 rows.
@@ -1314,7 +1314,7 @@ public abstract class BasePinotConnectorSmokeTest
 
         List<String> tooManyBrokerRowsTableValues = new ArrayList<>();
         for (int i = 0; i < MAX_ROWS_PER_SPLIT_FOR_BROKER_QUERIES; i++) {
-            tooManyBrokerRowsTableValues.add(format("('string_%s', '%s')", i, initialUpdatedAt.plusMillis(i * 1000).getEpochSecond()));
+            tooManyBrokerRowsTableValues.add(format("('string_%s', '%s')", i, initialUpdatedAt.plusMillis(i * 1000L).getEpochSecond()));
         }
 
         // Explicit limit is necessary otherwise pinot returns 10 rows.
@@ -2777,7 +2777,7 @@ public abstract class BasePinotConnectorSmokeTest
         assertThat(query("SELECT ts FROM " + ALL_TYPES_TABLE + " ORDER BY ts DESC LIMIT 1")).matches("SELECT max(ts) FROM " + ALL_TYPES_TABLE);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(ZoneOffset.UTC);
         for (int i = 0, step = 1200; i < MAX_ROWS_PER_SPLIT_FOR_SEGMENT_QUERIES - 2; i++) {
-            String initialUpdatedAtStr = formatter.format(initialUpdatedAt.plusMillis(i * step));
+            String initialUpdatedAtStr = formatter.format(initialUpdatedAt.plusMillis((long) i * step));
             assertThat(query("SELECT ts FROM " + ALL_TYPES_TABLE + " WHERE ts >= TIMESTAMP '" + initialUpdatedAtStr + "' ORDER BY ts LIMIT 1"))
                     .matches("SELECT ts FROM " + ALL_TYPES_TABLE + " WHERE ts <= TIMESTAMP '" + initialUpdatedAtStr + "' ORDER BY ts DESC LIMIT 1");
             assertThat(query("SELECT ts FROM " + ALL_TYPES_TABLE + " WHERE ts = TIMESTAMP '" + initialUpdatedAtStr + "' LIMIT 1"))

--- a/pom.xml
+++ b/pom.xml
@@ -2470,6 +2470,7 @@
                                     <!-- Sometimes our javadoc contains just a @see directive -->
                                     -Xep:MissingSummary:OFF \
                                     -Xep:MutablePublicArray:ERROR \
+                                    -Xep:NarrowCalculation:ERROR \
                                     -Xep:NarrowingCompoundAssignment:ERROR \
                                     -Xep:NullOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \


### PR DESCRIPTION
This mostly matches IntelliJ's `integer multiplication implicitly cast to long` inspection. While places changed do not look like bugs, so can be viewed as false positives, this helps avoid IDE warnings and thus makes spotting problems easier.
