### PR TITLE
Add physicalWrittenBytes to StatementStats

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/StatementStats.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementStats.java
@@ -43,6 +43,7 @@ public class StatementStats
     private final long processedRows;
     private final long processedBytes;
     private final long physicalInputBytes;
+    private final long physicalWrittenBytes;
     private final long peakMemoryBytes;
     private final long spilledBytes;
     private final StageStats rootStage;
@@ -66,6 +67,7 @@ public class StatementStats
             @JsonProperty("processedRows") long processedRows,
             @JsonProperty("processedBytes") long processedBytes,
             @JsonProperty("physicalInputBytes") long physicalInputBytes,
+            @JsonProperty("physicalWrittenBytes") long physicalWrittenBytes,
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("rootStage") StageStats rootStage)
@@ -87,6 +89,7 @@ public class StatementStats
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
         this.physicalInputBytes = physicalInputBytes;
+        this.physicalWrittenBytes = physicalWrittenBytes;
         this.peakMemoryBytes = peakMemoryBytes;
         this.spilledBytes = spilledBytes;
         this.rootStage = rootStage;
@@ -195,6 +198,12 @@ public class StatementStats
     }
 
     @JsonProperty
+    public long getPhysicalWrittenBytes()
+    {
+        return physicalWrittenBytes;
+    }
+
+    @JsonProperty
     public long getPeakMemoryBytes()
     {
         return peakMemoryBytes;
@@ -234,6 +243,7 @@ public class StatementStats
                 .add("processedRows", processedRows)
                 .add("processedBytes", processedBytes)
                 .add("physicalInputBytes", physicalInputBytes)
+                .add("physicalWrittenBytes", physicalWrittenBytes)
                 .add("peakMemoryBytes", peakMemoryBytes)
                 .add("spilledBytes", spilledBytes)
                 .add("rootStage", rootStage)
@@ -264,6 +274,7 @@ public class StatementStats
         private long processedRows;
         private long processedBytes;
         private long physicalInputBytes;
+        private long physicalWrittenBytes;
         private long peakMemoryBytes;
         private long spilledBytes;
         private StageStats rootStage;
@@ -372,6 +383,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setPhysicalWrittenBytes(long physicalWrittenBytes)
+        {
+            this.physicalWrittenBytes = physicalWrittenBytes;
+            return this;
+        }
+
         public Builder setPeakMemoryBytes(long peakMemoryBytes)
         {
             this.peakMemoryBytes = peakMemoryBytes;
@@ -410,6 +427,7 @@ public class StatementStats
                     processedRows,
                     processedBytes,
                     physicalInputBytes,
+                    physicalWrittenBytes,
                     peakMemoryBytes,
                     spilledBytes,
                     rootStage);

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
@@ -92,7 +92,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, OptionalDouble.of(0), OptionalDouble.of(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, OptionalDouble.of(0), OptionalDouble.of(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ProtocolUtil.java
@@ -193,6 +193,7 @@ public final class ProtocolUtil
                 .setProcessedRows(queryStats.getRawInputPositions())
                 .setProcessedBytes(queryStats.getRawInputDataSize().toBytes())
                 .setPhysicalInputBytes(queryStats.getPhysicalInputDataSize().toBytes())
+                .setPhysicalWrittenBytes(queryStats.getPhysicalWrittenDataSize().toBytes())
                 .setPeakMemoryBytes(queryStats.getPeakUserMemoryReservation().toBytes())
                 .setSpilledBytes(queryStats.getSpilledDataSize().toBytes())
                 .setRootStage(rootStageStats)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Includes the number of bytes written as part of the HTTP query result statistics.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Resolves https://github.com/trinodb/trino/issues/18651

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Add number of bytes written to HTTP query results response. ({issue}`18651`)
```
