### PR TITLE
Reduce max task writer scaling defaults

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -78,11 +78,11 @@ public class TaskManagerConfig
     private Duration interruptStuckSplitTasksDetectionInterval = new Duration(2, TimeUnit.MINUTES);
 
     private boolean scaleWritersEnabled = true;
-    // Set the value of default max writer count to 2 * max(the number of processors, 32). We can do this
+    // Set the value of default max writer count to the number of processors and cap it to 32. We can do this
     // because preferred write partitioning is always enabled for local exchange thus partitioned inserts will never
     // use this property. Hence, there is no risk in terms of more numbers of physical writers which can cause high
     // resource utilization.
-    private int scaleWritersMaxWriterCount = min(getAvailablePhysicalProcessorCount(), 32) * 2;
+    private int scaleWritersMaxWriterCount = min(getAvailablePhysicalProcessorCount(), 32);
     private int writerCount = 1;
     // Default value of partitioned task writer count should be above 1, otherwise it can create a plan
     // with a single gather exchange node on the coordinator due to a single available processor. Whereas,

--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -89,7 +89,7 @@ public class TaskManagerConfig
     // on the worker nodes due to more available processors, the default value could be above 1. Therefore,
     // it can cause error due to config mismatch during execution. Additionally, cap it to 32 in order to
     // avoid small pages produced by local partitioning exchanges.
-    private int partitionedWriterCount = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32) * 2;
+    private int partitionedWriterCount = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32);
     // Default value of task concurrency should be above 1, otherwise it can create a plan with a single gather
     // exchange node on the coordinator due to a single available processor. Whereas, on the worker nodes due to
     // more available processors, the default value could be above 1. Therefore, it can cause error due to config

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -34,7 +34,7 @@ import static java.lang.Math.min;
 public class TestTaskManagerConfig
 {
     private static final int DEFAULT_PROCESSOR_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32);
-    private static final int DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT = min(getAvailablePhysicalProcessorCount(), 32) * 2;
+    private static final int DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT = min(getAvailablePhysicalProcessorCount(), 32);
 
     @Test
     public void testDefaults()

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -35,7 +35,6 @@ public class TestTaskManagerConfig
 {
     private static final int DEFAULT_PROCESSOR_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32);
     private static final int DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT = min(getAvailablePhysicalProcessorCount(), 32) * 2;
-    private static final int DEFAULT_PARTITIONED_WRITER_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32) * 2;
 
     @Test
     public void testDefaults()
@@ -66,7 +65,7 @@ public class TestTaskManagerConfig
                 .setScaleWritersEnabled(true)
                 .setScaleWritersMaxWriterCount(DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT)
                 .setWriterCount(1)
-                .setPartitionedWriterCount(DEFAULT_PARTITIONED_WRITER_COUNT)
+                .setPartitionedWriterCount(DEFAULT_PROCESSOR_COUNT)
                 .setTaskConcurrency(DEFAULT_PROCESSOR_COUNT)
                 .setHttpResponseThreads(100)
                 .setHttpTimeoutThreads(3)
@@ -85,7 +84,6 @@ public class TestTaskManagerConfig
     {
         int processorCount = DEFAULT_PROCESSOR_COUNT == 32 ? 16 : 32;
         int maxWriterCount = DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT == 32 ? 16 : 32;
-        int partitionedWriterCount = DEFAULT_PARTITIONED_WRITER_COUNT == 64 ? 32 : 64;
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("task.initial-splits-per-node", "1")
                 .put("task.split-concurrency-adjustment-interval", "1s")
@@ -112,7 +110,7 @@ public class TestTaskManagerConfig
                 .put("task.scale-writers.enabled", "false")
                 .put("task.scale-writers.max-writer-count", Integer.toString(maxWriterCount))
                 .put("task.writer-count", "4")
-                .put("task.partitioned-writer-count", Integer.toString(partitionedWriterCount))
+                .put("task.partitioned-writer-count", Integer.toString(processorCount))
                 .put("task.concurrency", Integer.toString(processorCount))
                 .put("task.http-response-threads", "4")
                 .put("task.http-timeout-threads", "10")
@@ -152,7 +150,7 @@ public class TestTaskManagerConfig
                 .setScaleWritersEnabled(false)
                 .setScaleWritersMaxWriterCount(maxWriterCount)
                 .setWriterCount(4)
-                .setPartitionedWriterCount(partitionedWriterCount)
+                .setPartitionedWriterCount(processorCount)
                 .setTaskConcurrency(processorCount)
                 .setHttpResponseThreads(4)
                 .setHttpTimeoutThreads(10)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
A high default for task.partitioned-writer-count and task.scale-writers.max-writer-count
can lead to queries running out of memory more often


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Defaults were increased in https://github.com/trinodb/trino/pull/18005 in 422
and found to cause previously working INSERTs to OOM

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Reduce defaults for `task.partitioned-writer-count` and `task.scale-writers.max-writer-count` to reduce memory requirements of write queries. ({issue}`18488`)
```
