### PR TITLE
Use tracing for testing ConnectorMetadata invocations 

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -150,6 +150,7 @@ public class TestTrinoDatabaseMetaData
     {
         server.close();
         server = null;
+        countingMockConnector.close();
         countingMockConnector = null;
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -256,7 +256,7 @@ public class TracingConnectorMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        Span span = startSpan("listTables");
+        Span span = startSpan("listTables", schemaName);
         try (var ignored = scopedSpan(span)) {
             return delegate.listTables(session, schemaName);
         }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -131,6 +131,7 @@ public class MockConnector
     private static final String UPDATE_ROW_ID = "update_row_id";
     private static final String MERGE_ROW_ID = "merge_row_id";
 
+    private final Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper;
     private final Function<ConnectorSession, List<String>> listSchemaNames;
     private final BiFunction<ConnectorSession, String, List<String>> listTables;
     private final Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Iterator<TableColumnsMetadata>>> streamTableColumns;
@@ -176,6 +177,7 @@ public class MockConnector
     private final BiFunction<ConnectorSession, ConnectorTableExecuteHandle, Optional<ConnectorTableLayout>> getLayoutForTableExecute;
 
     MockConnector(
+            Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper,
             List<PropertyMetadata<?>> sessionProperties,
             Function<ConnectorSession, List<String>> listSchemaNames,
             BiFunction<ConnectorSession, String, List<String>> listTables,
@@ -220,6 +222,7 @@ public class MockConnector
             OptionalInt maxWriterTasks,
             BiFunction<ConnectorSession, ConnectorTableExecuteHandle, Optional<ConnectorTableLayout>> getLayoutForTableExecute)
     {
+        this.metadataWrapper = requireNonNull(metadataWrapper, "metadataWrapper is null");
         this.sessionProperties = ImmutableList.copyOf(requireNonNull(sessionProperties, "sessionProperties is null"));
         this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
         this.listTables = requireNonNull(listTables, "listTables is null");
@@ -280,7 +283,7 @@ public class MockConnector
     @Override
     public ConnectorMetadata getMetadata(ConnectorSession session, ConnectorTransactionHandle transaction)
     {
-        return new MockConnectorMetadata();
+        return metadataWrapper.apply(new MockConnectorMetadata());
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -81,12 +82,14 @@ import static io.trino.spi.metrics.Metrics.EMPTY;
 import static io.trino.spi.statistics.TableStatistics.empty;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public class MockConnectorFactory
         implements ConnectorFactory
 {
     private final String name;
     private final List<PropertyMetadata<?>> sessionProperty;
+    private final Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper;
     private final Function<ConnectorSession, List<String>> listSchemaNames;
     private final BiFunction<ConnectorSession, String, List<String>> listTables;
     private final Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Iterator<TableColumnsMetadata>>> streamTableColumns;
@@ -135,6 +138,7 @@ public class MockConnectorFactory
     private MockConnectorFactory(
             String name,
             List<PropertyMetadata<?>> sessionProperty,
+            Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper,
             Function<ConnectorSession, List<String>> listSchemaNames,
             BiFunction<ConnectorSession, String, List<String>> listTables,
             Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Iterator<TableColumnsMetadata>>> streamTableColumns,
@@ -180,6 +184,7 @@ public class MockConnectorFactory
     {
         this.name = requireNonNull(name, "name is null");
         this.sessionProperty = ImmutableList.copyOf(requireNonNull(sessionProperty, "sessionProperty is null"));
+        this.metadataWrapper = requireNonNull(metadataWrapper, "metadataWrapper is null");
         this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
         this.listTables = requireNonNull(listTables, "listTables is null");
         this.streamTableColumns = requireNonNull(streamTableColumns, "streamTableColumns is null");
@@ -234,6 +239,7 @@ public class MockConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         return new MockConnector(
+                metadataWrapper,
                 sessionProperty,
                 listSchemaNames,
                 listTables,
@@ -367,6 +373,7 @@ public class MockConnectorFactory
     {
         private String name = "mock";
         private final List<PropertyMetadata<?>> sessionProperties = new ArrayList<>();
+        private Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper = identity();
         private Function<ConnectorSession, List<String>> listSchemaNames = defaultListSchemaNames();
         private BiFunction<ConnectorSession, String, List<String>> listTables = defaultListTables();
         private Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Iterator<TableColumnsMetadata>>> streamTableColumns = Optional.empty();
@@ -435,6 +442,12 @@ public class MockConnectorFactory
             for (PropertyMetadata<?> sessionProperty : sessionProperties) {
                 withSessionProperty(sessionProperty);
             }
+            return this;
+        }
+
+        public Builder withMetadataWrapper(Function<ConnectorMetadata, ConnectorMetadata> metadataWrapper)
+        {
+            this.metadataWrapper = requireNonNull(metadataWrapper, "metadataWrapper is null");
             return this;
         }
 
@@ -733,6 +746,7 @@ public class MockConnectorFactory
             return new MockConnectorFactory(
                     name,
                     sessionProperties,
+                    metadataWrapper,
                     listSchemaNames,
                     listTables,
                     streamTableColumns,

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -87,6 +87,16 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-client</artifactId>
         </dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
@@ -57,7 +57,7 @@ public class CountingMockConnector
     private final AtomicLong listTablesCallsCounter = new AtomicLong();
     private final AtomicLong getTableHandleCallsCounter = new AtomicLong();
     private final AtomicLong getColumnsCallsCounter = new AtomicLong();
-    private final ListRoleGrantsCounter listRoleGranstCounter = new ListRoleGrantsCounter();
+    private final ListRoleGrantsCounter listRoleGrantCounter = new ListRoleGrantsCounter();
 
     public Plugin getPlugin()
     {
@@ -87,7 +87,7 @@ public class CountingMockConnector
             listTablesCallsCounter.set(0);
             getTableHandleCallsCounter.set(0);
             getColumnsCallsCounter.set(0);
-            listRoleGranstCounter.reset();
+            listRoleGrantCounter.reset();
 
             runnable.run();
 
@@ -96,10 +96,10 @@ public class CountingMockConnector
                     listTablesCallsCounter.get(),
                     getTableHandleCallsCounter.get(),
                     getColumnsCallsCounter.get(),
-                    listRoleGranstCounter.listRowGrantsCallsCounter.get(),
-                    listRoleGranstCounter.rolesPushedCounter.get(),
-                    listRoleGranstCounter.granteesPushedCounter.get(),
-                    listRoleGranstCounter.limitPushedCounter.get());
+                    listRoleGrantCounter.listRowGrantsCallsCounter.get(),
+                    listRoleGrantCounter.rolesPushedCounter.get(),
+                    listRoleGrantCounter.granteesPushedCounter.get(),
+                    listRoleGrantCounter.limitPushedCounter.get());
         }
     }
 
@@ -129,7 +129,7 @@ public class CountingMockConnector
                     return defaultGetColumns().apply(schemaTableName);
                 })
                 .withListRoleGrants((connectorSession, roles, grantees, limit) -> {
-                    listRoleGranstCounter.incrementListRoleGrants(roles, grantees, limit);
+                    listRoleGrantCounter.incrementListRoleGrants(roles, grantees, limit);
                     return roleGrants;
                 })
                 .build();

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -206,13 +206,11 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'test_catalog' AND table_schema = 'wrong_schema1' AND table_name = 'test_table1'",
                 "VALUES 0",
                 new MetadataCallsCount()
-                        .withListTablesCount(1)
                         .withGetTableHandleCount(1));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog IN ('wrong', 'test_catalog') AND table_schema = 'wrong_schema1' AND table_name = 'test_table1'",
                 "VALUES 0",
                 new MetadataCallsCount()
-                        .withListTablesCount(1)
                         .withGetTableHandleCount(1));
         assertMetadataCalls(
                 "SELECT count(*) FROM (SELECT * from test_catalog.information_schema.columns LIMIT 1)",


### PR DESCRIPTION
This refactors `TestInformationSchemaConnector.testMetadataCalls` to
leverage `TracingConnectorMetadata` instead of manually performed counts
within `CountingMockConnector. Among other things this exposes
`listViews` calls which were previously not counted.

The differences in expected counts in the test come from the fact how
the counting was done previously. For example
`MockConnectorMetadata.listTables` calls `listSchemaNames` before
`listTables`, so this single metadata call was being recorded as both
`listSchemaNames` and `listTables` (zero or more times).

Extracted from https://github.com/trinodb/trino/pull/18586