### PR TITLE
Add support for DROP SCHEMA CASCADE in PostgreSQL

### DIFF
--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -346,17 +346,6 @@ public class PostgreSqlClient
     }
 
     @Override
-    protected void dropSchema(ConnectorSession session, Connection connection, String remoteSchemaName, boolean cascade)
-            throws SQLException
-    {
-        if (cascade) {
-            // Dropping schema with cascade option may lead to other metadata listing operations. Disable until finding the solution.
-            throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas with CASCADE option");
-        }
-        execute(session, connection, "DROP SCHEMA " + quoted(remoteSchemaName));
-    }
-
-    @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
         try {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -116,9 +116,6 @@ public class TestPostgreSqlConnectorTest
             case SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN:
                 return false;
 
-            case SUPPORTS_DROP_SCHEMA_CASCADE:
-                return false;
-
             case SUPPORTS_CREATE_TABLE_WITH_COLUMN_COMMENT:
             case SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS:
                 return false;


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# PostgreSQL
* Add support for `CASCADE` option in `DROP SCHEMA` statement. ({issue}`18663`)
```
