### PR TITLE
Accelerate information_schema.columns with bulk retrieval

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1271,7 +1271,7 @@ public class TestTrinoDatabaseMetaData
                         .mapToObj(i -> list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_" + i, "varchar"))
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
-                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
 
         // Equality predicate on catalog name, schema name, table name and column name
@@ -1282,7 +1282,7 @@ public class TestTrinoDatabaseMetaData
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                 new MetadataCallsCount()
-                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
 
         // Equality predicate on catalog name, LIKE predicate on schema name, table name and column name
@@ -1294,7 +1294,8 @@ public class TestTrinoDatabaseMetaData
                 list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                 new MetadataCallsCount()
                         .withListSchemasCount(1)
-                        .withListTablesCount(2)
+                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
 
         // LIKE predicate on schema name and table name, but no predicate on catalog name
@@ -1308,7 +1309,8 @@ public class TestTrinoDatabaseMetaData
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
                         .withListSchemasCount(1)
-                        .withListTablesCount(2)
+                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
 
         // LIKE predicate on schema name, but no predicate on catalog name and table name
@@ -1340,8 +1342,8 @@ public class TestTrinoDatabaseMetaData
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
                         .withListSchemasCount(5)
-                        .withListTablesCount(4)
-                        .withGetTableHandleCount(8)
+                        .withListTablesCount(2)
+                        .withGetTableHandleCount(10)
                         .withGetColumnsCount(2));
 
         // Equality predicate on schema name and table name, but no predicate on catalog name
@@ -1354,7 +1356,7 @@ public class TestTrinoDatabaseMetaData
                         .mapToObj(i -> list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_" + i, "varchar"))
                         .collect(toImmutableList()),
                 new MetadataCallsCount()
-                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
 
         // catalog does not exist
@@ -1374,7 +1376,7 @@ public class TestTrinoDatabaseMetaData
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(),
                 new MetadataCallsCount()
-                        .withListTablesCount(1));
+                        .withGetTableHandleCount(1));
 
         // schema does not exist
         assertMetadataCalls(
@@ -1477,7 +1479,7 @@ public class TestTrinoDatabaseMetaData
                             .mapToObj(i -> list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_" + i, "varchar"))
                             .collect(toImmutableList()),
                     new MetadataCallsCount()
-                            .withListTablesCount(1)
+                            .withGetTableHandleCount(1)
                             .withGetColumnsCount(1));
 
             // getColumns's schema, table and column name patterns treated as literals
@@ -1488,7 +1490,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                     new MetadataCallsCount()
-                            .withListTablesCount(1)
+                            .withGetTableHandleCount(1)
                             .withGetColumnsCount(1));
 
             // no matches in getColumns call as table name pattern treated as literal
@@ -1499,7 +1501,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                     list(),
                     new MetadataCallsCount()
-                            .withListTablesCount(1));
+                            .withGetTableHandleCount(1));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -174,7 +174,7 @@ public interface Metadata
      * Gets the columns metadata for all tables that match the specified prefix.
      * TODO: consider returning a stream for more efficient processing
      */
-    List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix);
+    List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix, UnaryOperator<Set<SchemaTableName>> relationFilter);
 
     /**
      * Gets the comments metadata for all relations (tables, views, materialized views) that match the specified prefix.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -243,23 +243,17 @@ public final class MetadataListing
 
     private static Map<SchemaTableName, List<ColumnMetadata>> doListTableColumns(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        List<TableColumnsMetadata> catalogColumns = metadata.listTableColumns(session, prefix);
+        List<TableColumnsMetadata> catalogColumns = metadata.listTableColumns(
+                session,
+                prefix,
+                relationNames -> accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), relationNames));
 
         Map<SchemaTableName, Optional<List<ColumnMetadata>>> tableColumns = catalogColumns.stream()
                 .collect(toImmutableMap(TableColumnsMetadata::getTable, TableColumnsMetadata::getColumns));
 
-        Set<SchemaTableName> allowedTables = accessControl.filterTables(
-                session.toSecurityContext(),
-                prefix.getCatalogName(),
-                tableColumns.keySet());
-
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> result = ImmutableMap.builder();
 
         tableColumns.forEach((table, columnsOptional) -> {
-            if (!allowedTables.contains(table)) {
-                return;
-            }
-
             QualifiedObjectName originalTableName = new QualifiedObjectName(prefix.getCatalogName(), table.getSchemaName(), table.getTableName());
             List<ColumnMetadata> columns;
             Optional<QualifiedObjectName> targetTableName = Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -588,42 +588,42 @@ public final class MetadataManager
                                 tableColumns.put(columnsMetadata.getTable(), columnsMetadata.getColumns());
                             }
                         });
+            }
 
-                // Collect column metadata from views. if table and view names overlap, the view wins
-                for (Entry<QualifiedObjectName, ViewInfo> entry : getViews(session, prefix).entrySet()) {
-                    ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
-                    for (ViewColumn column : entry.getValue().getColumns()) {
-                        try {
-                            columns.add(ColumnMetadata.builder()
-                                    .setName(column.getName())
-                                    .setType(typeManager.getType(column.getType()))
-                                    .setComment(column.getComment())
-                                    .build());
-                        }
-                        catch (TypeNotFoundException e) {
-                            throw new TrinoException(INVALID_VIEW, format("Unknown type '%s' for column '%s' in view: %s", column.getType(), column.getName(), entry.getKey()));
-                        }
+            // Collect column metadata from views. if table and view names overlap, the view wins
+            for (Entry<QualifiedObjectName, ViewInfo> entry : getViews(session, prefix).entrySet()) {
+                ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+                for (ViewColumn column : entry.getValue().getColumns()) {
+                    try {
+                        columns.add(ColumnMetadata.builder()
+                                .setName(column.getName())
+                                .setType(typeManager.getType(column.getType()))
+                                .setComment(column.getComment())
+                                .build());
                     }
-                    tableColumns.put(entry.getKey().asSchemaTableName(), Optional.of(columns.build()));
+                    catch (TypeNotFoundException e) {
+                        throw new TrinoException(INVALID_VIEW, format("Unknown type '%s' for column '%s' in view: %s", column.getType(), column.getName(), entry.getKey()));
+                    }
                 }
+                tableColumns.put(entry.getKey().asSchemaTableName(), Optional.of(columns.build()));
+            }
 
-                // if view and materialized view names overlap, the materialized view wins
-                for (Entry<QualifiedObjectName, ViewInfo> entry : getMaterializedViews(session, prefix).entrySet()) {
-                    ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
-                    for (ViewColumn column : entry.getValue().getColumns()) {
-                        try {
-                            columns.add(ColumnMetadata.builder()
-                                    .setName(column.getName())
-                                    .setType(typeManager.getType(column.getType()))
-                                    .setComment(column.getComment())
-                                    .build());
-                        }
-                        catch (TypeNotFoundException e) {
-                            throw new TrinoException(INVALID_VIEW, format("Unknown type '%s' for column '%s' in materialized view: %s", column.getType(), column.getName(), entry.getKey()));
-                        }
+            // if view and materialized view names overlap, the materialized view wins
+            for (Entry<QualifiedObjectName, ViewInfo> entry : getMaterializedViews(session, prefix).entrySet()) {
+                ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+                for (ViewColumn column : entry.getValue().getColumns()) {
+                    try {
+                        columns.add(ColumnMetadata.builder()
+                                .setName(column.getName())
+                                .setType(typeManager.getType(column.getType()))
+                                .setComment(column.getComment())
+                                .build());
                     }
-                    tableColumns.put(entry.getKey().asSchemaTableName(), Optional.of(columns.build()));
+                    catch (TypeNotFoundException e) {
+                        throw new TrinoException(INVALID_VIEW, format("Unknown type '%s' for column '%s' in materialized view: %s", column.getType(), column.getName(), entry.getKey()));
+                    }
                 }
+                tableColumns.put(entry.getKey().asSchemaTableName(), Optional.of(columns.build()));
             }
         }
         return tableColumns.entrySet().stream()

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -565,7 +565,7 @@ public final class MetadataManager
     }
 
     @Override
-    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
         requireNonNull(prefix, "prefix is null");
 
@@ -608,6 +608,7 @@ public final class MetadataManager
                         // Not found, or getting metadata failed.
                         return Optional.empty();
                     })
+                    .filter(relationColumnsMetadata -> relationFilter.apply(ImmutableSet.of(relationColumnsMetadata.name())).contains(relationColumnsMetadata.name()))
                     .map(relationColumnsMetadata -> ImmutableList.of(tableColumnsMetadata(catalogName, relationColumnsMetadata)))
                     .orElse(ImmutableList.of());
         }
@@ -622,8 +623,7 @@ public final class MetadataManager
                 }
                 ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
                 ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
-                // TODO relation filter
-                metadata.streamRelationColumns(connectorSession, schemaName, UnaryOperator.identity())
+                metadata.streamRelationColumns(connectorSession, schemaName, relationFilter)
                         .forEachRemaining(relationColumnsMetadata -> {
                             if (!isExternalInformationSchema(catalogHandle, relationColumnsMetadata.name().getSchemaName())) {
                                 // putIfAbsent to resolve any potential conflicts between system tables and regular tables

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -49,6 +49,7 @@ import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
@@ -296,6 +297,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("streamTableColumns", prefix);
         try (var ignored = scopedSpan(span)) {
             return delegate.streamTableColumns(session, prefix);
+        }
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(ConnectorSession session, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        Span span = startSpan("streamRelationColumns", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.streamRelationColumns(session, schemaName, relationFilter);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -327,11 +327,11 @@ public class TracingMetadata
     }
 
     @Override
-    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
         Span span = startSpan("listTableColumns", prefix);
         try (var ignored = scopedSpan(span)) {
-            return delegate.listTableColumns(session, prefix);
+            return delegate.listTableColumns(session, prefix, relationFilter);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorTableHandle.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorTableHandle.java
@@ -89,4 +89,10 @@ public class MockConnectorTableHandle
     {
         return Objects.hash(tableName, constraint, columns);
     }
+
+    @Override
+    public String toString()
+    {
+        return tableName.toString();
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -232,7 +232,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix)
+    public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -53,7 +53,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -65,6 +64,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Locale.ENGLISH;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
@@ -306,11 +306,53 @@ public interface ConnectorMetadata
     /**
      * Gets the metadata for all columns that match the specified table prefix. Redirected table names are included, but
      * the column metadata for them is not. Views and materialized views are not included.
+     *
+     * @deprecated Implement {@link #streamRelationColumns}.
      */
+    @Deprecated
     default Iterator<TableColumnsMetadata> streamTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
         return listTableColumns(session, prefix).entrySet().stream()
                 .map(entry -> TableColumnsMetadata.forTable(entry.getKey(), entry.getValue()))
+                .iterator();
+    }
+
+    /**
+     * Gets columns for all relations (tables, views, materialized views), possibly filtered by schemaName.
+     * (e.g. for all relations that would be returned by {@link #listTables(ConnectorSession, Optional)}).
+     * Redirected table names are included, but the comment for them is not.
+     */
+    @Experimental(eta = "2024-01-01")
+    default Iterator<RelationColumnsMetadata> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        Map<SchemaTableName, RelationColumnsMetadata> relationColumns = new HashMap<>();
+
+        // Collect column metadata from tables
+        SchemaTablePrefix prefix = schemaName.map(SchemaTablePrefix::new)
+                .orElseGet(SchemaTablePrefix::new);
+        streamTableColumns(session, prefix)
+                .forEachRemaining(columnsMetadata -> {
+                    SchemaTableName name = columnsMetadata.getTable();
+                    relationColumns.put(name, columnsMetadata.getColumns()
+                            .map(columns -> RelationColumnsMetadata.forTable(name, columns))
+                            .orElseGet(() -> RelationColumnsMetadata.forRedirectedTable(name)));
+                });
+
+        // Collect column metadata from views. if table and view names overlap, the view wins
+        for (Map.Entry<SchemaTableName, ConnectorViewDefinition> entry : getViews(session, schemaName).entrySet()) {
+            relationColumns.put(entry.getKey(), RelationColumnsMetadata.forView(entry.getKey(), entry.getValue().getColumns()));
+        }
+
+        // if view and materialized view names overlap, the materialized view wins
+        for (Map.Entry<SchemaTableName, ConnectorMaterializedViewDefinition> entry : getMaterializedViews(session, schemaName).entrySet()) {
+            relationColumns.put(entry.getKey(), RelationColumnsMetadata.forMaterializedView(entry.getKey(), entry.getValue().getColumns()));
+        }
+
+        return relationFilter.apply(relationColumns.keySet()).stream()
+                .map(relationColumns::get)
                 .iterator();
     }
 
@@ -618,7 +660,7 @@ public interface ConnectorMetadata
         return properties.getTablePartitioning()
                 .map(partitioning -> {
                     Map<ColumnHandle, String> columnNamesByHandle = getColumnHandles(session, tableHandle).entrySet().stream()
-                            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+                            .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
                     List<String> partitionColumns = partitioning.getPartitioningColumns().stream()
                             .map(columnNamesByHandle::get)
                             .collect(toUnmodifiableList());

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/RelationColumnsMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/RelationColumnsMetadata.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static io.trino.spi.connector.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public record RelationColumnsMetadata(
+        SchemaTableName name,
+        Optional<List<ConnectorMaterializedViewDefinition.Column>> materializedViewColumns,
+        Optional<List<ConnectorViewDefinition.ViewColumn>> viewColumns,
+        Optional<List<ColumnMetadata>> tableColumns,
+        boolean redirected)
+{
+    public RelationColumnsMetadata
+    {
+        requireNonNull(name, "name is null");
+        materializedViewColumns = materializedViewColumns.map(List::copyOf);
+        viewColumns = viewColumns.map(List::copyOf);
+        tableColumns = tableColumns.map(List::copyOf);
+
+        checkArgument(
+                Stream.of(materializedViewColumns.isPresent(), viewColumns.isPresent(), tableColumns.isPresent(), redirected)
+                        .filter(value -> value)
+                        .count() == 1,
+                "Expected exactly one to be true. Use factory methods to ensure correct instantiation");
+    }
+
+    public static RelationColumnsMetadata forMaterializedView(SchemaTableName name, List<ConnectorMaterializedViewDefinition.Column> columns)
+    {
+        return new RelationColumnsMetadata(
+                name,
+                Optional.of(columns),
+                Optional.empty(),
+                Optional.empty(),
+                false);
+    }
+
+    public static RelationColumnsMetadata forView(SchemaTableName name, List<ConnectorViewDefinition.ViewColumn> columns)
+    {
+        return new RelationColumnsMetadata(
+                name,
+                Optional.empty(),
+                Optional.of(columns),
+                Optional.empty(),
+                false);
+    }
+
+    public static RelationColumnsMetadata forTable(SchemaTableName name, List<ColumnMetadata> columns)
+    {
+        return new RelationColumnsMetadata(
+                name,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(columns),
+                false);
+    }
+
+    public static RelationColumnsMetadata forRedirectedTable(SchemaTableName name)
+    {
+        return new RelationColumnsMetadata(
+                name,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                true);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -49,6 +49,7 @@ import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
@@ -310,6 +311,17 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeIterator<>(delegate.streamTableColumns(session, prefix), classLoader);
+        }
+    }
+
+    @Override
+    public ClassLoaderSafeIterator<RelationColumnsMetadata> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> schemaName,
+            UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeIterator<>(delegate.streamRelationColumns(session, schemaName, relationFilter), classLoader);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -78,6 +78,7 @@ import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
@@ -694,6 +695,16 @@ public class IcebergMetadata
                 })
                 .flatMap(List::stream)
                 .iterator();
+    }
+
+    @Override
+    public Iterator<RelationColumnsMetadata> streamRelationColumns(ConnectorSession session, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
+    {
+        return catalog.streamRelationColumns(session, schemaName, relationFilter, tableName -> redirectTable(session, tableName).isPresent())
+                .orElseGet(() -> {
+                    // Catalog does not support streamRelationColumns
+                    return ConnectorMetadata.super.streamRelationColumns(session, schemaName, relationFilter);
+                });
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -199,9 +199,7 @@ import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_PARTITION_
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_MERGE_ROW_ID;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.TRINO_ROW_ID_NAME;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnHandle;
-import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnMetadata;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnHandle;
-import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnMetadata;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
@@ -229,6 +227,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.fileName;
 import static io.trino.plugin.iceberg.IcebergUtil.firstSnapshot;
 import static io.trino.plugin.iceberg.IcebergUtil.firstSnapshotAfter;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
+import static io.trino.plugin.iceberg.IcebergUtil.getColumnMetadatas;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableProperties;
@@ -246,7 +245,6 @@ import static io.trino.plugin.iceberg.TableStatisticsWriter.StatsUpdateMode.INCR
 import static io.trino.plugin.iceberg.TableStatisticsWriter.StatsUpdateMode.REPLACE;
 import static io.trino.plugin.iceberg.TableType.DATA;
 import static io.trino.plugin.iceberg.TypeConverter.toIcebergTypeForNewColumn;
-import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalog.DEPENDS_ON_TABLES;
 import static io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalog.TRINO_QUERY_START_TIME;
 import static io.trino.plugin.iceberg.procedure.IcebergTableProcedureId.DROP_EXTENDED_STATS;
@@ -601,7 +599,7 @@ public class IcebergMetadata
         // This method does not calculate column metadata for the projected columns
         checkArgument(tableHandle.getProjectedColumns().isEmpty(), "Unexpected projected columns");
         Table icebergTable = catalog.loadTable(session, tableHandle.getSchemaTableName());
-        List<ColumnMetadata> columns = getColumnMetadatas(SchemaParser.fromJson(tableHandle.getTableSchemaJson()));
+        List<ColumnMetadata> columns = getColumnMetadatas(SchemaParser.fromJson(tableHandle.getTableSchemaJson()), typeManager);
         return new ConnectorTableMetadata(tableHandle.getSchemaTableName(), columns, getIcebergTableProperties(icebergTable), getTableComment(icebergTable));
     }
 
@@ -675,7 +673,7 @@ public class IcebergMetadata
                     for (SchemaTableName tableName : remainingTables) {
                         try {
                             Table icebergTable = catalog.loadTable(session, tableName);
-                            List<ColumnMetadata> columns = getColumnMetadatas(icebergTable.schema());
+                            List<ColumnMetadata> columns = getColumnMetadatas(icebergTable.schema(), typeManager);
                             tableMetadatas.add(TableColumnsMetadata.forTable(tableName, columns));
                         }
                         catch (TableNotFoundException e) {
@@ -1904,25 +1902,6 @@ public class IcebergMetadata
         catch (RuntimeException e) {
             throw new TrinoException(ICEBERG_COMMIT_ERROR, "Failed to set field type: " + firstNonNull(e.getMessage(), e), e);
         }
-    }
-
-    private List<ColumnMetadata> getColumnMetadatas(Schema schema)
-    {
-        List<NestedField> icebergColumns = schema.columns();
-        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builderWithExpectedSize(icebergColumns.size() + 2);
-
-        icebergColumns.stream()
-                .map(column ->
-                        ColumnMetadata.builder()
-                                .setName(column.name())
-                                .setType(toTrinoType(column.type(), typeManager))
-                                .setNullable(column.isOptional())
-                                .setComment(Optional.ofNullable(column.doc()))
-                                .build())
-                .forEach(columns::add);
-        columns.add(pathColumnMetadata());
-        columns.add(fileModifiedTimeColumnMetadata());
-        return columns.build();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1908,9 +1908,10 @@ public class IcebergMetadata
 
     private List<ColumnMetadata> getColumnMetadatas(Schema schema)
     {
-        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
+        List<NestedField> icebergColumns = schema.columns();
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builderWithExpectedSize(icebergColumns.size() + 2);
 
-        List<ColumnMetadata> schemaColumns = schema.columns().stream()
+        icebergColumns.stream()
                 .map(column ->
                         ColumnMetadata.builder()
                                 .setName(column.name())
@@ -1918,8 +1919,7 @@ public class IcebergMetadata
                                 .setNullable(column.isOptional())
                                 .setComment(Optional.ofNullable(column.doc()))
                                 .build())
-                .collect(toImmutableList());
-        columns.addAll(schemaColumns);
+                .forEach(columns::add);
         columns.add(pathColumnMetadata());
         columns.add(fileModifiedTimeColumnMetadata());
         return columns.build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -95,6 +95,8 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.io.ByteBuffers.getWrappedBytes;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.fileModifiedTimeColumnMetadata;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.pathColumnMetadata;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.iceberg.IcebergMetadata.ORC_BLOOM_FILTER_COLUMNS_KEY;
@@ -252,6 +254,25 @@ public final class IcebergUtil
         return schema.columns().stream()
                 .map(column -> getColumnHandle(column, typeManager))
                 .collect(toImmutableList());
+    }
+
+    public static List<ColumnMetadata> getColumnMetadatas(Schema schema, TypeManager typeManager)
+    {
+        List<NestedField> icebergColumns = schema.columns();
+        ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builderWithExpectedSize(icebergColumns.size() + 2);
+
+        icebergColumns.stream()
+                .map(column ->
+                        ColumnMetadata.builder()
+                                .setName(column.name())
+                                .setType(toTrinoType(column.type(), typeManager))
+                                .setNullable(column.isOptional())
+                                .setComment(Optional.ofNullable(column.doc()))
+                                .build())
+                .forEach(columns::add);
+        columns.add(pathColumnMetadata());
+        columns.add(fileModifiedTimeColumnMetadata());
+        return columns.build();
     }
 
     public static IcebergColumnHandle getColumnHandle(NestedField column, TypeManager typeManager)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -345,9 +345,7 @@ public abstract class AbstractTrinoCatalog
                 Optional.of(new CatalogSchemaTableName(catalogName.toString(), storageTableName)),
                 definition.getCatalog(),
                 definition.getSchema(),
-                definition.getColumns().stream()
-                        .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType(), column.getComment()))
-                        .collect(toImmutableList()),
+                toSpiMaterializedViewColumns(definition.getColumns()),
                 definition.getGracePeriod(),
                 definition.getComment(),
                 owner,
@@ -355,6 +353,13 @@ public abstract class AbstractTrinoCatalog
                         .putAll(getIcebergTableProperties(icebergTable))
                         .put(STORAGE_SCHEMA, storageTableName.getSchemaName())
                         .buildOrThrow());
+    }
+
+    protected List<ConnectorMaterializedViewDefinition.Column> toSpiMaterializedViewColumns(List<IcebergMaterializedViewDefinition.Column> columns)
+    {
+        return columns.stream()
+                .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType(), column.getComment()))
+                .collect(toImmutableList());
     }
 
     protected Map<String, String> createMaterializedViewProperties(ConnectorSession session, SchemaTableName storageTableName)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
@@ -72,6 +73,12 @@ public interface TrinoCatalog
     void renameNamespace(ConnectorSession session, String source, String target);
 
     List<SchemaTableName> listTables(ConnectorSession session, Optional<String> namespace);
+
+    Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> namespace,
+            UnaryOperator<Set<SchemaTableName>> relationFilter,
+            Predicate<SchemaTableName> isRedirected);
 
     Optional<Iterator<RelationCommentMetadata>> streamRelationComments(
             ConnectorSession session,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -770,33 +770,6 @@ public class TrinoGlueCatalog
         return Optional.of(table);
     }
 
-    private void createTable(String schemaName, TableInput tableInput)
-    {
-        glueTableCache.invalidateAll();
-        stats.getCreateTable().call(() ->
-                glueClient.createTable(new CreateTableRequest()
-                        .withDatabaseName(schemaName)
-                        .withTableInput(tableInput)));
-    }
-
-    private void updateTable(String schemaName, TableInput tableInput)
-    {
-        glueTableCache.invalidateAll();
-        stats.getUpdateTable().call(() ->
-                glueClient.updateTable(new UpdateTableRequest()
-                        .withDatabaseName(schemaName)
-                        .withTableInput(tableInput)));
-    }
-
-    private void deleteTable(String schema, String table)
-    {
-        glueTableCache.invalidateAll();
-        stats.getDeleteTable().call(() ->
-                glueClient.deleteTable(new DeleteTableRequest()
-                        .withDatabaseName(schema)
-                        .withName(table)));
-    }
-
     @Override
     public String defaultTableLocation(ConnectorSession session, SchemaTableName schemaTableName)
     {
@@ -1330,5 +1303,32 @@ public class TrinoGlueCatalog
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new TrinoException(GENERIC_INTERNAL_ERROR, "Get table request failed: " + firstNonNull(e.getMessage(), e), e.getCause());
         }
+    }
+
+    private void createTable(String schemaName, TableInput tableInput)
+    {
+        glueTableCache.invalidateAll();
+        stats.getCreateTable().call(() ->
+                glueClient.createTable(new CreateTableRequest()
+                        .withDatabaseName(schemaName)
+                        .withTableInput(tableInput)));
+    }
+
+    private void updateTable(String schemaName, TableInput tableInput)
+    {
+        glueTableCache.invalidateAll();
+        stats.getUpdateTable().call(() ->
+                glueClient.updateTable(new UpdateTableRequest()
+                        .withDatabaseName(schemaName)
+                        .withTableInput(tableInput)));
+    }
+
+    private void deleteTable(String schema, String table)
+    {
+        glueTableCache.invalidateAll();
+        stats.getDeleteTable().call(() ->
+                glueClient.deleteTable(new DeleteTableRequest()
+                        .withDatabaseName(schema)
+                        .withName(table)));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -39,6 +39,7 @@ import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.MaterializedViewNotFoundException;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -317,6 +318,16 @@ public class TrinoHiveCatalog
             metastore.getAllTables(schemaName).forEach(tableName -> tablesListBuilder.add(new SchemaTableName(schemaName, tableName)));
         }
         return tablesListBuilder.build().asList();
+    }
+
+    @Override
+    public Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> namespace,
+            UnaryOperator<Set<SchemaTableName>> relationFilter,
+            Predicate<SchemaTableName> isRedirected)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -27,6 +27,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -169,6 +170,16 @@ public class TrinoJdbcCatalog
             }
         }
         return tablesListBuilder.build().asList();
+    }
+
+    @Override
+    public Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> namespace,
+            UnaryOperator<Set<SchemaTableName>> relationFilter,
+            Predicate<SchemaTableName> isRedirected)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -158,6 +159,16 @@ public class TrinoNessieCatalog
                 .stream()
                 .map(id -> schemaTableName(id.namespace().toString(), id.name()))
                 .collect(toImmutableList());
+    }
+
+    @Override
+    public Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> namespace,
+            UnaryOperator<Set<SchemaTableName>> relationFilter,
+            Predicate<SchemaTableName> isRedirected)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -195,6 +196,16 @@ public class TrinoRestCatalog
             }
         }
         return tables.build();
+    }
+
+    @Override
+    public Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
+            ConnectorSession session,
+            Optional<String> namespace,
+            UnaryOperator<Set<SchemaTableName>> relationFilter,
+            Predicate<SchemaTableName> isRedirected)
+    {
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -497,7 +497,7 @@ public class TestIcebergGlueCatalogAccessOperations
                             session,
                             "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name LIKE 'test_select_i_s_columns%'",
                             ImmutableMultiset.<GlueMetastoreMethod>builder()
-                                    .addCopies(GET_TABLES, 7)
+                                    .addCopies(GET_TABLES, 3)
                                     .addCopies(GET_TABLE, tables * 2)
                                     .build(),
                             ImmutableMultiset.of());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -497,8 +497,7 @@ public class TestIcebergGlueCatalogAccessOperations
                             session,
                             "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name LIKE 'test_select_i_s_columns%'",
                             ImmutableMultiset.<GlueMetastoreMethod>builder()
-                                    .addCopies(GET_TABLES, 3)
-                                    .addCopies(GET_TABLE, tables * 2)
+                                    .add(GET_TABLES)
                                     .build(),
                             ImmutableMultiset.of());
                 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -249,12 +249,12 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_schema = 'test_schema1' AND table_name = 'test_table1'",
                 "VALUES 100",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.streamTableColumns(schema=test_schema1, table=test_table1)")
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 8)
                         .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 2)
                         .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
-                        .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
+                        .addCopies("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)", 2)
+                        .addCopies("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)", 2)
+                        .add("ConnectorMetadata.getTableMetadata(handle=test_schema1.test_table1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'wrong'",
@@ -291,9 +291,7 @@ public class TestInformationSchemaConnector
                 "VALUES 1000",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.streamTableColumns(schema=test_schema1)")
-                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.getViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.streamRelationColumns(schema=test_schema1)")
                         .build());
 
         // Empty table schema and table name

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -251,8 +251,8 @@ public class TestInformationSchemaConnector
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.streamTableColumns(schema=test_schema1, table=test_table1)")
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 4)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 2)
+                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
                         .build());
@@ -292,8 +292,8 @@ public class TestInformationSchemaConnector
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.streamTableColumns(schema=test_schema1)")
-                        .addCopies("ConnectorMetadata.getMaterializedViews(schema=test_schema1)", 3)
-                        .addCopies("ConnectorMetadata.getViews(schema=test_schema1)", 3)
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getViews(schema=test_schema1)")
                         .build());
 
         // Empty table schema and table name


### PR DESCRIPTION
### Description

Introduce APIs necessary to implement `information_schema.columns` efficiently and implement it for Iceberg with Glue Catalog. This fully eliminates GetTable calls for individual tables (previously twice for each Glue table), and reduces number of table listings (from 7 to 1).

### RN

```
Iceberg
* Improve performance of ``information_schema.columns`` when using Glue catalog.
```