### PR TITLE
Avoid unnecessary nested loop O(N*N) on DiscoveryNodeManager#refreshNodesInternal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
@@ -209,8 +209,9 @@ public final class DiscoveryNodeManager
     private synchronized void refreshNodesInternal()
     {
         // This is a deny-list.
+        Set<ServiceDescriptor> failed = failureDetector.getFailed();
         Set<ServiceDescriptor> services = serviceSelector.selectAllServices().stream()
-                .filter(service -> !failureDetector.getFailed().contains(service))
+                .filter(service -> !failed.contains(service))
                 .collect(toImmutableSet());
 
         ImmutableSet.Builder<InternalNode> activeNodesBuilder = ImmutableSet.builder();


### PR DESCRIPTION
## Description
Avoid unnecessary nested loops O(N*N) on DiscoveryNodeManager#refreshNodesInternal

## Additional context and related issues
It does nested loop O(N*N) when services filter out failure nodes on DiscoveryNodeManager#refreshNodesInternal, it's no big deal on small clusters with few nodes, however it consumes quite a lot of cpu cycles on large cluster with over 1000 nodes, that will do 1,000,000 cycles per round of refreshNodeInternal. According to acutal cpu profiling, we found jvm does not optimize the code automatically, so this commit optimize it and avoid nested loop.

## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Reduce unnecessary nested loops overhead on DiscoveryNodeManager#refreshNodesInternal.
   This can avoid unnecessary nested loops while services filtering out failure nodes on DiscoveryNodeManager.
```

