### PR TITLE
Skip getTableHandle call in information_schema.columns with table filter

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -249,11 +249,11 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_schema = 'test_schema1' AND table_name = 'test_table1'",
                 "VALUES 100",
                 ImmutableMultiset.<String>builder()
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 8)
-                        .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)", 2)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getTableMetadata(handle=test_schema1.test_table1)")
                         .build());
         assertMetadataCalls(


### PR DESCRIPTION
When reading `information_schema.columns` with a filter on table name (either `=` or `IN`), the code was doing
`getRedirectionAwareTableHandle` call to check whether target table exists. However, the redirected tables are handled in `doListTableColumns` (also catching `TABLE_REDIRECTION_ERROR`), so the call inside `calculatePrefixesWithTableName` is redundant.
