### PR TITLE
Remove redundant QualifiedTablePrefix.matches checks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -529,7 +529,6 @@ public final class MetadataManager
                 metadata.listTables(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .filter(table -> !isExternalInformationSchema(catalogHandle, table.getSchemaName()))
-                        .filter(prefix::matches)
                         .forEach(tables::add);
             }
         }
@@ -1186,7 +1185,6 @@ public final class MetadataManager
                 metadata.listViews(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .filter(view -> !isExternalInformationSchema(catalogHandle, view.getSchemaName()))
-                        .filter(prefix::matches)
                         .forEach(views::add);
             }
         }
@@ -1420,7 +1418,6 @@ public final class MetadataManager
                 metadata.listMaterializedViews(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .filter(materializedView -> !isExternalInformationSchema(catalogHandle, materializedView.getSchemaName()))
-                        .filter(prefix::matches)
                         .forEach(materializedViews::add);
             }
         }


### PR DESCRIPTION
The case where table name is present is handled earlier in the method (`prefix.asQualifiedObjectName().isPresent()` check). The connector is asked to list entities for given schema (or all entities if schema is `Optional.empty`), thus subsequent check for `prefix.matches` was redundant.
