### PR TITLE
in substring function, change start param 0 to the same as 1

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -277,8 +277,12 @@ public final class StringFunctions
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start)
     {
-        if ((start == 0) || utf8.length() == 0) {
+        if (utf8.length() == 0) {
             return Slices.EMPTY_SLICE;
+        }
+
+        if (start == 0) {
+            start = 1;
         }
 
         int startCodePoint = Ints.saturatedCast(start);
@@ -324,8 +328,12 @@ public final class StringFunctions
     @SqlType("varchar(x)")
     public static Slice substring(@SqlType("varchar(x)") Slice utf8, @SqlType(StandardTypes.BIGINT) long start, @SqlType(StandardTypes.BIGINT) long length)
     {
-        if (start == 0 || (length <= 0) || (utf8.length() == 0)) {
+        if ((length <= 0) || (utf8.length() == 0)) {
             return Slices.EMPTY_SLICE;
+        }
+
+        if (start == 0) {
+            start = 1;
         }
 
         int startCodePoint = Ints.saturatedCast(start);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -794,7 +794,7 @@ public class TestStringFunctions
 
         assertThat(assertions.function("substr", "'Quadratically'", "0"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quadratically");
 
         assertThat(assertions.function("substr", "'Quadratically'", "5", "6"))
                 .hasType(createVarcharType(13))
@@ -826,7 +826,7 @@ public class TestStringFunctions
 
         assertThat(assertions.function("substr", "'Quadratically'", "0", "4"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quad");
 
         assertThat(assertions.function("substr", "'Quadratically'", "5", "0"))
                 .hasType(createVarcharType(13))
@@ -860,7 +860,7 @@ public class TestStringFunctions
                 .binding("value", "'Quadratically'")
                 .binding("start", "0"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quadratically");
 
         assertThat(assertions.expression("SUBSTRING(value FROM start FOR length)")
                 .binding("value", "'Quadratically'")
@@ -939,7 +939,7 @@ public class TestStringFunctions
 
         assertThat(assertions.function("substr", "CAST('Quadratically' AS CHAR(13))", "0"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quadratically");
 
         assertThat(assertions.function("substr", "CAST('Quadratically' AS CHAR(13))", "5", "6"))
                 .hasType(createVarcharType(13))
@@ -971,7 +971,7 @@ public class TestStringFunctions
 
         assertThat(assertions.function("substr", "CAST('Quadratically' AS CHAR(13))", "0", "4"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quad");
 
         assertThat(assertions.function("substr", "CAST('Quadratically' AS CHAR(13))", "5", "0"))
                 .hasType(createVarcharType(13))
@@ -1021,7 +1021,7 @@ public class TestStringFunctions
                 .binding("value", "CAST('Quadratically' AS CHAR(13))")
                 .binding("start", "0"))
                 .hasType(createVarcharType(13))
-                .isEqualTo("");
+                .isEqualTo("Quadratically");
 
         assertThat(assertions.function("substring", "CAST('Quadratically' AS CHAR(13))", "5", "6"))
                 .hasType(createVarcharType(13))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

I run some SQLs in hive and trino, then I find the substring function is difference between hive and trino when the start parameter is 0.
In hive: the start parameter 0 is the same as 1
hive> select substr('20191125',0,4);
OK
_c0
2019
Time taken: 0.134 seconds, Fetched: 1 row(s)
In spark, it is the same as hive.
spark-sql (default)>  select substr('20191125',0,4);
substr(20191125, 0, 4)
2019

But in trino, when the start is 0, the substring return empty string.
before pr:
trino:tpcds_bin_partitioned_orc_2> select substr('20191125',0,4);
_col0

(1 row)

So I change the substring function.
after pr:
trino:tpcds_bin_partitioned_orc_2> select substr('20191125',0,4);
_col0
2019
(1 row)

trino:tpcds_bin_partitioned_orc_2> select substr('20191125',1,4);
_col0
2019
(1 row)

Additional context and related issues
Release notes
(x) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
( ) Release notes are required, with the following suggested text:

The previous PR was closed due to my mistake. Related link: https://github.com/trinodb/trino/pull/15454 , 