### PR TITLE
Changed the default value of node-scheduler.include-coordinator as TRUE in the documenatation

### DIFF
--- a/docs/src/main/sphinx/admin/properties-node-scheduler.md
+++ b/docs/src/main/sphinx/admin/properties-node-scheduler.md
@@ -3,7 +3,7 @@
 ## `node-scheduler.include-coordinator`
 
 - **Type:** {ref}`prop-type-boolean`
-- **Default value:** `false`
+- **Default value:** `true`
 
 Allows scheduling work on the coordinator so that a single machine can function
 as both coordinator and worker. For large clusters, processing work on the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Default value of node-scheduler.include-coordinator property is true but in the documentation it is defined as false which causes confusion specially for multiple node cluster where user don't want coordinator node to act as worker. User have to manually set the value in config.properties to false.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Opened an issue https://github.com/trinodb/trino/issues/18749 for the same



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
