### PR TITLE
Use stable grouping set symbol orderings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -280,7 +280,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Functions.forMap;
@@ -1887,7 +1886,7 @@ public class LocalExecutionPlanner
 
             int outputChannel = 0;
 
-            for (Symbol output : node.getGroupingSets().stream().flatMap(Collection::stream).collect(Collectors.toSet())) {
+            for (Symbol output : node.getDistinctGroupingSetSymbols()) {
                 newLayout.put(output, outputChannel++);
                 outputTypes.add(source.getTypes().get(source.getLayout().get(node.getGroupingColumns().get(output))));
             }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1343,7 +1343,7 @@ class QueryPlanner
             List<Set<FieldId>> sets = IntStream.rangeClosed(0, rollup.size())
                     .mapToObj(prefixLength -> rollup.subList(0, prefixLength).stream()
                             .flatMap(Collection::stream)
-                            .collect(Collectors.toSet()))
+                            .collect(toImmutableSet()))
                     .collect(toImmutableList());
 
             partialSets.add(sets);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Previously, `GroupIdNode` grouping set and output symbol orderings were potentially unstable for the same logical sub-plan due to the use of set constructions that were not order-preserving. While this did not affect correctness, it could result in different symbol orderings within grouping sets in differing branches of `UNION ALL` operations with the same query on both sides. For example, a query like:
```
(SELECT
  shippriority, custkey, sum(totalprice)
FROM
  orders
GROUP BY ROLLUP (shippriority, custkey))
UNION ALL
(SELECT
  shippriority, custkey, sum(totalprice)
FROM
  orders
GROUP BY ROLLUP (shippriority, custkey))
```
could result in logical plans with GroupIdNode grouping sets of either:
1. [[],[“tpch:shippriority$gid”],[“tpch:shippriority$gid”,“tpch:custkey$gid”]]
2. [[],[“tpch:shippriority$gid”],[“tpch:custkey$gid”,“tpch:shippriority$gid”]]

This unnecessary variation could make the logical plan harder than necessary for a human to interpret.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
