### PR TITLE
Estimate row count when BETWEEN value is an expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
@@ -314,7 +314,8 @@ public class FilterStatsCalculator
         @Override
         protected PlanNodeStatsEstimate visitBetweenPredicate(BetweenPredicate node, Void context)
         {
-            if (!(node.getValue() instanceof SymbolReference)) {
+            SymbolStatsEstimate valueStats = getExpressionStats(node.getValue());
+            if (valueStats.isUnknown()) {
                 return PlanNodeStatsEstimate.unknown();
             }
             if (!getExpressionStats(node.getMin()).isSingleValue()) {
@@ -324,7 +325,6 @@ public class FilterStatsCalculator
                 return PlanNodeStatsEstimate.unknown();
             }
 
-            SymbolStatsEstimate valueStats = input.getSymbolStatistics(Symbol.from(node.getValue()));
             Expression lowerBound = new ComparisonExpression(GREATER_THAN_OR_EQUAL, node.getValue(), node.getMin());
             Expression upperBound = new ComparisonExpression(LESS_THAN_OR_EQUAL, node.getValue(), node.getMax());
 

--- a/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestFilterStatsCalculator.java
@@ -608,6 +608,16 @@ public class TestFilterStatsCalculator
                                 .highValue(100.0)
                                 .nullsFraction(0.0));
 
+        // Expression as value. CAST from DOUBLE to DECIMAL(7,2)
+        // Produces row count estimate without updating symbol stats
+        assertExpression("CAST(x AS DECIMAL(7,2)) BETWEEN CAST(DECIMAL '-2.50' AS DECIMAL(7, 2)) AND CAST(DECIMAL '2.50' AS DECIMAL(7, 2))")
+                .outputRowsCount(219.726563)
+                .symbolStats("x", symbolStats ->
+                        symbolStats.distinctValuesCount(xStats.getDistinctValuesCount())
+                                .lowValue(xStats.getLowValue())
+                                .highValue(xStats.getHighValue())
+                                .nullsFraction(xStats.getNullsFraction()));
+
         assertExpression("'a' IN ('a', 'b')").equalTo(standardInputStatistics);
         assertExpression("'a' IN ('a', 'b', NULL)").equalTo(standardInputStatistics);
         assertExpression("'a' IN ('b', 'c')").outputRowsCount(0);

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q85.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q85.plan.txt
@@ -36,7 +36,7 @@ local exchange (GATHER, SINGLE, [])
                                                                     scan customer_demographics
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_page
+                                                    scan reason
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan reason
+                                                scan web_page


### PR DESCRIPTION
## Description
Estimate row count when BETWEEN value is an expression


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve CBO estimates for queries with BETWEEN clause. ({issue}`18501`)
```
