### PR TITLE
Update tests to oldest supported Postgres version

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcVendorCompatibility.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcVendorCompatibility.java
@@ -570,7 +570,7 @@ public class TestJdbcVendorCompatibility
         PostgresqlReferenceDriver()
         {
             // Use the current latest PostgreSQL version as the reference
-            postgresqlContainer = new PostgreSQLContainer<>("postgres:12.4");
+            postgresqlContainer = new PostgreSQLContainer<>("postgres:15");
             postgresqlContainer.start();
         }
 

--- a/docs/src/main/sphinx/connector/postgresql.md
+++ b/docs/src/main/sphinx/connector/postgresql.md
@@ -19,7 +19,7 @@ PostgreSQL instances.
 
 To connect to PostgreSQL, you need:
 
-- PostgreSQL 10.x or higher.
+- PostgreSQL 11.x or higher.
 - Network access from the Trino coordinator and workers to PostgreSQL.
   Port 5432 is the default port.
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -65,7 +65,7 @@ public class TestingPostgreSqlServer
     public TestingPostgreSqlServer(boolean shouldExposeFixedPorts)
     {
         // Use the oldest supported PostgreSQL version
-        dockerContainer = new PostgreSQLContainer<>("postgres:10.20")
+        dockerContainer = new PostgreSQLContainer<>("postgres:11")
                 .withStartupAttempts(3)
                 .withDatabaseName(DATABASE)
                 .withUsername(USER)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupsPostgresqlFlywayMigration.java
@@ -24,7 +24,7 @@ public class TestDbResourceGroupsPostgresqlFlywayMigration
     @Override
     protected final JdbcDatabaseContainer<?> startContainer()
     {
-        JdbcDatabaseContainer<?> container = new PostgreSQLContainer<>("postgres:10.20");
+        JdbcDatabaseContainer<?> container = new PostgreSQLContainer<>("postgres:11");
         container.start();
         return container;
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodePostgresql.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodePostgresql.java
@@ -60,7 +60,7 @@ public final class EnvMultinodePostgresql
     private DockerContainer createPostgreSql()
     {
         // Use the oldest supported PostgreSQL version
-        DockerContainer container = new DockerContainer("postgres:10.20", "postgresql")
+        DockerContainer container = new DockerContainer("postgres:11", "postgresql")
                 .withEnv("POSTGRES_PASSWORD", "test")
                 .withEnv("POSTGRES_USER", "test")
                 .withEnv("POSTGRES_DB", "test")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Postgres 10 is end-of-life and also not available on any cloud providers. 11 will also be end-of-life in November 2023 though it makes sense to test with 11 for some time.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# PostgreSQL
* Drop support for Postgres versions older than 11. ({issue}`18696`)
```
