### PR TITLE
Refactor to always use JdbcColumnHandle.Builder instead of a constructor

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -280,7 +280,11 @@ public abstract class BaseJdbcClient
             Type type = toColumnMapping(session, connection, jdbcTypeHandle)
                     .orElseThrow(() -> new UnsupportedOperationException(format("Unsupported type: %s of column: %s", jdbcTypeHandle, name)))
                     .getType();
-            columns.add(new JdbcColumnHandle(name, jdbcTypeHandle, type));
+            columns.add(JdbcColumnHandle.builder()
+                    .setColumnName(name)
+                    .setJdbcTypeHandle(jdbcTypeHandle)
+                    .setColumnType(type)
+                    .build());
         }
         return columns.build();
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -874,10 +874,11 @@ public class DefaultJdbcMetadata
     {
         verify(!isTableHandleForProcedure(tableHandle), "Not a table reference: %s", tableHandle);
         // The column is used for row-level merge, which is not supported, but it's required during analysis anyway.
-        return new JdbcColumnHandle(
-                MERGE_ROW_ID,
-                new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()),
-                BIGINT);
+        return JdbcColumnHandle.builder()
+                .setColumnName(MERGE_ROW_ID)
+                .setJdbcTypeHandle(new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()))
+                .setColumnType(BIGINT)
+                .build();
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -152,6 +152,15 @@ public final class JdbcColumnHandle
                 + jdbcTypeHandle.getRetainedSizeInBytes();
     }
 
+    public static JdbcColumnHandle createJdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType)
+    {
+        return builder()
+                .setColumnName(columnName)
+                .setJdbcTypeHandle(jdbcTypeHandle)
+                .setColumnType(columnType)
+                .build();
+    }
+
     public static Builder builder()
     {
         return new Builder();

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -133,9 +134,9 @@ public class TestDefaultJdbcMetadata
     {
         // known table
         assertThat(metadata.getColumnHandles(SESSION, tableHandle)).isEqualTo(ImmutableMap.of(
-                "text", new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
-                "text_short", new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                "value", new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
+                "text", createJdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
+                "text_short", createJdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                "value", createJdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(new SchemaTableName("unknown", "unknown"), new RemoteTableName(Optional.of("unknown"), Optional.of("unknown"), "unknown"), Optional.empty()));
@@ -220,7 +221,7 @@ public class TestDefaultJdbcMetadata
     @Test
     public void getColumnMetadata()
     {
-        assertThat(metadata.getColumnMetadata(SESSION, tableHandle, new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR))).isEqualTo(new ColumnMetadata("text", VARCHAR));
+        assertThat(metadata.getColumnMetadata(SESSION, tableHandle, createJdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR))).isEqualTo(new ColumnMetadata("text", VARCHAR));
     }
 
     @Test
@@ -242,7 +243,7 @@ public class TestDefaultJdbcMetadata
         assertThat(layout.getColumns().get(0)).isEqualTo(new ColumnMetadata("text", VARCHAR));
         assertThat(layout.getColumns().get(1)).isEqualTo(new ColumnMetadata("x", VARCHAR));
 
-        JdbcColumnHandle columnHandle = new JdbcColumnHandle("x", JDBC_VARCHAR, VARCHAR);
+        JdbcColumnHandle columnHandle = createJdbcColumnHandle("x", JDBC_VARCHAR, VARCHAR);
         metadata.dropColumn(SESSION, handle, columnHandle);
         layout = metadata.getTableMetadata(SESSION, handle);
         assertThat(layout.getColumns()).hasSize(1);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -59,6 +59,7 @@ import static com.google.common.base.Strings.padEnd;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.testing.Assertions.assertContains;
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BOOLEAN;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_CHAR;
@@ -119,18 +120,18 @@ public class TestDefaultJdbcQueryBuilder
         CharType charType = CharType.createCharType(0);
 
         columns = ImmutableList.of(
-                new JdbcColumnHandle("col_0", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("col_1", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("col_2", JDBC_BOOLEAN, BOOLEAN),
-                new JdbcColumnHandle("col_3", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("col_4", JDBC_DATE, DATE),
-                new JdbcColumnHandle("col_5", JDBC_TIME, TIME_MILLIS),
-                new JdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
-                new JdbcColumnHandle("col_7", JDBC_TINYINT, TINYINT),
-                new JdbcColumnHandle("col_8", JDBC_SMALLINT, SMALLINT),
-                new JdbcColumnHandle("col_9", JDBC_INTEGER, INTEGER),
-                new JdbcColumnHandle("col_10", JDBC_REAL, REAL),
-                new JdbcColumnHandle("col_11", JDBC_CHAR, charType));
+                createJdbcColumnHandle("col_0", JDBC_BIGINT, BIGINT),
+                createJdbcColumnHandle("col_1", JDBC_DOUBLE, DOUBLE),
+                createJdbcColumnHandle("col_2", JDBC_BOOLEAN, BOOLEAN),
+                createJdbcColumnHandle("col_3", JDBC_VARCHAR, VARCHAR),
+                createJdbcColumnHandle("col_4", JDBC_DATE, DATE),
+                createJdbcColumnHandle("col_5", JDBC_TIME, TIME_MILLIS),
+                createJdbcColumnHandle("col_6", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
+                createJdbcColumnHandle("col_7", JDBC_TINYINT, TINYINT),
+                createJdbcColumnHandle("col_8", JDBC_SMALLINT, SMALLINT),
+                createJdbcColumnHandle("col_9", JDBC_INTEGER, INTEGER),
+                createJdbcColumnHandle("col_10", JDBC_REAL, REAL),
+                createJdbcColumnHandle("col_11", JDBC_CHAR, charType));
 
         Connection connection = database.getConnection();
         try (PreparedStatement preparedStatement = connection.prepareStatement("create table \"test_table\" (" +

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
@@ -89,9 +90,9 @@ public class TestJdbcClient
         assertThat(table.get().getRequiredNamedRelation().getRemoteTableName().getTableName()).isEqualTo("NUMBERS");
         assertThat(table.get().getRequiredNamedRelation().getSchemaTableName()).isEqualTo(schemaTableName);
         assertThat(jdbcClient.getColumns(session, table.orElse(null))).containsExactly(
-                new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT));
+                createJdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
+                createJdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
+                createJdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -101,8 +102,8 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT));
+                createJdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
+                createJdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -112,10 +113,10 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("COL4", JDBC_REAL, REAL));
+                createJdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),
+                createJdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
+                createJdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
+                createJdbcColumnHandle("COL4", JDBC_REAL, REAL));
     }
 
     @Test
@@ -125,9 +126,9 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
-                new JdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
-                new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS));
+                createJdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
+                createJdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
+                createJdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS));
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcColumnHandle.java
@@ -18,6 +18,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.MetadataUtil.COLUMN_CODEC;
 import static io.trino.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
@@ -45,15 +46,15 @@ public class TestJdbcColumnHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("columnName", JDBC_BIGINT, BIGINT),
-                        new JdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR))
+                        createJdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
+                        createJdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR),
+                        createJdbcColumnHandle("columnName", JDBC_BIGINT, BIGINT),
+                        createJdbcColumnHandle("columnName", JDBC_VARCHAR, VARCHAR))
                 .addEquivalentGroup(
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
-                        new JdbcColumnHandle("columnNameX", JDBC_BIGINT, BIGINT),
-                        new JdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR))
+                        createJdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
+                        createJdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR),
+                        createJdbcColumnHandle("columnNameX", JDBC_BIGINT, BIGINT),
+                        createJdbcColumnHandle("columnNameX", JDBC_VARCHAR, VARCHAR))
                 .check();
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSet.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
 import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -73,20 +74,20 @@ public class TestJdbcRecordSet
     public void testGetColumnTypes()
     {
         RecordSet recordSet = createRecordSet(ImmutableList.of(
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT)));
+                createJdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR),
+                createJdbcColumnHandle("text_short", JDBC_VARCHAR, createVarcharType(32)),
+                createJdbcColumnHandle("value", JDBC_BIGINT, BIGINT)));
         assertThat(recordSet.getColumnTypes()).containsExactly(VARCHAR, createVarcharType(32), BIGINT);
 
         recordSet = createRecordSet(ImmutableList.of(
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
+                createJdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                createJdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertThat(recordSet.getColumnTypes()).containsExactly(BIGINT, VARCHAR);
 
         recordSet = createRecordSet(ImmutableList.of(
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
+                createJdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                createJdbcColumnHandle("value", JDBC_BIGINT, BIGINT),
+                createJdbcColumnHandle("text", JDBC_VARCHAR, VARCHAR)));
         assertThat(recordSet.getColumnTypes()).containsExactly(BIGINT, BIGINT, VARCHAR);
 
         recordSet = createRecordSet(ImmutableList.of());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
@@ -25,6 +25,7 @@ import java.sql.Types;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.MetadataUtil.TABLE_CODEC;
 import static io.trino.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
 
@@ -70,7 +71,7 @@ public class TestJdbcTableHandle
                 ImmutableList.of(),
                 Optional.empty(),
                 OptionalLong.of(1),
-                Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
+                Optional.of(ImmutableList.of(createJdbcColumnHandle("i", type, IntegerType.INTEGER))),
                 Optional.of(ImmutableSet.of()),
                 0,
                 Optional.empty());
@@ -88,7 +89,7 @@ public class TestJdbcTableHandle
                 ImmutableList.of(),
                 Optional.empty(),
                 OptionalLong.of(1),
-                Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
+                Optional.of(ImmutableList.of(createJdbcColumnHandle("i", type, IntegerType.INTEGER))),
                 Optional.of(ImmutableSet.of()),
                 0,
                 Optional.empty());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/BaseTestRewriteLikeWithCaseSensitivity.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/BaseTestRewriteLikeWithCaseSensitivity.java
@@ -16,7 +16,6 @@ package io.trino.plugin.jdbc.expression;
 import com.google.common.collect.ImmutableList;
 import io.trino.matching.Match;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
-import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.QueryParameter;
 import io.trino.spi.connector.ColumnHandle;
@@ -31,6 +30,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.trino.plugin.jdbc.CaseSensitivity.CASE_SENSITIVE;
+import static io.trino.plugin.jdbc.JdbcColumnHandle.createJdbcColumnHandle;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,8 +50,8 @@ public abstract class BaseTestRewriteLikeWithCaseSensitivity
             @Override
             public Map<String, ColumnHandle> getAssignments()
             {
-                return Map.of("case_insensitive_value", new JdbcColumnHandle("case_insensitive_value", JDBC_BIGINT, VARCHAR),
-                        "case_sensitive_value", new JdbcColumnHandle("case_sensitive_value", new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.of(CASE_SENSITIVE)), VARCHAR));
+                return Map.of("case_insensitive_value", createJdbcColumnHandle("case_insensitive_value", JDBC_BIGINT, VARCHAR),
+                        "case_sensitive_value", createJdbcColumnHandle("case_sensitive_value", new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), Optional.of(10), Optional.empty(), Optional.empty(), Optional.of(CASE_SENSITIVE)), VARCHAR));
             }
 
             @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Refactor to always use JdbcColumnHandle.Builder instead of a constructor. This is a prerequisite change for a bugfix.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
