### PR TITLE
Allow splitting textfiles using BZIP2 compression

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -151,10 +151,13 @@ public enum HiveStorageFormat
 
     public boolean isSplittable(String path)
     {
-        // Only uncompressed text input format is splittable
         return switch (this) {
             case ORC, PARQUET, AVRO, RCBINARY, RCTEXT, SEQUENCEFILE -> true;
-            case JSON, OPENX_JSON, TEXTFILE, CSV, REGEX -> CompressionKind.forFile(path).isEmpty();
+            case JSON, OPENX_JSON, TEXTFILE, CSV, REGEX -> {
+                // Only uncompressed or BZIP2 text input format files are splittable
+                Optional<CompressionKind> compressionKind = CompressionKind.forFile(path);
+                yield compressionKind.isEmpty() || CompressionKind.BZIP2 == compressionKind.get();
+            }
         };
     }
 


### PR DESCRIPTION
## Description
The logic that determined whether text files were splittable before https://github.com/trinodb/trino/pull/16531 checked whether the hadoop `CompressionCodec` used was an instance of `SplittableCompressionCodec`, which the `BZip2Codec` was. This change restores that behavior and allows splitting BZIP2 compressed text files.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Allow splitting text files compressed with BZIP2 to improve parallelism
```
