### PR TITLE
Remove redundant copy in ConnectorIdentity.Builder

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/security/ConnectorIdentity.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/ConnectorIdentity.java
@@ -157,7 +157,6 @@ public class ConnectorIdentity
 
         public Builder withEnabledSystemRoles(Set<String> enabledSystemRoles)
         {
-            enabledSystemRoles = new HashSet<>(requireNonNull(enabledSystemRoles, "enabledSystemRoles is null"));
             this.enabledSystemRoles = new HashSet<>(requireNonNull(enabledSystemRoles, "enabledSystemRoles is null"));
             return this;
         }


### PR DESCRIPTION
## Description
Removes redundant `HashSet` copy in `ConnectorIdentity.Builder#withEnabledSystemRoles`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:
