### PR TITLE
Add support for OpenTelemetry in MongoDB connector

### DIFF
--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-mongo-3.1</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-cache</artifactId>
         </dependency>

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnectorFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.mongodb;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -54,7 +55,8 @@ public class MongoConnectorFactory
         Bootstrap app = new Bootstrap(
                 new JsonModule(),
                 new MongoClientModule(),
-                binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()));
+                binder -> binder.bind(TypeManager.class).toInstance(context.getTypeManager()),
+                binder -> binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry()));
 
         Injector injector = app.doNotInitializeLogging()
                 .setRequiredConfigurationProperties(config)


### PR DESCRIPTION
## Description

Attached the screenshot of the example usage:
<img width="1920" alt="Screenshot 2023-08-21 at 8 37 31" src="https://github.com/trinodb/trino/assets/6237050/f5f4b20c-68ec-4f63-9173-2eb208815fe3">


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
