### PR TITLE
Update SQL support docs for Blackhole

### DIFF
--- a/docs/src/main/sphinx/connector/blackhole.md
+++ b/docs/src/main/sphinx/connector/blackhole.md
@@ -14,11 +14,6 @@ In such cases, writes behave in the same way, but reads
 always return the specified number of some constant rows.
 You shouldn't rely on the content of such rows.
 
-:::{warning}
-This connector does not work properly with multiple coordinators,
-since each coordinator has different metadata.
-:::
-
 ## Configuration
 
 Create `etc/catalog/example.properties` to mount the `blackhole` connector
@@ -121,12 +116,19 @@ additional features:
 - {doc}`/sql/merge`
 - {doc}`/sql/create-table`
 - {doc}`/sql/create-table-as`
+- {doc}`/sql/show-create-table`
 - {doc}`/sql/drop-table`
 - {doc}`/sql/create-schema`
 - {doc}`/sql/drop-schema`
+- {doc}`/sql/create-view`
+- {doc}`/sql/show-create-view`
+- {doc}`/sql/drop-view`
+- {doc}`/sql/create-materialized-view`
+- {doc}`/sql/show-create-materialized-view`
+- {doc}`/sql/drop-materialized-view`
 
 :::{note}
 The connector discards all written data. While read operations are supported,
-they will return rows with all NULL values, with the number of rows controlled
+they return rows with all NULL values, with the number of rows controlled
 via table properties.
 :::


### PR DESCRIPTION
## Description

Adding view and materialized view support. 

I am not sure we can claim this as correct since ALTER VIEW and ALTER MATERIALIZED view might not be supported.. if that is the case I have to list the supported commands separately.


## Additional context and related issues

Caused by missing docs in https://github.com/trinodb/trino/pull/18016

## Release notes

Release notes are already tackled with implementation PR.