### PR TITLE
Document `postgresql.include-system-tables` config property

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -51,6 +51,21 @@ determine the user credentials for the connection, often a service user. You can
 use {doc}`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+### Access to system tables
+
+The PostgreSQL connector supports reading [PostgreSQ catalog
+tables](https://www.postgresql.org/docs/current/catalogs.html), such as
+`pg_namespace`. The functionality is turned off by default, and can be enabled
+using the `postgresql.include-system-tables` configuration property.
+
+You can see more details in the `pg_catalog` schema in the `example` catalog,
+for example about the `pg_namespace` system table:
+
+```sql
+SHOW TABLES FROM example.pg_catalog;
+SELECT * FROM example.pg_catalog.pg_namespace;
+```
+
 (postgresql-tls)=
 
 ### Connection security


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Added in general postgreSQL connector configuration in the documentation for support for reading PostgreSQL system tables, e.g., pg_catalog relations. The functionality is disabled by default.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #15424 
Relates to https://trinodb.slack.com/archives/CGB0QHWSW/p1671165424335919


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
