### PR TITLE
Fix correctness bug in constant literal distinct aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyCountOverConstant.java
@@ -108,6 +108,10 @@ public class SimplifyCountOverConstant
             return false;
         }
 
+        if (aggregation.isDistinct()) {
+            return false;
+        }
+
         Expression argument = aggregation.getArguments().get(0);
         if (argument instanceof Reference) {
             argument = inputs.get(Symbol.from(argument));

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
@@ -140,4 +140,11 @@ public class TestAggregation
                             (3, DECIMAL '130303030303030303029.6666666633', DECIMAL '21717171717171717171.6111111106')) t(i, s, v)
                         """);
     }
+
+    @Test
+    void testCountDistinctOverConstant()
+    {
+        assertThat(assertions.query("SELECT count(DISTINCT 'x'), count(*) FROM (VALUES 1, 2, 3)"))
+                .matches("VALUES (BIGINT '1', BIGINT '3')");
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
SimplifyCountOverConstant replaces count(constant_literal) with count(*). But this will give incorrect results when there is distinct aggregation. This CR fixes this issue by not applying this optimization when distinct clause is present.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect results for distinct count aggregation over a constant value. ({issue}`18562`)
```
