### PR TITLE
Update roaringbitmap to 0.9.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1868,7 +1868,7 @@
             <dependency>
                 <groupId>org.roaringbitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
-                <version>0.9.46</version>
+                <version>0.9.47</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
No release notes needed

Includes: https://github.com/RoaringBitmap/RoaringBitmap/pull/648