### PR TITLE
POC Expose Pinot metrics

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotBrokerPageSource.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotBrokerPageSource.java
@@ -155,5 +155,10 @@ public class PinotBrokerPageSource
     }
 
     @Override
+    public Metrics getMetrics() {
+        return new Metrics(pinotClient.getMetrics(session, query));
+    }
+
+    @Override
     public void close() {}
 }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -592,7 +592,11 @@ public class PinotClient
     {
         BrokerResponseNative response = submitBrokerQueryJson(session, query);
         Map<String, Metric<?>> metrics = ImmutableMap.of(
-                "numDocsScanned", new LongCount(response.getNumDocsScanned())
+                "numDocsScanned", new LongCount(response.getNumDocsScanned()),
+                "numSegmentsQueried", new LongCount(response.getNumSegmentsQueried()),
+                "totalDocs", new LongCount(response.getTotalDocs()),
+                "numSegmentsProcessed", new LongCount(response.getNumSegmentsProcessed()),
+                "numSegmentsMatched", new LongCount(response.getNumSegmentsMatched()),
         );
         return metrics;
     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -588,6 +588,15 @@ public class PinotClient
         return fromResultTable(response, columnHandles, query.getGroupByClauses());
     }
 
+    public Map<String, Metric<?>> getMetrics(ConnectorSession session, PinotQueryInfo query)
+    {
+        BrokerResponseNative response = submitBrokerQueryJson(session, query);
+        Map<String, Metric<?>> metrics = ImmutableMap.of(
+                "numDocsScanned", new LongCount(response.getNumDocsScanned())
+        );
+        return metrics;
+    }
+
     @VisibleForTesting
     public static ResultsIterator fromResultTable(BrokerResponseNative brokerResponse, List<PinotColumnHandle> columnHandles, int groupByClauses)
     {


### PR DESCRIPTION
Exposes Pinot Metrics

An issue with the above code is that it makes a separate call to Pinot just to get the metrics. Ideally we would have a single call to both:
a) construct the result data 
b) construct metrics
Code is just for illustrative purposes / proof-of-concept.