### PR TITLE
Restore original behavior for URI extract functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/UrlFunctions.java
@@ -34,7 +34,6 @@ import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Iterator;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
@@ -54,8 +53,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractProtocol(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        return slice(uri.getScheme());
+        URI uri = parseUrl(url);
+        return (uri == null) ? null : slice(uri.getScheme());
     }
 
     @SqlNullable
@@ -65,8 +64,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractHost(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        return slice(uri.getHost());
+        URI uri = parseUrl(url);
+        return (uri == null) ? null : slice(uri.getHost());
     }
 
     @SqlNullable
@@ -76,8 +75,8 @@ public final class UrlFunctions
     @SqlType(StandardTypes.BIGINT)
     public static Long urlExtractPort(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        if (uri.getPort() < 0) {
+        URI uri = parseUrl(url);
+        if ((uri == null) || (uri.getPort() < 0)) {
             return null;
         }
         return (long) uri.getPort();
@@ -90,8 +89,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractPath(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        return slice(uri.getPath());
+        URI uri = parseUrl(url);
+        return (uri == null) ? null : slice(uri.getPath());
     }
 
     @SqlNullable
@@ -101,8 +100,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractQuery(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        return slice(uri.getQuery());
+        URI uri = parseUrl(url);
+        return (uri == null) ? null : slice(uri.getQuery());
     }
 
     @SqlNullable
@@ -112,8 +111,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractFragment(@SqlType("varchar(x)") Slice url)
     {
-        URI uri = parseUriArgument(url);
-        return slice(uri.getFragment());
+        URI uri = parseUrl(url);
+        return (uri == null) ? null : slice(uri.getFragment());
     }
 
     @SqlNullable
@@ -123,8 +122,8 @@ public final class UrlFunctions
     @SqlType("varchar(x)")
     public static Slice urlExtractParameter(@SqlType("varchar(x)") Slice url, @SqlType("varchar(y)") Slice parameterName)
     {
-        URI uri = parseUriArgument(url);
-        if (uri.getRawQuery() == null) {
+        URI uri = parseUrl(url);
+        if ((uri == null) || (uri.getRawQuery() == null)) {
             return null;
         }
 
@@ -185,13 +184,13 @@ public final class UrlFunctions
     }
 
     @Nullable
-    private static URI parseUriArgument(Slice url)
+    private static URI parseUrl(Slice url)
     {
         try {
             return new URI(url.toStringUtf8());
         }
         catch (URISyntaxException e) {
-            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Cannot parse as URI value '%s': %s".formatted(url.toStringUtf8(), firstNonNull(e.getMessage(), e)), e);
+            return null;
         }
     }
 }


### PR DESCRIPTION
This reverts commit 3befdbb4736b034ca1bd876357ae5294dd426d48 which introduces a backward incompatible change to the behavior of those functions.

The original behavior was intentional, and dates back to when alternatives such as try() didn't exist. Changing their behavior requires more careful consideration and exploration of possible alternatives. If we decide to break compatibility, we may need a way to restore the legacy behavior during the transition.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
