### PR TITLE
Add `@Flaky` annotation to testNonTransactionalMetadataDelete

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -732,6 +732,7 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
     public void testNonTransactionalMetadataDelete()
     {
         withTemporaryTable("non_transactional_metadata_delete", false, true, NONE, tableName -> {


### PR DESCRIPTION
## Description

The test failed at https://github.com/trinodb/trino/actions/runs/5793009956/job/15700618792?pr=17477

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.