### PR TITLE
Update AWS SDK v2 and netty dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
         <dep.iceberg.version>1.3.0</dep.iceberg.version>
         <dep.protobuf.version>3.23.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <!-- Netty 4.1.94.Final breaks Apache Arrow -->
         <dep.netty.version>4.1.96.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
         <dep.okio.version>3.3.0</dep.okio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.takari.version>2.1.1</dep.takari.version>
         <dep.aws-sdk.version>1.12.505</dep.aws-sdk.version>
-        <dep.aws-sdk-v2.version>2.20.93</dep.aws-sdk-v2.version>
+        <dep.aws-sdk-v2.version>2.20.124</dep.aws-sdk-v2.version>
         <dep.jsonwebtoken.version>0.11.5</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.21</dep.drift.version>


### PR DESCRIPTION
The Arrow's conflicting Netty change was reverted so it's safe to update.

No release notes needed.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
