### PR TITLE
Improve Hive JSON writer performance

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/json/JsonSerializer.java
@@ -15,6 +15,7 @@ package io.trino.hive.formats.line.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.io.SerializedString;
 import io.airlift.slice.SliceOutput;
 import io.trino.hive.formats.HiveFormatUtils;
 import io.trino.hive.formats.line.Column;
@@ -37,7 +38,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Locale;
-import java.util.function.IntFunction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -52,6 +52,7 @@ import static io.trino.spi.type.RowType.field;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Deserializer that is bug for bug compatible with Hive JsonSerDe.
@@ -61,12 +62,15 @@ public class JsonSerializer
 {
     private final RowType type;
     private final JsonFactory jsonFactory;
+    private final FieldWriter[] fieldWriters;
 
     public JsonSerializer(List<Column> columns)
     {
         this.type = RowType.from(columns.stream()
                 .map(column -> field(column.name().toLowerCase(Locale.ROOT), column.type()))
                 .collect(toImmutableList()));
+
+        fieldWriters = createRowTypeFieldWriters(this.type);
 
         jsonFactory = jsonFactory();
     }
@@ -82,157 +86,219 @@ public class JsonSerializer
             throws IOException
     {
         try (JsonGenerator generator = jsonFactory.createGenerator((OutputStream) sliceOutput)) {
-            writeStruct(generator, type, page::getBlock, position);
+            generator.writeStartObject();
+            for (int field = 0; field < fieldWriters.length; field++) {
+                fieldWriters[field].writeField(generator, page.getBlock(field), position);
+            }
+            generator.writeEndObject();
         }
     }
 
-    private static void writeStruct(JsonGenerator generator, RowType rowType, IntFunction<Block> blocks, int position)
-            throws IOException
+    private static ValueWriter createValueWriter(Type type)
     {
-        generator.writeStartObject();
-        List<Field> fields = rowType.getFields();
-        for (int fieldIndex = 0; fieldIndex < fields.size(); fieldIndex++) {
-            Field field = fields.get(fieldIndex);
-            generator.writeFieldName(field.getName().orElseThrow());
-            Block block = blocks.apply(fieldIndex);
-            writeValue(generator, field.getType(), block, position);
-        }
-        generator.writeEndObject();
-    }
-
-    private static void writeValue(JsonGenerator generator, Type type, Block block, int position)
-            throws IOException
-    {
-        if (block.isNull(position)) {
-            generator.writeNull();
-            return;
-        }
-
         if (BOOLEAN.equals(type)) {
-            generator.writeBoolean(BOOLEAN.getBoolean(block, position));
+            return (generator, block, position) -> generator.writeBoolean(BOOLEAN.getBoolean(block, position));
         }
         else if (BIGINT.equals(type)) {
-            generator.writeNumber(BIGINT.getLong(block, position));
+            return (generator, block, position) -> generator.writeNumber(BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            generator.writeNumber(INTEGER.getInt(block, position));
+            return (generator, block, position) -> generator.writeNumber(INTEGER.getInt(block, position));
         }
         else if (SMALLINT.equals(type)) {
-            generator.writeNumber(SMALLINT.getShort(block, position));
+            return (generator, block, position) -> generator.writeNumber(SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
-            generator.writeNumber(TINYINT.getByte(block, position));
+            return (generator, block, position) -> generator.writeNumber(TINYINT.getByte(block, position));
         }
-        else if (type instanceof DecimalType) {
-            SqlDecimal value = (SqlDecimal) type.getObjectValue(null, block, position);
-            generator.writeNumber(value.toBigDecimal().toString());
+        else if (type instanceof DecimalType decimalType) {
+            return (generator, block, position) -> {
+                SqlDecimal value = (SqlDecimal) decimalType.getObjectValue(null, block, position);
+                generator.writeNumber(value.toBigDecimal().toString());
+            };
         }
         else if (REAL.equals(type)) {
-            generator.writeNumber(REAL.getFloat(block, position));
+            return (generator, block, position) -> generator.writeNumber(REAL.getFloat(block, position));
         }
         else if (DOUBLE.equals(type)) {
-            generator.writeNumber(DOUBLE.getDouble(block, position));
+            return (generator, block, position) -> generator.writeNumber(DOUBLE.getDouble(block, position));
         }
         else if (DATE.equals(type)) {
-            generator.writeString(HiveFormatUtils.formatHiveDate(block, position));
+            return (generator, block, position) -> generator.writeString(HiveFormatUtils.formatHiveDate(block, position));
         }
-        else if (type instanceof TimestampType) {
-            generator.writeString(HiveFormatUtils.formatHiveTimestamp(type, block, position));
+        else if (type instanceof TimestampType timestampType) {
+            return (generator, block, position) -> generator.writeString(HiveFormatUtils.formatHiveTimestamp(timestampType, block, position));
         }
         else if (VARBINARY.equals(type)) {
-            // This corrupts the data, but this is exactly what Hive does, so we get the same result as Hive
-            String value = type.getSlice(block, position).toStringUtf8();
-            generator.writeString(value);
+            return (generator, block, position) -> {
+                // This corrupts the data, but this is exactly what Hive does, so we get the same result as Hive
+                String value = VARBINARY.getSlice(block, position).toStringUtf8();
+                generator.writeString(value);
+            };
         }
-        else if (type instanceof VarcharType) {
-            generator.writeString(type.getSlice(block, position).toStringUtf8());
+        else if (type instanceof VarcharType varcharType) {
+            return (generator, block, position) -> generator.writeString(varcharType.getSlice(block, position).toStringUtf8());
         }
         else if (type instanceof CharType charType) {
-            generator.writeString(Chars.padSpaces(charType.getSlice(block, position), charType).toStringUtf8());
+            return (generator, block, position) -> generator.writeString(Chars.padSpaces(charType.getSlice(block, position), charType).toStringUtf8());
         }
         else if (type instanceof ArrayType arrayType) {
-            Type elementType = arrayType.getElementType();
-            Block arrayBlock = arrayType.getObject(block, position);
-
-            generator.writeStartArray();
-            for (int arrayIndex = 0; arrayIndex < arrayBlock.getPositionCount(); arrayIndex++) {
-                writeValue(generator, elementType, arrayBlock, arrayIndex);
-            }
-            generator.writeEndArray();
+            return new ArrayValueWriter(arrayType, createValueWriter(arrayType.getElementType()));
         }
         else if (type instanceof MapType mapType) {
-            Type keyType = mapType.getKeyType();
-            Type valueType = mapType.getValueType();
-            Block mapBlock = mapType.getObject(block, position);
-
-            generator.writeStartObject();
-            for (int mapIndex = 0; mapIndex < mapBlock.getPositionCount(); mapIndex += 2) {
-                generator.writeFieldName(toMapKey(keyType, mapBlock, mapIndex));
-                writeValue(generator, valueType, mapBlock, mapIndex + 1);
-            }
-            generator.writeEndObject();
+            return new MapValueWriter(mapType, createMapKeyFunction(mapType.getKeyType()), createValueWriter(mapType.getValueType()));
         }
         else if (type instanceof RowType rowType) {
-            List<Field> fields = rowType.getFields();
-            Block rowBlock = rowType.getObject(block, position);
-
-            generator.writeStartObject();
-            for (int fieldIndex = 0; fieldIndex < fields.size(); fieldIndex++) {
-                Field field = fields.get(fieldIndex);
-                generator.writeFieldName(field.getName().orElseThrow());
-                writeValue(generator, field.getType(), rowBlock, fieldIndex);
-            }
-            generator.writeEndObject();
+            return new RowValueWriter(rowType, createRowTypeFieldWriters(rowType));
         }
         else {
             throw new UnsupportedOperationException("Unsupported column type: " + type);
         }
     }
 
-    private static String toMapKey(Type type, Block block, int position)
+    private static FieldWriter[] createRowTypeFieldWriters(RowType rowType)
     {
-        checkArgument(!block.isNull(position), "map key is null");
+        List<Field> fields = rowType.getFields();
+        FieldWriter[] writers = new FieldWriter[fields.size()];
+        int index = 0;
+        for (Field field : fields) {
+            writers[index++] = new FieldWriter(new SerializedString(field.getName().orElseThrow()), createValueWriter(field.getType()));
+        }
+        return writers;
+    }
 
+    private static ToMapKeyFunction createMapKeyFunction(Type type)
+    {
         if (BOOLEAN.equals(type)) {
-            return String.valueOf(BOOLEAN.getBoolean(block, position));
+            return (block, position) -> String.valueOf(BOOLEAN.getBoolean(block, position));
         }
         else if (BIGINT.equals(type)) {
-            return String.valueOf(BIGINT.getLong(block, position));
+            return (block, position) -> String.valueOf(BIGINT.getLong(block, position));
         }
         else if (INTEGER.equals(type)) {
-            return String.valueOf(INTEGER.getInt(block, position));
+            return (block, position) -> String.valueOf(INTEGER.getInt(block, position));
         }
         else if (SMALLINT.equals(type)) {
-            return String.valueOf(SMALLINT.getShort(block, position));
+            return (block, position) -> String.valueOf(SMALLINT.getShort(block, position));
         }
         else if (TINYINT.equals(type)) {
-            return String.valueOf(TINYINT.getByte(block, position));
+            return (block, position) -> String.valueOf(TINYINT.getByte(block, position));
         }
-        else if (type instanceof DecimalType) {
-            return type.getObjectValue(null, block, position).toString();
+        else if (type instanceof DecimalType decimalType) {
+            return (block, position) -> decimalType.getObjectValue(null, block, position).toString();
         }
         else if (REAL.equals(type)) {
-            return String.valueOf(REAL.getFloat(block, position));
+            return (block, position) -> String.valueOf(REAL.getFloat(block, position));
         }
         else if (DOUBLE.equals(type)) {
-            return String.valueOf(DOUBLE.getDouble(block, position));
+            return (block, position) -> String.valueOf(DOUBLE.getDouble(block, position));
         }
         else if (DATE.equals(type)) {
-            return HiveFormatUtils.formatHiveDate(block, position);
+            return HiveFormatUtils::formatHiveDate;
         }
-        else if (type instanceof TimestampType) {
-            return HiveFormatUtils.formatHiveTimestamp(type, block, position);
+        else if (type instanceof TimestampType timestampType) {
+            return (block, position) -> HiveFormatUtils.formatHiveTimestamp(timestampType, block, position);
         }
         else if (VARBINARY.equals(type)) {
             // This corrupts the data, but this is exactly what Hive does, so we get the same result as Hive
-            return type.getSlice(block, position).toStringUtf8();
+            return (block, position) -> VARBINARY.getSlice(block, position).toStringUtf8();
         }
-        else if (type instanceof VarcharType) {
-            return type.getSlice(block, position).toStringUtf8();
+        else if (type instanceof VarcharType varcharType) {
+            return (block, position) -> varcharType.getSlice(block, position).toStringUtf8();
         }
         else if (type instanceof CharType charType) {
-            return Chars.padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
+            return (block, position) -> Chars.padSpaces(charType.getSlice(block, position), charType).toStringUtf8();
         }
         throw new UnsupportedOperationException("Unsupported map key type: " + type);
+    }
+
+    private record FieldWriter(SerializedString fieldName, ValueWriter valueWriter)
+    {
+        /**
+         * Writes the combined field name and value for the given position into the JSON output
+         */
+        public void writeField(JsonGenerator generator, Block block, int position)
+                throws IOException
+        {
+            generator.writeFieldName(fieldName);
+            valueWriter.writeValue(generator, block, position);
+        }
+    }
+
+    private interface ValueWriter
+    {
+        default void writeValue(JsonGenerator generator, Block block, int position)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                generator.writeNull();
+            }
+            else {
+                writeNonNull(generator, block, position);
+            }
+        }
+
+        /**
+         * Writes only a single position value as JSON without any field name. This caller <strong>must</strong> ensure
+         * that the block position is non-null before invoking this method.
+         */
+        void writeNonNull(JsonGenerator generator, Block block, int position)
+                throws IOException;
+    }
+
+    private record ArrayValueWriter(ArrayType arrayType, ValueWriter elementWriter)
+            implements ValueWriter
+    {
+        @Override
+        public void writeNonNull(JsonGenerator generator, Block block, int position)
+                throws IOException
+        {
+            Block arrayBlock = requireNonNull(arrayType.getObject(block, position));
+            generator.writeStartArray();
+            for (int arrayIndex = 0; arrayIndex < arrayBlock.getPositionCount(); arrayIndex++) {
+                elementWriter.writeValue(generator, arrayBlock, arrayIndex);
+            }
+            generator.writeEndArray();
+        }
+    }
+
+    private interface ToMapKeyFunction
+    {
+        String apply(Block mapBlock, int mapIndex);
+    }
+
+    private record MapValueWriter(MapType mapType, ToMapKeyFunction toMapKey, ValueWriter valueWriter)
+            implements ValueWriter
+    {
+        @Override
+        public void writeNonNull(JsonGenerator generator, Block block, int position)
+                throws IOException
+        {
+            Block mapBlock = requireNonNull(mapType.getObject(block, position));
+            generator.writeStartObject();
+            for (int mapIndex = 0; mapIndex < mapBlock.getPositionCount(); mapIndex += 2) {
+                checkArgument(!mapBlock.isNull(mapIndex), "map key is null");
+                generator.writeFieldName(toMapKey.apply(mapBlock, mapIndex));
+                valueWriter.writeValue(generator, mapBlock, mapIndex + 1);
+            }
+            generator.writeEndObject();
+        }
+    }
+
+    private record RowValueWriter(RowType rowType, FieldWriter[] fieldWriters)
+            implements ValueWriter
+    {
+        @Override
+        public void writeNonNull(JsonGenerator generator, Block block, int position)
+                throws IOException
+        {
+            Block rowBlock = requireNonNull(rowType.getObject(block, position));
+            generator.writeStartObject();
+            for (int field = 0; field < fieldWriters.length; field++) {
+                FieldWriter writer = fieldWriters[field];
+                writer.writeField(generator, rowBlock, field);
+            }
+            generator.writeEndObject();
+        }
     }
 }


### PR DESCRIPTION
## Description
Avoids dynamically switching over each field and nested field type for each row of input when writing JSON output files by constructing type specific field writers for each output field and using virtual dispatch instead.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve performance of native Hive JSON file writer 
```
