### PR TITLE
Add support for DROP SCHEMA CASCADE in Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -718,8 +718,19 @@ public class IcebergMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
+        if (cascade) {
+            for (SchemaTableName materializedView : listMaterializedViews(session, Optional.of(schemaName))) {
+                dropMaterializedView(session, materializedView);
+            }
+            for (SchemaTableName viewName : listViews(session, Optional.of(schemaName))) {
+                dropView(session, viewName);
+            }
+            for (SchemaTableName tableName : listTables(session, Optional.of(schemaName))) {
+                dropTable(session, getTableHandle(session, tableName, Optional.empty(), Optional.empty()));
+            }
+        }
         catalog.dropNamespace(session, schemaName);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -223,9 +223,6 @@ public abstract class BaseIcebergConnectorTest
             case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
 
-            case SUPPORTS_DROP_SCHEMA_CASCADE:
-                return false;
-
             case SUPPORTS_RENAME_MATERIALIZED_VIEW_ACROSS_SCHEMAS:
                 return false;
 


### PR DESCRIPTION
## Description

Relates to #17649

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for `CASCADE` option in `DROP SCHEMA` statement. ({issue}`18689`)
```
