### PR TITLE
Remove redundant lowercasing in Delta error messages

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1223,7 +1223,7 @@ public class DeltaLakeMetadata
         checkSupportedWriterVersion(session, handle);
         ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
         if (columnMappingMode != ID && columnMappingMode != NAME && columnMappingMode != NONE) {
-            throw new TrinoException(NOT_SUPPORTED, "Setting a table comment with column mapping %s is not supported".formatted(columnMappingMode.name().toLowerCase(ENGLISH)));
+            throw new TrinoException(NOT_SUPPORTED, "Setting a table comment with column mapping %s is not supported".formatted(columnMappingMode));
         }
 
         ConnectorTableMetadata tableMetadata = getTableMetadata(session, handle);
@@ -1259,7 +1259,7 @@ public class DeltaLakeMetadata
         checkSupportedWriterVersion(session, deltaLakeTableHandle);
         ColumnMappingMode columnMappingMode = getColumnMappingMode(deltaLakeTableHandle.getMetadataEntry());
         if (columnMappingMode != ID && columnMappingMode != NAME && columnMappingMode != NONE) {
-            throw new TrinoException(NOT_SUPPORTED, "Setting a column comment with column mapping %s is not supported".formatted(columnMappingMode.name().toLowerCase(ENGLISH)));
+            throw new TrinoException(NOT_SUPPORTED, "Setting a column comment with column mapping %s is not supported".formatted(columnMappingMode));
         }
 
         ConnectorTableMetadata tableMetadata = getTableMetadata(session, deltaLakeTableHandle);
@@ -1809,7 +1809,7 @@ public class DeltaLakeMetadata
         ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
         if (changeDataFeedEnabled(handle.getMetadataEntry()) && columnMappingMode != NONE) {
             // TODO https://github.com/trinodb/trino/issues/16967 Support CDF for tables with 'id' and 'name' column mapping
-            throw new TrinoException(NOT_SUPPORTED, "Unsupported column mapping mode for tables with change data feed enabled: " + columnMappingMode.name().toLowerCase(ENGLISH));
+            throw new TrinoException(NOT_SUPPORTED, "Unsupported column mapping mode for tables with change data feed enabled: " + columnMappingMode);
         }
         checkWriteSupported(session, handle);
 
@@ -2129,7 +2129,7 @@ public class DeltaLakeMetadata
         checkUnsupportedGeneratedColumns(handle.getMetadataEntry());
         ColumnMappingMode columnMappingMode = getColumnMappingMode(handle.getMetadataEntry());
         if (!(columnMappingMode == NONE || columnMappingMode == ColumnMappingMode.NAME || columnMappingMode == ColumnMappingMode.ID)) {
-            throw new TrinoException(NOT_SUPPORTED, "Writing with column mapping %s is not supported".formatted(columnMappingMode.name().toLowerCase(ENGLISH)));
+            throw new TrinoException(NOT_SUPPORTED, "Writing with column mapping %s is not supported".formatted(columnMappingMode));
         }
         // TODO: Check writer-features
     }
@@ -2681,7 +2681,7 @@ public class DeltaLakeMetadata
         Type columnType = switch (columnMappingMode) {
             case ID, NAME -> column.getBasePhysicalType();
             case NONE -> column.getBaseType();
-            default -> throw new TrinoException(NOT_SUPPORTED, "Projecting columns with column mapping %s is not supported".formatted(columnMappingMode.name().toLowerCase(ENGLISH)));
+            default -> throw new TrinoException(NOT_SUPPORTED, "Projecting columns with column mapping %s is not supported".formatted(columnMappingMode));
         };
 
         for (int index : dereferenceIndices.build()) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeColumnMappingMode.java
@@ -50,6 +50,7 @@ import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getTableC
 import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.getTablePropertyOnDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onDelta;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -1385,16 +1386,16 @@ public class TestDeltaLakeColumnMappingMode
 
             // Column mapping mode 'none' is tested in TestDeltaLakeDatabricksChangeDataFeedCompatibility
             assertQueryFailure(() -> onTrino().executeQuery("UPDATE delta.default." + targetTableName + " SET regionkey = 10"))
-                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode.toUpperCase(ENGLISH));
             assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM delta.default." + targetTableName))
-                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode.toUpperCase(ENGLISH));
             assertQueryFailure(() -> onTrino().executeQuery("MERGE INTO delta.default." + targetTableName + " cdf USING delta.default." + sourceTableName + " n " +
                     "ON (cdf.nationkey = n.nationkey) " +
                     "WHEN MATCHED " +
                     "THEN UPDATE SET nationkey = (cdf.nationkey + n.nationkey + n.regionkey) " +
                     "WHEN NOT MATCHED " +
                     "THEN INSERT (nationkey, name, regionkey) VALUES (n.nationkey, n.name, n.regionkey)"))
-                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode);
+                    .hasMessageContaining("Unsupported column mapping mode for tables with change data feed enabled: " + mode.toUpperCase(ENGLISH));
 
             assertThat(onDelta().executeQuery("SELECT nationkey, name, regionkey, _change_type, _commit_version " +
                     "FROM table_changes('default." + targetTableName + "', 0)"))


### PR DESCRIPTION
This produces not worse error messages and additionally makes it easier to find places where we lowercase e.g. column names.

relates to https://github.com/trinodb/trino/pull/18123 