### PR TITLE
Add support for DROP SCHEMA CASCADE in Kudu and MongoDB

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -261,9 +261,9 @@ public class KuduClientSession
         schemaEmulation.createSchema(client, schemaName);
     }
 
-    public void dropSchema(String schemaName)
+    public void dropSchema(String schemaName, boolean cascade)
     {
-        schemaEmulation.dropSchema(client, schemaName);
+        schemaEmulation.dropSchema(client, schemaName, cascade);
     }
 
     public void dropTable(SchemaTableName schemaTableName)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -242,9 +242,9 @@ public class KuduMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
-        clientSession.dropSchema(schemaName);
+        clientSession.dropSchema(schemaName, cascade);
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/NoSchemaEmulation.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/NoSchemaEmulation.java
@@ -37,7 +37,7 @@ public class NoSchemaEmulation
     }
 
     @Override
-    public void dropSchema(KuduClientWrapper client, String schemaName)
+    public void dropSchema(KuduClientWrapper client, String schemaName, boolean cascade)
     {
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new TrinoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulation.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulation.java
@@ -22,7 +22,7 @@ public interface SchemaEmulation
 {
     void createSchema(KuduClientWrapper client, String schemaName);
 
-    void dropSchema(KuduClientWrapper client, String schemaName);
+    void dropSchema(KuduClientWrapper client, String schemaName, boolean cascade);
 
     boolean existsSchema(KuduClientWrapper client, String schemaName);
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulationByTableNameConvention.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/schema/SchemaEmulationByTableNameConvention.java
@@ -39,6 +39,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.kudu.KuduClientSession.DEFAULT_SCHEMA;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
+import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 
 public class SchemaEmulationByTableNameConvention
         implements SchemaEmulation
@@ -81,14 +82,18 @@ public class SchemaEmulationByTableNameConvention
     }
 
     @Override
-    public void dropSchema(KuduClientWrapper client, String schemaName)
+    public void dropSchema(KuduClientWrapper client, String schemaName, boolean cascade)
     {
         if (DEFAULT_SCHEMA.equals(schemaName)) {
             throw new TrinoException(GENERIC_USER_ERROR, "Deleting default schema not allowed.");
         }
         try (KuduOperationApplier operationApplier = KuduOperationApplier.fromKuduClientWrapper(client)) {
             String prefix = getPrefixForTablesOfSchema(schemaName);
-            for (String name : client.getTablesList(prefix).getTablesList()) {
+            List<String> tables = client.getTablesList(prefix).getTablesList();
+            if (!cascade && !tables.isEmpty()) {
+                throw new TrinoException(SCHEMA_NOT_EMPTY, "Cannot drop non-empty schema '%s'".formatted(schemaName));
+            }
+            for (String name : tables) {
                 client.deleteTable(name);
             }
 

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -72,7 +72,6 @@ public class TestKuduConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
-            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -147,9 +147,9 @@ public class MongoMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
-        mongoSession.dropSchema(schemaName);
+        mongoSession.dropSchema(schemaName, cascade);
     }
 
     @Override

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -93,6 +93,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
 import static io.trino.plugin.mongodb.ptf.Query.parseFilter;
 import static io.trino.spi.HostAddress.fromParts;
+import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.Chars.padSpaces;
@@ -212,9 +213,20 @@ public class MongoSession
         client.getDatabase(schemaName).createCollection(schemaCollection);
     }
 
-    public void dropSchema(String schemaName)
+    public void dropSchema(String schemaName, boolean cascade)
     {
-        client.getDatabase(toRemoteSchemaName(schemaName)).drop();
+        MongoDatabase database = client.getDatabase(toRemoteSchemaName(schemaName));
+        if (!cascade) {
+            try (MongoCursor<String> collections = database.listCollectionNames().cursor()) {
+                while (collections.hasNext()) {
+                    if (collections.next().equals(schemaCollection)) {
+                        continue;
+                    }
+                    throw new TrinoException(SCHEMA_NOT_EMPTY, "Cannot drop non-empty schema '%s'".formatted(schemaName));
+                }
+            }
+        }
+        database.drop();
     }
 
     public Set<String> getAllTables(String schema)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -107,7 +107,6 @@ public class TestMongoConnectorTest
                 return false;
 
             case SUPPORTS_RENAME_SCHEMA:
-            case SUPPORTS_DROP_SCHEMA_CASCADE:
                 return false;
 
             case SUPPORTS_ADD_FIELD:


### PR DESCRIPTION
## Description

Add support for DROP SCHEMA CASCADE in Kudu and MongoDB
Relates to #17649

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Kudu, MongoDB
* Add support for `CASCADE` option in `DROP SCHEMA` statement. ({issue}`issuenumber`)
```
