### PR TITLE
Fix typo in the element name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2237,7 +2237,7 @@
                                     </dependency>
                                 </conflictingDependencies>
                                 <packages>
-                                    <pacakge>shaded.parquet.it.unimi.dsi.fastutil</pacakge>
+                                    <package>shaded.parquet.it.unimi.dsi.fastutil</package>
                                 </packages>
                             </exception>
                         </exceptions>


### PR DESCRIPTION
Despite the fact that <packages> child element name can be arbitrary, let's keep it a proper word.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
