### PR TITLE
Error Prone 2.21.0, NullableOptional check

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
+++ b/core/trino-main/src/main/java/io/trino/server/ResourceGroupInfo.java
@@ -20,7 +20,6 @@ import io.airlift.units.Duration;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.spi.resourcegroups.ResourceGroupState;
 import io.trino.spi.resourcegroups.SchedulingPolicy;
-import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -181,7 +180,6 @@ public class ResourceGroupInfo
     }
 
     @JsonProperty
-    @Nullable
     public Optional<List<QueryStateInfo>> getRunningQueries()
     {
         return runningQueries;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
@@ -51,6 +51,7 @@ public class TableScanNode
 
     @Nullable // null on workers
     private final TupleDomain<ColumnHandle> enforcedConstraint;
+    @SuppressWarnings("NullableOptional")
     @Nullable // null on workers
     private final Optional<PlanNodeStatsEstimate> statistics;
     private final boolean updateTarget;

--- a/pom.xml
+++ b/pom.xml
@@ -2475,6 +2475,7 @@
                                     -Xep:MutablePublicArray:ERROR \
                                     -Xep:NarrowingCompoundAssignment:ERROR \
                                     -Xep:NullOptional:ERROR \
+                                    -Xep:NullableOptional:ERROR \
                                     -Xep:ObjectToString:ERROR \
                                     -Xep:OptionalNotPresent:ERROR \
                                     -Xep:OrphanedFormatString:ERROR \

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <dep.tempto.version>200</dep.tempto.version>
         <dep.gcs.version>2.2.8</dep.gcs.version>
 
-        <dep.errorprone.version>2.20.0</dep.errorprone.version>
+        <dep.errorprone.version>2.21.0</dep.errorprone.version>
         <dep.testcontainers.version>1.18.3</dep.testcontainers.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.confluent.version>7.3.1</dep.confluent.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Bump Error Prone to 2.21.0
* Enable check: `NullableOptional`

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The check enabled is a new one in that release, and it looks like it complements `NullOptional` pretty nicely.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
