### PR TITLE
Add framework to support complex expression filter pushdown in MongoDB

### DIFF
--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -55,7 +55,17 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoClientConfig.java
@@ -45,6 +45,7 @@ public class MongoClientConfig
     private String requiredReplicaSetName;
     private String implicitRowFieldPrefix = "_pos";
     private boolean projectionPushDownEnabled = true;
+    private boolean complexExpressionPushdownEnabled;
 
     @NotNull
     public String getSchemaCollection()
@@ -249,6 +250,18 @@ public class MongoClientConfig
     public MongoClientConfig setProjectionPushdownEnabled(boolean projectionPushDownEnabled)
     {
         this.projectionPushDownEnabled = projectionPushDownEnabled;
+        return this;
+    }
+
+    public boolean isComplexExpressionPushdownEnabled()
+    {
+        return complexExpressionPushdownEnabled;
+    }
+
+    @Config("mongodb.complex-expression-pushdown.enabled")
+    public MongoClientConfig setComplexExpressionPushdownEnabled(boolean complexExpressionPushdownEnabled)
+    {
+        this.complexExpressionPushdownEnabled = complexExpressionPushdownEnabled;
         return this;
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -146,6 +146,8 @@ public class MongoSession
     private static final String LTE_OP = "$lte";
     private static final String IN_OP = "$in";
 
+    private static final String EXPR = "$expr";
+
     public static final String DATABASE_NAME = "databaseName";
     public static final String COLLECTION_NAME = "collectionName";
     public static final String ID = "id";
@@ -566,8 +568,20 @@ public class MongoSession
         // Use $and operator because Document.putAll method overwrites existing entries where the key already exists
         ImmutableList.Builder<Document> filter = ImmutableList.builder();
         table.getFilter().ifPresent(json -> filter.add(parseFilter(json)));
+        filter.add(buildFilterExpression(table.getConstraintExpressions()));
         filter.add(buildQuery(table.getConstraint()));
         return andPredicate(filter.build());
+    }
+
+    static Document buildFilterExpression(List<String> constraintExpression)
+    {
+        ImmutableList.Builder<Document> expressionFilterBuilder = ImmutableList.builder();
+        constraintExpression.forEach(json -> expressionFilterBuilder.add(parseFilter(json)));
+        List<Document> filterExpression = expressionFilterBuilder.build();
+        if (filterExpression.isEmpty()) {
+            return new Document();
+        }
+        return documentOf(EXPR, andPredicate(filterExpression));
     }
 
     @VisibleForTesting

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSessionProperties.java
@@ -27,6 +27,7 @@ public final class MongoSessionProperties
         implements SessionPropertiesProvider
 {
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
+    private static final String COMPLEX_EXPRESSION_PUSHDOWN_ENABLED = "complex_expression_pushdown_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -38,6 +39,11 @@ public final class MongoSessionProperties
                         PROJECTION_PUSHDOWN_ENABLED,
                         "Read only required fields from a row type",
                         mongoConfig.isProjectionPushdownEnabled(),
+                        false))
+                .add(booleanProperty(
+                        COMPLEX_EXPRESSION_PUSHDOWN_ENABLED,
+                        "Allow complex expression pushdown into connectors",
+                        mongoConfig.isComplexExpressionPushdownEnabled(),
                         false))
                 .build();
     }
@@ -51,5 +57,10 @@ public final class MongoSessionProperties
     public static boolean isProjectionPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(PROJECTION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isComplexExpressionPushdown(ConnectorSession session)
+    {
+        return session.getProperty(COMPLEX_EXPRESSION_PUSHDOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoTableHandle.java
@@ -15,12 +15,14 @@ package io.trino.plugin.mongodb;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -36,12 +38,13 @@ public class MongoTableHandle
     private final RemoteTableName remoteTableName;
     private final Optional<String> filter;
     private final TupleDomain<ColumnHandle> constraint;
+    private final List<String> constraintExpressions;
     private final Set<MongoColumnHandle> projectedColumns;
     private final OptionalInt limit;
 
     public MongoTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, Optional<String> filter)
     {
-        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableSet.of(), OptionalInt.empty());
+        this(schemaTableName, remoteTableName, filter, TupleDomain.all(), ImmutableList.of(), ImmutableSet.of(), OptionalInt.empty());
     }
 
     @JsonCreator
@@ -50,6 +53,7 @@ public class MongoTableHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("filter") Optional<String> filter,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("constraintExpressions") List<String> constraintExpressions,
             @JsonProperty("projectedColumns") Set<MongoColumnHandle> projectedColumns,
             @JsonProperty("limit") OptionalInt limit)
     {
@@ -57,6 +61,7 @@ public class MongoTableHandle
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.filter = requireNonNull(filter, "filter is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.constraintExpressions = ImmutableList.copyOf(requireNonNull(constraintExpressions, "constraintExpressions is null"));
         this.projectedColumns = ImmutableSet.copyOf(requireNonNull(projectedColumns, "projectedColumns is null"));
         this.limit = requireNonNull(limit, "limit is null");
     }
@@ -86,6 +91,12 @@ public class MongoTableHandle
     }
 
     @JsonProperty
+    public List<String> getConstraintExpressions()
+    {
+        return constraintExpressions;
+    }
+
+    @JsonProperty
     public Set<MongoColumnHandle> getProjectedColumns()
     {
         return projectedColumns;
@@ -104,6 +115,7 @@ public class MongoTableHandle
                 remoteTableName,
                 filter,
                 constraint,
+                constraintExpressions,
                 projectedColumns,
                 limit);
     }
@@ -111,7 +123,7 @@ public class MongoTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, filter, constraint, projectedColumns, limit);
+        return Objects.hash(schemaTableName, filter, constraint, constraintExpressions, projectedColumns, limit);
     }
 
     @Override
@@ -128,6 +140,7 @@ public class MongoTableHandle
                 Objects.equals(this.remoteTableName, other.remoteTableName) &&
                 Objects.equals(this.filter, other.filter) &&
                 Objects.equals(this.constraint, other.constraint) &&
+                Objects.equals(this.constraintExpressions, other.constraintExpressions) &&
                 Objects.equals(this.projectedColumns, other.projectedColumns) &&
                 Objects.equals(this.limit, other.limit);
     }
@@ -140,6 +153,7 @@ public class MongoTableHandle
                 .add("remoteTableName", remoteTableName)
                 .add("filter", filter)
                 .add("constraint", constraint)
+                .add("constraintExpressions", constraintExpressions)
                 .add("projectedColumns", projectedColumns)
                 .add("limit", limit)
                 .toString();

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionInfo.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/ExpressionInfo.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.util.Objects.requireNonNull;
+
+public class ExpressionInfo
+{
+    private final String name;
+    private final Type type;
+    private final Optional<String> mongoType;
+
+    public ExpressionInfo(String name, Type type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+        this.mongoType = toMongoType(type);
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public Optional<String> getMongoType()
+    {
+        return mongoType;
+    }
+
+    private Optional<String> toMongoType(Type type)
+    {
+        if (type == TINYINT || type == SMALLINT || type == IntegerType.INTEGER) {
+            return Optional.of("int");
+        }
+
+        if (type == BIGINT) {
+            return Optional.of("long");
+        }
+
+        if (type instanceof DecimalType) {
+            return Optional.of("decimal");
+        }
+
+        if (type instanceof VarcharType) {
+            return Optional.of("string");
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        ExpressionInfo that = (ExpressionInfo) obj;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("name", name)
+                .add("type", type)
+                .toString();
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/FilterExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/FilterExpression.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import jakarta.annotation.Nullable;
+
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public record FilterExpression(@Nullable Object expression, ExpressionType expressionType, Optional<ExpressionInfo> expressionInfo)
+{
+    public enum ExpressionType
+    {
+        LITERAL,
+        DOCUMENT,
+        VARIABLE,
+    }
+
+    public FilterExpression(@Nullable Object expression, ExpressionType expressionType)
+    {
+        this(expression, expressionType, Optional.empty());
+    }
+
+    public FilterExpression(@Nullable Object expression, ExpressionType expressionType, Optional<ExpressionInfo> expressionInfo)
+    {
+        this.expression = expression;
+        this.expressionType = requireNonNull(expressionType, "expressionType is null");
+        this.expressionInfo = requireNonNull(expressionInfo, "expressionInfo is null");
+        if (expressionType == ExpressionType.VARIABLE) {
+            verify(expressionInfo.isPresent(), "expressionInfo is mandatory when expressionType is VARIABLE");
+        }
+    }
+
+    public boolean isLiteral()
+    {
+        return expressionType == ExpressionType.LITERAL;
+    }
+
+    public boolean isDocument()
+    {
+        return expressionType == ExpressionType.DOCUMENT;
+    }
+
+    public boolean isVariable()
+    {
+        return expressionType == ExpressionType.VARIABLE;
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpressionRewriter.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpressionRewriter.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+
+public class MongoExpressionRewriter
+{
+    private final ImmutableSet.Builder<ConnectorExpressionRule<?, FilterExpression>> rules = ImmutableSet.builder();
+
+    public MongoExpressionRewriter()
+    {
+        rules.add(new RewriteVariable());
+        rules.add(new RewriteVarcharConstant());
+        rules.add(new RewriteExactNumericConstant());
+        rules.add(new RewriteAnd());
+        rules.add(new RewriteOr());
+        rules.add(new RewriteComparison());
+        rules.add(new RewriteIn());
+        rules.add(new RewriteIsNull());
+        rules.add(new RewriteNot());
+    }
+
+    public ConnectorExpressionRewriter<FilterExpression> getRewriter()
+    {
+        return new ConnectorExpressionRewriter<>(rules.build());
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpressions.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/MongoExpressions.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.VarcharType;
+import org.bson.Document;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.Objects.requireNonNull;
+
+public final class MongoExpressions
+{
+    private MongoExpressions() {}
+
+    public static Document documentOf(String key, Object value)
+    {
+        requireNonNull(key, "key is null");
+        requireNonNull(value, "value is null");
+        return new Document(key, value);
+    }
+
+    public static Document toDecimal(Object value)
+    {
+        requireNonNull(value, "value is null");
+        return documentOf("$toDecimal", value);
+    }
+
+    public static Document toString(Object value)
+    {
+        requireNonNull(value, "value is null");
+        Document convertValue = documentOf("input", value)
+                .append("to", "string")
+                .append("onError", null);
+        return documentOf("$convert", convertValue);
+    }
+
+    public static Optional<List<Document>> buildVariableExpression(FilterExpression filterExpression)
+    {
+        requireNonNull(filterExpression, "filterExpression is null");
+        checkArgument(filterExpression.isVariable(), "Filter expression is not variable");
+        checkArgument(filterExpression.expressionInfo().isPresent(), "expressionInfo of variable is not present");
+        ExpressionInfo expressionInfo = filterExpression.expressionInfo().get();
+        Optional<String> mongoType = expressionInfo.getMongoType();
+        // If mapping between trino type and mongo type does not happen, then pushdown won't be supported
+        if (mongoType.isEmpty()) {
+            return Optional.empty();
+        }
+        ImmutableList.Builder<Document> expressionBuilder = ImmutableList.builder();
+        // When using aggregate operators, if the field being compared either does not exist in the document or has a null value,
+        // comparison operators include those documents in the results. To address this, comparing operands greater than null
+        // ensures that the output excludes documents where the compared field is either missing or has a null value.
+        // https://www.mongodb.com/community/forums/t/why-aggregate-operators-behave-differently-than-projection-operators/237219
+        expressionBuilder.add(documentOf("$gt", Arrays.asList(filterExpression.expression(), null)));
+
+        // Handle mismatched data type value of documents by matching the data type of column and document value
+        if (expressionInfo.getType() == BIGINT) {
+            expressionBuilder.add(documentOf("$in", ImmutableList.of(documentOf("$type", expressionInfo.getName()), ImmutableList.of(mongoType.get(), "int"))));
+        }
+        else if (!(expressionInfo.getType() instanceof VarcharType)) {
+            expressionBuilder.add(documentOf("$eq", ImmutableList.of(documentOf("$type", expressionInfo.getName()), mongoType.get())));
+        }
+        return Optional.of(expressionBuilder.build());
+    }
+
+    public static boolean isVarchar(FilterExpression filterExpression)
+    {
+        requireNonNull(filterExpression, "filterExpression is null");
+        if (!filterExpression.isVariable()) {
+            return false;
+        }
+        verify(filterExpression.expressionInfo().isPresent(), "expressionInfo of variable is not present");
+        return filterExpression.expressionInfo().get().getType() instanceof VarcharType;
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteAnd.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+
+public class RewriteAnd
+        extends RewriteLogicalExpression
+{
+    public RewriteAnd()
+    {
+        super(AND_FUNCTION_NAME, "$and");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteComparison.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+import org.bson.Document;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.buildVariableExpression;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.isVarchar;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class RewriteComparison
+        implements ConnectorExpressionRule<Call, FilterExpression>
+{
+    private static final Capture<ConnectorExpression> LEFT = newCapture();
+    private static final Capture<ConnectorExpression> RIGHT = newCapture();
+
+    public enum ComparisonOperator
+    {
+        EQUAL(EQUAL_OPERATOR_FUNCTION_NAME, "$eq"),
+        NOT_EQUAL(NOT_EQUAL_OPERATOR_FUNCTION_NAME, "$ne"),
+        LESS_THAN(LESS_THAN_OPERATOR_FUNCTION_NAME, "$lt"),
+        LESS_THAN_OR_EQUAL(LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$lte"),
+        GREATER_THAN(GREATER_THAN_OPERATOR_FUNCTION_NAME, "$gt"),
+        GREATER_THAN_OR_EQUAL(GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, "$gte"),
+        /**/;
+
+        private final FunctionName functionName;
+        private final String operator;
+
+        private static final Map<FunctionName, ComparisonOperator> OPERATOR_BY_FUNCTION_NAME = Stream.of(values())
+                .collect(toImmutableMap(ComparisonOperator::getFunctionName, identity()));
+
+        ComparisonOperator(FunctionName functionName, String operator)
+        {
+            this.functionName = requireNonNull(functionName, "functionName is null");
+            this.operator = requireNonNull(operator, "operator is null");
+        }
+
+        private FunctionName getFunctionName()
+        {
+            return functionName;
+        }
+
+        private String getOperator()
+        {
+            return operator;
+        }
+
+        private static ComparisonOperator forFunctionName(FunctionName functionName)
+        {
+            return verifyNotNull(OPERATOR_BY_FUNCTION_NAME.get(functionName), "Function name not recognized: %s", functionName);
+        }
+    }
+
+    private final Pattern<Call> pattern;
+
+    public RewriteComparison()
+    {
+        Set<FunctionName> functionNames = Stream.of(ComparisonOperator.values())
+                .map(ComparisonOperator::getFunctionName)
+                .collect(toImmutableSet());
+
+        pattern = call()
+                .with(functionName().matching(functionNames::contains))
+                .with(type().equalTo(BOOLEAN))
+                .with(argumentCount().equalTo(2))
+                .with(argument(0).matching(expression().capturedAs(LEFT)))
+                .with(argument(1).matching(expression().capturedAs(RIGHT)));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Call call, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        Optional<FilterExpression> left = context.defaultRewrite(captures.get(LEFT));
+        if (left.isEmpty()) {
+            return Optional.empty();
+        }
+        Optional<FilterExpression> right = context.defaultRewrite(captures.get(RIGHT));
+        if (right.isEmpty()) {
+            return Optional.empty();
+        }
+        verify(call.getFunctionName().getCatalogSchema().isEmpty()); // filtered out by the pattern
+        FilterExpression leftFilterExpression = left.get();
+        Object leftValue = leftFilterExpression.expression();
+        FilterExpression rightFilterExpression = right.get();
+        Object rightValue = rightFilterExpression.expression();
+
+        ComparisonOperator operator = ComparisonOperator.forFunctionName(call.getFunctionName());
+        ImmutableList.Builder<Document> expressionBuilder = ImmutableList.builder();
+
+        if (leftFilterExpression.isVariable()) {
+            Optional<List<Document>> expression = buildVariableExpression(leftFilterExpression);
+            if (expression.isEmpty()) {
+                return Optional.empty();
+            }
+            expressionBuilder.addAll(expression.get());
+        }
+
+        if (rightFilterExpression.isVariable()) {
+            Optional<List<Document>> expression = buildVariableExpression(rightFilterExpression);
+            if (expression.isEmpty()) {
+                return Optional.empty();
+            }
+            expressionBuilder.addAll(expression.get());
+        }
+
+        if (isVarchar(leftFilterExpression)) {
+            leftValue = MongoExpressions.toString(leftValue);
+        }
+
+        if (isVarchar(rightFilterExpression)) {
+            rightValue = MongoExpressions.toString(rightValue);
+        }
+
+        expressionBuilder.add(documentOf(operator.getOperator(), Arrays.asList(leftValue, rightValue)));
+
+        return Optional.of(new FilterExpression(
+                documentOf("$and", expressionBuilder.build()),
+                FilterExpression.ExpressionType.DOCUMENT));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteConstant.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+public abstract class RewriteConstant
+        implements ConnectorExpressionRule<Constant, FilterExpression>
+{
+    @Override
+    public Optional<FilterExpression> rewrite(Constant constant, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        Type type = constant.getType();
+        Object value = constant.getValue();
+        if (value == null) {
+            return Optional.of(new FilterExpression(null, FilterExpression.ExpressionType.LITERAL));
+        }
+        return handleNonNullValue(type, value);
+    }
+
+    protected abstract Optional<FilterExpression> handleNonNullValue(Type type, Object value);
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteExactNumericConstant.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Pattern;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.toDecimal;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+
+public class RewriteExactNumericConstant
+        extends RewriteConstant
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().matching(type ->
+            type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT || type instanceof DecimalType));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<FilterExpression> handleNonNullValue(Type type, Object value)
+    {
+        if (type == TINYINT || type == SMALLINT || type == INTEGER || type == BIGINT) {
+            return Optional.of(new FilterExpression(value, FilterExpression.ExpressionType.LITERAL));
+        }
+
+        if (type instanceof DecimalType decimalType) {
+            if (decimalType.isShort()) {
+                return Optional.of(new FilterExpression(toDecimal(Decimals.toString((long) value, decimalType.getScale())), FilterExpression.ExpressionType.LITERAL));
+            }
+            return Optional.of(new FilterExpression(toDecimal(Decimals.toString((Int128) value, decimalType.getScale())), FilterExpression.ExpressionType.LITERAL));
+        }
+
+        throw new UnsupportedOperationException("Unsupported type: " + type);
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIn.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argument;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.arguments;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.expression;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.buildVariableExpression;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.isVarchar;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteIn
+        implements ConnectorExpressionRule<Call, FilterExpression>
+{
+    private static final Capture<ConnectorExpression> VALUE = newCapture();
+    private static final Capture<List<ConnectorExpression>> EXPRESSIONS = newCapture();
+
+    private static final Pattern<Call> PATTERN = call()
+            .with(functionName().equalTo(IN_PREDICATE_FUNCTION_NAME))
+            .with(type().equalTo(BOOLEAN))
+            .with(argumentCount().equalTo(2))
+            .with(argument(0).matching(expression().capturedAs(VALUE)))
+            .with(argument(1).matching(call().with(functionName().equalTo(ARRAY_CONSTRUCTOR_FUNCTION_NAME)).with(arguments().capturedAs(EXPRESSIONS))));
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Call call, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        Optional<FilterExpression> rewrittenValue = context.defaultRewrite(captures.get(VALUE));
+        if (rewrittenValue.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<ConnectorExpression> expressions = captures.get(EXPRESSIONS);
+
+        // IN elements could be null, so use mutable list
+        List<Object> rewrittenInValues = new ArrayList<>(expressions.size());
+        for (ConnectorExpression expression : expressions) {
+            Optional<FilterExpression> rewritten = context.defaultRewrite(expression);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            rewrittenInValues.add(rewritten.get().expression());
+        }
+        verify(!rewrittenInValues.isEmpty(), "rewrittenInValues is empty");
+        FilterExpression leftFilterExpression = rewrittenValue.get();
+
+        ImmutableList.Builder<Document> expressionBuilder = ImmutableList.builder();
+
+        if (leftFilterExpression.isVariable()) {
+            Optional<List<Document>> expression = buildVariableExpression(leftFilterExpression);
+            if (expression.isEmpty()) {
+                return Optional.empty();
+            }
+            expressionBuilder.addAll(expression.get());
+        }
+
+        Object leftValue = leftFilterExpression.expression();
+        if (isVarchar(rewrittenValue.get())) {
+            leftValue = MongoExpressions.toString(leftValue);
+        }
+
+        expressionBuilder.add(documentOf("$in", Arrays.asList(leftValue, rewrittenInValues)));
+
+        return Optional.of(new FilterExpression(
+                documentOf("$and", expressionBuilder.build()),
+                FilterExpression.ExpressionType.DOCUMENT));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteIsNull.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.type.VarcharType;
+import org.bson.Document;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteIsNull
+        implements ConnectorExpressionRule<Call, FilterExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteIsNull()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(IS_NULL_FUNCTION_NAME))
+                .with(type().equalTo(BOOLEAN))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Call call, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        ConnectorExpression argumentValue = getOnlyElement(call.getArguments());
+        Optional<FilterExpression> rewrittenValue = context.defaultRewrite(argumentValue);
+        if (rewrittenValue.isEmpty()) {
+            return Optional.empty();
+        }
+        FilterExpression filterExpression = rewrittenValue.get();
+        Object value = filterExpression.expression();
+
+        ImmutableList.Builder<Document> expressionBuilder = ImmutableList.<Document>builder()
+                .add(documentOf("$eq", Arrays.asList(value, null)))
+                .add(documentOf("$eq", Arrays.asList(value, documentOf("$undefined", true))));
+
+        if (filterExpression.isVariable()) {
+            ExpressionInfo expressionInfo = filterExpression.expressionInfo().orElseThrow();
+            Optional<String> mongoType = expressionInfo.getMongoType();
+            // If mapping between trino type and mongo type does not happen, then pushdown won't be supported
+            if (mongoType.isEmpty()) {
+                return Optional.empty();
+            }
+            // Handle mismatched data type value of documents by matching the data type of column and document value
+            if (expressionInfo.getType() == BIGINT) {
+                expressionBuilder.add(documentOf("$not", documentOf("$in", ImmutableList.of(documentOf("$type", expressionInfo.getName()), ImmutableList.of(mongoType.get(), "int")))));
+            }
+            else if (!(expressionInfo.getType() instanceof VarcharType)) {
+                expressionBuilder.add(documentOf("$ne", ImmutableList.of(documentOf("$type", value), mongoType.get())));
+            }
+        }
+
+        return Optional.of(new FilterExpression(
+                documentOf("$or", expressionBuilder.build()),
+                FilterExpression.ExpressionType.DOCUMENT));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteLogicalExpression.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.FunctionName;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static java.util.Objects.requireNonNull;
+
+class RewriteLogicalExpression
+        implements ConnectorExpressionRule<Call, FilterExpression>
+{
+    private final Pattern<Call> pattern;
+    private final String operator;
+
+    RewriteLogicalExpression(FunctionName functionName, String operator)
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(requireNonNull(functionName, "functionName is null")))
+                .with(type().equalTo(BOOLEAN));
+        this.operator = requireNonNull(operator, "operator is null");
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Call call, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        List<ConnectorExpression> arguments = call.getArguments();
+        verify(!arguments.isEmpty(), "no arguments");
+        ImmutableList.Builder<Object> terms = ImmutableList.builder();
+        for (ConnectorExpression argument : arguments) {
+            verify(argument.getType() == BOOLEAN, "Unexpected type of argument: %s", argument.getType());
+            Optional<FilterExpression> rewritten = context.defaultRewrite(argument);
+            if (rewritten.isEmpty()) {
+                return Optional.empty();
+            }
+            terms.add(rewritten.get().expression());
+        }
+        return Optional.of(new FilterExpression(documentOf(operator, terms.build()), FilterExpression.ExpressionType.DOCUMENT));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteNot.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.argumentCount;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.call;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.functionName;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+
+public class RewriteNot
+        implements ConnectorExpressionRule<Call, FilterExpression>
+{
+    private final Pattern<Call> pattern;
+
+    public RewriteNot()
+    {
+        this.pattern = call()
+                .with(functionName().equalTo(NOT_FUNCTION_NAME))
+                .with(type().equalTo(BOOLEAN))
+                .with(argumentCount().equalTo(1));
+    }
+
+    @Override
+    public Pattern<Call> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Call call, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        ConnectorExpression argumentValue = getOnlyElement(call.getArguments());
+
+        Optional<FilterExpression> rewritten = context.defaultRewrite(argumentValue);
+        if (rewritten.isEmpty()) {
+            return Optional.empty();
+        }
+        Object value = rewritten.get().expression();
+        return Optional.of(new FilterExpression(documentOf("$not", Collections.singletonList(value)), FilterExpression.ExpressionType.DOCUMENT));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteOr.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+
+public class RewriteOr
+        extends RewriteLogicalExpression
+{
+    public RewriteOr()
+    {
+        super(OR_FUNCTION_NAME, "$or");
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVarcharConstant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.airlift.slice.Slice;
+import io.trino.matching.Pattern;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.constant;
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.type;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class RewriteVarcharConstant
+        extends RewriteConstant
+{
+    private static final Pattern<Constant> PATTERN = constant().with(type().equalTo(VARCHAR));
+
+    @Override
+    public Pattern<Constant> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<FilterExpression> handleNonNullValue(Type type, Object value)
+    {
+        Slice slice = (Slice) value;
+        return Optional.of(new FilterExpression(slice.toStringUtf8(), FilterExpression.ExpressionType.LITERAL));
+    }
+}

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/expression/RewriteVariable.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.expression.Variable;
+
+import java.util.Optional;
+
+import static io.trino.plugin.base.expression.ConnectorExpressionPatterns.variable;
+
+public class RewriteVariable
+        implements ConnectorExpressionRule<Variable, FilterExpression>
+{
+    @Override
+    public Pattern<Variable> getPattern()
+    {
+        return variable();
+    }
+
+    @Override
+    public Optional<FilterExpression> rewrite(Variable variable, Captures captures, RewriteContext<FilterExpression> context)
+    {
+        MongoColumnHandle columnHandle = (MongoColumnHandle) context.getAssignment(variable.getName());
+        String expressionVariable = toExpressionVariable(columnHandle.getQualifiedName());
+        return Optional.of(new FilterExpression(expressionVariable, FilterExpression.ExpressionType.VARIABLE, Optional.of(
+                new ExpressionInfo(expressionVariable, columnHandle.getType()))));
+    }
+
+    private static String toExpressionVariable(String variable)
+    {
+        return "$" + variable;
+    }
+}

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/BaseMongoConnectorSmokeTest.java
@@ -129,4 +129,13 @@ public abstract class BaseMongoConnectorSmokeTest
             assertQuery("SELECT id, row1_t.row2_t.row3_t.f1 FROM " + testTable.getName() + " WHERE row1_t = ROW(22, 23, ROW(24, 25, ROW(26, 27)))", "VALUES (21, 26)");
         }
     }
+
+    @Test
+    public void testComplexExpressionPredicatePushdown()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_complex_expression_predicate_pushdown", "AS SELECT varchar 'India' col, varchar 'Poland' another_col")) {
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE col = 'India' OR another_col = 'Poland'"))
+                    .isFullyPushedDown();
+        }
+    }
 }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -66,6 +66,7 @@ public final class MongoQueryRunner
 
             connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
             connectorProperties.putIfAbsent("mongodb.connection-url", server.getConnectionString().toString());
+            connectorProperties.putIfAbsent("mongodb.complex-expression-pushdown.enabled", "true");
 
             queryRunner.installPlugin(new MongoPlugin());
             queryRunner.createCatalog("mongodb", "mongodb", connectorProperties);

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoClientConfig.java
@@ -43,7 +43,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.ACKNOWLEDGED)
                 .setRequiredReplicaSetName(null)
                 .setImplicitRowFieldPrefix("_pos")
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setComplexExpressionPushdownEnabled(false));
     }
 
     @Test
@@ -67,6 +68,7 @@ public class TestMongoClientConfig
                 .put("mongodb.required-replica-set", "replica_set")
                 .put("mongodb.implicit-row-field-prefix", "_prefix")
                 .put("mongodb.projection-pushdown-enabled", "false")
+                .put("mongodb.complex-expression-pushdown.enabled", "true")
                 .buildOrThrow();
 
         MongoClientConfig expected = new MongoClientConfig()
@@ -85,7 +87,8 @@ public class TestMongoClientConfig
                 .setWriteConcern(WriteConcernType.UNACKNOWLEDGED)
                 .setRequiredReplicaSetName("replica_set")
                 .setImplicitRowFieldPrefix("_prefix")
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setComplexExpressionPushdownEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTableHandle.java
@@ -122,6 +122,7 @@ public class TestMongoTableHandle
                 remoteTableName,
                 Optional.empty(),
                 TupleDomain.all(),
+                ImmutableList.of(),
                 projectedColumns,
                 OptionalInt.empty());
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/expression/TestMongoExpressionRewriter.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/expression/TestMongoExpressionRewriter.java
@@ -1,0 +1,466 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mongodb.expression;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
+import io.trino.plugin.mongodb.MongoColumnHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.Type;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.mongodb.expression.MongoExpressions.documentOf;
+import static io.trino.plugin.mongodb.expression.MongoExpressions.toDecimal;
+import static io.trino.spi.expression.StandardFunctions.AND_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.ARRAY_CONSTRUCTOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IN_PREDICATE_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IS_NULL_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.OR_FUNCTION_NAME;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMongoExpressionRewriter
+{
+    private final ConnectorSession connectorSession;
+    private final ConnectorExpressionRewriter<FilterExpression> mongoExpressionRewriter;
+
+    private TestMongoExpressionRewriter()
+    {
+        this.mongoExpressionRewriter = new MongoExpressionRewriter().getRewriter();
+        this.connectorSession = testSessionBuilder().build().toConnectorSession();
+    }
+
+    @Test
+    public void testRewriteVarcharConstant()
+    {
+        ConnectorExpression varcharConstant = new Constant(Slices.wrappedBuffer("value".getBytes(UTF_8)), VARCHAR);
+        assertRewrite(varcharConstant, createLiteralExpression("value"));
+    }
+
+    @Test
+    public void testRewriteExactNumericConstant()
+    {
+        ConnectorExpression tinyintConstant = new Constant(1, TINYINT);
+        assertRewrite(tinyintConstant, createLiteralExpression(1));
+
+        ConnectorExpression smallintConstant = new Constant(15, SMALLINT);
+        assertRewrite(smallintConstant, createLiteralExpression(15));
+
+        ConnectorExpression intConstant = new Constant(123456, INTEGER);
+        assertRewrite(intConstant, createLiteralExpression(123456));
+
+        ConnectorExpression bigintConstant = new Constant(123456789, BIGINT);
+        assertRewrite(bigintConstant, createLiteralExpression(123456789));
+
+        long shortDecimalValue = Decimals.encodeShortScaledValue(new BigDecimal("3.14"), 2);
+        ConnectorExpression shortDecimalConstant = new Constant(shortDecimalValue, createDecimalType(3, 2));
+        assertRewrite(shortDecimalConstant, createLiteralExpression(toDecimal("3.14")));
+
+        Int128 longDecimalValue = Decimals.encodeScaledValue(new BigDecimal("1234567890.123456789"), 9);
+        ConnectorExpression longDecimalConstant = new Constant(longDecimalValue, createDecimalType(19, 9));
+        assertRewrite(longDecimalConstant, createLiteralExpression(toDecimal("1234567890.123456789")));
+    }
+
+    @Test
+    public void testRewriteWithNullConstant()
+    {
+        ConnectorExpression varcharConstant = new Constant(null, VARCHAR);
+        assertRewrite(varcharConstant, createLiteralExpression(null));
+
+        ConnectorExpression tinyintConstant = new Constant(null, TINYINT);
+        assertRewrite(tinyintConstant, createLiteralExpression(null));
+
+        ConnectorExpression smallintConstant = new Constant(null, SMALLINT);
+        assertRewrite(smallintConstant, createLiteralExpression(null));
+
+        ConnectorExpression intConstant = new Constant(null, INTEGER);
+        assertRewrite(intConstant, createLiteralExpression(null));
+
+        ConnectorExpression bigintConstant = new Constant(null, BIGINT);
+        assertRewrite(bigintConstant, createLiteralExpression(null));
+
+        ConnectorExpression shortDecimalConstant = new Constant(null, createDecimalType(3, 2));
+        assertRewrite(shortDecimalConstant, createLiteralExpression(null));
+
+        ConnectorExpression longDecimalConstant = new Constant(null, createDecimalType(19, 9));
+        assertRewrite(longDecimalConstant, createLiteralExpression(null));
+    }
+
+    @Test
+    public void testRewriteVariable()
+    {
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        assertRewrite(variable, createVariableExpression("$col", new ExpressionInfo("$col", BIGINT)), assignments);
+    }
+
+    @Test
+    public void testRewriteIsNull()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression isNullExpression = new Call(BOOLEAN, IS_NULL_FUNCTION_NAME, ImmutableList.of(variable));
+        assertRewrite(
+                isNullExpression,
+                createDocumentExpression(
+                        documentOf("$or", ImmutableList.of(
+                                documentOf("$eq", Arrays.asList("$col", null)),
+                                documentOf("$eq", Arrays.asList("$col", documentOf("$undefined", true))),
+                                documentOf("$not", documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteIsNotNull()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression isNullExpression = new Call(BOOLEAN, IS_NULL_FUNCTION_NAME, ImmutableList.of(variable));
+        ConnectorExpression isNotNullExpression = new Call(BOOLEAN, NOT_FUNCTION_NAME, ImmutableList.of(isNullExpression));
+        assertRewrite(
+                isNotNullExpression,
+                createDocumentExpression(
+                        documentOf("$not", ImmutableList.of(
+                                documentOf("$or", ImmutableList.of(
+                                        documentOf("$eq", Arrays.asList("$col", null)),
+                                        documentOf("$eq", Arrays.asList("$col", documentOf("$undefined", true))),
+                                        documentOf("$not", documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))))))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteIn()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        List<ConnectorExpression> constants = ImmutableList.of(
+                new Constant(10, BIGINT),
+                new Constant(15, BIGINT),
+                new Constant(null, BIGINT));
+        ConnectorExpression arrayExpression = new Call(BOOLEAN, ARRAY_CONSTRUCTOR_FUNCTION_NAME, constants);
+        ConnectorExpression inExpression = new Call(BOOLEAN, IN_PREDICATE_FUNCTION_NAME, ImmutableList.of(variable, arrayExpression));
+        assertRewrite(
+                inExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$in", ImmutableList.of("$col", Arrays.asList(10, 15, null)))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteNotIn()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        List<ConnectorExpression> constants = ImmutableList.of(
+                new Constant(10, BIGINT),
+                new Constant(15, BIGINT),
+                new Constant(null, BIGINT));
+        ConnectorExpression arrayExpression = new Call(BOOLEAN, ARRAY_CONSTRUCTOR_FUNCTION_NAME, constants);
+        ConnectorExpression inExpression = new Call(BOOLEAN, IN_PREDICATE_FUNCTION_NAME, ImmutableList.of(variable, arrayExpression));
+        ConnectorExpression notInExpression = new Call(BOOLEAN, NOT_FUNCTION_NAME, ImmutableList.of(inExpression));
+        assertRewrite(
+                notInExpression,
+                createDocumentExpression(
+                        documentOf("$not", ImmutableList.of(
+                                documentOf("$and", ImmutableList.of(
+                                        documentOf("$gt", Arrays.asList("$col", null)),
+                                        documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                        documentOf("$in", ImmutableList.of("$col", Arrays.asList(10, 15, null)))))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteEqual()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression equalExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                equalExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$eq", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteNotEqual()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression notEqualExpression = new Call(BOOLEAN, NOT_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                notEqualExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$ne", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteLessThan()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression lessThanExpression = new Call(BOOLEAN, LESS_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                lessThanExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$lt", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteGreaterThan()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression greaterThanExpression = new Call(BOOLEAN, GREATER_THAN_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                greaterThanExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$gt", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteLessThanOrEqual()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression lessThanOrEqualExpression = new Call(BOOLEAN, LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                lessThanOrEqualExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$lte", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteGreaterThanOrEqual()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", BIGINT));
+        ConnectorExpression variable = new Variable("col", BIGINT);
+        ConnectorExpression constant = new Constant(10, BIGINT);
+
+        ConnectorExpression greaterThanOrEqualExpression = new Call(BOOLEAN, GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                greaterThanOrEqualExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$in", ImmutableList.of(documentOf("$type", "$col"), ImmutableList.of("long", "int"))),
+                                documentOf("$gte", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteEqualWithVarchar()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", VARCHAR));
+        ConnectorExpression variable = new Variable("col", VARCHAR);
+        ConnectorExpression constant = new Constant(Slices.wrappedBuffer("value".getBytes(UTF_8)), VARCHAR);
+
+        ConnectorExpression equalExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                equalExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$eq", ImmutableList.of(MongoExpressions.toString("$col"), "value"))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteEqualWithInteger()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of("col", createColumnHandle("col", INTEGER));
+        ConnectorExpression variable = new Variable("col", VARCHAR);
+        ConnectorExpression constant = new Constant(10, INTEGER);
+
+        ConnectorExpression equalExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable, constant));
+        assertRewrite(
+                equalExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$gt", Arrays.asList("$col", null)),
+                                documentOf("$eq", ImmutableList.of(documentOf("$type", "$col"), "int")),
+                                documentOf("$eq", ImmutableList.of("$col", 10))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteOr()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of(
+                "col1", createColumnHandle("col1", BIGINT),
+                "col2", createColumnHandle("col2", BIGINT));
+        ConnectorExpression variable1 = new Variable("col1", BIGINT);
+        ConnectorExpression constant1 = new Constant(10, BIGINT);
+        ConnectorExpression variable2 = new Variable("col2", BIGINT);
+        ConnectorExpression constant2 = new Constant(20, BIGINT);
+
+        ConnectorExpression leftExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable1, constant1));
+        ConnectorExpression rightExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable2, constant2));
+
+        ConnectorExpression orExpression = new Call(BOOLEAN, OR_FUNCTION_NAME, ImmutableList.of(leftExpression, rightExpression));
+        assertRewrite(
+                orExpression,
+                createDocumentExpression(
+                        documentOf("$or", ImmutableList.of(
+                                documentOf("$and", ImmutableList.of(
+                                        documentOf("$gt", Arrays.asList("$col1", null)),
+                                        documentOf("$in", ImmutableList.of(documentOf("$type", "$col1"), ImmutableList.of("long", "int"))),
+                                        documentOf("$eq", ImmutableList.of("$col1", 10)))),
+                                documentOf("$and", ImmutableList.of(
+                                        documentOf("$gt", Arrays.asList("$col2", null)),
+                                        documentOf("$in", ImmutableList.of(documentOf("$type", "$col2"), ImmutableList.of("long", "int"))),
+                                        documentOf("$eq", ImmutableList.of("$col2", 20))))))),
+                assignments);
+    }
+
+    @Test
+    public void testRewriteAnd()
+    {
+        Map<String, ColumnHandle> assignments = ImmutableMap.of(
+                "col1", createColumnHandle("col1", BIGINT),
+                "col2", createColumnHandle("col2", BIGINT));
+        ConnectorExpression variable1 = new Variable("col1", BIGINT);
+        ConnectorExpression constant1 = new Constant(10, BIGINT);
+        ConnectorExpression variable2 = new Variable("col2", BIGINT);
+        ConnectorExpression constant2 = new Constant(20, BIGINT);
+
+        ConnectorExpression leftExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable1, constant1));
+        ConnectorExpression rightExpression = new Call(BOOLEAN, EQUAL_OPERATOR_FUNCTION_NAME, ImmutableList.of(variable2, constant2));
+
+        ConnectorExpression andExpression = new Call(BOOLEAN, AND_FUNCTION_NAME, ImmutableList.of(leftExpression, rightExpression));
+        assertRewrite(
+                andExpression,
+                createDocumentExpression(
+                        documentOf("$and", ImmutableList.of(
+                                documentOf("$and", ImmutableList.of(
+                                        documentOf("$gt", Arrays.asList("$col1", null)),
+                                        documentOf("$in", ImmutableList.of(documentOf("$type", "$col1"), ImmutableList.of("long", "int"))),
+                                        documentOf("$eq", ImmutableList.of("$col1", 10)))),
+                                documentOf("$and", ImmutableList.of(
+                                        documentOf("$gt", Arrays.asList("$col2", null)),
+                                        documentOf("$in", ImmutableList.of(documentOf("$type", "$col2"), ImmutableList.of("long", "int"))),
+                                        documentOf("$eq", ImmutableList.of("$col2", 20))))))),
+                assignments);
+    }
+
+    @Test
+    public void testUnsupportedRewriteExpression()
+    {
+        Slice slice = Slices.wrappedBuffer("value".getBytes(UTF_8));
+        ConnectorExpression charConstant = new Constant(slice, createCharType(8));
+        assertThat(mongoExpressionRewriter.rewrite(connectorSession, charConstant, ImmutableMap.of()))
+                .isEmpty();
+    }
+
+    private void assertRewrite(ConnectorExpression expression, FilterExpression expectedExpression)
+    {
+        assertRewrite(expression, expectedExpression, ImmutableMap.of());
+    }
+
+    private void assertRewrite(ConnectorExpression expression, FilterExpression expectedExpression, Map<String, ColumnHandle> assignments)
+    {
+        Optional<FilterExpression> actualExpression = mongoExpressionRewriter.rewrite(connectorSession, expression, assignments);
+        assertThat(actualExpression).isEqualTo(Optional.of(expectedExpression));
+    }
+
+    private static FilterExpression createLiteralExpression(Object expression)
+    {
+        return new FilterExpression(expression, FilterExpression.ExpressionType.LITERAL, Optional.empty());
+    }
+
+    private static FilterExpression createVariableExpression(Object expression, ExpressionInfo expressionInfo)
+    {
+        return new FilterExpression(expression, FilterExpression.ExpressionType.VARIABLE, Optional.of(expressionInfo));
+    }
+
+    private static FilterExpression createDocumentExpression(Object expression)
+    {
+        return new FilterExpression(expression, FilterExpression.ExpressionType.DOCUMENT, Optional.empty());
+    }
+
+    private static MongoColumnHandle createColumnHandle(String baseName, Type type, String... dereferenceNames)
+    {
+        return new MongoColumnHandle(
+                baseName,
+                ImmutableList.copyOf(dereferenceNames),
+                type,
+                false,
+                false,
+                Optional.empty());
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR covers use case for connector expression Filter pushdown:

- Complex Filter which can not represent by TupleDomain

Covered Logical operator:

- `OR`, `AND`

Covered Comparision Operator:

- `=`, `!=`, `<`, `>`, `>=`, `<=`

Other Operators:

- `IN`
- `IS NULL`
- `IS NOT NULL`

Covered Type:

-  `VarcharType`
- `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `DecimalType`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
