### PR TITLE
Deprecate getTableHandle without versions

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -104,8 +104,10 @@ public interface ConnectorMetadata
      * cannot be queried.
      * @see #getView(ConnectorSession, SchemaTableName)
      * @see #getMaterializedView(ConnectorSession, SchemaTableName)
+     * @deprecated Implement {@link #getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional)}.
      */
     @Nullable
+    @Deprecated
     default ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         return null;


### PR DESCRIPTION
It got superseded by an overload that takes versions in 2a466edc37e26047d8cbc7f98023aa62452e782c. It should be deprecated since then. Some connectors (like Iceberg) do not implement the version-less overload at all.

Notes
```
# SPI
* Deprecate `ConnectorMetadata.getTableHandle(ConnectorSession, SchemaTableName)`.
  Connectors should implement `ConnectorMetadata.getTableHandle(ConnectorSession, SchemaTableName, Optional, Optional)`.
```
