### PR TITLE
Fix code style error

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -273,7 +273,7 @@ public class TestAccessControl
         assertAccessDenied("SELECT count(*) FROM mock.default.test_view_invoker", "Cannot select from columns.*", privilege("test_view_invoker", SELECT_COLUMN));
         assertAccessAllowed("SELECT count(*) FROM mock.default.test_view_definer");
         assertAccessDenied("SELECT count(*) FROM mock.default.test_view_definer", "Cannot select from columns.*", privilege("test_view_definer", SELECT_COLUMN));
-        
+
         assertAccessDenied(
                 "SELECT orders.custkey, lineitem.quantity FROM orders JOIN lineitem USING (orderkey)",
                 "Cannot select from columns \\[orderkey, custkey] in table .*",


### PR DESCRIPTION
Fix redundant whitespace added in https://github.com/trinodb/trino/pull/18371.
The PR was merged after a force push (with github not showing any changes), and after a green build, but apparently there was some glitch in the observations. 