### PR TITLE
Refactor is*View ViewReaderUtil methods 

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -87,7 +87,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     public static void verifyDeltaLakeTable(Table table)
     {
         if (isHiveOrPrestoView(table)) {
-            // this is a Hive view, hence not a table
+            // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
             throw new NotADeltaLakeTableException(table.getDatabaseName(), table.getTableName());
         }
         if (!TABLE_PROVIDER_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_PROVIDER_PROPERTY))) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.PATH_PROPERTY;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -86,8 +86,8 @@ public class HiveMetastoreBackedDeltaLakeMetastore
 
     public static void verifyDeltaLakeTable(Table table)
     {
-        if (isHiveOrPrestoView(table)) {
-            // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
+        if (isSomeKindOfAView(table)) {
+            // Looks like a view, so not a table
             throw new NotADeltaLakeTableException(table.getDatabaseName(), table.getTableName());
         }
         if (!TABLE_PROVIDER_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_PROVIDER_PROPERTY))) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -615,8 +615,8 @@ public class HiveMetadata
             throw new TrinoException(UNSUPPORTED_TABLE_TYPE, format("Not a Hive table '%s'", tableName));
         }
 
-        boolean isTrinoView = isPrestoView(table);
-        boolean isHiveView = !isTrinoView && isHiveOrPrestoView(table);
+        boolean isTrinoView = isPrestoView(table) && !isTrinoMaterializedView(table);
+        boolean isHiveView = isHiveOrPrestoView(table) && !isTrinoView && !isTrinoMaterializedView(table);
         boolean isTrinoMaterializedView = isTrinoMaterializedView(table);
         if (isHiveView && translateHiveViews) {
             // Produce metadata for a (translated) Hive view as if it was a table. This is incorrect from ConnectorMetadata.streamTableColumns

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1455,7 +1455,7 @@ public class HiveMetadata
     @Override
     public void setViewComment(ConnectorSession session, SchemaTableName viewName, Optional<String> comment)
     {
-        Table view = getView(viewName);
+        Table view = getTrinoView(viewName);
 
         ConnectorViewDefinition definition = toConnectorViewDefinition(session, viewName, Optional.of(view))
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
@@ -1474,7 +1474,7 @@ public class HiveMetadata
     @Override
     public void setViewColumnComment(ConnectorSession session, SchemaTableName viewName, String columnName, Optional<String> comment)
     {
-        Table view = getView(viewName);
+        Table view = getTrinoView(viewName);
 
         ConnectorViewDefinition definition = toConnectorViewDefinition(session, viewName, Optional.of(view))
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
@@ -1498,11 +1498,12 @@ public class HiveMetadata
         hiveMaterializedViewMetadata.setMaterializedViewColumnComment(session, viewName, columnName, comment);
     }
 
-    private Table getView(SchemaTableName viewName)
+    private Table getTrinoView(SchemaTableName viewName)
     {
         Table view = metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
+                .filter(table -> isHiveOrPrestoView(table) && !isTrinoMaterializedView(table))
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
-        if (translateHiveViews && !isPrestoView(view)) {
+        if (!isPrestoView(view)) {
             throw new HiveViewNotSupportedException(viewName);
         }
         return view;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -256,6 +256,7 @@ import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.ViewReaderUtil.createViewReader;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
 import static io.trino.plugin.hive.ViewReaderUtil.isHiveView;
+import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
@@ -3814,7 +3815,7 @@ public class HiveMetadata
         // we need to chop off any "$partitions" and similar suffixes from table name while querying the metastore for the Table object
         TableNameSplitResult tableNameSplit = splitTableName(tableName.getTableName());
         Optional<Table> table = metastore.getTable(tableName.getSchemaName(), tableNameSplit.getBaseTableName());
-        if (table.isEmpty() || VIRTUAL_VIEW.name().equals(table.get().getTableType())) {
+        if (table.isEmpty() || isSomeKindOfAView(table.get())) {
             return Optional.empty();
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
@@ -168,7 +168,6 @@ public final class TrinoViewHiveMetastore
         }
         return metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .flatMap(view -> TrinoViewUtil.getView(
-                        viewName,
                         view.getViewOriginalText(),
                         view.getTableType(),
                         view.getParameters(),
@@ -180,7 +179,7 @@ public final class TrinoViewHiveMetastore
         io.trino.plugin.hive.metastore.Table view = metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
 
-        ConnectorViewDefinition definition = TrinoViewUtil.getView(viewName, view.getViewOriginalText(), view.getTableType(), view.getParameters(), view.getOwner())
+        ConnectorViewDefinition definition = TrinoViewUtil.getView(view.getViewOriginalText(), view.getTableType(), view.getParameters(), view.getOwner())
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
         ConnectorViewDefinition newDefinition = new ConnectorViewDefinition(
                 definition.getOriginalSql(),
@@ -199,7 +198,7 @@ public final class TrinoViewHiveMetastore
         io.trino.plugin.hive.metastore.Table view = metastore.getTable(viewName.getSchemaName(), viewName.getTableName())
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
 
-        ConnectorViewDefinition definition = TrinoViewUtil.getView(viewName, view.getViewOriginalText(), view.getTableType(), view.getParameters(), view.getOwner())
+        ConnectorViewDefinition definition = TrinoViewUtil.getView(view.getViewOriginalText(), view.getTableType(), view.getParameters(), view.getOwner())
                 .orElseThrow(() -> new ViewNotFoundException(viewName));
         ConnectorViewDefinition newDefinition = new ConnectorViewDefinition(
                 definition.getOriginalSql(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewHiveMetastore.java
@@ -39,7 +39,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.TrinoViewUtil.createViewProperties;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
@@ -87,7 +87,7 @@ public final class TrinoViewHiveMetastore
 
         Optional<io.trino.plugin.hive.metastore.Table> existing = metastore.getTable(schemaViewName.getSchemaName(), schemaViewName.getTableName());
         if (existing.isPresent()) {
-            if (!replace || !isPrestoView(existing.get())) {
+            if (!replace || !isTrinoView(existing.get())) {
                 throw new ViewAlreadyExistsException(schemaViewName);
             }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
@@ -27,7 +27,7 @@ import static io.trino.plugin.hive.HiveMetadata.PRESTO_VIEW_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_CREATED_BY;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 
 public final class TrinoViewUtil
 {
@@ -39,7 +39,7 @@ public final class TrinoViewUtil
             Map<String, String> tableParameters,
             Optional<String> tableOwner)
     {
-        if (!(isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT)))) {
+        if (!isTrinoView(tableType, tableParameters)) {
             // Filter out Tables, Hive views and Trino Materialized Views
             return Optional.empty();
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
-import io.trino.spi.connector.SchemaTableName;
 
 import java.util.Map;
 import java.util.Optional;
@@ -29,14 +28,12 @@ import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TRINO_CREATED_BY;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
 
 public final class TrinoViewUtil
 {
     private TrinoViewUtil() {}
 
     public static Optional<ConnectorViewDefinition> getView(
-            SchemaTableName viewName,
             Optional<String> viewOriginalText,
             String tableType,
             Map<String, String> tableParameters,
@@ -45,11 +42,6 @@ public final class TrinoViewUtil
         if (!(isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT)))) {
             // Filter out Tables, Hive views and Trino Materialized Views
             return Optional.empty();
-        }
-
-        if (!isPrestoView(tableParameters)) {
-            // Hive views are not compatible
-            throw new HiveViewNotSupportedException(viewName);
         }
 
         checkArgument(viewOriginalText.isPresent(), "viewOriginalText must be present");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TrinoViewUtil.java
@@ -42,8 +42,8 @@ public final class TrinoViewUtil
             Map<String, String> tableParameters,
             Optional<String> tableOwner)
     {
-        if (!isView(tableType, tableParameters)) {
-            // Filter out Tables and Materialized Views
+        if (!(isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT)))) {
+            // Filter out Tables, Hive views and Trino Materialized Views
             return Optional.empty();
         }
 
@@ -66,11 +66,6 @@ public final class TrinoViewUtil
                     false);
         }
         return Optional.of(definition);
-    }
-
-    private static boolean isView(String tableType, Map<String, String> tableParameters)
-    {
-        return isHiveOrPrestoView(tableType) && PRESTO_VIEW_COMMENT.equals(tableParameters.get(TABLE_COMMENT));
     }
 
     public static Map<String, String> createViewProperties(ConnectorSession session, String trinoVersion, String connectorName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -49,6 +49,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linkedin.coral.trino.rel2trino.functions.TrinoKeywordsConverter.quoteWordIfNotQuoted;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_VIEW_DATA;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_VIEW_TRANSLATION_ERROR;
+import static io.trino.plugin.hive.HiveMetadata.PRESTO_VIEW_COMMENT;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveSessionProperties.isHiveViewsLegacyTranslation;
 import static io.trino.plugin.hive.HiveStorageFormat.TEXTFILE;
@@ -82,7 +83,7 @@ public final class ViewReaderUtil
             boolean runHiveViewRunAsInvoker,
             HiveTimestampPrecision hiveViewsTimestampPrecision)
     {
-        if (isPrestoView(table)) {
+        if (isTrinoView(table)) {
             return new PrestoViewReader();
         }
         if (isHiveViewsLegacyTranslation(session)) {
@@ -130,26 +131,44 @@ public final class ViewReaderUtil
     private static final JsonCodec<ConnectorViewDefinition> VIEW_CODEC =
             new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(ConnectorViewDefinition.class);
 
-    public static boolean isPrestoView(Table table)
+    /**
+     * Returns true if table represents a Hive view, Trino/Presto view, materialized view or anything
+     * else that gets registered using table type "VIRTUAL_VIEW".
+     * Note: this method returns false for a table that represents Hive's own materialized view
+     * ("MATERIALIZED_VIEW" table type). Hive own's materialized views are currently treated as ordinary
+     * tables by Trino.
+     */
+    public static boolean isSomeKindOfAView(Table table)
     {
-        return isPrestoView(table.getParameters());
+        return table.getTableType().equals(VIRTUAL_VIEW.name());
     }
 
-    public static boolean isPrestoView(Map<String, String> tableParameters)
+    public static boolean isHiveView(Table table)
     {
-        // TODO isPrestoView should not return true for materialized views
-        return "true".equals(tableParameters.get(PRESTO_VIEW_FLAG));
+        return table.getTableType().equals(VIRTUAL_VIEW.name()) &&
+                !table.getParameters().containsKey(PRESTO_VIEW_FLAG);
     }
 
-    public static boolean isHiveOrPrestoView(Table table)
+    /**
+     * Returns true when the table represents a "Trino view" (AKA "presto view").
+     * Returns false for Hive views or Trino materialized views.
+     */
+    public static boolean isTrinoView(Table table)
     {
-        return isHiveOrPrestoView(table.getTableType());
+        return isTrinoView(table.getTableType(), table.getParameters());
     }
 
-    public static boolean isHiveOrPrestoView(String tableType)
+    /**
+     * Returns true when the table represents a "Trino view" (AKA "presto view").
+     * Returns false for Hive views or Trino materialized views.
+     */
+    public static boolean isTrinoView(String tableType, Map<String, String> tableParameters)
     {
-        // TODO isHiveOrPrestoView should not return true for materialized views
-        return tableType.equals(VIRTUAL_VIEW.name());
+        // A Trino view can be recognized by table type "VIRTUAL_VIEW" and table parameters presto_view="true" and comment="Presto View" since their first implementation see
+        // https://github.com/trinodb/trino/blame/38bd0dff736024f3ae01dbbe7d1db5bd1d50c43e/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java#L902.
+        return tableType.equals(VIRTUAL_VIEW.name()) &&
+                "true".equals(tableParameters.get(PRESTO_VIEW_FLAG)) &&
+                tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(PRESTO_VIEW_COMMENT);
     }
 
     public static boolean isTrinoMaterializedView(Table table)
@@ -159,15 +178,12 @@ public final class ViewReaderUtil
 
     public static boolean isTrinoMaterializedView(String tableType, Map<String, String> tableParameters)
     {
-        // TODO isHiveOrPrestoView should not return true for materialized views
-        return isHiveOrPrestoView(tableType) && isPrestoView(tableParameters) && tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
-    }
-
-    public static boolean canDecodeView(Table table)
-    {
-        // we can decode Hive or Presto view
-        return table.getTableType().equals(VIRTUAL_VIEW.name()) &&
-                !isTrinoMaterializedView(table.getTableType(), table.getParameters());
+        // A Trino materialized view can be recognized by table type "VIRTUAL_VIEW" and table parameters presto_view="true" and comment="Presto Materialized View"
+        // since their first implementation see
+        // https://github.com/trinodb/trino/blame/ff4a1e31fb9cb49f1b960abfc16ad469e7126a64/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java#L898
+        return tableType.equals(VIRTUAL_VIEW.name()) &&
+                "true".equals(tableParameters.get(PRESTO_VIEW_FLAG)) &&
+                tableParameters.get(TABLE_COMMENT).equalsIgnoreCase(ICEBERG_MATERIALIZED_VIEW_COMMENT);
     }
 
     public static String encodeViewData(ConnectorViewDefinition definition)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -69,6 +69,9 @@ public interface HiveMetastore
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 
+    /**
+     * Lists views and materialized views from given database.
+     */
     List<String> getAllViews(String databaseName);
 
     /**

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -105,7 +105,8 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_TABLE_DROPPED_DURING_QUERY
 import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
@@ -3296,7 +3297,7 @@ public class SemiTransactionalHiveMetastore
             }
             tableCreated = true;
 
-            if (created && !isPrestoView(newTable)) {
+            if (created && !isTrinoView(newTable) && !isTrinoMaterializedView(newTable)) {
                 metastore.updateTableStatistics(newTable.getDatabaseName(), newTable.getTableName(), transaction, ignored -> statistics);
             }
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -36,6 +36,7 @@ import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.SchemaAlreadyExistsException;
 import io.trino.plugin.hive.TableAlreadyExistsException;
 import io.trino.plugin.hive.TableType;
+import io.trino.plugin.hive.ViewReaderUtil;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveColumnStatistics;
@@ -97,7 +98,7 @@ import static io.trino.plugin.hive.HivePartitionManager.extractPartitionValues;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
 import static io.trino.plugin.hive.TableType.MATERIALIZED_VIEW;
-import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
+import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.makePartitionName;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.verifyCanDropColumn;
@@ -328,7 +329,7 @@ public class FileHiveMetastore
         Path tableMetadataDirectory = getTableMetadataDirectory(table);
 
         // validate table location
-        if (table.getTableType().equals(VIRTUAL_VIEW.name())) {
+        if (isSomeKindOfAView(table)) {
             checkArgument(table.getStorage().getLocation().isEmpty(), "Storage location for view must be empty");
         }
         else if (table.getTableType().equals(MANAGED_TABLE.name())) {
@@ -555,7 +556,7 @@ public class FileHiveMetastore
                 .map(tableName -> getTable(databaseName, tableName))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .filter(table -> table.getTableType().equals(VIRTUAL_VIEW.name()))
+                .filter(ViewReaderUtil::isSomeKindOfAView)
                 .map(Table::getTableName)
                 .collect(toImmutableList());
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -177,7 +177,7 @@ public class GlueHiveMetastore
     private static final int BATCH_UPDATE_PARTITION_MAX_PAGE_SIZE = 100;
     private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 1000;
     private static final Comparator<Iterable<String>> PARTITION_VALUE_COMPARATOR = lexicographical(String.CASE_INSENSITIVE_ORDER);
-    private static final Predicate<com.amazonaws.services.glue.model.Table> VIEWS_FILTER = table -> VIRTUAL_VIEW.name().equals(getTableTypeNullable(table));
+    private static final Predicate<com.amazonaws.services.glue.model.Table> SOME_KIND_OF_VIEW_FILTER = table -> VIRTUAL_VIEW.name().equals(getTableTypeNullable(table));
     private static final RetryPolicy<?> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.builder()
             .handleIf(throwable -> Throwables.getRootCause(throwable) instanceof ConcurrentModificationException)
             .withDelay(Duration.ofMillis(100))
@@ -448,7 +448,7 @@ public class GlueHiveMetastore
     @Override
     public List<String> getAllViews(String databaseName)
     {
-        return getTableNames(databaseName, VIEWS_FILTER);
+        return getTableNames(databaseName, SOME_KIND_OF_VIEW_FILTER);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -42,8 +42,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableParameters;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.getTableType;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
@@ -93,8 +93,9 @@ public class GlueIcebergTableOperations
         Table table = getTable(invalidateCaches);
         glueVersionId = table.getVersionId();
 
+        String tableType = getTableType(table);
         Map<String, String> parameters = getTableParameters(table);
-        if (isPrestoView(parameters) && isHiveOrPrestoView(getTableType(table))) {
+        if (isTrinoView(tableType, parameters) || isTrinoMaterializedView(tableType, parameters)) {
             // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
             // TODO table operations should not be constructed for views (remove exception-driven code path)
             throw new TableNotFoundException(getSchemaTableName());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/GlueIcebergTableOperations.java
@@ -95,7 +95,8 @@ public class GlueIcebergTableOperations
 
         Map<String, String> parameters = getTableParameters(table);
         if (isPrestoView(parameters) && isHiveOrPrestoView(getTableType(table))) {
-            // this is a Presto Hive view, hence not a table
+            // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
+            // TODO table operations should not be constructed for views (remove exception-driven code path)
             throw new TableNotFoundException(getSchemaTableName());
         }
         if (!isIcebergTable(parameters)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -830,7 +830,7 @@ public class TrinoGlueCatalog
             }
 
             try {
-                TrinoViewUtil.getView(schemaTableName,
+                TrinoViewUtil.getView(
                                 Optional.ofNullable(table.getViewOriginalText()),
                                 getTableType(table),
                                 parameters,
@@ -1014,7 +1014,6 @@ public class TrinoGlueCatalog
         }
         com.amazonaws.services.glue.model.Table viewDefinition = table.get();
         return TrinoViewUtil.getView(
-                viewName,
                 Optional.ofNullable(viewDefinition.getViewOriginalText()),
                 getTableType(viewDefinition),
                 getTableParameters(viewDefinition),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -74,7 +74,8 @@ public abstract class AbstractMetastoreTableOperations
         Table table = getTable();
 
         if (isPrestoView(table) && isHiveOrPrestoView(table)) {
-            // this is a Hive view, hence not a table
+            // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
+            // TODO table operations should not be constructed for views (remove exception-driven code path)
             throw new TableNotFoundException(getSchemaTableName());
         }
         if (!isIcebergTable(table)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -33,8 +33,8 @@ import java.util.Optional;
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
-import static io.trino.plugin.hive.ViewReaderUtil.isPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
+import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
@@ -73,7 +73,7 @@ public abstract class AbstractMetastoreTableOperations
         }
         Table table = getTable();
 
-        if (isPrestoView(table) && isHiveOrPrestoView(table)) {
+        if (isTrinoView(table) || isTrinoMaterializedView(table)) {
             // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
             // TODO table operations should not be constructed for views (remove exception-driven code path)
             throw new TableNotFoundException(getSchemaTableName());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -79,7 +79,7 @@ import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
 import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
-import static io.trino.plugin.hive.ViewReaderUtil.isHiveOrPrestoView;
+import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
@@ -699,7 +699,7 @@ public class TrinoHiveCatalog
 
         Optional<io.trino.plugin.hive.metastore.Table> table = metastore.getTable(tableNameBase.getSchemaName(), tableNameBase.getTableName());
 
-        if (table.isEmpty() || isHiveOrPrestoView(table.get().getTableType())) {
+        if (table.isEmpty() || isSomeKindOfAView(table.get())) {
             return Optional.empty();
         }
         if (!isIcebergTable(table.get())) {


### PR DESCRIPTION
A "trino view" and "trino materialized view" need separate handling in
connectors (regardless what philosophical question whether materialized
view is also a view), so let this be expressed on utility function
level.

This changes

- `isTrinoMaterializedView` refactor-only change, no behavioral changes,
- `isPrestoView` - deprecated, replaced with `isTrinoView` which returns
  false for materialized views; `isPrestoView` is equivalent of
  `isTrinoView || isTrinoMaterializedView`,
- `isHiveOrTrinoView` - deprecated, replaced with `isSomeKindOfAView` which
  still returns true for materialized views (but returns false for
  Hive's own materialzied view which is treated as an ordinary table by
  Trino),
- `isHiveView` - new method.