### PR TITLE
Fix structure and execution of type tests

### DIFF
--- a/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
+++ b/core/trino-main/src/test/java/io/trino/type/AbstractTestType.java
@@ -73,7 +73,6 @@ import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableSortedMap;
 import static java.util.Objects.requireNonNull;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -201,41 +200,6 @@ public abstract class AbstractTestType
             assertPositionEquals(testBlockWithNulls, entry.getKey() * 2, entry.getValue(), expectedObjectValues.get(entry.getKey()));
             assertPositionEquals(testBlockWithNulls, (entry.getKey() * 2) + 1, null, null);
         }
-    }
-
-    @Test
-    public void testRange()
-    {
-        assertThat(type.getRange())
-                .isEmpty();
-    }
-
-    @Test
-    public void testPreviousValue()
-    {
-        Object sampleValue = getSampleValue();
-        if (!type.isOrderable()) {
-            assertThatThrownBy(() -> type.getPreviousValue(sampleValue))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Type is not orderable: " + type);
-            return;
-        }
-        assertThat(type.getPreviousValue(sampleValue))
-                .isEmpty();
-    }
-
-    @Test
-    public void testNextValue()
-    {
-        Object sampleValue = getSampleValue();
-        if (!type.isOrderable()) {
-            assertThatThrownBy(() -> type.getNextValue(sampleValue))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Type is not orderable: " + type);
-            return;
-        }
-        assertThat(type.getNextValue(sampleValue))
-                .isEmpty();
     }
 
     protected Object getSampleValue()

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintArrayType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestBigintArrayType
         extends AbstractTestType
@@ -53,5 +55,26 @@ public class TestBigintArrayType
         BIGINT.writeLong(blockBuilder, 1L);
 
         return blockBuilder.build();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type.Range;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class TestBigintType
         return ((Long) value) + 1;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -62,7 +63,7 @@ public class TestBigintType
         assertEquals(range.getMax(), Long.MAX_VALUE);
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Long.MIN_VALUE;
@@ -82,7 +83,7 @@ public class TestBigintType
                 .isEqualTo(Optional.of(maxValue - 1));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Long.MIN_VALUE;

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintVarcharMapType.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static io.trino.util.StructuralTestUtil.mapType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBigintVarcharMapType
         extends AbstractTestType
@@ -45,5 +48,28 @@ public class TestBigintVarcharMapType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestBooleanType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBooleanType.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.trino.block.BlockAssertions.assertBlockEquals;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -86,5 +87,26 @@ public class TestBooleanType
     protected Object getGreaterValue(Object value)
     {
         return true;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestBoundedVarcharType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBoundedVarcharType.java
@@ -19,9 +19,11 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Character.MAX_CODE_POINT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestBoundedVarcharType
@@ -55,11 +57,25 @@ public class TestBoundedVarcharType
         return Slices.utf8Slice(((Slice) value).toStringUtf8() + "_");
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Type.Range range = type.getRange().orElseThrow();
         assertEquals(range.getMin(), Slices.utf8Slice(""));
         assertEquals(range.getMax(), Slices.utf8Slice(Character.toString(MAX_CODE_POINT).repeat(((VarcharType) type).getBoundedLength())));
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestCharType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestCharType.java
@@ -31,6 +31,7 @@ import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.MIN_CODE_POINT;
 import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
 import static java.lang.Character.isSupplementaryCodePoint;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -89,11 +90,25 @@ public class TestCharType
         }
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Type.Range range = type.getRange().orElseThrow();
         assertEquals(range.getMin(), Slices.utf8Slice(Character.toString(MIN_CODE_POINT).repeat(((CharType) type).getLength())));
         assertEquals(range.getMax(), Slices.utf8Slice(Character.toString(MAX_CODE_POINT).repeat(((CharType) type).getLength())));
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestColorArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestColorArrayType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -23,6 +24,8 @@ import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.type.ColorType.COLOR;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestColorArrayType
         extends AbstractTestType
@@ -46,5 +49,28 @@ public class TestColorArrayType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getNextValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestColorType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestColorType.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import static io.trino.operator.scalar.ColorFunctions.rgb;
 import static io.trino.type.ColorType.COLOR;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestColorType
@@ -33,7 +35,7 @@ public class TestColorType
     @Test
     public void testGetObjectValue()
     {
-        int[] valuesOfInterest = new int[]{0, 1, 15, 16, 127, 128, 255};
+        int[] valuesOfInterest = new int[] {0, 1, 15, 16, 127, 128, 255};
         BlockBuilder builder = COLOR.createFixedSizeBlockBuilder(valuesOfInterest.length * valuesOfInterest.length * valuesOfInterest.length);
         for (int r : valuesOfInterest) {
             for (int g : valuesOfInterest) {
@@ -73,5 +75,28 @@ public class TestColorType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getNextValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestDateType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDateType.java
@@ -17,6 +17,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlDate;
 import io.trino.spi.type.Type.Range;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -55,7 +56,7 @@ public class TestDateType
         return ((Long) value) + 1;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -63,7 +64,7 @@ public class TestDateType
         assertEquals(range.getMax(), (long) Integer.MAX_VALUE);
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Integer.MIN_VALUE;
@@ -83,7 +84,7 @@ public class TestDateType
                 .isEqualTo(Optional.of(maxValue - 1));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Integer.MIN_VALUE;

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleType.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestDoubleType
@@ -78,5 +79,26 @@ public class TestDoubleType
         assertEquals(xxHash64Operator.xxHash64(blockBuilder, 0), xxHash64Operator.xxHash64(blockBuilder, 2));
         assertEquals(xxHash64Operator.xxHash64(blockBuilder, 0), xxHash64Operator.xxHash64(blockBuilder, 3));
         assertEquals(xxHash64Operator.xxHash64(blockBuilder, 0), xxHash64Operator.xxHash64(blockBuilder, 4));
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerArrayType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIntegerArrayType
         extends AbstractTestType
@@ -53,5 +55,26 @@ public class TestIntegerArrayType
         INTEGER.writeLong(blockBuilder, 1L);
 
         return blockBuilder.build();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type.Range;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class TestIntegerType
         return ((Long) value) + 1;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -62,7 +63,7 @@ public class TestIntegerType
         assertEquals(range.getMax(), (long) Integer.MAX_VALUE);
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Integer.MIN_VALUE;
@@ -82,7 +83,7 @@ public class TestIntegerType
                 .isEqualTo(Optional.of(maxValue - 1));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Integer.MIN_VALUE;

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerVarcharMapType.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static io.trino.util.StructuralTestUtil.mapType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIntegerVarcharMapType
         extends AbstractTestType
@@ -45,5 +48,40 @@ public class TestIntegerVarcharMapType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getPreviousValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getPreviousValue(sampleValue))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getNextValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getNextValue(sampleValue))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTimeType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalDayTimeType.java
@@ -15,8 +15,10 @@ package io.trino.type;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIntervalDayTimeType
         extends AbstractTestType
@@ -47,5 +49,26 @@ public class TestIntervalDayTimeType
     protected Object getGreaterValue(Object value)
     {
         return ((Long) value) + 1;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntervalYearMonthType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntervalYearMonthType.java
@@ -15,8 +15,10 @@ package io.trino.type;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIntervalYearMonthType
         extends AbstractTestType
@@ -47,5 +49,26 @@ public class TestIntervalYearMonthType
     protected Object getGreaterValue(Object value)
     {
         return ((Long) value) + 1;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIpAddressType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIpAddressType.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.type.IpAddressType.IPADDRESS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestIpAddressType
@@ -71,5 +72,26 @@ public class TestIpAddressType
     private static Slice getSliceForAddress(String address)
     {
         return Slices.wrappedBuffer(InetAddresses.forString(address).getAddress());
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestJsonType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestJsonType.java
@@ -17,8 +17,11 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.type.JsonType.JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestJsonType
         extends AbstractTestType
@@ -40,5 +43,28 @@ public class TestJsonType
     protected Object getGreaterValue(Object value)
     {
         return null;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getNextValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestLongDecimalType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLongDecimalType.java
@@ -19,10 +19,12 @@ import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.SqlDecimal;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
 import static io.trino.spi.type.Decimals.writeBigDecimal;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestLongDecimalType
         extends AbstractTestType
@@ -68,5 +70,26 @@ public class TestLongDecimalType
     private static BigDecimal toBigDecimal(Int128 value, int scale)
     {
         return new BigDecimal(value.toBigInteger(), scale);
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestLongTimestampType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLongTimestampType.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampType.createTimestampType;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestLongTimestampType
@@ -59,7 +60,7 @@ public class TestLongTimestampType
         return new LongTimestamp(timestamp.getEpochMicros() + 1, 0);
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -86,6 +87,20 @@ public class TestLongTimestampType
                 new MaxPrecision(10, new LongTimestamp(Long.MAX_VALUE, 999_900)),
                 new MaxPrecision(11, new LongTimestamp(Long.MAX_VALUE, 999_990)),
                 new MaxPrecision(12, new LongTimestamp(Long.MAX_VALUE, 999_999)));
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 
     record MaxPrecision(int precision, LongTimestamp expectedMax)

--- a/core/trino-main/src/test/java/io/trino/type/TestLongTimestampWithTimeZoneType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestLongTimestampWithTimeZoneType.java
@@ -18,10 +18,13 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
 import io.trino.spi.type.Type;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
@@ -61,7 +64,7 @@ public class TestLongTimestampWithTimeZoneType
         return LongTimestampWithTimeZone.fromEpochMillisAndFraction(((LongTimestampWithTimeZone) value).getEpochMillis() + 1, 0, getTimeZoneKeyForOffset(33));
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY);
@@ -83,7 +86,7 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.of(previousToMaxValue));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         LongTimestampWithTimeZone minValue = LongTimestampWithTimeZone.fromEpochMillisAndFraction(Long.MIN_VALUE, 0, UTC_KEY);
@@ -105,7 +108,8 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.empty());
     }
 
-    @Test(dataProvider = "testPreviousNextValueEveryPrecisionDatProvider")
+    @ParameterizedTest
+    @MethodSource("testPreviousNextValueEveryPrecisionDataProvider")
     public void testPreviousValueEveryPrecision(int precision, long minValue, long maxValue, long step)
     {
         Type type = createTimestampType(precision);
@@ -126,7 +130,8 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.of(maxValue - step));
     }
 
-    @Test(dataProvider = "testPreviousNextValueEveryPrecisionDatProvider")
+    @ParameterizedTest
+    @MethodSource("testPreviousNextValueEveryPrecisionDataProvider")
     public void testNextValueEveryPrecision(int precision, long minValue, long maxValue, long step)
     {
         Type type = createTimestampType(precision);
@@ -147,17 +152,22 @@ public class TestLongTimestampWithTimeZoneType
                 .isEqualTo(Optional.empty());
     }
 
-    @DataProvider
-    public Object[][] testPreviousNextValueEveryPrecisionDatProvider()
+    public static Stream<Arguments> testPreviousNextValueEveryPrecisionDataProvider()
     {
-        return new Object[][] {
-                {0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807, 1_000_000L},
-                {1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807, 100_000L},
-                {2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807, 10_000L},
-                {3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807, 1_000L},
-                {4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 100L},
-                {5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 10L},
-                {6, Long.MIN_VALUE, Long.MAX_VALUE, 1L},
-        };
+        return Stream.of(
+                Arguments.of(0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807, 1_000_000L),
+                Arguments.of(1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807, 100_000L),
+                Arguments.of(2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807, 10_000L),
+                Arguments.of(3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807, 1_000L),
+                Arguments.of(4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 100L),
+                Arguments.of(5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 10L),
+                Arguments.of(6, Long.MIN_VALUE, Long.MAX_VALUE, 1L));
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestRealType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealType.java
@@ -23,6 +23,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Float.intBitsToFloat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 public class TestRealType
@@ -74,5 +75,26 @@ public class TestRealType
         assertEquals(hashCodeOperator.hashCode(blockBuilder, 0), hashCodeOperator.hashCode(blockBuilder, 2));
         assertEquals(hashCodeOperator.hashCode(blockBuilder, 0), hashCodeOperator.hashCode(blockBuilder, 3));
         assertEquals(hashCodeOperator.hashCode(blockBuilder, 0), hashCodeOperator.hashCode(blockBuilder, 4));
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestShortDecimalType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestShortDecimalType.java
@@ -17,8 +17,10 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.SqlDecimal;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestShortDecimalType
         extends AbstractTestType
@@ -51,5 +53,26 @@ public class TestShortDecimalType
     protected Object getGreaterValue(Object value)
     {
         return ((long) value) + 1;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestShortTimestampType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestShortTimestampType.java
@@ -18,10 +18,13 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.Type.Range;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.createTimestampType;
@@ -59,7 +62,7 @@ public class TestShortTimestampType
         return ((Long) value) + 1_000;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -67,7 +70,8 @@ public class TestShortTimestampType
         assertEquals(range.getMax(), Long.MAX_VALUE - 807);
     }
 
-    @Test(dataProvider = "testRangeEveryPrecisionDataProvider")
+    @ParameterizedTest
+    @MethodSource("testRangeEveryPrecisionDataProvider")
     public void testRangeEveryPrecision(int precision, long expectedMin, long expectedMax)
     {
         Range range = createTimestampType(precision).getRange().orElseThrow();
@@ -75,21 +79,19 @@ public class TestShortTimestampType
         assertEquals(range.getMax(), expectedMax);
     }
 
-    @DataProvider
-    public static Object[][] testRangeEveryPrecisionDataProvider()
+    public static Stream<Arguments> testRangeEveryPrecisionDataProvider()
     {
-        return new Object[][] {
-                {0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807},
-                {1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807},
-                {2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807},
-                {3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807},
-                {4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7},
-                {5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7},
-                {6, Long.MIN_VALUE, Long.MAX_VALUE},
-        };
+        return Stream.of(
+                Arguments.of(0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807),
+                Arguments.of(1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807),
+                Arguments.of(2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807),
+                Arguments.of(3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807),
+                Arguments.of(4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7),
+                Arguments.of(5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7),
+                Arguments.of(6, Long.MIN_VALUE, Long.MAX_VALUE));
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Long.MIN_VALUE + 808;
@@ -109,7 +111,7 @@ public class TestShortTimestampType
                 .isEqualTo(Optional.of(maxValue - 1_000));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Long.MIN_VALUE + 808;
@@ -129,7 +131,8 @@ public class TestShortTimestampType
                 .isEqualTo(Optional.empty());
     }
 
-    @Test(dataProvider = "testPreviousNextValueEveryPrecisionDatProvider")
+    @ParameterizedTest
+    @MethodSource("testPreviousNextValueEveryPrecisionDataProvider")
     public void testPreviousValueEveryPrecision(int precision, long minValue, long maxValue, long step)
     {
         Type type = createTimestampType(precision);
@@ -150,7 +153,8 @@ public class TestShortTimestampType
                 .isEqualTo(Optional.of(maxValue - step));
     }
 
-    @Test(dataProvider = "testPreviousNextValueEveryPrecisionDatProvider")
+    @ParameterizedTest
+    @MethodSource("testPreviousNextValueEveryPrecisionDataProvider")
     public void testNextValueEveryPrecision(int precision, long minValue, long maxValue, long step)
     {
         Type type = createTimestampType(precision);
@@ -171,17 +175,15 @@ public class TestShortTimestampType
                 .isEqualTo(Optional.empty());
     }
 
-    @DataProvider
-    public Object[][] testPreviousNextValueEveryPrecisionDatProvider()
+    public static Stream<Arguments> testPreviousNextValueEveryPrecisionDataProvider()
     {
-        return new Object[][] {
-                {0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807, 1_000_000L},
-                {1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807, 100_000L},
-                {2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807, 10_000L},
-                {3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807, 1_000L},
-                {4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 100L},
-                {5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 10L},
-                {6, Long.MIN_VALUE, Long.MAX_VALUE, 1L},
-        };
+        return Stream.of(
+                Arguments.of(0, Long.MIN_VALUE + 775808, Long.MAX_VALUE - 775807, 1_000_000L),
+                Arguments.of(1, Long.MIN_VALUE + 75808, Long.MAX_VALUE - 75807, 100_000L),
+                Arguments.of(2, Long.MIN_VALUE + 5808, Long.MAX_VALUE - 5807, 10_000L),
+                Arguments.of(3, Long.MIN_VALUE + 808, Long.MAX_VALUE - 807, 1_000L),
+                Arguments.of(4, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 100L),
+                Arguments.of(5, Long.MIN_VALUE + 8, Long.MAX_VALUE - 7, 10L),
+                Arguments.of(6, Long.MIN_VALUE, Long.MAX_VALUE, 1L));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestShortTimestampWithTimeZoneType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestShortTimestampWithTimeZoneType.java
@@ -16,11 +16,13 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKeyForOffset;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestShortTimestampWithTimeZoneType
         extends AbstractTestType
@@ -52,5 +54,26 @@ public class TestShortTimestampWithTimeZoneType
     {
         // time zone doesn't matter for ordering
         return packDateTimeWithZone(unpackMillisUtc((Long) value) + 10, getTimeZoneKeyForOffset(33));
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestSimpleRowType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSimpleRowType.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlockBuilder;
 import io.trino.spi.type.RowType;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ import static io.trino.spi.block.RowValueBuilder.buildRowValue;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSimpleRowType
         extends AbstractTestType
@@ -68,5 +70,26 @@ public class TestSimpleRowType
             BIGINT.writeLong(fieldBuilders.get(0), block.getSingleValueBlock(0).getLong(0, 0) + 1);
             VARCHAR.writeSlice(fieldBuilders.get(1), block.getSingleValueBlock(1).getSlice(0, 0, 1));
         });
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintArrayType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSmallintArrayType
         extends AbstractTestType
@@ -53,5 +55,26 @@ public class TestSmallintArrayType
         SMALLINT.writeLong(blockBuilder, 1L);
 
         return blockBuilder.build();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type.Range;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class TestSmallintType
         return ((Long) value) + 1;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -62,7 +63,7 @@ public class TestSmallintType
         assertEquals(range.getMax(), (long) Short.MAX_VALUE);
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Short.MIN_VALUE;
@@ -82,7 +83,7 @@ public class TestSmallintType
                 .isEqualTo(Optional.of(maxValue - 1));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Short.MIN_VALUE;

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintVarcharMapType.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static io.trino.util.StructuralTestUtil.mapType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestSmallintVarcharMapType
         extends AbstractTestType
@@ -45,5 +48,28 @@ public class TestSmallintVarcharMapType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getNextValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTimeType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTimeType.java
@@ -16,8 +16,10 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlTime;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTimeType
         extends AbstractTestType
@@ -48,5 +50,26 @@ public class TestTimeType
     protected Object getGreaterValue(Object value)
     {
         return ((Long) value) + 1;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTimeWithTimeZoneType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTimeWithTimeZoneType.java
@@ -16,11 +16,13 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlTimeWithTimeZone;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.DateTimeEncoding.packTimeWithTimeZone;
 import static io.trino.spi.type.DateTimeEncoding.unpackOffsetMinutes;
 import static io.trino.spi.type.DateTimeEncoding.unpackTimeNanos;
 import static io.trino.spi.type.TimeWithTimeZoneType.TIME_TZ_MILLIS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTimeWithTimeZoneType
         extends AbstractTestType
@@ -51,5 +53,26 @@ public class TestTimeWithTimeZoneType
     protected Object getGreaterValue(Object value)
     {
         return packTimeWithTimeZone(unpackTimeNanos((Long) value) + 10, unpackOffsetMinutes((Long) value));
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintArrayType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestTinyintArrayType
         extends AbstractTestType
@@ -53,5 +55,26 @@ public class TestTinyintArrayType
         TINYINT.writeLong(blockBuilder, 1L);
 
         return blockBuilder.build();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintType.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type.Range;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
@@ -54,7 +55,7 @@ public class TestTinyintType
         return ((Long) value) + 1;
     }
 
-    @Override
+    @Test
     public void testRange()
     {
         Range range = type.getRange().orElseThrow();
@@ -62,7 +63,7 @@ public class TestTinyintType
         assertEquals(range.getMax(), (long) Byte.MAX_VALUE);
     }
 
-    @Override
+    @Test
     public void testPreviousValue()
     {
         long minValue = Byte.MIN_VALUE;
@@ -82,7 +83,7 @@ public class TestTinyintType
                 .isEqualTo(Optional.of(maxValue - 1));
     }
 
-    @Override
+    @Test
     public void testNextValue()
     {
         long minValue = Byte.MIN_VALUE;

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintVarcharMapType.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -24,6 +25,8 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static io.trino.util.StructuralTestUtil.mapType;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTinyintVarcharMapType
         extends AbstractTestType
@@ -45,5 +48,28 @@ public class TestTinyintVarcharMapType
     protected Object getGreaterValue(Object value)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThatThrownBy(() -> type.getNextValue(getSampleValue()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Type is not orderable: " + type);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestUnboundedVarcharType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestUnboundedVarcharType.java
@@ -17,8 +17,10 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUnboundedVarcharType
         extends AbstractTestType
@@ -49,5 +51,26 @@ public class TestUnboundedVarcharType
     protected Object getGreaterValue(Object value)
     {
         return Slices.utf8Slice(((Slice) value).toStringUtf8() + "_");
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestUnknownType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestUnknownType.java
@@ -13,7 +13,10 @@
  */
 package io.trino.type;
 
+import org.junit.jupiter.api.Test;
+
 import static io.trino.type.UnknownType.UNKNOWN;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUnknownType
         extends AbstractTestType
@@ -35,15 +38,10 @@ public class TestUnknownType
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public void testPreviousValue()
+    @Test
+    public void testRange()
     {
-        // There is no value of this type, so getPreviousValue() cannot be invoked
-    }
-
-    @Override
-    public void testNextValue()
-    {
-        // There is no value of this type, so getNextValue() cannot be invoked
+        assertThat(type.getRange())
+                .isEmpty();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestUuidType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestUuidType.java
@@ -114,4 +114,25 @@ public class TestUuidType
                 .as("comparing slices lexicographically")
                 .isLessThan(higherSlice);
     }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestVarbinaryType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVarbinaryType.java
@@ -18,8 +18,10 @@ import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.SqlVarbinary;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestVarbinaryType
         extends AbstractTestType
@@ -50,5 +52,26 @@ public class TestVarbinaryType
     protected Object getGreaterValue(Object value)
     {
         return Slices.utf8Slice(((Slice) value).toStringUtf8() + "_");
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeType.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeType.java
@@ -19,11 +19,14 @@ import io.trino.geospatial.Rectangle;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.type.AbstractTestType;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.OptionalInt;
 
 import static io.trino.plugin.geospatial.KdbTreeType.KDB_TREE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestKdbTreeType
         extends AbstractTestType
@@ -50,5 +53,40 @@ public class TestKdbTreeType
     protected Object getGreaterValue(Object value)
     {
         return null;
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getPreviousValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getPreviousValue(sampleValue))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getNextValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getNextValue(sampleValue))
+                .isEmpty();
     }
 }


### PR DESCRIPTION
Do not use inheritance/overriding for code reuse and specialization, as it makes it harder to reason about what's being tested.

Also, annotate the tests directly so that they are picked up by JUnit


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
