### PR TITLE
Improve performance of node discovery in large clusters

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
@@ -209,8 +209,9 @@ public final class DiscoveryNodeManager
     private synchronized void refreshNodesInternal()
     {
         // This is a deny-list.
+        Set<ServiceDescriptor> failed = failureDetector.getFailed();
         Set<ServiceDescriptor> services = serviceSelector.selectAllServices().stream()
-                .filter(service -> !failureDetector.getFailed().contains(service))
+                .filter(service -> !failed.contains(service))
                 .collect(toImmutableSet());
 
         ImmutableSet.Builder<InternalNode> activeNodesBuilder = ImmutableSet.builder();


### PR DESCRIPTION
FailureDetector.getFailed() can be an non-trivial operation, so hoist it out of the filtering loop.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.
