### PR TITLE
Alluxio cache

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/pom.xml
+++ b/lib/trino-filesystem-cache-alluxio/pom.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>438-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-filesystem-cache-alluxio</artifactId>
+    <description>Trino Filesystem - Alluxio</description>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-client-fs</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCacheStats.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioCacheStats.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import com.google.errorprone.annotations.ThreadSafe;
+import io.airlift.stats.DistributionStat;
+import io.trino.filesystem.Location;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+@ThreadSafe
+public class AlluxioCacheStats
+        implements CacheStats
+{
+    private final DistributionStat externalReads = new DistributionStat();
+    private final DistributionStat cacheReads = new DistributionStat();
+
+    @Managed
+    @Nested
+    public DistributionStat getExternalReads()
+    {
+        return externalReads;
+    }
+
+    @Managed
+    @Nested
+    public DistributionStat getCacheReads()
+    {
+        return cacheReads;
+    }
+
+    @Override
+    public void recordCacheRead(Location location, int length)
+    {
+        cacheReads.add(length);
+    }
+
+    @Override
+    public void recordExternalRead(Location location, int length)
+    {
+        externalReads.add(length);
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCache.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.CacheContext;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.wire.FileInfo;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.google.inject.Inject;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class AlluxioFileSystemCache
+        implements TrinoFileSystemCache
+{
+    private final CacheManager cacheManager;
+    private final AlluxioConfiguration config;
+    private final CacheStats statistics;
+    private final HashFunction hashFunction = Hashing.murmur3_128();
+
+    @Inject
+    public AlluxioFileSystemCache(CacheManager cacheManager, AlluxioConfiguration config, CacheStats statistics)
+    {
+        this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
+        this.config = requireNonNull(config, "config is null");
+        this.statistics = requireNonNull(statistics, "statistics is null");
+    }
+
+    @Override
+    public TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new AlluxioInput(delegate, uriStatus(delegate, key), cacheManager, config, statistics);
+    }
+
+    @Override
+    public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return new AlluxioInputStream(delegate, uriStatus(delegate, key), cacheManager, config, statistics);
+    }
+
+    @Override
+    public void expire(Location source)
+            throws IOException
+    {
+    }
+
+    @VisibleForTesting
+    protected URIStatus uriStatus(TrinoInputFile file, String key)
+            throws IOException
+    {
+        FileInfo info = new FileInfo()
+                .setPath(file.location().toString())
+                .setLength(file.length());
+        String cacheIdentifier = hashFunction.hashString(key, UTF_8).toString();
+        return new URIStatus(info, CacheContext.defaults().setCacheIdentifier(cacheIdentifier));
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheConfig.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDataSize;
+import io.airlift.units.MinDataSize;
+import io.airlift.units.MinDuration;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class AlluxioFileSystemCacheConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+
+    static final String CACHE_DIRECTORIES = "fs.cache.directories";
+    static final String CACHE_MAX_SIZES = "fs.cache.max-sizes";
+    static final String CACHE_MAX_PERCENTAGES = "fs.cache.max-disk-usage-percentages";
+
+    private List<String> cacheDirectories;
+    private List<DataSize> maxCacheSizes = ImmutableList.of();
+    private Optional<Duration> cacheTTL = Optional.of(Duration.valueOf("7d"));
+    private List<Integer> maxCacheDiskUsagePercentages = ImmutableList.of();
+    private DataSize cachePageSize = DataSize.valueOf("1MB");
+
+    @NotNull
+    public List<String> getCacheDirectories()
+    {
+        return cacheDirectories;
+    }
+
+    @Config(CACHE_DIRECTORIES)
+    @ConfigDescription("Base directory to cache data. Use a comma-separated list to cache data in multiple directories.")
+    public AlluxioFileSystemCacheConfig setCacheDirectories(String cacheDirectories)
+    {
+        this.cacheDirectories = cacheDirectories == null ? null : SPLITTER.splitToList(cacheDirectories);
+        return this;
+    }
+
+    public List<DataSize> getMaxCacheSizes()
+    {
+        return maxCacheSizes;
+    }
+
+    @Config(CACHE_MAX_SIZES)
+    @ConfigDescription("The maximum cache size for a cache directory. Use a comma-separated list of sizes to specify allowed maximum values for each directory.")
+    public AlluxioFileSystemCacheConfig setMaxCacheSizes(String maxCacheSizes)
+    {
+        this.maxCacheSizes = SPLITTER.splitToStream(firstNonNull(maxCacheSizes, "")).map(DataSize::valueOf).collect(toImmutableList());
+        return this;
+    }
+
+    @NotNull
+    public Optional<@MinDuration("0s") Duration> getCacheTTL()
+    {
+        return cacheTTL;
+    }
+
+    @Config("fs.cache.ttl")
+    @ConfigDescription("Duration to keep files in the cache prior to eviction")
+    public AlluxioFileSystemCacheConfig setCacheTTL(Duration cacheTTL)
+    {
+        this.cacheTTL = Optional.of(cacheTTL);
+        return this;
+    }
+
+    public AlluxioFileSystemCacheConfig disableTTL()
+    {
+        this.cacheTTL = Optional.empty();
+        return this;
+    }
+
+    public List<@Min(0) @Max(100) Integer> getMaxCacheDiskUsagePercentages()
+    {
+        return maxCacheDiskUsagePercentages;
+    }
+
+    @Config(CACHE_MAX_PERCENTAGES)
+    @ConfigDescription("The maximum percentage (0-100) of total disk size the cache can use. Use a comma-separated list of percentage values if supplying several cache directories.")
+    public AlluxioFileSystemCacheConfig setMaxCacheDiskUsagePercentages(String maxCacheDiskUsagePercentages)
+    {
+        this.maxCacheDiskUsagePercentages = SPLITTER.splitToStream(firstNonNull(maxCacheDiskUsagePercentages, ""))
+                .map(Integer::valueOf)
+                .collect(toImmutableList());
+        return this;
+    }
+
+    @NotNull
+    @MaxDataSize("15MB")
+    @MinDataSize("64kB")
+    public DataSize getCachePageSize()
+    {
+        return this.cachePageSize;
+    }
+
+    @Config("fs.cache.alluxio.page-size")
+    @ConfigDescription("Page size of Alluxio cache")
+    public AlluxioFileSystemCacheConfig setCachePageSize(DataSize cachePageSize)
+    {
+        this.cachePageSize = cachePageSize;
+        return this;
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.AlluxioProperties;
+import alluxio.conf.InstancedConfiguration;
+import alluxio.metrics.MetricsConfig;
+import alluxio.metrics.MetricsSystem;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_DIRS;
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_ENABLED;
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE;
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_SIZE;
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_TTL_ENABLED;
+import static alluxio.conf.PropertyKey.USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.filesystem.alluxio.AlluxioFileSystemCacheConfig.CACHE_DIRECTORIES;
+import static io.trino.filesystem.alluxio.AlluxioFileSystemCacheConfig.CACHE_MAX_PERCENTAGES;
+import static io.trino.filesystem.alluxio.AlluxioFileSystemCacheConfig.CACHE_MAX_SIZES;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class AlluxioFileSystemCacheModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(AlluxioFileSystemCacheConfig.class);
+        binder.bind(CacheStats.class).to(AlluxioCacheStats.class).in(SINGLETON);
+        newExporter(binder).export(CacheStats.class).as(generator -> generator.generatedNameOf(AlluxioCacheStats.class));
+
+        binder.bind(TrinoFileSystemCache.class).to(AlluxioFileSystemCache.class).in(SINGLETON);
+
+        Properties metricProps = new Properties();
+        metricProps.put("sink.jmx.class", "alluxio.metrics.sink.JmxSink");
+        metricProps.put("sink.jmx.domain", "org.alluxio");
+        MetricsSystem.startSinksFromConfig(new MetricsConfig(metricProps));
+    }
+
+    @Provides
+    @Singleton
+    public static AlluxioConfiguration getAlluxioConfiguration(AlluxioFileSystemCacheConfig config)
+    {
+        checkArgument(config.getMaxCacheSizes().isEmpty() ^ config.getMaxCacheDiskUsagePercentages().isEmpty(),
+                "Either %s or %s must be specified", CACHE_MAX_SIZES, CACHE_MAX_PERCENTAGES);
+        int size = config.getMaxCacheSizes().isEmpty() ? config.getMaxCacheDiskUsagePercentages().size() : config.getMaxCacheSizes().size();
+        checkArgument(config.getCacheDirectories().size() == size,
+                "%s and %s must have the same size", CACHE_DIRECTORIES, config.getMaxCacheSizes().isEmpty() ? CACHE_MAX_PERCENTAGES : CACHE_MAX_SIZES);
+        config.getCacheDirectories().forEach(directory -> canWrite(Path.of(directory)));
+        List<DataSize> maxCacheSizes = config.getMaxCacheSizes().isEmpty() ?
+                calculateMaxCacheSizes(config.getMaxCacheDiskUsagePercentages(), config.getCacheDirectories().stream()
+                        .map(directory -> totalSpace(Path.of(directory))).collect(toImmutableList()))
+                : config.getMaxCacheSizes();
+
+        AlluxioProperties alluxioProperties = new AlluxioProperties();
+        alluxioProperties.set(USER_CLIENT_CACHE_ENABLED, true);
+        alluxioProperties.set(USER_CLIENT_CACHE_DIRS, join(",", config.getCacheDirectories()));
+        alluxioProperties.set(USER_CLIENT_CACHE_SIZE, join(",", maxCacheSizes.stream().map(DataSize::toBytesValueString).toList()));
+        alluxioProperties.set(USER_CLIENT_CACHE_PAGE_SIZE, config.getCachePageSize().toBytesValueString());
+        Optional<Duration> ttl = config.getCacheTTL();
+        if (ttl.isPresent()) {
+            alluxioProperties.set(USER_CLIENT_CACHE_TTL_THRESHOLD_SECONDS, ttl.orElseThrow().roundTo(TimeUnit.SECONDS));
+            alluxioProperties.set(USER_CLIENT_CACHE_TTL_ENABLED, true);
+        }
+        return new InstancedConfiguration(alluxioProperties);
+    }
+
+    @Provides
+    @Singleton
+    public static CacheManager getCacheManager(AlluxioConfiguration alluxioConfiguration)
+    {
+        try {
+            return CacheManager.Factory.create(alluxioConfiguration);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static List<DataSize> calculateMaxCacheSizes(List<Integer> cachePercentages, List<Long> cacheDiskSizes)
+    {
+        ImmutableList.Builder<DataSize> maxCacheSizes = ImmutableList.builderWithExpectedSize(cacheDiskSizes.size());
+        for (int i = 0; i < cacheDiskSizes.size(); i++) {
+            maxCacheSizes.add(DataSize.of(Math.round(cachePercentages.get(i) / 100.0 * cacheDiskSizes.get(i)), DataSize.Unit.BYTE));
+        }
+        return maxCacheSizes.build();
+    }
+
+    private static void canWrite(Path path)
+    {
+        Path originalPath = path;
+        while (!Files.exists(path) && path.getParent() != null) {
+            path = path.getParent();
+        }
+        checkArgument(Files.isDirectory(path), format("Cache directory %s is not a directory", path));
+        checkArgument(Files.isReadable(path), format("Cannot read from cache directory %s", originalPath));
+        checkArgument(Files.isWritable(path), format("Cannot write to cache directory %s", originalPath));
+    }
+
+    /**
+     * Get total space of the partition named by the path or its parent paths.
+     */
+    @VisibleForTesting
+    static long totalSpace(Path path)
+    {
+        while (!Files.exists(path) && path.getParent() != null) {
+            path = path.getParent();
+        }
+        return path.toFile().getTotalSpace();
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInput.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static java.lang.Math.min;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+public class AlluxioInput
+        implements TrinoInput
+{
+    private final TrinoInputFile inputFile;
+    private final long fileLength;
+    private final CacheStats statistics;
+    private final AlluxioInputHelper helper;
+
+    private TrinoInput input;
+    private boolean closed;
+
+    public AlluxioInput(
+            TrinoInputFile inputFile,
+            URIStatus status,
+            CacheManager cacheManager,
+            AlluxioConfiguration configuration,
+            CacheStats statistics)
+    {
+        this.inputFile = requireNonNull(inputFile, "inputFile is null");
+        this.fileLength = requireNonNull(status, "status is null").getLength();
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.helper = new AlluxioInputHelper(inputFile.location(), status, cacheManager, configuration, statistics);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(offset, length, buffer.length);
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (length == 0) {
+            return;
+        }
+
+        int bytesRead = helper.doCacheRead(position, buffer, offset, length);
+        if (length > bytesRead && position + bytesRead == fileLength) {
+            throw new EOFException("Read %s of %s requested bytes: %s".formatted(bytesRead, length, inputFile.location()));
+        }
+        doExternalRead(position + bytesRead, buffer, offset + bytesRead, length - bytesRead);
+    }
+
+    private int doExternalRead(long position, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return 0;
+        }
+        AlluxioInputHelper.PageAlignedRead aligned = helper.alignRead(position, length);
+        byte[] readBuffer = new byte[aligned.length()];
+        getInput().readFully(aligned.pageStart(), readBuffer, 0, readBuffer.length);
+        helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, aligned.length());
+        System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, length);
+        statistics.recordExternalRead(inputFile.location(), readBuffer.length);
+        return length;
+    }
+
+    private TrinoInput getInput()
+            throws IOException
+    {
+        if (input == null) {
+            input = inputFile.newInput();
+        }
+        return input;
+    }
+
+    @Override
+    public int readTail(byte[] buffer, int bufferOffset, int bufferLength)
+            throws IOException
+    {
+        ensureOpen();
+        checkFromIndexSize(bufferOffset, bufferLength, buffer.length);
+
+        int readSize = (int) min(fileLength, bufferLength);
+        readFully(fileLength - readSize, buffer, bufferOffset, readSize);
+        return readSize;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Stream closed: " + inputFile.location());
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        closed = true;
+        if (input != null) {
+            input.close();
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputHelper.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.CacheContext;
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.client.file.cache.PageId;
+import alluxio.conf.AlluxioConfiguration;
+import alluxio.conf.PropertyKey;
+import com.google.common.primitives.Ints;
+import io.trino.filesystem.Location;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Integer.max;
+import static java.lang.Math.addExact;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+// Inspired by https://github.com/Alluxio/alluxio/blob/4e39eda0305a0042edaeae649b503b4508623619/dora/core/client/fs/src/main/java/alluxio/client/file/cache/LocalCacheFileInStream.java#L50
+// We implement a variant of this class to enable positioned reads
+public class AlluxioInputHelper
+{
+    private final URIStatus status;
+    private final CacheManager cacheManager;
+    private final CacheStats statistics;
+    private final Location location;
+    private final int pageSize;
+    private final long fileLength;
+    private final int bufferSize;
+    private final byte[] readBuffer;
+
+    // Tracks the start and end positions of the portion of the file in the buffer
+    private long bufferStartPosition;
+    private long bufferEndPosition;
+
+    public AlluxioInputHelper(Location location, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, CacheStats statistics)
+    {
+        this.status = requireNonNull(status, "status is null");
+        this.fileLength = status.getLength();
+        this.cacheManager = requireNonNull(cacheManager, "cacheManager is null");
+        this.pageSize = (int) requireNonNull(configuration, "configuration is null").getBytes(PropertyKey.USER_CLIENT_CACHE_PAGE_SIZE);
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.location = requireNonNull(location, "location is null");
+        // Buffer to reduce the cost of doing page aligned reads for small sequential reads pattern
+        this.bufferSize = pageSize;
+        this.readBuffer = new byte[bufferSize];
+    }
+
+    public int doCacheRead(long position, byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        int bytesRead = doBufferRead(position, bytes, offset, length);
+        return addExact(bytesRead, doInternalCacheRead(position + bytesRead, bytes, offset + bytesRead, length - bytesRead));
+    }
+
+    private int doBufferRead(long position, byte[] bytes, int offset, int length)
+    {
+        if (length == 0) {
+            return 0;
+        }
+        if (position < bufferStartPosition || position >= bufferEndPosition) {
+            return 0;
+        }
+        int bytesToCopy = min(length, Ints.saturatedCast(bufferEndPosition - position));
+        System.arraycopy(readBuffer, Ints.saturatedCast(position - bufferStartPosition), bytes, offset, bytesToCopy);
+        return bytesToCopy;
+    }
+
+    private int doInternalCacheRead(long position, byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        // TODO: Support reading cache hits from the back as well
+        if (length == 0) {
+            return 0;
+        }
+        int remainingLength = length;
+        while (remainingLength > 0) {
+            int bytesReadFromCache = readPageFromCache(position, bytes, offset, remainingLength);
+            if (bytesReadFromCache == 0) {
+                break;
+            }
+            if (bytesReadFromCache < 0) {
+                throw new IOException("Read %d bytes from cache".formatted(bytesReadFromCache));
+            }
+            position += bytesReadFromCache;
+            remainingLength -= bytesReadFromCache;
+            offset += bytesReadFromCache;
+        }
+        int bytesRead = length - remainingLength;
+        statistics.recordCacheRead(location, bytesRead);
+        return bytesRead;
+    }
+
+    private int readPageFromCache(long position, byte[] buffer, int offset, int length)
+    {
+        long currentPage = position / pageSize;
+        int currentPageOffset = (int) (position % pageSize);
+        int bytesLeftInPage = (int) min(pageSize - currentPageOffset, fileLength - position);
+        int bytesToReadInPage = min(bytesLeftInPage, length);
+        if (bytesToReadInPage == 0) {
+            return 0;
+        }
+        CacheContext cacheContext = status.getCacheContext();
+        PageId pageId = new PageId(cacheContext.getCacheIdentifier(), currentPage);
+        if (bytesLeftInPage > length && bufferSize > length) { // Read page into buffer
+            int putBytes = putBuffer(position, currentPageOffset, pageId, cacheContext);
+            if (putBytes <= 0) {
+                return putBytes;
+            }
+            return doBufferRead(position, buffer, offset, length);
+        }
+        else {
+            return cacheManager.get(pageId, currentPageOffset, bytesToReadInPage, buffer, offset, cacheContext);
+        }
+    }
+
+    private int putBuffer(long position, int pageOffset, PageId pageId, CacheContext cacheContext)
+    {
+        pageOffset = min(pageOffset, max(pageSize - bufferSize, 0));
+        int bytesToReadInPage = Ints.saturatedCast(min(pageSize - pageOffset, fileLength - position));
+        int bytesRead = cacheManager.get(pageId, pageOffset, min(bytesToReadInPage, bufferSize), readBuffer, 0, cacheContext);
+        if (bytesRead < 0) {
+            // Buffer could be corrupted
+            bufferStartPosition = 0;
+            bufferEndPosition = 0;
+            return bytesRead;
+        }
+        if (bytesRead == 0) {
+            return bytesRead;
+        }
+        bufferStartPosition = pageOffset + (pageId.getPageIndex() * pageSize);
+        bufferEndPosition = bufferStartPosition + bytesRead;
+        return bytesRead;
+    }
+
+    public record PageAlignedRead(long pageStart, long pageEnd, int pageOffset)
+    {
+        public int length()
+        {
+            return (int) (pageEnd - pageStart);
+        }
+    }
+
+    public PageAlignedRead alignRead(long position, long length)
+    {
+        long pageStart = position - (position % pageSize);
+        int pageOffset = (int) (position % pageSize);
+        long readEnd = position + length;
+        long alignedReadEnd = readEnd + (pageSize - (readEnd % pageSize)) % pageSize;
+        long pageEnd = min(alignedReadEnd, fileLength);
+        return new PageAlignedRead(pageStart, pageEnd, pageOffset);
+    }
+
+    // Put length bytes from readBuffer into cache between pageStart and pageEnd
+    public void putCache(long pageStart, long pageEnd, byte[] readBuffer, int length)
+    {
+        checkArgument(pageStart + length <= pageEnd);
+        long end = pageEnd;
+        if (pageStart + length < pageEnd) {
+            end = pageStart + length - (length % pageSize);
+        }
+        int offset = 0;
+        while (pageStart < end) {
+            long currentPage = pageStart / pageSize;
+            int currentPageSize = (int) min(pageSize, pageEnd - pageStart);
+            CacheContext cacheContext = status.getCacheContext();
+            PageId pageId = new PageId(cacheContext.getCacheIdentifier(), currentPage);
+            cacheManager.put(pageId, ByteBuffer.wrap(readBuffer, offset, currentPageSize));
+            pageStart += currentPageSize;
+            offset += pageSize;
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.client.file.URIStatus;
+import alluxio.client.file.cache.CacheManager;
+import alluxio.conf.AlluxioConfiguration;
+import com.google.common.primitives.Longs;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+import static com.google.common.primitives.Ints.saturatedCast;
+import static java.lang.Integer.max;
+import static java.lang.Math.addExact;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+public class AlluxioInputStream
+        extends TrinoInputStream
+{
+    private final TrinoInputFile inputFile;
+    private final long fileLength;
+    private final Location location;
+    private final CacheStats statistics;
+    private final AlluxioInputHelper helper;
+
+    private TrinoInputStream externalStream;
+    private long position;
+    private boolean closed;
+
+    public AlluxioInputStream(TrinoInputFile inputFile, URIStatus status, CacheManager cacheManager, AlluxioConfiguration configuration, CacheStats statistics)
+    {
+        this.inputFile = requireNonNull(inputFile, "inputFile is null");
+        this.fileLength = requireNonNull(status, "status is null").getLength();
+        this.location = inputFile.location();
+        this.statistics = requireNonNull(statistics, "statistics is null");
+        this.helper = new AlluxioInputHelper(inputFile.location(), status, cacheManager, configuration, statistics);
+    }
+
+    @Override
+    public int available()
+            throws IOException
+    {
+        ensureOpen();
+
+        return saturatedCast(fileLength - position);
+    }
+
+    @Override
+    public long getPosition()
+    {
+        return position;
+    }
+
+    private void ensureOpen()
+            throws IOException
+    {
+        if (closed) {
+            throw new IOException("Output stream closed: " + location);
+        }
+    }
+
+    @Override
+    public int read()
+            throws IOException
+    {
+        ensureOpen();
+
+        byte[] bytes = new byte[1];
+        int n = read(bytes, 0, 1);
+        if (n == 1) {
+            // Converts the byte to an unsigned byte, an integer in the range 0 to 255
+            return bytes[0] & 0xff;
+        }
+        if (n == -1) {
+            return -1;
+        }
+        throw new IOException(format("%d bytes read", n));
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        ensureOpen();
+
+        checkFromIndexSize(offset, length, bytes.length);
+        if (position >= fileLength) {
+            return -1;
+        }
+        int bytesRead = doRead(bytes, offset, length);
+        position += bytesRead;
+        return bytesRead;
+    }
+
+    private int doRead(byte[] bytes, int offset, int length)
+            throws IOException
+    {
+        int bytesRead = helper.doCacheRead(position, bytes, offset, length);
+        return addExact(bytesRead, doExternalRead(position + bytesRead, bytes, offset + bytesRead, length - bytesRead));
+    }
+
+    private int doExternalRead(long readPosition, byte[] buffer, int offset, int length)
+            throws IOException
+    {
+        if (length == 0) {
+            return 0;
+        }
+        AlluxioInputHelper.PageAlignedRead aligned = helper.alignRead(readPosition, length);
+        if (externalStream == null) {
+            externalStream = inputFile.newStream();
+        }
+        externalStream.seek(aligned.pageStart());
+        byte[] readBuffer = new byte[aligned.length()];
+        int externalBytesRead = externalStream.read(readBuffer, 0, aligned.length());
+        if (externalBytesRead < 0) {
+            throw new IOException("Unexpected end of stream");
+        }
+        helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, externalBytesRead);
+        int bytesToCopy = min(length, max(externalBytesRead - aligned.pageOffset(), 0));
+        System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, bytesToCopy);
+        statistics.recordExternalRead(inputFile.location(), externalBytesRead);
+        return bytesToCopy;
+    }
+
+    @Override
+    public long skip(long n)
+            throws IOException
+    {
+        ensureOpen();
+
+        n = Longs.constrainToRange(n, 0, fileLength - position);
+        position += n;
+        return n;
+    }
+
+    @Override
+    public void skipNBytes(long n)
+            throws IOException
+    {
+        ensureOpen();
+
+        if (n <= 0) {
+            return;
+        }
+
+        long position;
+        try {
+            position = addExact(this.position, n);
+        }
+        catch (ArithmeticException e) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, this.position, fileLength, location));
+        }
+        if (position > fileLength) {
+            throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, this.position, fileLength, location));
+        }
+        this.position = position;
+    }
+
+    @Override
+    public void seek(long position)
+            throws IOException
+    {
+        ensureOpen();
+
+        if (position < 0) {
+            throw new IOException("Negative seek offset");
+        }
+        if (position > fileLength) {
+            throw new IOException("Cannot seek to %s. File size is %s: %s".formatted(position, fileLength, location));
+        }
+
+        this.position = position;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        if (!closed) {
+            closed = true;
+            if (externalStream != null) {
+                externalStream.close();
+                externalStream = null;
+            }
+        }
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/CacheStats.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/CacheStats.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import io.trino.filesystem.Location;
+
+public interface CacheStats
+{
+    void recordCacheRead(Location location, int length);
+
+    void recordExternalRead(Location location, int length);
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystem.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.conf.AlluxioConfiguration;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestAlluxioCacheFileSystem
+        extends AbstractTestTrinoFileSystem
+{
+    private CacheFileSystem fileSystem;
+    private Path tempDirectory;
+    private TestingAlluxioFileSystemCache cache;
+    private MemoryFileSystem memoryFileSystem;
+
+    @BeforeAll
+    void beforeAll()
+            throws IOException
+    {
+        tempDirectory = Files.createTempDirectory("test");
+        Path cacheDirectory = tempDirectory.resolve("cache");
+        Files.createDirectory(cacheDirectory);
+        AlluxioFileSystemCacheConfig configuration = new AlluxioFileSystemCacheConfig()
+                .setCacheDirectories(cacheDirectory.toAbsolutePath().toString())
+                .setCachePageSize(DataSize.valueOf("32003B"))
+                .disableTTL()
+                .setMaxCacheSizes("100MB");
+        AlluxioConfiguration alluxioConfiguration = AlluxioFileSystemCacheModule.getAlluxioConfiguration(configuration);
+        cache = new TestingAlluxioFileSystemCache(alluxioConfiguration, new DefaultCacheKeyProvider()) {
+            @Override
+            public void expire(Location location)
+            {
+                // Expire the entire cache on a single invalidation
+                clear();
+            }
+        };
+        memoryFileSystem = new MemoryFileSystem();
+        fileSystem = new CacheFileSystem(memoryFileSystem, cache, cache.getCacheKeyProvider());
+    }
+
+    @AfterEach
+    void afterEach()
+            throws IOException
+    {
+        cache.clear();
+    }
+
+    @AfterAll
+    void afterAll()
+            throws IOException
+    {
+        cleanupFiles(tempDirectory);
+        Files.delete(tempDirectory);
+    }
+
+    private void cleanupFiles(Path directory)
+            throws IOException
+    {
+        // tests will leave directories
+        try (Stream<Path> walk = Files.walk(directory)) {
+            Iterator<Path> iterator = walk.sorted(Comparator.reverseOrder()).iterator();
+            while (iterator.hasNext()) {
+                Path path = iterator.next();
+                if (!path.equals(directory)) {
+                    Files.delete(path);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean isFileContentCaching()
+    {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return true;
+    }
+
+    @Override
+    protected TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        assertThat(memoryFileSystem.isEmpty()).isTrue();
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioCacheFileSystemAccessOperations.java
@@ -1,0 +1,377 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.conf.AlluxioConfiguration;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrackingFileSystemFactory;
+import io.trino.filesystem.TrackingFileSystemFactory.OperationType;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_LAST_MODIFIED;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_NEW_STREAM;
+import static io.trino.filesystem.alluxio.TestingAlluxioFileSystemCache.OperationType.CACHE_READ;
+import static io.trino.filesystem.alluxio.TestingAlluxioFileSystemCache.OperationType.EXTERNAL_READ;
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static java.util.Collections.nCopies;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestAlluxioCacheFileSystemAccessOperations
+{
+    private static final int CACHE_SIZE = 1024;
+    private static final int PAGE_SIZE = 128;
+
+    private TrackingFileSystemFactory trackingFileSystemFactory;
+    private TestingAlluxioFileSystemCache alluxioCache;
+    private CacheFileSystem fileSystem;
+    private Path tempDirectory;
+
+    @BeforeAll
+    public void setUp()
+            throws IOException
+    {
+        tempDirectory = Files.createTempDirectory("test");
+        Path cacheDirectory = Files.createDirectory(tempDirectory.resolve("cache"));
+
+        AlluxioFileSystemCacheConfig configuration = new AlluxioFileSystemCacheConfig()
+                .setCacheDirectories(cacheDirectory.toAbsolutePath().toString())
+                .disableTTL()
+                .setCachePageSize(DataSize.ofBytes(PAGE_SIZE))
+                .setMaxCacheSizes(DataSize.ofBytes(CACHE_SIZE).toBytesValueString());
+        AlluxioConfiguration alluxioConfiguration = AlluxioFileSystemCacheModule.getAlluxioConfiguration(configuration);
+
+        trackingFileSystemFactory = new TrackingFileSystemFactory(new MemoryFileSystemFactory());
+        alluxioCache = new TestingAlluxioFileSystemCache(alluxioConfiguration, new DefaultCacheKeyProvider());
+        fileSystem = new CacheFileSystem(trackingFileSystemFactory.create(ConnectorIdentity.ofUser("hello")),
+                alluxioCache, alluxioCache.getCacheKeyProvider());
+    }
+
+    @AfterAll
+    public void tearDown()
+    {
+        trackingFileSystemFactory = null;
+        fileSystem = null;
+        tempDirectory.toFile().delete();
+        tempDirectory = null;
+    }
+
+    @Test
+    public void testCache()
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath("hello");
+        byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write(content);
+        }
+
+        assertReadOperations(location, content,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation(location, EXTERNAL_READ))
+                        .build());
+        assertReadOperations(location, content,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation(location, CACHE_READ))
+                        .build());
+
+        byte[] modifiedContent = "modified content".getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = fileSystem.newOutputFile(location).createOrOverwrite()) {
+            output.write(modifiedContent);
+        }
+
+        // Clear the cache, as lastModified time might be unchanged
+        alluxioCache.clear();
+        assertReadOperations(location, modifiedContent,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation(location, EXTERNAL_READ))
+                        .build());
+    }
+
+    @Test
+    public void testPartialCacheHits()
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath("partial");
+        byte[] content = new byte[2 * PAGE_SIZE];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) i;
+        }
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write(content);
+        }
+
+        assertSizedReadOperations(location, Arrays.copyOf(content, PAGE_SIZE),
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, EXTERNAL_READ, 128))
+                        .add(new CacheReadOperation(location, CACHE_READ, 0))
+                        .build());
+
+        assertSizedReadOperations(location, Arrays.copyOf(content, PAGE_SIZE + 10),
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, EXTERNAL_READ, 128))
+                        .add(new CacheReadOperation(location, CACHE_READ, 128))
+                        .build());
+
+        assertSizedReadOperations(location, Arrays.copyOf(content, PAGE_SIZE + 10),
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, CACHE_READ, 138))
+                        .build());
+
+        assertSizedReadOperations(location, content,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, CACHE_READ, 256))
+                        .build());
+    }
+
+    @Test
+    public void testMultiPageExternalsReads()
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath("multipage");
+        byte[] content = new byte[2 * PAGE_SIZE];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) i;
+        }
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write(content);
+        }
+
+        assertSizedReadOperations(location, Arrays.copyOf(content, PAGE_SIZE + 1),
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, EXTERNAL_READ, 256))
+                        .add(new CacheReadOperation(location, CACHE_READ, 0))
+                        .build());
+
+        assertSizedReadOperations(location, Arrays.copyOf(content, 2 * PAGE_SIZE),
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheReadOperation>builder()
+                        .add(new CacheReadOperation(location, CACHE_READ, 256))
+                        .build());
+    }
+
+    @Test
+    public void testCacheInvalidation()
+            throws IOException
+    {
+        int cacheSize = (int) (0.9 * CACHE_SIZE);
+        Location aLocation = createFile("a", cacheSize);
+        Location bLocation = createFile("b", cacheSize);
+        Location cLocation = createFile("c", cacheSize / 2);
+        Location dLocation = createFile("d", cacheSize / 2);
+
+        assertUnCachedRead(aLocation);
+        assertCachedRead(aLocation);
+        assertUnCachedRead(bLocation);
+        assertUnCachedRead(aLocation);
+        assertCachedRead(aLocation);
+        assertCachedRead(aLocation);
+        assertUnCachedRead(bLocation);
+        assertCachedRead(bLocation);
+
+        assertUnCachedRead(cLocation);
+        assertUnCachedRead(dLocation);
+        assertCachedRead(cLocation);
+        assertCachedRead(dLocation);
+
+        assertUnCachedRead(bLocation);
+        assertCachedRead(bLocation);
+        assertUnCachedRead(cLocation);
+        assertUnCachedRead(dLocation);
+    }
+
+    private Location createFile(String name, int size)
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath(name);
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write("a".repeat(size).getBytes(StandardCharsets.UTF_8));
+        }
+        return location;
+    }
+
+    private Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    private void assertCachedRead(Location location)
+            throws IOException
+    {
+        assertReadOperations(location,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation(location, CACHE_READ))
+                        .build());
+    }
+
+    private void assertUnCachedRead(Location location)
+            throws IOException
+    {
+        assertReadOperations(location,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(location, INPUT_FILE_LAST_MODIFIED))
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation(location, EXTERNAL_READ))
+                        .build());
+    }
+
+    private void assertReadOperations(Location location, Multiset<FileOperation> fileOperations, Multiset<CacheOperation> cacheOperations)
+            throws IOException
+    {
+        TrinoInputFile file = fileSystem.newInputFile(location);
+        int length = (int) file.length();
+        trackingFileSystemFactory.reset();
+        alluxioCache.reset();
+        try (TrinoInput input = file.newInput()) {
+            input.readFully(0, length);
+        }
+        assertMultisetsEqual(getOperations(), fileOperations);
+        assertMultisetsEqual(getCacheOperations(), cacheOperations);
+    }
+
+    private void assertReadOperations(Location location, byte[] content, Multiset<FileOperation> fileOperations, Multiset<CacheOperation> cacheOperations)
+            throws IOException
+    {
+        TrinoInputFile file = fileSystem.newInputFile(location);
+        int length = content.length; //saturatedCast(file.length());
+        trackingFileSystemFactory.reset();
+        alluxioCache.reset();
+        try (TrinoInput input = file.newInput()) {
+            assertThat(input.readFully(0, length)).isEqualTo(Slices.wrappedBuffer(content));
+        }
+        assertMultisetsEqual(getOperations(), fileOperations);
+        assertMultisetsEqual(getCacheOperations(), cacheOperations);
+    }
+
+    private void assertSizedReadOperations(Location location, byte[] content, Multiset<FileOperation> fileOperations, Multiset<CacheReadOperation> cacheOperations)
+            throws IOException
+    {
+        TrinoInputFile file = fileSystem.newInputFile(location);
+        int length = content.length; //saturatedCast(file.length());
+        trackingFileSystemFactory.reset();
+        alluxioCache.reset();
+        try (TrinoInput input = file.newInput()) {
+            assertThat(input.readFully(0, length)).isEqualTo(Slices.wrappedBuffer(content));
+        }
+        assertMultisetsEqual(getOperations(), fileOperations);
+        assertMultisetsEqual(getCacheReadOperations(), cacheOperations);
+    }
+
+    private Multiset<FileOperation> getOperations()
+    {
+        return trackingFileSystemFactory.getOperationCounts()
+                .entrySet().stream()
+                .flatMap(entry -> nCopies(entry.getValue(), new FileOperation(
+                        entry.getKey().location(),
+                        entry.getKey().operationType())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private Multiset<CacheOperation> getCacheOperations()
+    {
+        return alluxioCache.getOperationCounts()
+                .entrySet().stream()
+                .flatMap(entry -> nCopies((int) entry.getValue().stream().filter(l -> l > 0).count(), new CacheOperation(
+                        entry.getKey().location(),
+                        entry.getKey().type())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private Multiset<CacheReadOperation> getCacheReadOperations()
+    {
+        return alluxioCache.getOperationCounts()
+                .entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream().map(length -> new CacheReadOperation(
+                        entry.getKey().location(),
+                        entry.getKey().type(), length)))
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private record FileOperation(Location path, OperationType operationType) {}
+
+    private record CacheOperation(Location path, TestingAlluxioFileSystemCache.OperationType operationType) {}
+
+    private record CacheReadOperation(Location path, TestingAlluxioFileSystemCache.OperationType operationType, int length) {}
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestAlluxioFileSystemCacheConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.filesystem.alluxio.AlluxioFileSystemCacheModule.totalSpace;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TestAlluxioFileSystemCacheConfig
+{
+    @Test
+    public void testInvalidConfiguration()
+    {
+        assertThatThrownBy(() ->
+                AlluxioFileSystemCacheModule.getAlluxioConfiguration(
+                        new AlluxioFileSystemCacheConfig()
+                                .setCacheDirectories("/cache1,/cache2")
+                                .setMaxCacheDiskUsagePercentages("0")
+                                .setMaxCacheSizes("1B")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Either fs.cache.max-sizes or fs.cache.max-disk-usage-percentages must be specified");
+        assertThatThrownBy(() ->
+                AlluxioFileSystemCacheModule.getAlluxioConfiguration(
+                        new AlluxioFileSystemCacheConfig()
+                                .setCacheDirectories("/cache1,/cache2")
+                                .setMaxCacheSizes("1B")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fs.cache.directories and fs.cache.max-sizes must have the same size");
+        assertThatThrownBy(() ->
+                AlluxioFileSystemCacheModule.getAlluxioConfiguration(
+                        new AlluxioFileSystemCacheConfig()
+                                .setCacheDirectories("/cache1,/cache2")
+                                .setMaxCacheDiskUsagePercentages("0")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fs.cache.directories and fs.cache.max-disk-usage-percentages must have the same size");
+    }
+
+    @Test
+    void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(AlluxioFileSystemCacheConfig.class)
+                .setCacheDirectories(null)
+                .setCachePageSize(DataSize.valueOf("1MB"))
+                .setMaxCacheSizes(null)
+                .setMaxCacheDiskUsagePercentages(null)
+                .setCacheTTL(Duration.valueOf("7d")));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path cacheDirectory = Files.createTempFile(null, null);
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("fs.cache.directories", cacheDirectory.toString())
+                .put("fs.cache.alluxio.page-size", "7MB")
+                .put("fs.cache.max-sizes", "1GB")
+                .put("fs.cache.max-disk-usage-percentages", "50")
+                .put("fs.cache.ttl", "1d")
+                .buildOrThrow();
+
+        AlluxioFileSystemCacheConfig expected = new AlluxioFileSystemCacheConfig()
+                .setCacheDirectories(cacheDirectory.toString())
+                .setCachePageSize(DataSize.valueOf("7MB"))
+                .setMaxCacheSizes("1GB")
+                .setMaxCacheDiskUsagePercentages("50")
+                .setCacheTTL(Duration.valueOf("1d"));
+
+        assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testTotalSpaceCalculation()
+            throws IOException
+    {
+        Path cacheDirectory = Files.createTempFile(null, null);
+
+        assertEquals(cacheDirectory.toFile().getTotalSpace(), totalSpace(cacheDirectory));
+        assertEquals(cacheDirectory.toFile().getTotalSpace(), totalSpace(cacheDirectory.resolve(Path.of("does-not-exist"))));
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestFuzzAlluxioCacheFileSystem.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestFuzzAlluxioCacheFileSystem.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.conf.AlluxioConfiguration;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.cache.CacheFileSystem;
+import io.trino.filesystem.cache.DefaultCacheKeyProvider;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static java.lang.Math.min;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(Lifecycle.PER_METHOD)
+public class TestFuzzAlluxioCacheFileSystem
+{
+    private static final int CACHE_SIZE = 8 * 1024;
+    private static final int PAGE_SIZE = 128;
+
+    @Test
+    public void testFuzzTrinoInputReadFully()
+            throws IOException
+    {
+        fuzzTrinoInputOperation((fs, l) -> fs.newInputFile(l).newInput(), TrinoInput::readFully);
+    }
+
+    @Test
+    public void testFuzzTrinoInputReadTail()
+            throws IOException
+    {
+        fuzzTrinoInputOperation((fs, l) -> fs.newInputFile(l).newInput(), (input, position, buffer, bufferOffset, bufferLength) -> input.readTail(buffer, bufferOffset, bufferLength));
+    }
+
+    @Test
+    public void testFuzzTrinoInputStreamRead()
+            throws IOException
+    {
+        fuzzTrinoInputOperation((fs, l) -> fs.newInputFile(l).newStream(), (input, position, buffer, bufferOffset, bufferLength) -> {
+            input.seek(position);
+            input.read(buffer, bufferOffset, bufferLength);
+        });
+    }
+
+    private <T> void fuzzTrinoInputOperation(CreateTrinoInput<T> createInput, TrinoInputOperation<T> operation)
+            throws IOException
+    {
+        Random random = new Random();
+        try (TestFileSystem expectedFileSystemState = new TestMemoryFileSystem()) {
+            try (TestFileSystem actualFileSystemState = new TestAlluxioFileSystem()) {
+                TrinoFileSystem expectedFileSystem = expectedFileSystemState.create();
+                TrinoFileSystem testFileSystem = actualFileSystemState.create();
+
+                Location expectedLocation = expectedFileSystemState.tempLocation();
+                Location testLocation = actualFileSystemState.tempLocation();
+
+                int fileSize = random.nextInt(0, CACHE_SIZE / 2);
+
+                createTestFile(expectedFileSystem, expectedLocation, fileSize);
+                createTestFile(testFileSystem, testLocation, fileSize);
+
+                T expectedInput = createInput.apply(expectedFileSystem, expectedLocation);
+                T actualInput = createInput.apply(testFileSystem, testLocation);
+
+                for (int i = 0; i < 1000; i++) {
+                    applyOperation(random, fileSize, expectedInput, actualInput, operation);
+                }
+            }
+        }
+    }
+
+    public <T> void applyOperation(Random random, int fileSize, T expectedInput, T actualInput, TrinoInputOperation<T> operation)
+            throws IOException
+    {
+        long position = random.nextLong(0, fileSize + 1);
+        int bufferSize = random.nextInt(0, fileSize + 1);
+        int bufferOffset = random.nextInt(0, bufferSize + 1);
+        int length = bufferSize - bufferOffset;
+        byte[] bufferExpected = new byte[bufferSize];
+        byte[] bufferActual = new byte[bufferSize];
+
+        operation.apply(expectedInput, position, bufferExpected, bufferOffset, length);
+        operation.apply(actualInput, position, bufferActual, bufferOffset, length);
+
+        assertEquals(Slices.wrappedBuffer(bufferExpected), Slices.wrappedBuffer(bufferActual));
+    }
+
+    private static void createTestFile(TrinoFileSystem fileSystem, Location location, int fileSize)
+            throws IOException
+    {
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            byte[] bytes = new byte[4];
+            Slice slice = Slices.wrappedBuffer(bytes);
+            for (int i = 0; i < fileSize; i++) {
+                slice.setInt(0, i);
+                output.write(bytes, 0, min(fileSize - i, 4));
+            }
+        }
+    }
+
+    private interface TestFileSystem
+            extends Closeable
+    {
+        TrinoFileSystem create()
+                throws IOException;
+
+        Location tempLocation();
+    }
+
+    private static class TestMemoryFileSystem
+            implements TestFileSystem
+    {
+        @Override
+        public TrinoFileSystem create()
+        {
+            return new MemoryFileSystemFactory().create(ConnectorIdentity.ofUser(""));
+        }
+
+        @Override
+        public Location tempLocation()
+        {
+            return Location.of("memory:///fuzz");
+        }
+
+        @Override
+        public void close()
+        {
+        }
+    }
+
+    private static class TestAlluxioFileSystem
+            implements TestFileSystem
+    {
+        private Path tempDirectory;
+
+        @Override
+        public TrinoFileSystem create()
+                throws IOException
+        {
+            tempDirectory = Files.createTempDirectory("test");
+            Path cacheDirectory = Files.createDirectory(tempDirectory.resolve("cache"));
+
+            AlluxioFileSystemCacheConfig configuration = new AlluxioFileSystemCacheConfig()
+                    .setCacheDirectories(cacheDirectory.toAbsolutePath().toString())
+                    .setCachePageSize(DataSize.ofBytes(PAGE_SIZE))
+                    .disableTTL()
+                    .setMaxCacheSizes(CACHE_SIZE + "B");
+            AlluxioConfiguration alluxioConfiguration = AlluxioFileSystemCacheModule.getAlluxioConfiguration(configuration);
+
+            MemoryFileSystemFactory fileSystemFactory = new MemoryFileSystemFactory();
+            TestingAlluxioFileSystemCache alluxioCache = new TestingAlluxioFileSystemCache(alluxioConfiguration, new DefaultCacheKeyProvider());
+            return new CacheFileSystem(fileSystemFactory.create(ConnectorIdentity.ofUser("hello")),
+                    alluxioCache, alluxioCache.getCacheKeyProvider());
+        }
+
+        @Override
+        public Location tempLocation()
+        {
+            return Location.of("memory:///fuzz");
+        }
+
+        @Override
+        public void close()
+        {
+            tempDirectory.toFile().delete();
+        }
+    }
+
+    private interface TrinoInputOperation<T>
+    {
+        void apply(T input, long position, byte[] buffer, int bufferOffset, int bufferLength)
+                throws IOException;
+    }
+
+    private interface CreateTrinoInput<T>
+    {
+        T apply(TrinoFileSystem fileSystem, Location location)
+                throws IOException;
+    }
+}

--- a/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestingAlluxioFileSystemCache.java
+++ b/lib/trino-filesystem-cache-alluxio/src/test/java/io/trino/filesystem/alluxio/TestingAlluxioFileSystemCache.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.alluxio;
+
+import alluxio.conf.AlluxioConfiguration;
+import com.google.common.collect.ImmutableMap;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.cache.CacheKeyProvider;
+import io.trino.filesystem.cache.TrinoFileSystemCache;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingAlluxioFileSystemCache
+        implements TrinoFileSystemCache
+{
+    private final AlluxioFileSystemCache cache;
+
+    @Override
+    public TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return cache.cacheInput(delegate, key);
+    }
+
+    @Override
+    public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        return cache.cacheStream(delegate, key);
+    }
+
+    @Override
+    public void expire(Location location)
+            throws IOException
+    {
+    }
+
+    public enum OperationType
+    {
+        CACHE_READ,
+        EXTERNAL_READ,
+    }
+
+    public record OperationContext(OperationType type, Location location)
+    {
+        public OperationContext
+        {
+            requireNonNull(type, "type is null");
+            requireNonNull(location, "location is null");
+        }
+    }
+
+    private final TestingAlluxioCacheStats statistics;
+    private final CacheKeyProvider delegateKeyProvider;
+    private final TestingCacheKeyProvider keyProvider;
+    private final AtomicInteger cacheGeneration = new AtomicInteger(0);
+
+    public TestingAlluxioFileSystemCache(AlluxioConfiguration alluxioConfiguration, CacheKeyProvider keyProvider)
+    {
+        statistics = new TestingAlluxioCacheStats();
+        cache = new AlluxioFileSystemCache(AlluxioFileSystemCacheModule.getCacheManager(alluxioConfiguration), alluxioConfiguration, statistics);
+        delegateKeyProvider = requireNonNull(keyProvider, "keyProvider is null");
+        this.keyProvider = new TestingCacheKeyProvider();
+    }
+
+    public CacheKeyProvider getCacheKeyProvider()
+    {
+        return this.keyProvider;
+    }
+
+    private class TestingCacheKeyProvider
+            implements CacheKeyProvider
+    {
+        @Override
+        public Optional<String> getCacheKey(TrinoInputFile delegate)
+                throws IOException
+        {
+            return delegateKeyProvider.getCacheKey(delegate).map(key -> key + cacheGeneration.get());
+        }
+    }
+
+    public void reset()
+    {
+        statistics.reset();
+    }
+
+    public void clear()
+    {
+        cacheGeneration.incrementAndGet();
+    }
+
+    public Map<OperationContext, List<Integer>> getOperationCounts()
+    {
+        return statistics.getOperationCounts();
+    }
+
+    private static class TestingAlluxioCacheStats
+            implements CacheStats
+    {
+        private final Map<OperationContext, List<Integer>> operationCounts = new ConcurrentHashMap<>();
+
+        public TestingAlluxioCacheStats()
+        {
+            super();
+        }
+
+        @Override
+        public void recordExternalRead(Location location, int length)
+        {
+            operationCounts.computeIfAbsent(new OperationContext(OperationType.EXTERNAL_READ, location), k -> new ArrayList<>()).add(length);
+        }
+
+        @Override
+        public void recordCacheRead(Location location, int length)
+        {
+            operationCounts.computeIfAbsent(new OperationContext(OperationType.CACHE_READ, location), k -> new ArrayList<>()).add(length);
+        }
+
+        public Map<OperationContext, List<Integer>> getOperationCounts()
+        {
+            return ImmutableMap.copyOf(operationCounts);
+        }
+
+        public void reset()
+        {
+            operationCounts.clear();
+        }
+    }
+}

--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -54,6 +54,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-cache-alluxio</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-filesystem-gcs</artifactId>
         </dependency>
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -15,12 +15,15 @@ package io.trino.filesystem.manager;
 
 import io.airlift.configuration.Config;
 
+import static io.trino.filesystem.manager.FileSystemConfig.CacheType.NONE;
+
 public class FileSystemConfig
 {
     private boolean hadoopEnabled = true;
     private boolean nativeAzureEnabled;
     private boolean nativeS3Enabled;
     private boolean nativeGcsEnabled;
+    private CacheType cacheType = NONE;
 
     public boolean isHadoopEnabled()
     {
@@ -68,5 +71,22 @@ public class FileSystemConfig
     {
         this.nativeGcsEnabled = nativeGcsEnabled;
         return this;
+    }
+
+    public CacheType getCacheType()
+    {
+        return cacheType;
+    }
+
+    @Config("fs.cache")
+    public FileSystemConfig setCacheType(CacheType cacheType)
+    {
+        this.cacheType = cacheType;
+        return this;
+    }
+
+    public enum CacheType
+    {
+        NONE,
     }
 }

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -88,5 +88,6 @@ public class FileSystemConfig
     public enum CacheType
     {
         NONE,
+        ALLUXIO,
     }
 }

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -15,6 +15,7 @@ package io.trino.filesystem.manager;
 
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
@@ -23,6 +24,8 @@ import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.azure.AzureFileSystemFactory;
 import io.trino.filesystem.azure.AzureFileSystemModule;
+import io.trino.filesystem.cache.CachingHostAddressProvider;
+import io.trino.filesystem.cache.NoneCachingHostAddressProvider;
 import io.trino.filesystem.gcs.GcsFileSystemFactory;
 import io.trino.filesystem.gcs.GcsFileSystemModule;
 import io.trino.filesystem.s3.S3FileSystemFactory;
@@ -91,6 +94,8 @@ public class FileSystemModule
             install(new GcsFileSystemModule());
             factories.addBinding("gs").to(GcsFileSystemFactory.class);
         }
+
+        newOptionalBinder(binder, CachingHostAddressProvider.class).setDefault().to(NoneCachingHostAddressProvider.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.filesystem.manager.FileSystemConfig.CacheType.NONE;
 
 public class TestFileSystemConfig
 {
@@ -31,7 +32,8 @@ public class TestFileSystemConfig
                 .setHadoopEnabled(true)
                 .setNativeAzureEnabled(false)
                 .setNativeS3Enabled(false)
-                .setNativeGcsEnabled(false));
+                .setNativeGcsEnabled(false)
+                .setCacheType(NONE));
     }
 
     @Test
@@ -42,13 +44,15 @@ public class TestFileSystemConfig
                 .put("fs.native-azure.enabled", "true")
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.native-gcs.enabled", "true")
+                .put("fs.cache", "none")
                 .buildOrThrow();
 
         FileSystemConfig expected = new FileSystemConfig()
                 .setHadoopEnabled(false)
                 .setNativeAzureEnabled(true)
                 .setNativeS3Enabled(true)
-                .setNativeGcsEnabled(true);
+                .setNativeGcsEnabled(true)
+                .setCacheType(NONE);
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.filesystem.manager.FileSystemConfig.CacheType.ALLUXIO;
 import static io.trino.filesystem.manager.FileSystemConfig.CacheType.NONE;
 
 public class TestFileSystemConfig
@@ -44,7 +45,7 @@ public class TestFileSystemConfig
                 .put("fs.native-azure.enabled", "true")
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.native-gcs.enabled", "true")
-                .put("fs.cache", "none")
+                .put("fs.cache", "alluxio")
                 .buildOrThrow();
 
         FileSystemConfig expected = new FileSystemConfig()
@@ -52,7 +53,7 @@ public class TestFileSystemConfig
                 .setNativeAzureEnabled(true)
                 .setNativeS3Enabled(true)
                 .setNativeGcsEnabled(true)
-                .setCacheType(NONE);
+                .setCacheType(ALLUXIO);
 
         assertFullMapping(properties, expected);
     }

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -84,6 +84,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -18,8 +18,34 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.github.ishugaliy</groupId>
+            <artifactId>allgood-consistent-hash</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
         </dependency>
 
         <dependency>
@@ -53,15 +79,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>concurrent</artifactId>
-            <scope>test</scope>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -73,6 +98,18 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystem.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.FileIterator;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoOutputFile;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public final class CacheFileSystem
+        implements TrinoFileSystem
+{
+    private final TrinoFileSystem delegate;
+    private final TrinoFileSystemCache cache;
+    private final CacheKeyProvider keyProvider;
+
+    public CacheFileSystem(TrinoFileSystem delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.cache = requireNonNull(cache, "cache is null");
+        this.keyProvider = requireNonNull(keyProvider, "keyProvider is null");
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location)
+    {
+        return new CacheInputFile(delegate.newInputFile(location), cache, keyProvider);
+    }
+
+    @Override
+    public TrinoInputFile newInputFile(Location location, long length)
+    {
+        return new CacheInputFile(delegate.newInputFile(location, length), cache, keyProvider);
+    }
+
+    @Override
+    public TrinoOutputFile newOutputFile(Location location)
+    {
+        TrinoOutputFile output = delegate.newOutputFile(location);
+        try {
+            cache.expire(location);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return output;
+    }
+
+    @Override
+    public void deleteFile(Location location)
+            throws IOException
+    {
+        delegate.deleteFile(location);
+        cache.expire(location);
+    }
+
+    @Override
+    public void deleteDirectory(Location location)
+            throws IOException
+    {
+        delegate.deleteDirectory(location);
+    }
+
+    @Override
+    public void renameFile(Location source, Location target)
+            throws IOException
+    {
+        delegate.renameFile(source, target);
+        cache.expire(source);
+        cache.expire(target);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location)
+            throws IOException
+    {
+        return delegate.listFiles(location);
+    }
+
+    @Override
+    public Optional<Boolean> directoryExists(Location location)
+            throws IOException
+    {
+        return delegate.directoryExists(location);
+    }
+
+    @Override
+    public void createDirectory(Location location)
+            throws IOException
+    {
+        delegate.createDirectory(location);
+    }
+
+    @Override
+    public void renameDirectory(Location source, Location target)
+            throws IOException
+    {
+        delegate.renameDirectory(source, target);
+    }
+
+    @Override
+    public Set<Location> listDirectories(Location location)
+            throws IOException
+    {
+        return delegate.listDirectories(location);
+    }
+
+    @Override
+    public Optional<Location> createTemporaryDirectory(Location targetPath, String temporaryPrefix, String relativePrefix)
+            throws IOException
+    {
+        return delegate.createTemporaryDirectory(targetPath, temporaryPrefix, relativePrefix);
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystemFactory.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheFileSystemFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.spi.security.ConnectorIdentity;
+
+import static java.util.Objects.requireNonNull;
+
+public final class CacheFileSystemFactory
+        implements TrinoFileSystemFactory
+{
+    private final TrinoFileSystemFactory delegate;
+    private final TrinoFileSystemCache cache;
+    private final CacheKeyProvider keyProvider;
+
+    public CacheFileSystemFactory(TrinoFileSystemFactory delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.cache = requireNonNull(cache, "cache is null");
+        this.keyProvider = requireNonNull(keyProvider, "keyProvider is null");
+    }
+
+    @Override
+    public TrinoFileSystem create(ConnectorIdentity identity)
+    {
+        return new CacheFileSystem(delegate.create(identity), cache, keyProvider);
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheInputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheInputFile.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public final class CacheInputFile
+        implements TrinoInputFile
+{
+    private final TrinoInputFile delegate;
+    private final TrinoFileSystemCache cache;
+    private final CacheKeyProvider keyProvider;
+
+    public CacheInputFile(TrinoInputFile delegate, TrinoFileSystemCache cache, CacheKeyProvider keyProvider)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.cache = requireNonNull(cache, "cache is null");
+        this.keyProvider = requireNonNull(keyProvider, "keyProvider is null");
+    }
+
+    @Override
+    public TrinoInput newInput()
+            throws IOException
+    {
+        Optional<String> key = keyProvider.getCacheKey(delegate);
+        if (key.isPresent()) {
+            return cache.cacheInput(delegate, key.orElseThrow());
+        }
+        return delegate.newInput();
+    }
+
+    @Override
+    public TrinoInputStream newStream()
+            throws IOException
+    {
+        Optional<String> key = keyProvider.getCacheKey(delegate);
+        if (key.isPresent()) {
+            return cache.cacheStream(delegate, key.orElseThrow());
+        }
+        return delegate.newStream();
+    }
+
+    @Override
+    public long length()
+            throws IOException
+    {
+        return delegate.length();
+    }
+
+    @Override
+    public Instant lastModified()
+            throws IOException
+    {
+        return delegate.lastModified();
+    }
+
+    @Override
+    public boolean exists()
+            throws IOException
+    {
+        return delegate.exists();
+    }
+
+    @Override
+    public Location location()
+    {
+        return delegate.location();
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheKeyProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CacheKeyProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.TrinoInputFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public interface CacheKeyProvider
+{
+    /**
+     * Get the cache key of a TrinoInputFile. Returns Optional.empty() if the file is not cacheable.
+     */
+    Optional<String> getCacheKey(TrinoInputFile delegate)
+            throws IOException;
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CachingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/CachingHostAddressProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.spi.HostAddress;
+
+import java.util.List;
+
+public interface CachingHostAddressProvider
+{
+    /**
+     * Returns a lists of hosts which are preferred to cache the split with the given path.
+     */
+    List<HostAddress> getHosts(String splitPath);
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProvider.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import io.airlift.log.Logger;
+import io.trino.spi.HostAddress;
+import io.trino.spi.Node;
+import io.trino.spi.NodeManager;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.ishugaliy.allgood.consistent.hash.ConsistentHash;
+import org.ishugaliy.allgood.consistent.hash.HashRing;
+import org.ishugaliy.allgood.consistent.hash.hasher.DefaultHasher;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class ConsistentHashingHostAddressProvider
+        implements CachingHostAddressProvider
+{
+    private static final Logger log = Logger.get(ConsistentHashingHostAddressProvider.class);
+
+    private final NodeManager nodeManager;
+    private final ScheduledExecutorService hashRingUpdater = newSingleThreadScheduledExecutor(daemonThreadsNamed("hash-ring-refresher-%s"));
+    private final int replicationFactor;
+    private final Comparator<HostAddress> hostAddressComparator = Comparator.comparing(HostAddress::getHostText).thenComparing(HostAddress::getPort);
+
+    private final ConsistentHash<TrinoNode> consistentHashRing = HashRing.<TrinoNode>newBuilder()
+            .hasher(DefaultHasher.METRO_HASH)
+            .build();
+
+    @Inject
+    public ConsistentHashingHostAddressProvider(NodeManager nodeManager, ConsistentHashingHostAddressProviderConfiguration configuration)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.replicationFactor = configuration.getPreferredHostsCount();
+    }
+
+    @Override
+    public List<HostAddress> getHosts(String splitPath)
+    {
+        return consistentHashRing.locate(splitPath, replicationFactor)
+                .stream()
+                .map(TrinoNode::getHostAndPort)
+                .sorted(hostAddressComparator)
+                .collect(toImmutableList());
+    }
+
+    @PostConstruct
+    public void startRefreshingHashRing()
+    {
+        hashRingUpdater.scheduleWithFixedDelay(this::refreshHashRing, 5, 5, TimeUnit.SECONDS);
+        refreshHashRing();
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        hashRingUpdater.shutdownNow();
+    }
+
+    @VisibleForTesting
+    synchronized void refreshHashRing()
+    {
+        try {
+            ImmutableSet<TrinoNode> trinoNodes = nodeManager.getWorkerNodes().stream().map(TrinoNode::of).collect(toImmutableSet());
+            Set<TrinoNode> hashRingNodes = consistentHashRing.getNodes();
+            Set<TrinoNode> removedNodes = Sets.difference(hashRingNodes, trinoNodes);
+            Set<TrinoNode> newNodes = Sets.difference(trinoNodes, hashRingNodes);
+            // Avoid acquiring a write lock in consistentHashRing if possible
+            if (!newNodes.isEmpty()) {
+                consistentHashRing.addAll(newNodes);
+            }
+            if (!removedNodes.isEmpty()) {
+                removedNodes.forEach(consistentHashRing::remove);
+            }
+        }
+        catch (Exception e) {
+            log.error(e, "Error refreshing hash ring");
+        }
+    }
+
+    private record TrinoNode(String nodeIdentifier, HostAddress hostAndPort)
+            implements org.ishugaliy.allgood.consistent.hash.node.Node
+    {
+        public static TrinoNode of(Node node)
+        {
+            return new TrinoNode(node.getNodeIdentifier(), node.getHostAndPort());
+        }
+
+        public HostAddress getHostAndPort()
+        {
+            return hostAndPort;
+        }
+
+        @Override
+        public String getKey()
+        {
+            return nodeIdentifier;
+        }
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProviderConfiguration.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/ConsistentHashingHostAddressProviderConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+public class ConsistentHashingHostAddressProviderConfiguration
+{
+    private int preferredHostsCount = 2;
+
+    @Config("fs.cache.preferred-hosts-count")
+    @ConfigDescription("The number of preferred nodes for caching a file. Defaults to 2.")
+    public ConsistentHashingHostAddressProviderConfiguration setPreferredHostsCount(int preferredHostsCount)
+    {
+        this.preferredHostsCount = preferredHostsCount;
+        return this;
+    }
+
+    public int getPreferredHostsCount()
+    {
+        return this.preferredHostsCount;
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCacheKeyProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/DefaultCacheKeyProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.TrinoInputFile;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public final class DefaultCacheKeyProvider
+        implements CacheKeyProvider
+{
+    @Override
+    public Optional<String> getCacheKey(TrinoInputFile delegate)
+            throws IOException
+    {
+        return Optional.of(delegate.location().path() + delegate.lastModified());
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/NoneCachingHostAddressProvider.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/NoneCachingHostAddressProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.HostAddress;
+
+import java.util.List;
+
+public class NoneCachingHostAddressProvider
+        implements CachingHostAddressProvider
+{
+    @Override
+    public List<HostAddress> getHosts(String splitPath)
+    {
+        return ImmutableList.of();
+    }
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/TrinoFileSystemCache.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/TrinoFileSystemCache.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+
+import java.io.IOException;
+
+public interface TrinoFileSystemCache
+{
+    /**
+     * Get the TrinoInput of the TrinoInputFile, potentially using or updating the data cached at key.
+     */
+    TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException;
+
+    /**
+     * Get the TrinoInputStream of the TrinoInputFile, potentially using or updating the data cached at key.
+     */
+    TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException;
+
+    /**
+     * Give a hint to the cache that the cache entry for location should be expired.
+     */
+    void expire(Location location)
+            throws IOException;
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
@@ -13,6 +13,7 @@
  */
 package io.trino.filesystem.memory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.filesystem.FileEntry;
@@ -42,7 +43,8 @@ public class MemoryFileSystem
 {
     private final ConcurrentMap<String, MemoryBlob> blobs = new ConcurrentHashMap<>();
 
-    boolean isEmpty()
+    @VisibleForTesting
+    public boolean isEmpty()
     {
         return blobs.isEmpty();
     }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystem.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.memory.MemoryFileSystem;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestCacheFileSystem
+        extends AbstractTestTrinoFileSystem
+{
+    private MemoryFileSystem delegate;
+    private CacheFileSystem fileSystem;
+
+    @BeforeAll
+    void setUp()
+    {
+        delegate = new MemoryFileSystem();
+        fileSystem = new CacheFileSystem(delegate, new TestingMemoryFileSystemCache(), new DefaultCacheKeyProvider());
+    }
+
+    @AfterAll
+    void tearDown()
+    {
+        delegate = null;
+        fileSystem = null;
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return true;
+    }
+
+    @Override
+    protected TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        assertThat(delegate.isEmpty()).isTrue();
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestCacheFileSystemAccessOperations.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrackingFileSystemFactory;
+import io.trino.filesystem.TrackingFileSystemFactory.OperationType;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.spi.block.TestingSession;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static java.util.Collections.nCopies;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestCacheFileSystemAccessOperations
+{
+    private TrackingFileSystemFactory trackingFileSystemFactory;
+    private CacheFileSystem fileSystem;
+
+    @BeforeAll
+    void setUp()
+    {
+        trackingFileSystemFactory = new TrackingFileSystemFactory(new MemoryFileSystemFactory());
+        fileSystem = new CacheFileSystem(trackingFileSystemFactory.create(TestingSession.SESSION), new TestingMemoryFileSystemCache(), new DefaultCacheKeyProvider());
+    }
+
+    @AfterAll
+    void tearDown()
+    {
+        trackingFileSystemFactory = null;
+        fileSystem = null;
+    }
+
+    @Test
+    void testCache()
+            throws IOException
+    {
+        Location location = getRootLocation().appendPath("hello");
+        byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = fileSystem.newOutputFile(location).create()) {
+            output.write(content);
+        }
+
+        assertReadOperations(location, content,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, OperationType.INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, OperationType.INPUT_FILE_LAST_MODIFIED))
+                        .build());
+        assertReadOperations(location, content,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, OperationType.INPUT_FILE_LAST_MODIFIED))
+                        .build());
+
+        byte[] modifiedContent = "modified content".getBytes(StandardCharsets.UTF_8);
+        try (OutputStream output = fileSystem.newOutputFile(location).createOrOverwrite()) {
+            output.write(modifiedContent);
+        }
+
+        assertReadOperations(location, modifiedContent,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(location, OperationType.INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(location, OperationType.INPUT_FILE_LAST_MODIFIED))
+                        .build());
+    }
+
+    private Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    private void assertReadOperations(Location location, byte[] content, Multiset<FileOperation> fileOperations)
+            throws IOException
+    {
+        TrinoInputFile file = fileSystem.newInputFile(location);
+        int length = (int) file.length();
+        trackingFileSystemFactory.reset();
+        try (TrinoInput input = file.newInput()) {
+            assertThat(input.readFully(0, length)).isEqualTo(Slices.wrappedBuffer(content));
+        }
+        assertMultisetsEqual(fileOperations, getOperations());
+    }
+
+    private Multiset<FileOperation> getOperations()
+    {
+        return trackingFileSystemFactory.getOperationCounts()
+                .entrySet().stream()
+                .flatMap(entry -> nCopies(entry.getValue(), new FileOperation(
+                        entry.getKey().location(),
+                        entry.getKey().operationType())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private record FileOperation(Location path, OperationType operationType) {}
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestConsistentHashingCacheHostAddressProvider.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestConsistentHashingCacheHostAddressProvider.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import com.google.common.collect.Sets;
+import io.trino.client.NodeVersion;
+import io.trino.metadata.InternalNode;
+import io.trino.spi.Node;
+import io.trino.testing.TestingNodeManager;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.abs;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestConsistentHashingCacheHostAddressProvider
+{
+    @Test
+    public void testConsistentHashing()
+    {
+        TestingNodeManager nodeManager = new TestingNodeManager(true);
+        nodeManager.addNode(node("test-1"));
+        nodeManager.addNode(node("test-2"));
+        nodeManager.addNode(node("test-3"));
+        ConsistentHashingHostAddressProvider provider = new ConsistentHashingHostAddressProvider(
+                nodeManager,
+                new ConsistentHashingHostAddressProviderConfiguration().setPreferredHostsCount(1));
+        provider.refreshHashRing();
+        assertFairDistribution(provider, nodeManager.getWorkerNodes());
+        nodeManager.removeNode(node("test-2"));
+        provider.refreshHashRing();
+        assertFairDistribution(provider, nodeManager.getWorkerNodes());
+        nodeManager.addNode(node("test-4"));
+        nodeManager.addNode(node("test-5"));
+        provider.refreshHashRing();
+        assertFairDistribution(provider, nodeManager.getWorkerNodes());
+    }
+
+    @Test
+    public void testConsistentHashingFairRedistribution()
+    {
+        TestingNodeManager nodeManager = new TestingNodeManager(true);
+        nodeManager.addNode(node("test-1"));
+        nodeManager.addNode(node("test-2"));
+        nodeManager.addNode(node("test-3"));
+        ConsistentHashingHostAddressProvider provider = new ConsistentHashingHostAddressProvider(
+                nodeManager,
+                new ConsistentHashingHostAddressProviderConfiguration().setPreferredHostsCount(1));
+        provider.refreshHashRing();
+        Map<String, Set<Integer>> distribution = getDistribution(provider);
+        nodeManager.removeNode(node("test-1"));
+        provider.refreshHashRing();
+        Map<String, Set<Integer>> removeOne = getDistribution(provider);
+        assertMinimalRedistribution(distribution, removeOne);
+        nodeManager.addNode(node("test-1"));
+        provider.refreshHashRing();
+        Map<String, Set<Integer>> addOne = getDistribution(provider);
+        assertMinimalRedistribution(removeOne, addOne);
+        assertThat(addOne).isEqualTo(distribution);
+        nodeManager.addNode(node("test-4"));
+        provider.refreshHashRing();
+        Map<String, Set<Integer>> addTwo = getDistribution(provider);
+        assertMinimalRedistribution(addOne, addTwo);
+    }
+
+    private static void assertFairDistribution(CachingHostAddressProvider cachingHostAddressProvider, Set<Node> nodeNames)
+    {
+        int n = 1000;
+        Map<String, Integer> counts = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            counts.merge(cachingHostAddressProvider.getHosts(String.valueOf(i)).get(0).getHostText(), 1, Math::addExact);
+        }
+        assertThat(nodeNames.stream().map(m -> m.getHostAndPort().getHostText()).collect(Collectors.toSet())).isEqualTo(counts.keySet());
+        counts.values().forEach(c -> assertThat(abs(c - n / nodeNames.size()) < 0.1 * n).isTrue());
+    }
+
+    private void assertMinimalRedistribution(Map<String, Set<Integer>> oldDistribution, Map<String, Set<Integer>> newDistribution)
+    {
+        oldDistribution.entrySet().stream().filter(e -> newDistribution.containsKey(e.getKey())).forEach(entry -> {
+            int sameKeySize = Sets.intersection(newDistribution.get(entry.getKey()), entry.getValue()).size();
+            int oldKeySize = entry.getValue().size();
+            assertThat(abs(sameKeySize - oldKeySize) < oldKeySize / oldDistribution.size()).isTrue();
+        });
+    }
+
+    private Map<String, Set<Integer>> getDistribution(ConsistentHashingHostAddressProvider provider)
+    {
+        int n = 1000;
+        Map<String, Set<Integer>> distribution = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            String host = provider.getHosts(String.valueOf(i)).get(0).getHostText();
+            distribution.computeIfAbsent(host, (k) -> new HashSet<>()).add(i);
+        }
+        return distribution;
+    }
+
+    private static Node node(String nodeName)
+    {
+        return new InternalNode(nodeName, URI.create("http://" + nodeName + "/"), NodeVersion.UNKNOWN, false);
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestingMemoryFileSystemCache.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/cache/TestingMemoryFileSystemCache.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.TrinoInputStream;
+import io.trino.filesystem.memory.MemoryFileSystem;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestingMemoryFileSystemCache
+        implements TrinoFileSystemCache
+{
+    private final MemoryFileSystem memoryCache = new MemoryFileSystem();
+    private final AtomicInteger cacheGeneration = new AtomicInteger(0);
+
+    @Override
+    public TrinoInput cacheInput(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        Location cacheLocation = Location.of("memory:///" + key.replace("memory:///", "") + key.hashCode() + cacheGeneration.get());
+        TrinoInputFile cacheEntry = memoryCache.newInputFile(cacheLocation);
+        if (!cacheEntry.exists()) {
+            try (OutputStream output = memoryCache.newOutputFile(cacheLocation).create();
+                    InputStream input = delegate.newStream()) {
+                input.transferTo(output);
+            }
+        }
+        return cacheEntry.newInput();
+    }
+
+    @Override
+    public TrinoInputStream cacheStream(TrinoInputFile delegate, String key)
+            throws IOException
+    {
+        Location cacheLocation = Location.of("memory:///" + key.replace("memory:///", "") + key.hashCode() + cacheGeneration.get());
+        TrinoInputFile cacheEntry = memoryCache.newInputFile(cacheLocation);
+        if (!cacheEntry.exists()) {
+            try (OutputStream output = memoryCache.newOutputFile(cacheLocation).create();
+                    InputStream input = delegate.newStream()) {
+                input.transferTo(output);
+            }
+        }
+        return cacheEntry.newStream();
+    }
+
+    @Override
+    public void expire(Location location)
+            throws IOException
+    {
+        // Expire the entire cache on a single invalidation
+        cacheGeneration.incrementAndGet();
+    }
+}

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -251,7 +251,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-cache-alluxio</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-memory-context</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.alluxio</groupId>
+            <artifactId>alluxio-core-common</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -281,6 +293,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-exchange-filesystem</artifactId>
             <scope>test</scope>
         </dependency>
@@ -301,8 +319,21 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-filesystem-cache-alluxio</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-hdfs</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.qubole.rubix</groupId>
+                    <artifactId>rubix-presto-shaded</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeModule.java
@@ -21,9 +21,11 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.filesystem.cache.CacheKeyProvider;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.deltalake.cache.DeltaLakeCacheKeyProvider;
 import io.trino.plugin.deltalake.functions.tablechanges.TableChangesFunctionProvider;
 import io.trino.plugin.deltalake.functions.tablechanges.TableChangesProcessorProvider;
 import io.trino.plugin.deltalake.procedure.DropExtendedStatsProcedure;
@@ -148,6 +150,8 @@ public class DeltaLakeModule
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(TableChangesFunctionProvider.class).in(Scopes.SINGLETON);
         binder.bind(FunctionProvider.class).to(DeltaLakeFunctionProvider.class).in(Scopes.SINGLETON);
         binder.bind(TableChangesProcessorProvider.class).in(Scopes.SINGLETON);
+
+        newOptionalBinder(binder, CacheKeyProvider.class).setBinding().to(DeltaLakeCacheKeyProvider.class).in(Scopes.SINGLETON);
     }
 
     @Singleton

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
@@ -14,14 +14,18 @@
 package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
+import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -45,6 +49,7 @@ public class DeltaLakeSplit
     private final Optional<Long> fileRowCount;
     private final long fileModifiedTime;
     private final Optional<DeletionVectorEntry> deletionVector;
+    private final List<HostAddress> addresses;
     private final SplitWeight splitWeight;
     private final TupleDomain<DeltaLakeColumnHandle> statisticsPredicate;
     private final Map<String, Optional<String>> partitionKeys;
@@ -62,6 +67,33 @@ public class DeltaLakeSplit
             @JsonProperty("statisticsPredicate") TupleDomain<DeltaLakeColumnHandle> statisticsPredicate,
             @JsonProperty("partitionKeys") Map<String, Optional<String>> partitionKeys)
     {
+        this(
+                path,
+                start,
+                length,
+                fileSize,
+                fileRowCount,
+                fileModifiedTime,
+                deletionVector,
+                ImmutableList.of(),
+                splitWeight,
+                statisticsPredicate,
+                partitionKeys);
+    }
+
+    public DeltaLakeSplit(
+            String path,
+            long start,
+            long length,
+            long fileSize,
+            Optional<Long> fileRowCount,
+            long fileModifiedTime,
+            Optional<DeletionVectorEntry> deletionVector,
+            List<HostAddress> addresses,
+            SplitWeight splitWeight,
+            TupleDomain<DeltaLakeColumnHandle> statisticsPredicate,
+            Map<String, Optional<String>> partitionKeys)
+    {
         this.path = requireNonNull(path, "path is null");
         this.start = start;
         this.length = length;
@@ -69,9 +101,18 @@ public class DeltaLakeSplit
         this.fileRowCount = requireNonNull(fileRowCount, "rowCount is null");
         this.fileModifiedTime = fileModifiedTime;
         this.deletionVector = requireNonNull(deletionVector, "deletionVector is null");
+        this.addresses = requireNonNull(addresses, "addresses is null");
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
         this.statisticsPredicate = requireNonNull(statisticsPredicate, "statisticsPredicate is null");
         this.partitionKeys = requireNonNull(partitionKeys, "partitionKeys is null");
+    }
+
+    // do not serialize addresses as they are not needed on workers
+    @JsonIgnore
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
     }
 
     @JsonProperty
@@ -157,6 +198,7 @@ public class DeltaLakeSplit
                 .put("path", path)
                 .put("start", start)
                 .put("length", length)
+                .put("addresses", addresses)
                 .buildOrThrow();
     }
 
@@ -171,6 +213,7 @@ public class DeltaLakeSplit
                 .add("rowCount", fileRowCount)
                 .add("fileModifiedTime", fileModifiedTime)
                 .add("deletionVector", deletionVector)
+                .add("addresses", addresses)
                 .add("statisticsPredicate", statisticsPredicate)
                 .add("partitionKeys", partitionKeys)
                 .toString();
@@ -193,6 +236,7 @@ public class DeltaLakeSplit
                 path.equals(that.path) &&
                 fileRowCount.equals(that.fileRowCount) &&
                 deletionVector.equals(that.deletionVector) &&
+                Objects.equals(addresses, that.addresses) &&
                 Objects.equals(statisticsPredicate, that.statisticsPredicate) &&
                 Objects.equals(partitionKeys, that.partitionKeys);
     }
@@ -200,6 +244,6 @@ public class DeltaLakeSplit
     @Override
     public int hashCode()
     {
-        return Objects.hash(path, start, length, fileSize, fileRowCount, fileModifiedTime, deletionVector, statisticsPredicate, partitionKeys);
+        return Objects.hash(path, start, length, fileSize, fileRowCount, fileModifiedTime, deletionVector, addresses, statisticsPredicate, partitionKeys);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/cache/DeltaLakeCacheKeyProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/cache/DeltaLakeCacheKeyProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake.cache;
+
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.filesystem.cache.CacheKeyProvider;
+
+import java.util.Optional;
+
+public class DeltaLakeCacheKeyProvider
+        implements CacheKeyProvider
+{
+    /**
+     * Get the cache key of a TrinoInputFile. Returns Optional.empty() if the file is not cacheable.
+     */
+    @Override
+    public Optional<String> getCacheKey(TrinoInputFile delegate)
+    {
+        // TODO: Consider caching of the Parquet checkpoint files within _delta_log
+        if (!delegate.location().path().contains("/_delta_log/")) {
+            return Optional.of(delegate.location().path());
+        }
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.trino.Session;
+import io.trino.filesystem.TrackingFileSystemFactory;
+import io.trino.filesystem.TrackingFileSystemFactory.OperationType;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.alluxio.AlluxioFileSystemCacheConfig;
+import io.trino.filesystem.alluxio.AlluxioFileSystemCacheModule;
+import io.trino.filesystem.alluxio.TestingAlluxioFileSystemCache;
+import io.trino.filesystem.cache.CacheFileSystemFactory;
+import io.trino.filesystem.cache.CachingHostAddressProvider;
+import io.trino.filesystem.cache.NoneCachingHostAddressProvider;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.plugin.deltalake.cache.DeltaLakeCacheKeyProvider;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.inject.Scopes.SINGLETON;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_NEW_STREAM;
+import static io.trino.filesystem.alluxio.TestingAlluxioFileSystemCache.OperationType.CACHE_READ;
+import static io.trino.filesystem.alluxio.TestingAlluxioFileSystemCache.OperationType.EXTERNAL_READ;
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.CDF_DATA;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.CHECKPOINT;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.DATA;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.LAST_CHECKPOINT;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.TRANSACTION_LOG_JSON;
+import static io.trino.plugin.deltalake.TestDeltaLakeAlluxioCacheFileOperations.FileType.TRINO_EXTENDED_STATS_JSON;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
+
+// single-threaded AccessTrackingFileSystemFactory is shared mutable state
+@Execution(ExecutionMode.SAME_THREAD)
+public class TestDeltaLakeAlluxioCacheFileOperations
+        extends AbstractTestQueryFramework
+{
+    private TrackingFileSystemFactory trackingFileSystemFactory;
+    private TestingAlluxioFileSystemCache alluxioFileSystemCache;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("delta_lake")
+                .setSchema("default")
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .build();
+        try {
+            File metastoreDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_metastore").toFile().getAbsoluteFile();
+            trackingFileSystemFactory = new TrackingFileSystemFactory(new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS));
+            AlluxioFileSystemCacheConfig alluxioFileSystemCacheConfiguration = new AlluxioFileSystemCacheConfig()
+                    .setCacheDirectories(metastoreDirectory.getAbsolutePath() + "/cache")
+                    .disableTTL()
+                    .setMaxCacheSizes("100MB");
+            alluxioFileSystemCache = new TestingAlluxioFileSystemCache(AlluxioFileSystemCacheModule.getAlluxioConfiguration(alluxioFileSystemCacheConfiguration), new DeltaLakeCacheKeyProvider());
+            TrinoFileSystemFactory fileSystemFactory = new CacheFileSystemFactory(trackingFileSystemFactory, alluxioFileSystemCache, alluxioFileSystemCache.getCacheKeyProvider());
+
+            Path dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data");
+            queryRunner.installPlugin(new TestingDeltaLakePlugin(dataDirectory, Optional.empty(), Optional.of(fileSystemFactory), binder -> binder.bind(CachingHostAddressProvider.class).to(NoneCachingHostAddressProvider.class).in(SINGLETON)));
+            queryRunner.createCatalog(
+                    "delta_lake",
+                    "delta_lake",
+                    Map.of(
+                            "hive.metastore", "file",
+                            "hive.metastore.catalog.dir", metastoreDirectory.toURI().toString(),
+                            "delta.enable-non-concurrent-writes", "true"));
+
+            queryRunner.execute("CREATE SCHEMA " + session.getSchema().orElseThrow());
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    @Test
+    public void testCacheFileOperations()
+    {
+        assertUpdate("DROP TABLE IF EXISTS test_cache_file_operations");
+        assertUpdate("CREATE TABLE test_cache_file_operations(key varchar, data varchar) with (partitioned_by=ARRAY['key'])");
+        assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p1', '1-abc')", 1);
+        assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p2', '2-xyz')", 1);
+        assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => 'test_cache_file_operations')");
+        alluxioFileSystemCache.clear();
+        assertFileSystemAccesses(
+                "SELECT * FROM test_cache_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_NEW_STREAM), 1)
+                        // All data cached when reading parquet file footers to collect statistics when writing
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p2/"), 1)
+                        .build());
+        assertFileSystemAccesses(
+                "SELECT * FROM test_cache_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p2/"), 1)
+                        .build());
+        assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p3', '3-xyz')", 1);
+        assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p4', '4-xyz')", 1);
+        assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p5', '5-xyz')", 1);
+        alluxioFileSystemCache.clear();
+        assertFileSystemAccesses(
+                "SELECT * FROM test_cache_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p3/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p4/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p5/", INPUT_FILE_NEW_STREAM), 1)
+                        // All data cached when reading parquet file footers to collect statistics when writing
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p2/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p3/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p4/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p5/"), 1)
+                        .build());
+        assertFileSystemAccesses(
+                "SELECT * FROM test_cache_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000004.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", INPUT_FILE_NEW_STREAM), 1)
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p2/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p3/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p4/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p5/"), 1)
+                        .build());
+    }
+
+    @Test
+    public void testCacheCheckpointFileOperations()
+    {
+        assertUpdate("DROP TABLE IF EXISTS test_checkpoint_file_operations");
+        assertUpdate("CREATE TABLE test_checkpoint_file_operations(key varchar, data varchar) with (checkpoint_interval = 2, partitioned_by=ARRAY['key'])");
+        assertUpdate("INSERT INTO test_checkpoint_file_operations VALUES ('p1', '1-abc')", 1);
+        assertUpdate("INSERT INTO test_checkpoint_file_operations VALUES ('p2', '2-xyz')", 1);
+        assertUpdate("CALL system.flush_metadata_cache(schema_name => CURRENT_SCHEMA, table_name => 'test_checkpoint_file_operations')");
+        alluxioFileSystemCache.clear();
+        assertFileSystemAccesses(
+                "SELECT * FROM test_checkpoint_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_NEW_STREAM), 1)
+                        // All data cached when reading parquet file footers to collect statistics when writing
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p2/"), 1)
+                        .build());
+        assertFileSystemAccesses(
+                "SELECT * FROM test_checkpoint_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000002.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 4)
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p2/"), 1)
+                        .build());
+        assertUpdate("INSERT INTO test_checkpoint_file_operations VALUES ('p3', '3-xyz')", 1);
+        assertUpdate("INSERT INTO test_checkpoint_file_operations VALUES ('p4', '4-xyz')", 1);
+        assertUpdate("INSERT INTO test_checkpoint_file_operations VALUES ('p5', '5-xyz')", 1);
+        alluxioFileSystemCache.clear();
+        assertFileSystemAccesses(
+                "SELECT * FROM test_checkpoint_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(DATA, "key=p1/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p2/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p3/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p4/", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(DATA, "key=p5/", INPUT_FILE_NEW_STREAM), 1)
+                        // All data cached when reading parquet file footers to collect statistics when writing
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p2/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p3/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p4/"), 1)
+                        .addCopies(new CacheOperation(EXTERNAL_READ, "key=p5/"), 1)
+                        .build());
+        assertFileSystemAccesses(
+                "SELECT * FROM test_checkpoint_file_operations",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000005.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000006.json", INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.parquet", INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(CHECKPOINT, "00000000000000000004.checkpoint.parquet", INPUT_FILE_GET_LENGTH), 4)
+                        .build(),
+                ImmutableMultiset.<CacheOperation>builder()
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p1/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p2/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p3/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p4/"), 1)
+                        .addCopies(new CacheOperation(CACHE_READ, "key=p5/"), 1)
+                        .build());
+    }
+
+    private void assertFileSystemAccesses(@Language("SQL") String query, Multiset<FileOperation> expectedAccesses, Multiset<CacheOperation> expectedCacheAccesses)
+    {
+        assertUpdate("CALL system.flush_metadata_cache()");
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+        trackingFileSystemFactory.reset();
+        alluxioFileSystemCache.reset();
+        queryRunner.executeWithPlan(queryRunner.getDefaultSession(), query);
+        assertMultisetsEqual(getOperations(), expectedAccesses);
+        assertMultisetsEqual(getCacheOperations(), expectedCacheAccesses);
+    }
+
+    private Multiset<CacheOperation> getCacheOperations()
+    {
+        return alluxioFileSystemCache.getOperationCounts()
+                .entrySet().stream()
+                .filter(entry -> {
+                    String path = entry.getKey().location().path();
+                    return !path.endsWith(".trinoSchema") && !path.contains(".trinoPermissions");
+                })
+                .flatMap(entry -> nCopies((int) entry.getValue().stream().filter(l -> l > 0).count(), CacheOperation.create(
+                        entry.getKey().type(),
+                        entry.getKey().location().path())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private static Pattern dataFilePattern = Pattern.compile(".*?/(?<partition>key=[^/]*/)?(?<queryId>\\d{8}_\\d{6}_\\d{5}_\\w{5})_(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})");
+
+    private record CacheOperation(TestingAlluxioFileSystemCache.OperationType type, String fileId)
+    {
+        public static CacheOperation create(TestingAlluxioFileSystemCache.OperationType operationType, String path)
+        {
+            String fileName = path.replaceFirst(".*/", "");
+            if (!path.contains("_delta_log") && !path.contains("/.trino")) {
+                Matcher matcher = dataFilePattern.matcher(path);
+                if (matcher.matches()) {
+                    return new CacheOperation(operationType, matcher.group("partition"));
+                }
+            }
+            else {
+                return new CacheOperation(operationType, fileName);
+            }
+            throw new IllegalArgumentException("File not recognized: " + path);
+        }
+    }
+
+    private Multiset<FileOperation> getOperations()
+    {
+        return trackingFileSystemFactory.getOperationCounts()
+                .entrySet().stream()
+                .filter(entry -> {
+                    String path = entry.getKey().location().path();
+                    return !path.endsWith(".trinoSchema") && !path.contains(".trinoPermissions");
+                })
+                .flatMap(entry -> nCopies(entry.getValue(), FileOperation.create(
+                        entry.getKey().location().path(),
+                        entry.getKey().operationType())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    private record FileOperation(FileType fileType, String fileId, OperationType operationType)
+    {
+        public static FileOperation create(String path, OperationType operationType)
+        {
+            String fileName = path.replaceFirst(".*/", "");
+            if (path.matches(".*/_delta_log/_last_checkpoint")) {
+                return new FileOperation(LAST_CHECKPOINT, fileName, operationType);
+            }
+            if (path.matches(".*/_delta_log/\\d+\\.json")) {
+                return new FileOperation(TRANSACTION_LOG_JSON, fileName, operationType);
+            }
+            if (path.matches(".*/_delta_log/\\d+\\.checkpoint.parquet")) {
+                return new FileOperation(CHECKPOINT, fileName, operationType);
+            }
+            if (path.matches(".*/_delta_log/_trino_meta/extended_stats.json")) {
+                return new FileOperation(TRINO_EXTENDED_STATS_JSON, fileName, operationType);
+            }
+            if (path.matches(".*/_change_data/.*")) {
+                Matcher matcher = dataFilePattern.matcher(path);
+                if (matcher.matches()) {
+                    return new FileOperation(CDF_DATA, matcher.group("partition"), operationType);
+                }
+            }
+            if (!path.contains("_delta_log")) {
+                Matcher matcher = dataFilePattern.matcher(path);
+                if (matcher.matches()) {
+                    return new FileOperation(DATA, matcher.group("partition"), operationType);
+                }
+            }
+            throw new IllegalArgumentException("File not recognized: " + path);
+        }
+
+        public FileOperation
+        {
+            requireNonNull(fileType, "fileType is null");
+            requireNonNull(fileId, "fileId is null");
+            requireNonNull(operationType, "operationType is null");
+        }
+    }
+
+    enum FileType
+    {
+        LAST_CHECKPOINT,
+        TRANSACTION_LOG_JSON,
+        CHECKPOINT,
+        TRINO_EXTENDED_STATS_JSON,
+        DATA,
+        CDF_DATA,
+        /**/;
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Delta Lake connector smoke test exercising Hive metastore and MinIO storage with Alluxio caching.
+ */
+public class TestDeltaLakeAlluxioCacheMinioAndHmsConnectorSmokeTest
+        extends TestDeltaLakeMinioAndHmsConnectorSmokeTest
+{
+    private Path cacheDirectory;
+
+    @BeforeAll
+    @Override
+    public void init()
+            throws Exception
+    {
+        cacheDirectory = Files.createTempDirectory("cache");
+        super.init();
+    }
+
+    @AfterAll
+    @Override
+    public void cleanUp()
+    {
+        try (Stream<Path> walk = Files.walk(cacheDirectory)) {
+            Iterator<Path> iterator = walk.sorted(Comparator.reverseOrder()).iterator();
+            while (iterator.hasNext()) {
+                Path path = iterator.next();
+                Files.delete(path);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        super.cleanUp();
+    }
+
+    @Override
+    protected Map<String, String> deltaStorageConfiguration()
+    {
+        return ImmutableMap.<String, String>builder()
+                .putAll(super.deltaStorageConfiguration())
+                .put("fs.cache", "alluxio")
+                .put("fs.cache.directories", cacheDirectory.toAbsolutePath().toString())
+                .put("fs.cache.max-sizes", "100MB")
+                .buildOrThrow();
+    }
+}

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -21,6 +21,8 @@ import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.filesystem.TrackingFileSystemFactory;
 import io.trino.filesystem.TrackingFileSystemFactory.OperationType;
+import io.trino.filesystem.cache.CachingHostAddressProvider;
+import io.trino.filesystem.cache.NoneCachingHostAddressProvider;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -42,7 +44,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static com.google.inject.Scopes.SINGLETON;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_EXISTS;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_GET_LENGTH;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_NEW_STREAM;
@@ -95,7 +97,7 @@ public class TestDeltaLakeFileOperations
             queryRunner.createCatalog("tpch", "tpch");
 
             Path dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("delta_lake_data");
-            queryRunner.installPlugin(new TestingDeltaLakePlugin(dataDirectory, Optional.empty(), Optional.of(trackingFileSystemFactory), EMPTY_MODULE));
+            queryRunner.installPlugin(new TestingDeltaLakePlugin(dataDirectory, Optional.empty(), Optional.of(trackingFileSystemFactory), binder -> binder.bind(CachingHostAddressProvider.class).to(NoneCachingHostAddressProvider.class).in(SINGLETON)));
             queryRunner.createCatalog(
                     "delta_lake",
                     "delta_lake",

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -24,6 +24,8 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.cache.CachingHostAddressProvider;
+import io.trino.filesystem.cache.NoneCachingHostAddressProvider;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.hdfs.HdfsEnvironment;
 import io.trino.hdfs.TrinoHdfsFileSystemStats;
@@ -205,6 +207,7 @@ public class TestDeltaLakeMetadata
                     binder.bind(HdfsEnvironment.class).toInstance(HDFS_ENVIRONMENT);
                     binder.bind(TrinoHdfsFileSystemStats.class).toInstance(HDFS_FILE_SYSTEM_STATS);
                     binder.bind(TrinoFileSystemFactory.class).to(HdfsFileSystemFactory.class).in(Scopes.SINGLETON);
+                    binder.bind(CachingHostAddressProvider.class).to(NoneCachingHostAddressProvider.class).in(Scopes.SINGLETON);
                 },
                 new AbstractModule()
                 {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -20,6 +20,7 @@ import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
 import io.airlift.units.DataSize;
 import io.trino.filesystem.Location;
+import io.trino.filesystem.cache.NoneCachingHostAddressProvider;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
 import io.trino.filesystem.memory.MemoryFileSystemFactory;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
@@ -239,7 +240,8 @@ public class TestDeltaLakeSplitManager
                 MoreExecutors.newDirectExecutorService(),
                 deltaLakeConfig,
                 HDFS_FILE_SYSTEM_FACTORY,
-                deltaLakeTransactionManager);
+                deltaLakeTransactionManager,
+                new NoneCachingHostAddressProvider());
     }
 
     private AddFileEntry addFileEntryOfSize(long fileSize)

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -363,6 +363,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-jakarta-servlet-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>runtime</scope>
@@ -531,12 +537,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty.toolchain</groupId>
-            <artifactId>jetty-jakarta-servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1159,6 +1159,13 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-hdfs</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-hive</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2477,12 +2477,20 @@
                                         <artifactId>rubix-presto-shaded</artifactId>
                                     </dependency>
                                     <dependency>
+                                        <groupId>com.github.ishugaliy</groupId>
+                                        <artifactId>allgood-consistent-hash</artifactId>
+                                    </dependency>
+                                    <dependency>
                                         <groupId>io.dropwizard.metrics</groupId>
                                         <artifactId>metrics-core</artifactId>
                                     </dependency>
                                     <dependency>
                                         <groupId>io.dropwizard.metrics</groupId>
                                         <artifactId>metrics-jvm</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>net.openhft</groupId>
+                                        <artifactId>zero-allocation-hashing</artifactId>
                                     </dependency>
                                 </conflictingDependencies>
                             </exception>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>lib/trino-cache</module>
         <module>lib/trino-filesystem</module>
         <module>lib/trino-filesystem-azure</module>
+        <module>lib/trino-filesystem-cache-alluxio</module>
         <module>lib/trino-filesystem-gcs</module>
         <module>lib/trino-filesystem-manager</module>
         <module>lib/trino-filesystem-s3</module>
@@ -176,6 +177,7 @@
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.accumulo.version>1.10.2</dep.accumulo.version>
         <dep.airlift.version>240</dep.airlift.version>
+        <dep.alluxio.version>307</dep.alluxio.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.avro.version>1.11.3</dep.avro.version>
         <dep.aws-sdk.version>1.12.643</dep.aws-sdk.version>
@@ -644,6 +646,12 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>1.6.0</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.16.0</version>
@@ -1092,6 +1100,19 @@
                 <groupId>io.trino</groupId>
                 <artifactId>trino-filesystem-azure</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-filesystem-cache-alluxio</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
+                <artifactId>trino-filesystem-cache-alluxio</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
             </dependency>
 
             <dependency>
@@ -1666,6 +1687,122 @@
                 <groupId>net.sf.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>2.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-core-client-fs</artifactId>
+                <version>${dep.alluxio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-stub</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.alluxio</groupId>
+                        <artifactId>alluxio-core-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.alluxio</groupId>
+                        <artifactId>alluxio-core-transport</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-core-common</artifactId>
+                <version>${dep.alluxio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.etcd</groupId>
+                        <artifactId>jetcd-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-netty</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-services</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.grpc</groupId>
+                        <artifactId>grpc-stub</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-tcnative-boringssl-static</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.servlet</groupId>
+                        <artifactId>jakarta.servlet-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.alluxio</groupId>
+                        <artifactId>alluxio-core-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.curator</groupId>
+                        <artifactId>curator-framework</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.zookeeper</groupId>
+                        <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.alluxio</groupId>
+                <artifactId>alluxio-shaded-client</artifactId>
+                <version>2.9.3</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -2312,6 +2449,42 @@
                                 <resources>
                                     <resource>mime.types</resource>
                                 </resources>
+                            </exception>
+                            <exception>
+                                <conflictingDependencies>
+                                    <dependency>
+                                        <groupId>org.alluxio</groupId>
+                                        <artifactId>alluxio-core-client-fs</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.alluxio</groupId>
+                                        <artifactId>alluxio-core-common</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>org.alluxio</groupId>
+                                        <artifactId>alluxio-core-transport</artifactId>
+                                    </dependency>
+                                </conflictingDependencies>
+                                <resources>
+                                    <resource>git.properties</resource>
+                                </resources>
+                            </exception>
+                            <!-- TODO: Remove once Rubix is removed -->
+                            <exception>
+                                <conflictingDependencies>
+                                    <dependency>
+                                        <groupId>com.qubole.rubix</groupId>
+                                        <artifactId>rubix-presto-shaded</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>io.dropwizard.metrics</groupId>
+                                        <artifactId>metrics-core</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>io.dropwizard.metrics</groupId>
+                                        <artifactId>metrics-jvm</artifactId>
+                                    </dependency>
+                                </conflictingDependencies>
                             </exception>
                             <exception>
                                 <conflictingDependencies>

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -185,6 +185,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-hdfs</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.qubole.rubix</groupId>
+                    <artifactId>rubix-presto-shaded</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/testing/trino-product-tests-groups/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests-groups/src/main/java/io/trino/tests/product/TestGroups.java
@@ -92,6 +92,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_DATABRICKS_113 = "delta-lake-databricks-113";
     public static final String DELTA_LAKE_DATABRICKS_122 = "delta-lake-databricks-122";
     public static final String DELTA_LAKE_EXCLUDE_91 = "delta-lake-exclude-91";
+    public static final String DELTA_LAKE_ALLUXIO_CACHING = "delta-lake-alluxio-caching";
     public static final String HUDI = "hudi";
     public static final String PARQUET = "parquet";
     public static final String IGNITE = "ignite";

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeMinioDataLakeCaching.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeMinioDataLakeCaching.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentProvider;
+import io.trino.tests.product.launcher.env.common.Hadoop;
+import io.trino.tests.product.launcher.env.common.Minio;
+import io.trino.tests.product.launcher.env.common.StandardMultinode;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+@TestsEnvironment
+public final class EnvMultinodeMinioDataLakeCaching
+        extends EnvironmentProvider
+{
+    private static final String CONTAINER_TRINO_DELTA_LAKE_PROPERTIES = CONTAINER_TRINO_ETC + "/catalog/delta.properties";
+    private static final String CONTAINER_TRINO_DELTA_LAKE_NON_CACHED_PROPERTIES = CONTAINER_TRINO_ETC + "/catalog/delta_non_cached.properties";
+    private final DockerFiles.ResourceProvider configDir;
+
+    @Inject
+    public EnvMultinodeMinioDataLakeCaching(StandardMultinode standardMultinode, Hadoop hadoop, Minio minio, DockerFiles dockerFiles)
+    {
+        super(standardMultinode, hadoop, minio);
+        this.configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment");
+    }
+
+    @Override
+    public void extendEnvironment(Environment.Builder builder)
+    {
+        builder.addConnector("delta_lake", forHostPath(configDir.getPath("multinode-minio-data-lake/delta.properties")), CONTAINER_TRINO_DELTA_LAKE_NON_CACHED_PROPERTIES);
+        builder.addConnector("delta_lake", forHostPath(configDir.getPath("multinode-minio-data-lake-cached/delta.properties")), CONTAINER_TRINO_DELTA_LAKE_PROPERTIES);
+        builder.configureContainers(container -> container.withTmpFs(ImmutableMap.of("/tmp/cache", "rw")));
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeOss.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDeltaLakeOss.java
@@ -16,6 +16,7 @@ package io.trino.tests.product.launcher.suite.suites;
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.environment.EnvMultinodeMinioDataLake;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeMinioDataLakeCaching;
 import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeKerberizedHdfs;
 import io.trino.tests.product.launcher.env.environment.EnvSinglenodeDeltaLakeOss;
 import io.trino.tests.product.launcher.suite.Suite;
@@ -24,6 +25,7 @@ import io.trino.tests.product.launcher.suite.SuiteTestRun;
 import java.util.List;
 
 import static io.trino.tests.product.TestGroups.CONFIGURED_FEATURES;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_ALLUXIO_CACHING;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_HDFS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_MINIO;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
@@ -48,6 +50,10 @@ public class SuiteDeltaLakeOss
                         // TODO: make the list of tests run here as close to those run on SinglenodeDeltaLakeDatabricks
                         //  e.g. replace `delta-lake-oss` group with `delta-lake-databricks` + any exclusions, of needed
                         .withGroups(CONFIGURED_FEATURES, DELTA_LAKE_OSS)
+                        .build(),
+
+                testOnEnvironment(EnvMultinodeMinioDataLakeCaching.class)
+                        .withGroups(CONFIGURED_FEATURES, DELTA_LAKE_ALLUXIO_CACHING)
                         .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-minio-data-lake-cached/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-minio-data-lake-cached/delta.properties
@@ -1,0 +1,11 @@
+connector.name=delta_lake
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.s3.aws-access-key=minio-access-key
+hive.s3.aws-secret-key=minio-secret-key
+hive.s3.endpoint=http://minio:9080/
+hive.s3.path-style-access=true
+hive.s3.ssl.enabled=false
+delta.register-table-procedure.enabled=true
+fs.cache=alluxio
+fs.cache.directories=/tmp/cache/delta
+fs.cache.max-disk-usage-percentages=90

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlluxioCaching.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeAlluxioCaching.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import io.airlift.units.Duration;
+import io.trino.tempto.ProductTest;
+import io.trino.tests.product.deltalake.util.CachingTestUtils.CacheStats;
+import org.testng.annotations.Test;
+
+import static io.airlift.testing.Assertions.assertGreaterThan;
+import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_ALLUXIO_CACHING;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.CachingTestUtils.getCacheStats;
+import static io.trino.tests.product.utils.QueryAssertions.assertEventually;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+
+public class TestDeltaLakeAlluxioCaching
+        extends ProductTest
+{
+    @Test(groups = {DELTA_LAKE_ALLUXIO_CACHING, PROFILE_SPECIFIC_TESTS})
+    public void testReadFromCache()
+    {
+        testReadFromTable("table1");
+        testReadFromTable("table2");
+    }
+
+    private void testReadFromTable(String tableNameSuffix)
+    {
+        String cachedTableName = "delta.default.test_cache_read" + tableNameSuffix;
+        String nonCachedTableName = "delta_non_cached.default.test_cache_read" + tableNameSuffix;
+
+        createTestTable(cachedTableName);
+
+        CacheStats beforeCacheStats = getCacheStats("delta");
+
+        long tableSize = (Long) onTrino().executeQuery("SELECT SUM(size) as size FROM (SELECT \"$path\", \"$file_size\" AS size FROM " + nonCachedTableName + " GROUP BY 1, 2)").getOnlyValue();
+
+        assertThat(onTrino().executeQuery("SELECT * FROM " + cachedTableName)).hasAnyRows();
+
+        assertEventually(
+                new Duration(20, SECONDS),
+                () -> {
+                    // first query via caching catalog should fetch external data
+                    CacheStats afterQueryCacheStats = getCacheStats("delta");
+                    assertGreaterThanOrEqual(afterQueryCacheStats.cacheSpaceUsed(), beforeCacheStats.cacheSpaceUsed() + tableSize);
+                    assertGreaterThan(afterQueryCacheStats.externalReads(), beforeCacheStats.externalReads());
+                    assertGreaterThanOrEqual(afterQueryCacheStats.cacheReads(), beforeCacheStats.cacheReads());
+                });
+
+        assertEventually(
+                new Duration(10, SECONDS),
+                () -> {
+                    CacheStats beforeQueryCacheStats = getCacheStats("delta");
+
+                    assertThat(onTrino().executeQuery("SELECT * FROM " + cachedTableName)).hasAnyRows();
+
+                    // query via caching catalog should read exclusively from cache
+                    CacheStats afterQueryCacheStats = getCacheStats("delta");
+                    assertGreaterThan(afterQueryCacheStats.cacheReads(), beforeQueryCacheStats.cacheReads());
+                    assertEquals(afterQueryCacheStats.externalReads(), beforeQueryCacheStats.externalReads());
+                    assertEquals(afterQueryCacheStats.cacheSpaceUsed(), beforeQueryCacheStats.cacheSpaceUsed());
+                });
+
+        onTrino().executeQuery("DROP TABLE " + nonCachedTableName);
+    }
+
+    /**
+     * Creates a table which should contain around 6 2 MB parquet files
+     */
+    private void createTestTable(String tableName)
+    {
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
+        onTrino().executeQuery("SET SESSION delta.target_max_file_size = '2MB'");
+        onTrino().executeQuery("CREATE TABLE " + tableName + " AS SELECT * FROM tpch.sf1.customer");
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/CachingTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/CachingTestUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake.util;
+
+import io.trino.tempto.query.QueryResult;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public final class CachingTestUtils
+{
+    private CachingTestUtils() {}
+
+    public static CacheStats getCacheStats(String catalog)
+    {
+        QueryResult queryResult = onTrino().executeQuery("SELECT " +
+                "  sum(\"cachereads.alltime.count\") as cachereads, " +
+                "  sum(\"externalreads.alltime.count\") as externalreads " +
+                "FROM jmx.current.\"io.trino.filesystem.alluxio:name=" + catalog + ",type=alluxiocachestats\";");
+
+        double cacheReads = (Double) getOnlyElement(queryResult.rows())
+                .get(queryResult.tryFindColumnIndex("cachereads").get() - 1);
+
+        double externalReads = (Double) getOnlyElement(queryResult.rows())
+                .get(queryResult.tryFindColumnIndex("externalreads").get() - 1);
+
+        long cacheSpaceUsed = (Long) onTrino().executeQuery("SELECT sum(count) FROM " +
+                "jmx.current.\"org.alluxio:name=client.cachespaceusedcount,type=counters\"").getOnlyValue();
+
+        return new CacheStats(cacheReads, externalReads, cacheSpaceUsed);
+    }
+
+    public record CacheStats(double cacheReads, double externalReads, long cacheSpaceUsed) {}
+}


### PR DESCRIPTION
## Description

👋 

This PR includes Alluxio caching into Trino. It is a reworking of #16375 with:
- Fully rebased on current code
- Fixed guice bindings / protobuf definitions / other small issues
- Added Delta Lake support to Alluxio cache
- Using `optimized-local-scheduling` rather than introducing a new concept of node affinity
- Passing the `lastModifiedTime` from the coordinator to the workers via ConnectorSplit to allow for immutable caching without workers having to maintain their own file status cache
- Full smoke tests for the caching file system by extending `TestDeltaLakeMinioAndHmsConnectorSmokeTest` into `TestCachingDeltaLakeMinioAndHmsConnectorSmokeTest`

## Additional context and related issues

This is very much #16375 from @beinan reworked after helpful feedback from @raunaqmorarka (thank you! 🙏 ).

I'm putting it out there so we can discuss next steps on integrating this to Trino 🥳 with the following notes:
- This PR only works with HDFS so far, and we'll have to make it compatible with the new S3-native implementation in a subsequent PR
- Using `optimized-local-scheduling` means each connector has to implement split scheduling by specifying an `address` on the splits it generates. Otherwise, each split will randomly be assigned to a worker node, and the cache won't be distributed.
- Connectors can now optionally pass a lastModifiedTime argument when creating a TrinoInputFile. This argument can be used by Alluxio to bypass checking the `lastModifiedTime` from the underlying file system, and use the cached file directly if available
- Both of the above are enabled for `trino-delta-lake`, the connector I'm developing this for, but will need to be implemented separately for other connectors to take full advantage of Alluxio 

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Improve performance of scans by adding the ability to cache data files on local SSDs ({issue}`18719`)
```
