### PR TITLE
Add concurrent writes reconciliation for `DELETE` pushdown/`TRUNCATE` in Delta Lake

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -272,7 +272,7 @@ public class BeginTableWrite
         private static List<TableHandle> findSourceTableHandles(PlanNode startNode)
         {
             return PlanNodeSearcher.searchFrom(startNode)
-                    .where(node -> node instanceof TableScanNode tableScanNode && !tableScanNode.isUpdateTarget())
+                    .where(TableScanNode.class::isInstance)
                     .findAll()
                     .stream()
                     .map(TableScanNode.class::cast)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2022,7 +2022,7 @@ public class DeltaLakeMetadata
             throws IOException
     {
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        long currentVersion = getMandatoryCurrentVersion(fileSystem, handle.location(), handle.readVersion());
+        long currentVersion = getMandatoryCurrentVersion(fileSystem, handle.location(), readVersion.get());
 
         List<DeltaLakeTableHandle> sameAsTargetSourceTableHandles = sourceTableHandles.stream()
                 .filter(sourceTableHandle -> sourceTableHandle instanceof DeltaLakeTableHandle)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3812,22 +3812,43 @@ public class DeltaLakeMetadata
         checkWriteAllowed(session, tableHandle);
         checkWriteSupported(tableHandle);
 
+        try {
+            CommitDeleteOperationResult commitDeleteOperationResult = commitDeleteOperation(session, tableHandle, operation);
+            writeCheckpointIfNeeded(
+                    session,
+                    tableHandle.getSchemaTableName(),
+                    tableHandle.location(),
+                    tableHandle.getReadVersion(),
+                    tableHandle.getMetadataEntry().getCheckpointInterval(),
+                    commitDeleteOperationResult.commitVersion());
+            return commitDeleteOperationResult.deletedRecords();
+        }
+        catch (Exception e) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
+        }
+    }
+
+    private CommitDeleteOperationResult commitDeleteOperation(
+            ConnectorSession session,
+            DeltaLakeTableHandle tableHandle,
+            String operation)
+            throws IOException
+    {
         String tableLocation = tableHandle.location();
+        TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, tableLocation);
 
+        long writeTimestamp = Instant.now().toEpochMilli();
+        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+        long currentVersion = getMandatoryCurrentVersion(fileSystem, tableLocation, tableHandle.getReadVersion());
+        if (currentVersion != tableHandle.getReadVersion()) {
+            throw new TransactionConflictException(format("Conflicting concurrent writes found. Expected transaction log version: %s, actual version: %s", tableHandle.getReadVersion(), currentVersion));
+        }
+        long commitVersion = currentVersion + 1;
+        transactionLogWriter.appendCommitInfoEntry(getCommitInfoEntry(session, IsolationLevel.WRITESERIALIZABLE, commitVersion, writeTimestamp, operation, tableHandle.getReadVersion(), false));
+
+        long deletedRecords = 0L;
+        boolean allDeletedFilesStatsPresent = true;
         try (Stream<AddFileEntry> activeFiles = getAddFileEntriesMatchingEnforcedPartitionConstraint(session, tableHandle)) {
-            TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, tableLocation);
-
-            long writeTimestamp = Instant.now().toEpochMilli();
-            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            long currentVersion = getMandatoryCurrentVersion(fileSystem, tableLocation, tableHandle.getReadVersion());
-            if (currentVersion != tableHandle.getReadVersion()) {
-                throw new TransactionConflictException(format("Conflicting concurrent writes found. Expected transaction log version: %s, actual version: %s", tableHandle.getReadVersion(), currentVersion));
-            }
-            long commitVersion = currentVersion + 1;
-            transactionLogWriter.appendCommitInfoEntry(getCommitInfoEntry(session, IsolationLevel.WRITESERIALIZABLE, commitVersion, writeTimestamp, operation, tableHandle.getReadVersion(), false));
-
-            long deletedRecords = 0L;
-            boolean allDeletedFilesStatsPresent = true;
             Iterator<AddFileEntry> addFileEntryIterator = activeFiles.iterator();
             while (addFileEntryIterator.hasNext()) {
                 AddFileEntry addFileEntry = addFileEntryIterator.next();
@@ -3837,19 +3858,17 @@ public class DeltaLakeMetadata
                 allDeletedFilesStatsPresent &= fileRecords.isPresent();
                 deletedRecords += fileRecords.orElse(0L);
             }
-
-            transactionLogWriter.flush();
-            writeCheckpointIfNeeded(
-                    session,
-                    tableHandle.getSchemaTableName(),
-                    tableHandle.location(),
-                    tableHandle.getReadVersion(),
-                    tableHandle.getMetadataEntry().getCheckpointInterval(),
-                    commitVersion);
-            return allDeletedFilesStatsPresent ? OptionalLong.of(deletedRecords) : OptionalLong.empty();
         }
-        catch (Exception e) {
-            throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
+
+        transactionLogWriter.flush();
+        return new CommitDeleteOperationResult(commitVersion, allDeletedFilesStatsPresent ? OptionalLong.of(deletedRecords) : OptionalLong.empty());
+    }
+
+    private record CommitDeleteOperationResult(long commitVersion, OptionalLong deletedRecords)
+    {
+        CommitDeleteOperationResult
+        {
+            requireNonNull(deletedRecords, "deletedRecords is null");
         }
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2024,16 +2024,39 @@ public class DeltaLakeMetadata
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
         long currentVersion = getMandatoryCurrentVersion(fileSystem, handle.location(), readVersion.get());
 
-        List<DeltaLakeTableHandle> sameAsTargetSourceTableHandles = sourceTableHandles.stream()
+        List<DeltaLakeTableHandle> sameAsTargetSourceTableHandles = getSameAsTargetSourceTableHandles(sourceTableHandles, handle.tableName());
+        checkForConcurrentTransactionConflicts(session, fileSystem, sameAsTargetSourceTableHandles, isolationLevel, currentVersion, readVersion, handle.location(), attemptCount);
+        long commitVersion = currentVersion + 1;
+        writeTransactionLogForInsertOperation(session, handle, sameAsTargetSourceTableHandles.isEmpty(), isolationLevel, dataFileInfos, commitVersion, currentVersion);
+        return commitVersion;
+    }
+
+    private List<DeltaLakeTableHandle> getSameAsTargetSourceTableHandles(
+            List<ConnectorTableHandle> sourceTableHandles,
+            SchemaTableName schemaTableName)
+    {
+        return sourceTableHandles.stream()
                 .filter(sourceTableHandle -> sourceTableHandle instanceof DeltaLakeTableHandle)
                 .map(DeltaLakeTableHandle.class::cast)
-                .filter(tableHandle -> handle.tableName().equals(tableHandle.getSchemaTableName())
+                .filter(tableHandle -> schemaTableName.equals(tableHandle.getSchemaTableName())
                         // disregard time travel table handles
                         && !tableHandle.isTimeTravel())
                 .collect(toImmutableList());
+    }
+
+    private void checkForConcurrentTransactionConflicts(
+            ConnectorSession session,
+            TrinoFileSystem fileSystem,
+            List<DeltaLakeTableHandle> sameAsTargetSourceTableHandles,
+            IsolationLevel isolationLevel,
+            long currentVersion,
+            AtomicReference<Long> readVersion,
+            String tableLocation,
+            int attemptCount)
+    {
         long readVersionValue = readVersion.get();
         if (currentVersion > readVersionValue) {
-            String transactionLogDirectory = getTransactionLogDir(handle.location());
+            String transactionLogDirectory = getTransactionLogDir(tableLocation);
             for (long version = readVersionValue + 1; version <= currentVersion; version++) {
                 List<DeltaLakeTransactionLogEntry> transactionLogEntries;
                 try {
@@ -2044,43 +2067,30 @@ public class DeltaLakeMetadata
                 catch (IOException e) {
                     throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, "Failed to access table metadata", e);
                 }
-                checkForInsertTransactionConflicts(session.getQueryId(), sameAsTargetSourceTableHandles, isolationLevel, new DeltaLakeCommitSummary(version, transactionLogEntries), attemptCount);
+                DeltaLakeCommitSummary commitSummary = new DeltaLakeCommitSummary(version, transactionLogEntries);
+                checkNoMetadataUpdates(commitSummary);
+                checkNoProtocolUpdates(commitSummary);
+
+                switch (isolationLevel) {
+                    case WRITESERIALIZABLE -> {
+                        if (!sameAsTargetSourceTableHandles.isEmpty()) {
+                            List<TupleDomain<DeltaLakeColumnHandle>> enforcedSourcePartitionConstraints = sameAsTargetSourceTableHandles.stream()
+                                    .map(DeltaLakeTableHandle::getEnforcedPartitionConstraint)
+                                    .collect(toImmutableList());
+
+                            checkIfCommittedAddedFilesConflictWithCurrentOperation(TupleDomain.columnWiseUnion(enforcedSourcePartitionConstraints), commitSummary);
+                            checkIfCommittedRemovedFilesConflictWithCurrentOperation(commitSummary);
+                        }
+                    }
+                    case SERIALIZABLE -> throw new TransactionFailedException("Conflicting concurrent writes with the current operation on Serializable isolation level");
+                }
+
+                LOG.debug("Completed checking for conflicts in the query %s for target table version: %s Attempt: %s ", session.getQueryId(), commitSummary.getVersion(), attemptCount);
             }
 
             // Avoid re-reading already processed transaction log entries in case of retries
             readVersion.set(currentVersion);
         }
-        long commitVersion = currentVersion + 1;
-        writeTransactionLogForInsertOperation(session, handle, sameAsTargetSourceTableHandles.isEmpty(), isolationLevel, dataFileInfos, commitVersion, currentVersion);
-        return commitVersion;
-    }
-
-    private void checkForInsertTransactionConflicts(
-            String queryId,
-            List<DeltaLakeTableHandle> sameAsTargetSourceTableHandles,
-            IsolationLevel isolationLevel,
-            DeltaLakeCommitSummary commitSummary,
-            int attemptCount)
-    {
-        checkNoMetadataUpdates(commitSummary);
-        checkNoProtocolUpdates(commitSummary);
-
-        switch (isolationLevel) {
-            case WRITESERIALIZABLE -> {
-                if (!sameAsTargetSourceTableHandles.isEmpty()) {
-                    // INSERT operations that contain sub-queries reading the same table support the same concurrency as MERGE.
-                    List<TupleDomain<DeltaLakeColumnHandle>> enforcedSourcePartitionConstraints = sameAsTargetSourceTableHandles.stream()
-                            .map(DeltaLakeTableHandle::getEnforcedPartitionConstraint)
-                            .collect(toImmutableList());
-
-                    checkIfCommittedAddedFilesConflictWithCurrentOperation(TupleDomain.columnWiseUnion(enforcedSourcePartitionConstraints), commitSummary);
-                    checkIfCommittedRemovedFilesConflictWithCurrentOperation(commitSummary);
-                }
-            }
-            case SERIALIZABLE -> throw new TransactionFailedException("Conflicting concurrent writes with the current INSERT operation on Serializable isolation level");
-        }
-
-        LOG.debug("Completed checking for conflicts in the query %s for target table version: %s Attempt: %s ", queryId, commitSummary.getVersion(), attemptCount);
     }
 
     private static void checkNoProtocolUpdates(DeltaLakeCommitSummary commitSummary)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow committing operations based on delete pushdown / truncate
in a concurrent context by placing these operations right after
any other previously concurrently completed write operations.

Disallow committing the operation in any of the following cases:

- table schema change has been committed in the meantime
- table protocol change has been committed in the meantime
- add files committed in the meantime should be read by
the current operation
- remove files committed in the meantime conflict with the
add files read by the current operation

The current changes also take into consideration the `delta.isolationLevel`
table property of the Delta Lake table for DELETE/TRUNCATE operations.

Relevant example taken from Databricks documentation in regards to the
distinction between `WriteSerializable` and `Serializable` isolation levels:

> For example, consider `txn1`, a long running delete and `txn2`,
> which inserts blindly data into the table.
> `txn2` and `txn1` complete and they are recorded in the order
> `txn2, txn1`
> into the history of the table.
> According to the history, the data inserted in `txn2` should not exist
> in the table. For `Serializable` level, a reader would never see data
> inserted by `txn2`. However, for the `WriteSerializable` level, a reader
> could at some point see the data inserted by `txn2`.

A few words about WriteSerializable isolation level taken from delta.io javadocs:

> This isolation level will ensure snapshot isolation consistency guarantee
> between write operations only.
> In other words, if only the write operations are considered, then
> there exists a serializable sequence between them that would produce the same
> result as seen in the table.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

INSERT scaffolding PRs:

- https://github.com/trinodb/trino/pull/18506
- https://github.com/trinodb/trino/pull/20983

Depends on the fix from https://github.com/trinodb/trino/pull/21330

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for concurrent `DELETE` pushdown / `TRUNCATE` queries. ({issue}`issuenumber`)
```
