### PR TITLE
Use ChunkedSliceOutput to chunk and buffer writes in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetCompressor.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetCompressor.java
@@ -17,7 +17,6 @@ import io.airlift.compress.Compressor;
 import io.airlift.compress.snappy.SnappyCompressor;
 import io.airlift.compress.zstd.ZstdCompressor;
 import io.airlift.slice.Slices;
-import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.format.CompressionCodec;
 
 import java.io.ByteArrayOutputStream;
@@ -68,7 +67,7 @@ interface ParquetCompressor
             try (GZIPOutputStream outputStream = new GZIPOutputStream(byteArrayOutputStream)) {
                 outputStream.write(input, 0, input.length);
             }
-            return createDataOutput(BytesInput.from(byteArrayOutputStream));
+            return createDataOutput(byteArrayOutputStream);
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
@@ -15,8 +15,8 @@ package io.trino.parquet.writer;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
-import org.apache.parquet.bytes.BytesInput;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import static java.util.Objects.requireNonNull;
@@ -29,7 +29,7 @@ public interface ParquetDataOutput
         return new ParquetDataOutput()
         {
             @Override
-            public long size()
+            public int size()
             {
                 return slice.length();
             }
@@ -42,22 +42,22 @@ public interface ParquetDataOutput
         };
     }
 
-    static ParquetDataOutput createDataOutput(BytesInput bytesInput)
+    static ParquetDataOutput createDataOutput(ByteArrayOutputStream byteArrayOutputStream)
     {
-        requireNonNull(bytesInput, "bytesInput is null");
+        requireNonNull(byteArrayOutputStream, "byteArrayOutputStream is null");
         return new ParquetDataOutput()
         {
             @Override
-            public long size()
+            public int size()
             {
-                return bytesInput.size();
+                return byteArrayOutputStream.size();
             }
 
             @Override
             public void writeData(SliceOutput sliceOutput)
             {
                 try {
-                    bytesInput.writeAllTo(sliceOutput);
+                    byteArrayOutputStream.writeTo(sliceOutput);
                 }
                 catch (IOException e) {
                     throw new RuntimeException(e);
@@ -69,7 +69,7 @@ public interface ParquetDataOutput
     /**
      * Number of bytes that will be written.
      */
-    long size();
+    int size();
 
     /**
      * Writes data to the output. The output must be exactly

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
@@ -15,6 +15,7 @@ package io.trino.parquet.writer;
 
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
+import io.trino.plugin.base.io.ChunkedSliceOutput;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,6 +39,25 @@ public interface ParquetDataOutput
             public void writeData(SliceOutput sliceOutput)
             {
                 sliceOutput.writeBytes(slice);
+            }
+        };
+    }
+
+    static ParquetDataOutput createDataOutput(ChunkedSliceOutput chunkedSliceOutput)
+    {
+        requireNonNull(chunkedSliceOutput, "chunkedSliceOutput is null");
+        return new ParquetDataOutput()
+        {
+            @Override
+            public int size()
+            {
+                return chunkedSliceOutput.size();
+            }
+
+            @Override
+            public void writeData(SliceOutput sliceOutput)
+            {
+                chunkedSliceOutput.getSlices().forEach(sliceOutput::writeBytes);
             }
         };
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -298,7 +298,9 @@ public class ParquetWriter
         if (rows == 0) {
             // Avoid writing empty row groups as these are ignored by the reader
             verify(
-                    bufferDataList.stream().allMatch(buffer -> buffer.getData().size() == 0),
+                    bufferDataList.stream()
+                            .flatMap(bufferData -> bufferData.getData().stream())
+                            .allMatch(dataOutput -> dataOutput.size() == 0),
                     "Buffer should be empty when there are no rows");
             return;
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -203,6 +203,7 @@ public class ParquetWriter
         try (outputStream) {
             columnWriters.forEach(ColumnWriter::close);
             flush();
+            columnWriters = ImmutableList.of();
             writeFooter();
         }
         bufferedBytes = 0;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -297,6 +297,7 @@ public class PrimitiveColumnWriter
     public long getRetainedBytes()
     {
         return INSTANCE_SIZE +
+                compressedOutputStream.getRetainedSize() +
                 primitiveValueWriter.getAllocatedSize() +
                 definitionLevelWriter.getAllocatedSize() +
                 repetitionLevelWriter.getAllocatedSize();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoids separate calls to output stream for writing page headers and page data.
Avoids holding on to extra memory for each buffered page due to over-allocation by compressors.
Adds memory usage accounting for buffered pages.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Should help with the memory usage accounting problems described in https://github.com/trinodb/trino/issues/18557

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Iceberg, Delta
* Improve memory usage accounting of parquet writer. ({issue}`18564`)
```
