### PR TITLE
Updated docs for PEM format support

### DIFF
--- a/docs/src/main/sphinx/security/inspect-pem.md
+++ b/docs/src/main/sphinx/security/inspect-pem.md
@@ -52,7 +52,8 @@ MIIEowIBAAKCAQEAwJL8CLeDFAHhZe3QOOF1vWt4Vuk9vyO38Y1y9SgBfB02b2jW
 If your key section reports `BEGIN ENCRYPTED PRIVATE KEY` instead, this means
 the key is encrypted and you must use the password to open or inspect the key.
 You may have specified the password when requesting the key, or the password
-could be assigned by your site's network managers.
+could be assigned by your site's network managers. Note that password protected
+PEM files are not supported by Trino.
 
 If your key section reports `BEGIN EC PRIVATE KEY` or `BEGIN DSA PRIVATE
 KEY`, this designates a key using Elliptical Curve or DSA alternatives to RSA.
@@ -107,6 +108,7 @@ openssl x509 -in clustercoord.pem -text -noout
 ```
 
 If your certificate was generated with a password, `openssl` prompts for it.
+Note that password protected PEM files are not supported by Trino.
 
 In the output of the `openssl` command, look for the following
 characteristics:

--- a/docs/src/main/sphinx/security/tls.md
+++ b/docs/src/main/sphinx/security/tls.md
@@ -220,9 +220,8 @@ http-server.https.keystore.path=/usr/local/certs/clustercoord.p12
 Relative paths are relative to the Trino server's root directory. In a
 `tar.gz` installation, the root directory is one level above `etc`.
 
-JKS keystores always require a password, while PEM format certificates can
-optionally require a password. For cases where you need a password, add the
-following line to the configuration.
+JKS keystores always require a password, while PEM files with passwords are not
+supported by Trino. For JKS, add the following line to the configuration:
 
 ```text
 http-server.https.keystore.key=<keystore-password>


### PR DESCRIPTION
## Description

Specifically add that password protected PEM files are not supported.

FYI [jdsjdk](https://github.com/jdsjdk)

## Additional context and related issues

Result of discussion in https://github.com/trinodb/trino/issues/17300

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
