### PR TITLE
Exclude TestParquetReader from default test profile

### DIFF
--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -553,6 +553,7 @@
                                 <exclude>**/TestTrinoS3FileSystemAwsS3.java</exclude>
                                 <exclude>**/TestS3SelectQueries.java</exclude>
                                 <exclude>**/TestFullParquetReader.java</exclude>
+                                <exclude>**/TestParquetReader.java</exclude>
                                 <exclude>**/Test*FailureRecoveryTest.java</exclude>
                             </excludes>
                         </configuration>
@@ -588,6 +589,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestFullParquetReader.java</include>
+                                <include>**/TestParquetReader.java</include>
                             </includes>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Description
TestFullParquetReader already includes all the tests and it is run in separate test-parquet profile

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

