### PR TITLE
Remove redundant character range in TypeCalculation

### DIFF
--- a/core/trino-grammar/src/main/antlr4/io/trino/grammar/type/TypeCalculation.g4
+++ b/core/trino-grammar/src/main/antlr4/io/trino/grammar/type/TypeCalculation.g4
@@ -59,7 +59,7 @@ fragment DIGIT
     ;
 
 fragment LETTER
-    : [A-Za-z]
+    : [A-Z]
     ;
 
 WS


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
