### PR TITLE
Require the JVM default charset is UTF-8

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -24,6 +24,8 @@ import java.lang.Runtime.Version;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.OptionalLong;
@@ -48,6 +50,7 @@ final class TrinoSystemRequirements
         verifyUsingG1Gc();
         verifyFileDescriptor();
         verifySlice();
+        verifyUtf8();
     }
 
     private static void verify64BitJvm()
@@ -147,6 +150,14 @@ final class TrinoSystemRequirements
         slice.setByte(1, 0xEF);
         if (slice.getInt(1) != 0xDEADBEEF) {
             failRequirement("Slice library produced an unexpected result");
+        }
+    }
+
+    private static void verifyUtf8()
+    {
+        Charset defaultCharset = Charset.defaultCharset();
+        if (!defaultCharset.equals(StandardCharsets.UTF_8)) {
+            failRequirement("Trino requires that the default charset is UTF-8 (found %s). This can be set with the JVM command line option -Dfile.encoding=UTF-8", defaultCharset.name());
         }
     }
 

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -44,6 +44,10 @@ as the JDK for Trino, as Trino is tested against that distribution.
 Zulu is also the JDK used by the
 [Trino Docker image](https://hub.docker.com/r/trinodb/trino).
 
+If you are using Java 17 or 18, the JVM must be configured to use UTF-8 as the default charset by
+adding `-Dfile.encoding=UTF-8` to `etc/jvm.config`. Starting with Java 19, the Java default 
+charset is UTF-8, so this configuration is not needed.
+
 (requirements-python)=
 
 ### Python
@@ -136,6 +140,7 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -Djdk.nio.maxCachedBufferSize=2000000
 -XX:+UnlockDiagnosticVMOptions
 -XX:+UseAESCTRIntrinsics
+-Dfile.encoding=UTF-8
 # Disable Preventive GC for performance reasons (JDK-8293861)
 -XX:-G1UsePreventiveGC
 ```


### PR DESCRIPTION
Java changed the default charset to UTF-8 in JEP 400 which is in Java 19

The error message is:
```
Trino requires that the default charset is UTF-8 (found XYZ). This can be set with the JVM command line option -Dfile.encoding=UTF-8
```

## Release notes

( ) Release notes are required, with the following suggested text:

```markdown
# General
* The JVM default charset is now required to be UTF-8. This can be set with the JVM command line option -Dfile.encoding=UTF-8. ({issue}`issuenumber`)
```
