### PR TITLE
Simplify Hive connector scale writers test

### DIFF
--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionConnectorTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/hive/TestHiveFaultTolerantExecutionConnectorTest.java
@@ -51,9 +51,15 @@ public class TestHiveFaultTolerantExecutionConnectorTest
     }
 
     @Override
-    public void testScaleWriters()
+    public void testMultipleWriters()
     {
-        testWithAllStorageFormats(this::testSingleWriter);
+        // Not applicable for fault-tolerant mode.
+    }
+
+    @Override
+    public void testMultipleWritersWithSkewedData()
+    {
+        // Not applicable for fault-tolerant mode.
     }
 
     // We need to override this method because in the case of pipeline execution,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Two changes:
- First, We need to use a large table (sf2) to see the
effect. Otherwise, a single writer will write the
entire data before ScaledWriterScheduler is able to
scale it to multiple machines.

- Second, since we now use page size to scale up instead
of physical written bytes, we don't have to test on different
file formats. This reduces the number of tests and overall
runtime.

fixes: https://github.com/trinodb/trino/issues/18670

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

