### PR TITLE
Increase PAGE_SIZE_IN_BYTES limits in PageProcessor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -52,8 +52,8 @@ import static java.util.Objects.requireNonNull;
 public class PageProcessor
 {
     public static final int MAX_BATCH_SIZE = 8 * 1024;
-    static final int MAX_PAGE_SIZE_IN_BYTES = 4 * 1024 * 1024;
-    static final int MIN_PAGE_SIZE_IN_BYTES = 1024 * 1024;
+    static final int MAX_PAGE_SIZE_IN_BYTES = 16 * 1024 * 1024;
+    static final int MIN_PAGE_SIZE_IN_BYTES = 4 * 1024 * 1024;
 
     private final ExpressionProfiler expressionProfiler;
     private final DictionarySourceIdFunction dictionarySourceIdFunction = new DictionarySourceIdFunction();

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageProcessor.java
@@ -277,7 +277,7 @@ public class TestPageProcessor
 
         // process large page which will reduce batch size
         Slice[] slices = new Slice[(int) (MAX_BATCH_SIZE * 2.5)];
-        Arrays.fill(slices, Slices.allocate(1024));
+        Arrays.fill(slices, Slices.allocate(4096));
         Page inputPage = new Page(createSlicesBlock(slices));
 
         Iterator<Optional<Page>> output = processAndAssertRetainedPageSize(pageProcessor, new DriverYieldSignal(), inputPage);
@@ -319,7 +319,7 @@ public class TestPageProcessor
 
         // process large page which will reduce batch size
         Slice[] slices = new Slice[(int) (MAX_BATCH_SIZE * 2.5)];
-        Arrays.fill(slices, Slices.allocate(1024));
+        Arrays.fill(slices, Slices.allocate(4096));
         Page inputPage = new Page(createSlicesBlock(slices));
 
         Iterator<Optional<Page>> output = processAndAssertRetainedPageSize(pageProcessor, inputPage);
@@ -359,9 +359,9 @@ public class TestPageProcessor
                 ImmutableList.of(new InputPageProjection(0, VARCHAR), new InputPageProjection(1, VARCHAR)),
                 OptionalInt.of(MAX_BATCH_SIZE));
 
-        // create 2 columns X 800 rows of strings with each string's size = 10KB
-        // this can force previouslyComputedResults to be saved given the page is 16MB in size
-        String value = join("", nCopies(10_000, "a"));
+        // create 2 columns X 800 rows of strings with each string's size = 30KB
+        // this can force previouslyComputedResults to be saved given the page is 48MB in size
+        String value = join("", nCopies(30_000, "a"));
         List<String> values = nCopies(800, value);
         Page inputPage = new Page(createStringsBlock(values), createStringsBlock(values));
 


### PR DESCRIPTION
## Description
Orc and parquet readers are configured to produce upto 16MB pages by default.
PageProcessor thresholds should be consistent with orc/parquet readers to avoid
unnecessary reductions in projection processing batch size.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
