### PR TITLE
Improve performance when planning multiple window functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -1687,6 +1687,30 @@ public class Analysis
         {
             return frameInherited;
         }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResolvedWindow that = (ResolvedWindow) o;
+            return partitionByInherited == that.partitionByInherited &&
+                    orderByInherited == that.orderByInherited &&
+                    frameInherited == that.frameInherited &&
+                    partitionBy.equals(that.partitionBy) &&
+                    orderBy.equals(that.orderBy) &&
+                    frame.equals(that.frame);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(partitionBy, orderBy, frame, partitionByInherited, orderByInherited, frameInherited);
+        }
     }
 
     public static class MergeAnalysis

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1385,11 +1385,13 @@ class QueryPlanner
             return subPlan;
         }
 
-        for (FunctionCall windowFunction : scopeAwareDistinct(subPlan, windowFunctions)) {
-            checkArgument(windowFunction.getFilter().isEmpty(), "Window functions cannot have filter");
+        Map<ResolvedWindow, List<FunctionCall>> functions = scopeAwareDistinct(subPlan, windowFunctions)
+                .stream()
+                .collect(Collectors.groupingBy(analysis::getWindow));
 
-            ResolvedWindow window = analysis.getWindow(windowFunction);
-            checkState(window != null, "no resolved window for: " + windowFunction);
+        for (Map.Entry<ResolvedWindow, List<FunctionCall>> entry : functions.entrySet()) {
+            ResolvedWindow window = entry.getKey();
+            List<FunctionCall> functionCalls = entry.getValue();
 
             // Pre-project inputs.
             // Predefined window parts (specified in WINDOW clause) can only use source symbols, and no output symbols.
@@ -1398,9 +1400,6 @@ class QueryPlanner
             // This issue is solved by analyzing window definitions in the source scope. After analysis, the expressions
             // are recorded as belonging to the source scope, and consequentially source symbols will be used to plan them.
             ImmutableList.Builder<Expression> inputsBuilder = ImmutableList.<Expression>builder()
-                    .addAll(windowFunction.getArguments().stream()
-                            .filter(argument -> !(argument instanceof LambdaExpression)) // lambda expression is generated at execution time
-                            .collect(Collectors.toList()))
                     .addAll(window.getPartitionBy())
                     .addAll(getSortItemsFromOrderBy(window.getOrderBy()).stream()
                             .map(SortItem::getSortKey)
@@ -1413,6 +1412,12 @@ class QueryPlanner
                 if (frame.getEnd().isPresent()) {
                     frame.getEnd().get().getValue().ifPresent(inputsBuilder::add);
                 }
+            }
+
+            for (FunctionCall windowFunction : functionCalls) {
+                inputsBuilder.addAll(windowFunction.getArguments().stream()
+                                .filter(argument -> !(argument instanceof LambdaExpression)) // lambda expression is generated at execution time
+                                .collect(Collectors.toList()));
             }
 
             List<Expression> inputs = inputsBuilder.build();
@@ -1475,10 +1480,10 @@ class QueryPlanner
             if (window.getFrame().isPresent() && window.getFrame().get().getPattern().isPresent()) {
                 WindowFrame frame = window.getFrame().get();
                 subPlan = subqueryPlanner.handleSubqueries(subPlan, extractPatternRecognitionExpressions(frame.getVariableDefinitions(), frame.getMeasures()), analysis.getSubqueries(node));
-                subPlan = planPatternRecognition(subPlan, windowFunction, window, coercions, frameEnd);
+                subPlan = planPatternRecognition(subPlan, functionCalls, window, coercions, frameEnd);
             }
             else {
-                subPlan = planWindow(subPlan, windowFunction, window, coercions, frameStart, sortKeyCoercedForFrameStartComparison, frameEnd, sortKeyCoercedForFrameEndComparison);
+                subPlan = planWindow(subPlan, functionCalls, window, coercions, frameStart, sortKeyCoercedForFrameStartComparison, frameEnd, sortKeyCoercedForFrameEndComparison);
             }
         }
 
@@ -1678,7 +1683,7 @@ class QueryPlanner
 
     private PlanBuilder planWindow(
             PlanBuilder subPlan,
-            FunctionCall windowFunction,
+            List<FunctionCall> windowFunctions,
             ResolvedWindow window,
             PlanAndMappings coercions,
             Optional<Symbol> frameStartSymbol,
@@ -1720,33 +1725,41 @@ class QueryPlanner
                 frameStartExpression,
                 frameEndExpression);
 
-        Symbol newSymbol = symbolAllocator.newSymbol(windowFunction, analysis.getType(windowFunction));
+        ImmutableMap.Builder<ScopeAware<Expression>, Symbol> mappings = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, WindowNode.Function> functions = ImmutableMap.builder();
 
-        NullTreatment nullTreatment = windowFunction.getNullTreatment()
-                .orElse(NullTreatment.RESPECT);
+        for (FunctionCall windowFunction : windowFunctions) {
+            Symbol newSymbol = symbolAllocator.newSymbol(windowFunction, analysis.getType(windowFunction));
 
-        WindowNode.Function function = new WindowNode.Function(
-                analysis.getResolvedFunction(windowFunction),
-                windowFunction.getArguments().stream()
-                        .map(argument -> {
-                            if (argument instanceof LambdaExpression) {
-                                return subPlan.rewrite(argument);
-                            }
-                            return coercions.get(argument).toSymbolReference();
-                        })
-                        .collect(toImmutableList()),
-                frame,
-                nullTreatment == NullTreatment.IGNORE);
+            NullTreatment nullTreatment = windowFunction.getNullTreatment()
+                    .orElse(NullTreatment.RESPECT);
+
+            WindowNode.Function function = new WindowNode.Function(
+                    analysis.getResolvedFunction(windowFunction),
+                    windowFunction.getArguments().stream()
+                            .map(argument -> {
+                                if (argument instanceof LambdaExpression) {
+                                    return subPlan.rewrite(argument);
+                                }
+                                return coercions.get(argument).toSymbolReference();
+                            })
+                            .collect(toImmutableList()),
+                    frame,
+                    nullTreatment == NullTreatment.IGNORE);
+
+            functions.put(newSymbol, function);
+            mappings.put(scopeAwareKey(windowFunction, analysis, subPlan.getScope()), newSymbol);
+        }
 
         // create window node
         return new PlanBuilder(
                 subPlan.getTranslations()
-                        .withAdditionalMappings(ImmutableMap.of(scopeAwareKey(windowFunction, analysis, subPlan.getScope()), newSymbol)),
+                        .withAdditionalMappings(mappings.buildOrThrow()),
                 new WindowNode(
                         idAllocator.getNextId(),
                         subPlan.getRoot(),
                         specification,
-                        ImmutableMap.of(newSymbol, function),
+                        functions.buildOrThrow(),
                         Optional.empty(),
                         ImmutableSet.of(),
                         0));
@@ -1754,7 +1767,7 @@ class QueryPlanner
 
     private PlanBuilder planPatternRecognition(
             PlanBuilder subPlan,
-            FunctionCall windowFunction,
+            List<FunctionCall> windowFunctions,
             ResolvedWindow window,
             PlanAndMappings coercions,
             Optional<Symbol> frameEndSymbol)
@@ -1775,23 +1788,31 @@ class QueryPlanner
                 Optional.empty(),
                 frameEnd.getValue());
 
-        Symbol newSymbol = symbolAllocator.newSymbol(windowFunction, analysis.getType(windowFunction));
+        ImmutableMap.Builder<ScopeAware<Expression>, Symbol> mappings = ImmutableMap.builder();
+        ImmutableMap.Builder<Symbol, WindowNode.Function> functions = ImmutableMap.builder();
 
-        NullTreatment nullTreatment = windowFunction.getNullTreatment()
-                .orElse(NullTreatment.RESPECT);
+        for (FunctionCall windowFunction : windowFunctions) {
+            Symbol newSymbol = symbolAllocator.newSymbol(windowFunction, analysis.getType(windowFunction));
 
-        WindowNode.Function function = new WindowNode.Function(
-                analysis.getResolvedFunction(windowFunction),
-                windowFunction.getArguments().stream()
-                        .map(argument -> {
-                            if (argument instanceof LambdaExpression) {
-                                return subPlan.rewrite(argument);
-                            }
-                            return coercions.get(argument).toSymbolReference();
-                        })
-                        .collect(toImmutableList()),
-                baseFrame,
-                nullTreatment == NullTreatment.IGNORE);
+            NullTreatment nullTreatment = windowFunction.getNullTreatment()
+                    .orElse(NullTreatment.RESPECT);
+
+            WindowNode.Function function = new WindowNode.Function(
+                    analysis.getResolvedFunction(windowFunction),
+                    windowFunction.getArguments().stream()
+                            .map(argument -> {
+                                if (argument instanceof LambdaExpression) {
+                                    return subPlan.rewrite(argument);
+                                }
+                                return coercions.get(argument).toSymbolReference();
+                            })
+                            .collect(toImmutableList()),
+                    baseFrame,
+                    nullTreatment == NullTreatment.IGNORE);
+
+            functions.put(newSymbol, function);
+            mappings.put(scopeAwareKey(windowFunction, analysis, subPlan.getScope()), newSymbol);
+        }
 
         PatternRecognitionComponents components = new RelationPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries)
                 .planPatternRecognitionComponents(
@@ -1806,7 +1827,7 @@ class QueryPlanner
         // create pattern recognition node
         return new PlanBuilder(
                 subPlan.getTranslations()
-                        .withAdditionalMappings(ImmutableMap.of(scopeAwareKey(windowFunction, analysis, subPlan.getScope()), newSymbol)),
+                        .withAdditionalMappings(mappings.buildOrThrow()),
                 new PatternRecognitionNode(
                         idAllocator.getNextId(),
                         subPlan.getRoot(),
@@ -1814,7 +1835,7 @@ class QueryPlanner
                         Optional.empty(),
                         ImmutableSet.of(),
                         0,
-                        ImmutableMap.of(newSymbol, function),
+                        functions.buildOrThrow(),
                         components.getMeasures(),
                         Optional.of(baseFrame),
                         RowsPerMatch.WINDOW,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -1057,12 +1057,12 @@ public class PlanPrinter
         {
             StringBuilder builder = new StringBuilder(frame.getType().toString());
 
-            frame.getOriginalStartValue()
+            frame.getStartValue()
                     .map(anonymizer::anonymize)
                     .ifPresent(value -> builder.append(" ").append(value));
             builder.append(" ").append(frame.getStartType());
 
-            frame.getOriginalEndValue()
+            frame.getEndValue()
                     .map(anonymizer::anonymize)
                     .ifPresent(value -> builder.append(" ").append(value));
             builder.append(" ").append(frame.getEndType());

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestWindow
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    @Timeout(2)
+    public void testManyFunctionsWithSameWindow()
+    {
+        assertThat(assertions.query("""
+                SELECT
+                          SUM(a) OVER w,
+                          COUNT(a) OVER w,
+                          MIN(a) OVER w,
+                          MAX(a) OVER w,
+                          SUM(b) OVER w,
+                          COUNT(b) OVER w,
+                          MIN(b) OVER w,
+                          MAX(b) OVER w,
+                          SUM(c) OVER w,
+                          COUNT(c) OVER w,
+                          MIN(c) OVER w,
+                          MAX(c) OVER w,
+                          SUM(d) OVER w,
+                          COUNT(d) OVER w,
+                          MIN(d) OVER w,
+                          MAX(d) OVER w,
+                          SUM(e) OVER w,
+                          COUNT(e) OVER w,
+                          MIN(e) OVER w,
+                          MAX(e) OVER w,
+                          SUM(f) OVER w,
+                          COUNT(f) OVER w,
+                          MIN(f) OVER w,
+                          MAX(f) OVER w
+                        FROM (
+                            VALUES (1, 1, 1, 1, 1, 1, 1)
+                        ) AS t(k, a, b, c, d, e, f)
+                        WINDOW w AS (ORDER BY k ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+                """))
+                .matches("VALUES (BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1, BIGINT '1', BIGINT '1', 1, 1)");
+    }
+}


### PR DESCRIPTION
Instead of planning each window function in a separate WindowNode, group them together as long as they have the same window specification.

This helps reduce deep plan trees and simplify the structure of the plan by removing redundant operations (e.g., projections to compute frame bounds, filters to ensure frame bounds are legal, etc.), that make it harder for optimizer rules to match and remove later.

Mitigates https://github.com/trinodb/trino/issues/18491

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance when planning queries involving multiple window functions. ({issue}`18491`)
```
