### PR TITLE
Improve doc for Window functions

### DIFF
--- a/docs/src/main/sphinx/functions/window.md
+++ b/docs/src/main/sphinx/functions/window.md
@@ -23,8 +23,9 @@ The window can be specified in two ways (see {ref}`window-clause`):
 ## Aggregate functions
 
 All {doc}`aggregate` can be used as window functions by adding the `OVER`
-clause. The aggregate function is computed for each row over the rows within
-the current row's window frame.
+clause. The aggregate function is computed for each row over the rows within the
+current row's window frame. Note that [ordering during
+aggregation](aggregate-function-ordering-during-aggregation) is not supported.
 
 For example, the following query produces a rolling sum of order prices
 by day for each clerk:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The doc should make it clear that the `ORDER BY` clause in an aggregate function is not supported, if the aggregate function is used as a window function.

For example, this works:
```
SELECT ARRAY_AGG(phone) OVER (PARTITION BY custkey) FROM customer
```
while this one fails:
```
SELECT ARRAY_AGG(phone ORDER BY phone) OVER (PARTITION BY custkey) FROM customer

line 1:59: PARTITION BY expression 'custkey' must be an aggregate expression or appear in GROUP BY clause
```



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
