### PR TITLE
Coerce boolean type for filter expression

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1231,11 +1231,7 @@ public class ExpressionAnalyzer
             if (node.getFilter().isPresent()) {
                 Expression expression = node.getFilter().get();
                 Type type = process(expression, context);
-                if (!type.equals(BOOLEAN)) {
-                    if (!type.equals(UNKNOWN)) {
-                        throw semanticException(TYPE_MISMATCH, expression, "Filter expression must evaluate to a boolean: actual type %s", type);
-                    }
-                }
+                coerceType(expression, type, BOOLEAN, "Filter expression");
             }
 
             List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -4035,6 +4035,7 @@ public class TestAnalyzer
     @Test
     public void testNullAggregationFilter()
     {
+        analyze("SELECT count(*) FILTER (WHERE NULL) FROM t1");
         analyze("SELECT a, count(*) FILTER (WHERE NULL) FROM t1 GROUP BY a");
     }
 
@@ -4052,10 +4053,10 @@ public class TestAnalyzer
                 .hasMessage("line 1:8: Filter is only valid for aggregation functions");
         assertFails("SELECT count(*) FILTER (WHERE 0) FROM t1")
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:31: Filter expression must evaluate to a boolean: actual type integer");
+                .hasMessage("line 1:31: Filter expression must evaluate to a boolean (actual: integer)");
         assertFails("SELECT a, count(*) FILTER (WHERE 0) FROM t1 GROUP BY a")
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:34: Filter expression must evaluate to a boolean: actual type integer");
+                .hasMessage("line 1:34: Filter expression must evaluate to a boolean (actual: integer)");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The following query fails with INTERNAL_ERROR:
```sql
select count(*) filter(where NULL) from system.runtime.queries;
```

Full stacktrace:
```
java.lang.IllegalArgumentException: Predicate must be an expression of boolean type: null
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218)
	at io.trino.sql.planner.plan.FilterNode.<init>(FilterNode.java:48)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitTableScan(PredicatePushDown.java:1579)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitTableScan(PredicatePushDown.java:168)
	at io.trino.sql.planner.plan.TableScanNode.accept(TableScanNode.java:222)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.rewrite(SimplePlanRewriter.java:81)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.lambda$defaultRewrite$0(SimplePlanRewriter.java:72)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:422)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.defaultRewrite(SimplePlanRewriter.java:72)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitProject(PredicatePushDown.java:309)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitProject(PredicatePushDown.java:168)
	at io.trino.sql.planner.plan.ProjectNode.accept(ProjectNode.java:81)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.rewrite(SimplePlanRewriter.java:81)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitFilter(PredicatePushDown.java:414)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitFilter(PredicatePushDown.java:168)
	at io.trino.sql.planner.plan.FilterNode.accept(FilterNode.java:79)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.rewrite(SimplePlanRewriter.java:81)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.lambda$defaultRewrite$0(SimplePlanRewriter.java:72)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:422)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.defaultRewrite(SimplePlanRewriter.java:72)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitPlan(PredicatePushDown.java:213)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitAggregation(PredicatePushDown.java:1459)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitAggregation(PredicatePushDown.java:168)
	at io.trino.sql.planner.plan.AggregationNode.accept(AggregationNode.java:221)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.rewrite(SimplePlanRewriter.java:81)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.lambda$defaultRewrite$0(SimplePlanRewriter.java:72)
	at com.google.common.collect.ImmutableList.forEach(ImmutableList.java:422)
	at io.trino.sql.planner.plan.SimplePlanRewriter$RewriteContext.defaultRewrite(SimplePlanRewriter.java:72)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitPlan(PredicatePushDown.java:213)
	at io.trino.sql.planner.optimizations.PredicatePushDown$Rewriter.visitPlan(PredicatePushDown.java:168)
	at io.trino.sql.planner.plan.PlanVisitor.visitOutput(PlanVisitor.java:49)
	at io.trino.sql.planner.plan.OutputNode.accept(OutputNode.java:82)
	at io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith(SimplePlanRewriter.java:31)
	at io.trino.sql.planner.optimizations.PredicatePushDown.optimize(PredicatePushDown.java:162)
	at io.trino.sql.planner.optimizations.StatsRecordingPlanOptimizer.optimize(StatsRecordingPlanOptimizer.java:56)
	at io.trino.sql.planner.LogicalPlanner.runOptimizer(LogicalPlanner.java:299)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:269)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:238)
	at io.trino.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:233)
	at io.trino.execution.SqlQueryExecution.doPlanQuery(SqlQueryExecution.java:482)
	at io.trino.execution.SqlQueryExecution.planQuery(SqlQueryExecution.java:462)
	at io.trino.execution.SqlQueryExecution.start(SqlQueryExecution.java:400)
	at io.trino.execution.SqlQueryManager.createQuery(SqlQueryManager.java:256)
	at io.trino.dispatcher.LocalDispatchQuery.startExecution(LocalDispatchQuery.java:145)
	at io.trino.dispatcher.LocalDispatchQuery.lambda$waitForMinimumWorkers$2(LocalDispatchQuery.java:129)
	at io.airlift.concurrent.MoreFutures.lambda$addSuccessCallback$12(MoreFutures.java:568)
	at io.airlift.concurrent.MoreFutures$3.onSuccess(MoreFutures.java:543)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1133)
	at io.trino.$gen.Trino_dev____20230805_065421_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
I made a related fix to reject non-boolean filter expression in https://github.com/trinodb/trino/pull/18460 recently but it seems better to coerce boolean type for filter expression there to cover this case.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/pull/18460
- https://github.com/trinodb/trino/pull/15744

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
