### PR TITLE
Close Input Streams in HDFS and Local Exchange storage

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/local/LocalFileSystemExchangeStorage.java
@@ -159,8 +159,13 @@ public class LocalFileSystemExchangeStorage
                 return null;
             }
 
-            if (sliceInput != null && sliceInput.isReadable()) {
-                return sliceInput.readSlice(sliceInput.readInt());
+            if (sliceInput != null) {
+                if (sliceInput.isReadable()) {
+                    return sliceInput.readSlice(sliceInput.readInt());
+                }
+                else {
+                    sliceInput.close();
+                }
             }
 
             ExchangeSourceFile sourceFile = sourceFiles.poll();

--- a/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
+++ b/plugin/trino-exchange-hdfs/src/main/java/io/trino/plugin/exchange/hdfs/HadoopFileSystemExchangeStorage.java
@@ -174,8 +174,13 @@ public class HadoopFileSystemExchangeStorage
                 return null;
             }
 
-            if (sliceInput != null && sliceInput.isReadable()) {
-                return sliceInput.readSlice(sliceInput.readInt());
+            if (sliceInput != null) {
+                if (sliceInput.isReadable()) {
+                    return sliceInput.readSlice(sliceInput.readInt());
+                }
+                else {
+                    sliceInput.close();
+                }
             }
 
             ExchangeSourceFile sourceFile = sourceFiles.poll();


### PR DESCRIPTION
## Description
When reading slices in HDFS and Local exchange storage, all input streams are not getting closed leading to connection leaks.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
