### PR TITLE
Remove duplicate property documentation

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -1064,8 +1064,8 @@ with the `delta.hive-catalog-name` catalog configuration property.
 
 ### Performance tuning configuration properties
 
-The following table describes performance tuning catalog properties for the
-connector.
+The following table describes performance tuning catalog properties specific to
+the Delta Lake connector.
 
 :::{warning}
 Performance tuning configuration properties are considered expert-level
@@ -1125,14 +1125,6 @@ keep a backup of the original values if you change them.
         with small files. A higher value might improve performance for queries
         with highly skewed aggregations or joins.
       - ``0.05``
-    * - ``parquet.max-read-block-row-count``
-      - Sets the maximum number of rows read in a batch. The equivalent catalog
-        session property is ``parquet_max_read_block_row_count``.
-      - ``8192``
-    * - ``parquet.use-column-index``
-      - Skip reading Parquet pages by using Parquet column indices. The equivalent
-        catalog session property is ``parquet_use_column_index``.
-      - ``true``
     * - ``delta.projection-pushdown-enabled``
       - Read only projected fields from row columns while performing ``SELECT`` queries
       - ``true``

--- a/docs/src/main/sphinx/connector/object-storage-file-formats.md
+++ b/docs/src/main/sphinx/connector/object-storage-file-formats.md
@@ -88,7 +88,13 @@ with Parquet files performed by supported object storage connectors:
         bloom filters by default. The equivalent catalog session property is
         ``parquet_use_bloom_filter``.
       - ``true``
+    * - ``parquet.use-column-index``
+      - Skip reading Parquet pages by using Parquet column indices. The
+        equivalent catalog session property is ``parquet_use_column_index``.
+        Only supported by the Delta Lake and Hive connectors.
+      - ``true``
     * - ``parquet.max-read-block-row-count``
-      - Sets the maximum number of rows read in a batch.
+      - Sets the maximum number of rows read in a batch. The equivalent catalog
+        session property is named ``parquet_max_read_block_row_count`` and
+        supported by the Delta Lake, Hive, and Iceberg connectors.
       - ``8192``
-```


### PR DESCRIPTION
## Description

Removed docs in Delta Lake connector and moved to the new page that applies to all Parquet usage.

## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/17510

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
