### PR TITLE
Fix correctness bug in constant literal distinct aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -112,6 +112,10 @@ public class SimplifyCountOverConstant
             return false;
         }
 
+        if (aggregation.isDistinct()) {
+            return false;
+        }
+
         Expression argument = aggregation.getArguments().get(0);
         if (argument instanceof SymbolReference) {
             argument = inputs.get(Symbol.from(argument));

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -508,4 +508,11 @@ public abstract class AbstractTestQueries
     {
         assertQuery("SELECT COUNT(*) FROM region r JOIN (SELECT nationkey FROM nation UNION ALL SELECT nationkey as key FROM nation) n ON r.regionkey = n.nationkey", "VALUES 10");
     }
+
+    @Test
+    public void testDistinctAggregationWithConstantLiterals()
+    {
+        String query = "with test_distinct_agg as (select orderkey, 'asdf' constant_str from orders limit 10) select count(distinct constant_str), count(*) from test_distinct_agg";
+	    assertQuery(query, "select 1, 10");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
SimplifyCountOverConstant replaces count(constant_literal) with count(*). But this will give incorrect results when there is distinct aggregation. This CR fixes this issue by not applying this optimization when distinct clause is present.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix correctness bug in constant literal distinct aggregation. ({issue}`18562`)
```
