### PR TITLE
Fix Hive written bytes reporting for uncompressed text

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/line/text/TextLineWriter.java
@@ -41,7 +41,7 @@ public class TextLineWriter
             this.outputStream = compressionKind.get().createCodec().createStreamCompressor(countingOutputStream);
         }
         else {
-            this.outputStream = outputStream;
+            this.outputStream = countingOutputStream;
         }
     }
 


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix reporting of written bytes for uncompressed text files. This prevented
  the `target_max_file_size` session property from working. ({issue}`18701`)
```
