### PR TITLE
Populate TestTable with multi-row INSERT

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -15,28 +15,23 @@ package io.trino.plugin.bigquery;
 
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TemporaryRelation;
-import io.trino.testing.sql.TestTable;
-
-import java.util.List;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryTestView
-        extends TestTable
+        implements TemporaryRelation
 {
+    private final SqlExecutor sqlExecutor;
     private final TemporaryRelation table;
     private final String viewName;
 
     public BigQueryTestView(SqlExecutor sqlExecutor, TemporaryRelation table)
     {
-        super(sqlExecutor, table.getName(), null);
+        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
         this.table = requireNonNull(table, "table is null");
         this.viewName = table.getName() + "_view";
     }
-
-    @Override
-    public void createAndInsert(List<String> rowsToInsert) {}
 
     public void createView()
     {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -31,10 +31,6 @@ public class BigQueryTestView
         this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
         this.relation = requireNonNull(relation, "relation is null");
         this.viewName = relation.getName() + "_view";
-    }
-
-    public void createView()
-    {
         sqlExecutor.execute(format("CREATE VIEW %s AS SELECT * FROM %s", viewName, relation.getName()));
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -23,19 +23,19 @@ public class BigQueryTestView
         implements TemporaryRelation
 {
     private final SqlExecutor sqlExecutor;
-    private final TemporaryRelation table;
+    private final TemporaryRelation relation;
     private final String viewName;
 
-    public BigQueryTestView(SqlExecutor sqlExecutor, TemporaryRelation table)
+    public BigQueryTestView(SqlExecutor sqlExecutor, TemporaryRelation relation)
     {
         this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
-        this.table = requireNonNull(table, "table is null");
-        this.viewName = table.getName() + "_view";
+        this.relation = requireNonNull(relation, "relation is null");
+        this.viewName = relation.getName() + "_view";
     }
 
     public void createView()
     {
-        sqlExecutor.execute(format("CREATE VIEW %s AS SELECT * FROM %s", viewName, table.getName()));
+        sqlExecutor.execute(format("CREATE VIEW %s AS SELECT * FROM %s", viewName, relation.getName()));
     }
 
     @Override
@@ -47,7 +47,7 @@ public class BigQueryTestView
     @Override
     public void close()
     {
-        sqlExecutor.execute("DROP TABLE " + table.getName());
+        relation.close();
         sqlExecutor.execute("DROP VIEW " + viewName);
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.bigquery;
 
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
 import io.trino.testing.sql.TestTable;
 
 import java.util.List;
@@ -24,10 +25,10 @@ import static java.util.Objects.requireNonNull;
 public class BigQueryTestView
         extends TestTable
 {
-    private final TestTable table;
+    private final TemporaryRelation table;
     private final String viewName;
 
-    public BigQueryTestView(SqlExecutor sqlExecutor, TestTable table)
+    public BigQueryTestView(SqlExecutor sqlExecutor, TemporaryRelation table)
     {
         super(sqlExecutor, table.getName(), null);
         this.table = requireNonNull(table, "table is null");

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryTestView.java
@@ -43,7 +43,8 @@ public class BigQueryTestView
     @Override
     public void close()
     {
-        relation.close();
-        sqlExecutor.execute("DROP VIEW " + viewName);
+        try (relation) {
+            sqlExecutor.execute("DROP VIEW " + viewName);
+        }
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
@@ -20,6 +20,7 @@ import io.trino.testing.sql.TemporaryRelation;
 
 import java.util.List;
 
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryViewCreateAndInsertDataSetup
@@ -37,8 +38,12 @@ public class BigQueryViewCreateAndInsertDataSetup
     public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TemporaryRelation table = super.setupTemporaryRelation(inputs);
-        BigQueryTestView view = new BigQueryTestView(sqlExecutor, table);
-        view.createView();
-        return view;
+        try {
+            return new BigQueryTestView(sqlExecutor, table);
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, table);
+            throw e;
+        }
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryViewCreateAndInsertDataSetup.java
@@ -16,7 +16,7 @@ package io.trino.plugin.bigquery;
 import io.trino.testing.datatype.ColumnSetup;
 import io.trino.testing.datatype.CreateAndInsertDataSetup;
 import io.trino.testing.sql.SqlExecutor;
-import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TemporaryRelation;
 
 import java.util.List;
 
@@ -34,9 +34,9 @@ public class BigQueryViewCreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTemporaryRelation(List<ColumnSetup> inputs)
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
-        TestTable table = super.setupTemporaryRelation(inputs);
+        TemporaryRelation table = super.setupTemporaryRelation(inputs);
         BigQueryTestView view = new BigQueryTestView(sqlExecutor, table);
         view.createView();
         return view;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -2321,8 +2321,11 @@ public class TestDeltaLakeConnectorTest
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_partition_filter_table_changes",
-                "(x integer, part integer) WITH (partitioned_by = ARRAY['part'], change_data_feed_enabled = true)",
-                ImmutableList.of("(1, 11)", "(2, 22)", "(3, 33)"))) {
+                "(x integer, part integer) WITH (partitioned_by = ARRAY['part'], change_data_feed_enabled = true)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 11)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 22)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (3, 33)", 1);
+
             @Language("RegExp")
             String expectedMessageRegExp = "Filter required on test_schema\\." + table.getName() + " for at least one partition column: part";
 
@@ -2367,8 +2370,11 @@ public class TestDeltaLakeConnectorTest
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_partition_filter_table_changes",
-                "(x integer, part integer) WITH (partitioned_by = ARRAY['part'], change_data_feed_enabled = true)",
-                ImmutableList.of("(1, 11)", "(2, 22)", "(3, 33)"))) {
+                "(x integer, part integer) WITH (partitioned_by = ARRAY['part'], change_data_feed_enabled = true)")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 11)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 22)", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (3, 33)", 1);
+
             @Language("RegExp")
             String expectedMessageRegExp = "Filter required on test_schema\\." + table.getName() + " for at least one partition column: part";
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorSmokeTest.java
@@ -611,8 +611,11 @@ public abstract class BaseIcebergConnectorSmokeTest
         try (TestTable table = new TestTable(
                 getQueryRunner()::execute,
                 "test_metadata_tables",
-                "(id int, part varchar) WITH (partitioning = ARRAY['part'])",
-                ImmutableList.of("1, 'p1'", "2, 'p1'", "3, 'p2'"))) {
+                "(id int, part varchar) WITH (partitioning = ARRAY['part'])")) {
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (1, 'p1')", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (2, 'p1')", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (3, 'p2')", 1);
+
             List<Long> snapshotIds = computeActual("SELECT snapshot_id FROM \"" + table.getName() + "$snapshots\" ORDER BY committed_at DESC")
                     .getOnlyColumn()
                     .map(Long.class::cast)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoCreateAndInsertDataSetup.java
@@ -17,7 +17,6 @@ import com.mongodb.client.MongoClient;
 import io.trino.testing.datatype.ColumnSetup;
 import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.sql.TemporaryRelation;
-import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 import org.bson.Document;
 
@@ -46,7 +45,7 @@ public final class MongoCreateAndInsertDataSetup
     @Override
     public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
-        TestTable testTable = new MongoTestTable(trinoSqlExecutor, tableNamePrefix);
+        MongoTestTable testTable = new MongoTestTable(trinoSqlExecutor, tableNamePrefix);
         try {
             insertRows(testTable, inputs);
         }
@@ -57,7 +56,7 @@ public final class MongoCreateAndInsertDataSetup
         return testTable;
     }
 
-    private void insertRows(TestTable testTable, List<ColumnSetup> inputs)
+    private void insertRows(MongoTestTable testTable, List<ColumnSetup> inputs)
     {
         int i = 0;
         StringBuilder json = new StringBuilder("{");

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoTestTable.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoTestTable.java
@@ -14,23 +14,32 @@
 package io.trino.plugin.mongodb;
 
 import io.trino.testing.sql.SqlExecutor;
-import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TemporaryRelation;
 
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static java.util.Objects.requireNonNull;
 
 public class MongoTestTable
-        extends TestTable
+        implements TemporaryRelation
 {
+    private final SqlExecutor sqlExecutor;
+    private final String name;
+
     public MongoTestTable(SqlExecutor sqlExecutor, String namePrefix)
     {
-        super(sqlExecutor, namePrefix, null);
+        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
+        this.name = requireNonNull(namePrefix, "namePrefix is null") + randomNameSuffix();
     }
 
     @Override
-    public void createAndInsert(List<String> rowsToInsert)
+    public String getName()
     {
-        checkArgument(rowsToInsert.isEmpty(), "rowsToInsert must be empty");
+        return name;
+    }
+
+    @Override
+    public void close()
+    {
+        sqlExecutor.execute("DROP TABLE " + name);
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
@@ -81,6 +81,18 @@ public class TestOracleConnectorTest
     @Override
     protected SqlExecutor onRemoteDatabase()
     {
-        return oracleServer::execute;
+        return new SqlExecutor() {
+            @Override
+            public boolean supportsMultiRowInsert()
+            {
+                return false;
+            }
+
+            @Override
+            public void execute(String sql)
+            {
+                oracleServer.execute(sql);
+            }
+        };
     }
 }

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixSqlExecutor.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixSqlExecutor.java
@@ -42,6 +42,12 @@ public class PhoenixSqlExecutor
     }
 
     @Override
+    public boolean supportsMultiRowInsert()
+    {
+        return false;
+    }
+
+    @Override
     public void execute(String sql)
     {
         sql = sql.replaceFirst("INSERT", "UPSERT");

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixTestTable.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixTestTable.java
@@ -29,7 +29,7 @@ public class PhoenixTestTable
     }
 
     @Override
-    public void createAndInsert(List<String> rowsToInsert)
+    protected void createAndInsert(List<String> rowsToInsert)
     {
         sqlExecutor.execute(format("CREATE TABLE %s %s", name, tableDefinition));
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndInsertDataSetup.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/CreateAndInsertDataSetup.java
@@ -14,6 +14,7 @@
 package io.trino.testing.datatype;
 
 import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.sql.TemporaryRelation;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 
@@ -38,7 +39,7 @@ public class CreateAndInsertDataSetup
     }
 
     @Override
-    public TestTable setupTemporaryRelation(List<ColumnSetup> inputs)
+    public TemporaryRelation setupTemporaryRelation(List<ColumnSetup> inputs)
     {
         TestTable testTable = createTestTable(inputs);
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/SqlExecutor.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/SqlExecutor.java
@@ -15,5 +15,10 @@ package io.trino.testing.sql;
 
 public interface SqlExecutor
 {
+    default boolean supportsMultiRowInsert()
+    {
+        return true;
+    }
+
     void execute(String sql);
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -23,6 +23,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static java.util.Objects.requireNonNull;
 
 public class TestTable
         implements TemporaryRelation
@@ -38,9 +39,9 @@ public class TestTable
 
     public TestTable(SqlExecutor sqlExecutor, String namePrefix, String tableDefinition, List<String> rowsToInsert)
     {
-        this.sqlExecutor = sqlExecutor;
-        this.name = namePrefix + randomNameSuffix();
-        this.tableDefinition = tableDefinition;
+        this.sqlExecutor = requireNonNull(sqlExecutor, "sqlExecutor is null");
+        this.name = requireNonNull(namePrefix, "namePrefix is null") + randomNameSuffix();
+        this.tableDefinition = requireNonNull(tableDefinition, "tableDefinition is null");
         createAndInsert(rowsToInsert);
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/sql/TestTable.java
@@ -45,7 +45,7 @@ public class TestTable
         createAndInsert(rowsToInsert);
     }
 
-    public void createAndInsert(List<String> rowsToInsert)
+    protected void createAndInsert(List<String> rowsToInsert)
     {
         sqlExecutor.execute(format("CREATE TABLE %s %s", name, tableDefinition));
         try {


### PR DESCRIPTION
Use single INSERT instead of multiple single-row inserts. Should be
    faster, especially e.g. for Trino.