### PR TITLE
Implement session logout in OAuth2Authenticator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NimbusOAuth2Client.java
@@ -128,13 +128,13 @@ public class NimbusOAuth2Client
     public void load()
     {
         OAuth2ServerConfig config = serverConfigurationProvider.get();
-        this.authUrl = config.getAuthUrl();
-        this.tokenUrl = config.getTokenUrl();
-        this.userinfoUrl = config.getUserinfoUrl();
+        this.authUrl = config.authUrl();
+        this.tokenUrl = config.tokenUrl();
+        this.userinfoUrl = config.userinfoUrl();
         try {
             jwsKeySelector = new JWSVerificationKeySelector<>(
                     Stream.concat(JWSAlgorithm.Family.RSA.stream(), JWSAlgorithm.Family.EC.stream()).collect(toImmutableSet()),
-                    JWKSourceBuilder.create(config.getJwksUrl().toURL(), httpClient).build());
+                    JWKSourceBuilder.create(config.jwksUrl().toURL(), httpClient).build());
         }
         catch (MalformedURLException e) {
             throw new RuntimeException(e);
@@ -148,7 +148,7 @@ public class NimbusOAuth2Client
         DefaultJWTClaimsVerifier<SecurityContext> accessTokenVerifier = new DefaultJWTClaimsVerifier<>(
                 accessTokenAudiences,
                 new JWTClaimsSet.Builder()
-                        .issuer(config.getAccessTokenIssuer().orElse(issuer.getValue()))
+                        .issuer(config.accessTokenIssuer().orElse(issuer.getValue()))
                         .build(),
                 ImmutableSet.of(principalField),
                 ImmutableSet.of());

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
@@ -34,6 +34,8 @@ public interface OAuth2Client
     Response refreshTokens(String refreshToken)
             throws ChallengeFailedException;
 
+    Optional<URI> getLogoutEndpoint(Optional<String> idToken, URI callbackUrl);
+
     class Request
     {
         private final URI authorizationUri;

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
@@ -22,7 +22,7 @@ public interface OAuth2ServerConfigProvider
 {
     OAuth2ServerConfig get();
 
-    record OAuth2ServerConfig(Optional<String> accessTokenIssuer, URI authUrl, URI tokenUrl, URI jwksUrl, Optional<URI> userinfoUrl)
+    record OAuth2ServerConfig(Optional<String> accessTokenIssuer, URI authUrl, URI tokenUrl, URI jwksUrl, Optional<URI> userinfoUrl, Optional<URI> endSessionUrl)
     {
         public OAuth2ServerConfig
         {
@@ -31,6 +31,7 @@ public interface OAuth2ServerConfigProvider
             requireNonNull(tokenUrl, "tokenUrl is null");
             requireNonNull(jwksUrl, "jwksUrl is null");
             requireNonNull(userinfoUrl, "userinfoUrl is null");
+            requireNonNull(endSessionUrl, "endSessionUrl is null");
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServerConfigProvider.java
@@ -22,46 +22,15 @@ public interface OAuth2ServerConfigProvider
 {
     OAuth2ServerConfig get();
 
-    class OAuth2ServerConfig
+    record OAuth2ServerConfig(Optional<String> accessTokenIssuer, URI authUrl, URI tokenUrl, URI jwksUrl, Optional<URI> userinfoUrl)
     {
-        private final Optional<String> accessTokenIssuer;
-        private final URI authUrl;
-        private final URI tokenUrl;
-        private final URI jwksUrl;
-        private final Optional<URI> userinfoUrl;
-
-        public OAuth2ServerConfig(Optional<String> accessTokenIssuer, URI authUrl, URI tokenUrl, URI jwksUrl, Optional<URI> userinfoUrl)
+        public OAuth2ServerConfig
         {
-            this.accessTokenIssuer = requireNonNull(accessTokenIssuer, "accessTokenIssuer is null");
-            this.authUrl = requireNonNull(authUrl, "authUrl is null");
-            this.tokenUrl = requireNonNull(tokenUrl, "tokenUrl is null");
-            this.jwksUrl = requireNonNull(jwksUrl, "jwksUrl is null");
-            this.userinfoUrl = requireNonNull(userinfoUrl, "userinfoUrl is null");
-        }
-
-        public Optional<String> getAccessTokenIssuer()
-        {
-            return accessTokenIssuer;
-        }
-
-        public URI getAuthUrl()
-        {
-            return authUrl;
-        }
-
-        public URI getTokenUrl()
-        {
-            return tokenUrl;
-        }
-
-        public URI getJwksUrl()
-        {
-            return jwksUrl;
-        }
-
-        public Optional<URI> getUserinfoUrl()
-        {
-            return userinfoUrl;
+            requireNonNull(accessTokenIssuer, "accessTokenIssuer is null");
+            requireNonNull(authUrl, "authUrl is null");
+            requireNonNull(tokenUrl, "tokenUrl is null");
+            requireNonNull(jwksUrl, "jwksUrl is null");
+            requireNonNull(userinfoUrl, "userinfoUrl is null");
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -37,6 +37,7 @@ import static io.airlift.http.client.HttpStatus.REQUEST_TIMEOUT;
 import static io.airlift.http.client.HttpStatus.TOO_MANY_REQUESTS;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.ACCESS_TOKEN_ISSUER;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.AUTH_URL;
+import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.END_SESSION_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.JWKS_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.TOKEN_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfiguration.USERINFO_URL;
@@ -114,6 +115,7 @@ public class OidcDiscovery
             else {
                 userinfoEndpoint = Optional.empty();
             }
+            Optional<URI> endSessionEndpoint = Optional.of(getRequiredField("end_session_endpoint", metadata.getEndSessionEndpointURI(), END_SESSION_URL, Optional.empty()));
             return new OAuth2ServerConfig(
                     // AD FS server can include "access_token_issuer" field in OpenID Provider Metadata.
                     // It's not a part of the OIDC standard thus have to be handled separately.
@@ -122,7 +124,8 @@ public class OidcDiscovery
                     getRequiredField("authorization_endpoint", metadata.getAuthorizationEndpointURI(), AUTH_URL, authUrl),
                     getRequiredField("token_endpoint", metadata.getTokenEndpointURI(), TOKEN_URL, tokenUrl),
                     getRequiredField("jwks_uri", metadata.getJWKSetURI(), JWKS_URL, jwksUrl),
-                    userinfoEndpoint.map(URI::create));
+                    userinfoEndpoint.map(URI::create),
+                    endSessionEndpoint);
         }
         catch (JsonProcessingException e) {
             throw new ParseException("Invalid JSON value", e);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticConfigurationProvider.java
@@ -30,7 +30,8 @@ public class StaticConfigurationProvider
                 URI.create(config.getAuthUrl()),
                 URI.create(config.getTokenUrl()),
                 URI.create(config.getJwksUrl()),
-                config.getUserinfoUrl().map(URI::create));
+                config.getUserinfoUrl().map(URI::create),
+                config.getEndSessionUrl().map(URI::create));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfiguration.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/StaticOAuth2ServerConfiguration.java
@@ -26,12 +26,14 @@ public class StaticOAuth2ServerConfiguration
     public static final String TOKEN_URL = "http-server.authentication.oauth2.token-url";
     public static final String JWKS_URL = "http-server.authentication.oauth2.jwks-url";
     public static final String USERINFO_URL = "http-server.authentication.oauth2.userinfo-url";
+    public static final String END_SESSION_URL = "http-server.authentication.oauth2.end-session-url";
 
     private Optional<String> accessTokenIssuer = Optional.empty();
     private String authUrl;
     private String tokenUrl;
     private String jwksUrl;
     private Optional<String> userinfoUrl = Optional.empty();
+    private Optional<String> endSessionUrl = Optional.empty();
 
     @NotNull
     public Optional<String> getAccessTokenIssuer()
@@ -99,6 +101,19 @@ public class StaticOAuth2ServerConfiguration
     public StaticOAuth2ServerConfiguration setUserinfoUrl(String userinfoUrl)
     {
         this.userinfoUrl = Optional.ofNullable(userinfoUrl);
+        return this;
+    }
+
+    public Optional<String> getEndSessionUrl()
+    {
+        return endSessionUrl;
+    }
+
+    @Config(END_SESSION_URL)
+    @ConfigDescription("URL of the end session endpoint")
+    public StaticOAuth2ServerConfiguration setEndSessionUrl(String endSessionUrl)
+    {
+        this.endSessionUrl = Optional.ofNullable(endSessionUrl);
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
@@ -14,32 +14,63 @@
 package io.trino.server.ui;
 
 import com.google.common.io.Resources;
+import com.google.inject.Inject;
 import io.trino.server.security.ResourceSecurity;
+import io.trino.server.security.oauth2.OAuth2Client;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
 
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
+import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
 import static io.trino.server.ui.OAuthWebUiCookie.delete;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 @Path(UI_LOGOUT)
 public class OAuth2WebUiLogoutResource
 {
+    private final OAuth2Client auth2Client;
+
+    @Inject
+    public OAuth2WebUiLogoutResource(OAuth2Client auth2Client)
+    {
+        this.auth2Client = requireNonNull(auth2Client, "auth2Client is null");
+    }
+
     @ResourceSecurity(WEB_UI)
     @GET
     public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
             throws IOException
     {
+        Optional<String> idToken = OAuthIdTokenCookie.read(httpHeaders.getCookies().get(ID_TOKEN_COOKIE));
+        URI callBackUri = UriBuilder.fromUri(uriInfo.getAbsolutePath())
+                .path("logout.html")
+                .build();
+
+        return Response.seeOther(auth2Client.getLogoutEndpoint(idToken, callBackUri).orElse(callBackUri))
+                .cookie(delete(), OAuthIdTokenCookie.delete())
+                .build();
+    }
+
+    @ResourceSecurity(PUBLIC)
+    @GET
+    @Path("/logout.html")
+    public Response logoutPage(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
+            throws IOException
+    {
         return Response.ok(Resources.toString(Resources.getResource(getClass(), "/oauth2/logout.html"), UTF_8))
-                .cookie(delete())
                 .build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuthIdTokenCookie.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuthIdTokenCookie.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.ui;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.NewCookie;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION;
+import static jakarta.ws.rs.core.Cookie.DEFAULT_VERSION;
+import static jakarta.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+import static java.util.function.Predicate.not;
+
+public final class OAuthIdTokenCookie
+{
+    // prefix according to: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-4.1.3.1
+    public static final String ID_TOKEN_COOKIE = "__Secure-Trino-ID-Token";
+
+    private OAuthIdTokenCookie() {}
+
+    public static NewCookie create(String token, Instant tokenExpiration)
+    {
+        return new NewCookie(
+                ID_TOKEN_COOKIE,
+                token,
+                UI_LOCATION,
+                null,
+                DEFAULT_VERSION,
+                null,
+                DEFAULT_MAX_AGE,
+                Date.from(tokenExpiration),
+                true,
+                true);
+    }
+
+    public static Optional<String> read(Cookie cookie)
+    {
+        return Optional.ofNullable(cookie)
+                .map(Cookie::getValue)
+                .filter(not(String::isBlank));
+    }
+
+    public static NewCookie delete()
+    {
+        return new NewCookie(
+                ID_TOKEN_COOKIE,
+                "delete",
+                UI_LOCATION,
+                null,
+                DEFAULT_VERSION,
+                null,
+                0,
+                null,
+                true,
+                true);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -89,7 +89,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.hash.Hashing.sha256;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
@@ -106,6 +105,7 @@ import static io.trino.server.security.jwt.JwtUtil.newJwtBuilder;
 import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
 import static io.trino.server.security.oauth2.OAuth2Service.NONCE;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION;
+import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
 import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
 import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
 import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
@@ -684,12 +684,20 @@ public class TestResourceSecurity
 
             // if Web UI is using oauth so we should get a cookie
             if (webUiEnabled) {
-                HttpCookie cookie = getOnlyElement(cookieManager.getCookieStore().getCookies());
+                HttpCookie cookie = getCookie(cookieManager, OAUTH2_COOKIE);
                 assertEquals(cookie.getValue(), tokenServer.getAccessToken());
                 assertEquals(cookie.getPath(), "/ui/");
                 assertEquals(cookie.getDomain(), baseUri.getHost());
                 assertTrue(cookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
                 assertTrue(cookie.isHttpOnly());
+
+                HttpCookie idTokenCookie = getCookie(cookieManager, ID_TOKEN_COOKIE);
+                assertEquals(idTokenCookie.getValue(), tokenServer.issueIdToken(Optional.of(hashNonce(bearer.getNonceCookie().getValue()))));
+                assertEquals(idTokenCookie.getPath(), "/ui/");
+                assertEquals(idTokenCookie.getDomain(), baseUri.getHost());
+                assertTrue(idTokenCookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
+                assertTrue(idTokenCookie.isHttpOnly());
+
                 cookieManager.getCookieStore().removeAll();
             }
             else {
@@ -1069,7 +1077,7 @@ public class TestResourceSecurity
                     if (!"TEST_CODE".equals(code)) {
                         throw new IllegalArgumentException("Expected TEST_CODE");
                     }
-                    return new Response(accessToken, now().plus(5, ChronoUnit.MINUTES), Optional.of(issueIdToken(nonce.map(this::hashNonce))), Optional.of(REFRESH_TOKEN));
+                    return new Response(accessToken, now().plus(5, ChronoUnit.MINUTES), Optional.of(issueIdToken(nonce.map(TestResourceSecurity::hashNonce))), Optional.of(REFRESH_TOKEN));
                 }
 
                 @Override
@@ -1085,11 +1093,10 @@ public class TestResourceSecurity
                     throw new UnsupportedOperationException("refresh tokens not supported");
                 }
 
-                private String hashNonce(String nonce)
+                @Override
+                public Optional<URI> getLogoutEndpoint(Optional<String> idToken, URI callbackUrl)
                 {
-                    return sha256()
-                            .hashString(nonce, UTF_8)
-                            .toString();
+                    return Optional.empty();
                 }
             };
         }
@@ -1395,6 +1402,21 @@ public class TestResourceSecurity
             return new BasicPrincipal(user);
         }
         throw new AccessDeniedException("Invalid credentials2");
+    }
+
+    private static HttpCookie getCookie(CookieManager cookieManager, String cookieName)
+    {
+        return cookieManager.getCookieStore().getCookies().stream()
+                .filter(cookie -> cookie.getName().equals(cookieName))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static String hashNonce(String nonce)
+    {
+        return sha256()
+                .hashString(nonce, UTF_8)
+                .toString();
     }
 
     private static class TestSystemAccessControl

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestJweTokenSerializer.java
@@ -224,6 +224,12 @@ public class TestJweTokenSerializer
         {
             throw new UnsupportedOperationException("operation is not yet supported");
         }
+
+        @Override
+        public Optional<URI> getLogoutEndpoint(Optional<String> idToken, URI callbackUrl)
+        {
+            return Optional.empty();
+        }
     }
 
     private static class TestingClock

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
@@ -37,6 +37,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithJwt
                 .put("http-server.authentication.oauth2.issuer", "https://localhost:4444/")
                 .put("http-server.authentication.oauth2.auth-url", idpUrl + "/oauth2/auth")
                 .put("http-server.authentication.oauth2.token-url", idpUrl + "/oauth2/token")
+                .put("http-server.authentication.oauth2.end-session-url", idpUrl + "/oauth2/sessions/logout")
                 .put("http-server.authentication.oauth2.jwks-url", idpUrl + "/.well-known/jwks.json")
                 .put("http-server.authentication.oauth2.client-id", TRINO_CLIENT_ID)
                 .put("http-server.authentication.oauth2.client-secret", TRINO_CLIENT_SECRET)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
@@ -15,17 +15,11 @@ package io.trino.server.security.oauth2;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
-import io.airlift.http.client.HttpClientConfig;
-import io.airlift.http.client.jetty.JettyHttpClient;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
-import io.trino.server.security.jwt.JwkService;
-import io.trino.server.security.jwt.JwkSigningKeyResolver;
 
-import java.net.URI;
 import java.util.Map;
 
-import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestOAuth2WebUiAuthenticationFilterWithJwt
@@ -68,13 +62,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithJwt
     protected void validateAccessToken(String cookieValue)
     {
         assertThat(cookieValue).isNotBlank();
-        Jws<Claims> jwt = newJwtParserBuilder()
-                .setSigningKeyResolver(new JwkSigningKeyResolver(new JwkService(
-                        URI.create("https://localhost:" + hydraIdP.getAuthPort() + "/.well-known/jwks.json"),
-                        new JettyHttpClient(new HttpClientConfig()
-                                .setTrustStorePath(Resources.getResource("cert/localhost.pem").getPath())))))
-                .build()
-                .parseClaimsJws(cookieValue);
+        Jws<Claims> jwt = parseJwsClaims(cookieValue);
         Claims claims = jwt.getBody();
         assertThat(claims.getSubject()).isEqualTo("foo@bar.com");
         assertThat(claims.get("client_id")).isEqualTo(TRINO_CLIENT_ID);

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithOpaque.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithOpaque.java
@@ -43,6 +43,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithOpaque
                 .put("http-server.authentication.oauth2.issuer", "https://localhost:4444/")
                 .put("http-server.authentication.oauth2.auth-url", idpUrl + "/oauth2/auth")
                 .put("http-server.authentication.oauth2.token-url", idpUrl + "/oauth2/token")
+                .put("http-server.authentication.oauth2.end-session-url", idpUrl + "/oauth2/sessions/logout")
                 .put("http-server.authentication.oauth2.jwks-url", idpUrl + "/.well-known/jwks.json")
                 .put("http-server.authentication.oauth2.userinfo-url", idpUrl + "/userinfo")
                 .put("http-server.authentication.oauth2.client-id", TRINO_CLIENT_ID)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithRefreshTokens.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithRefreshTokens.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.google.inject.Key;
+import io.airlift.http.client.HttpClientConfig;
+import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
+import io.trino.server.security.jwt.JwkService;
+import io.trino.server.security.jwt.JwkSigningKeyResolver;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
+import io.trino.server.ui.WebUiModule;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.CookieManager;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
+import java.time.Duration;
+
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.client.OkHttpUtil.setupInsecureSsl;
+import static io.trino.server.security.jwt.JwtUtil.newJwtParserBuilder;
+import static io.trino.server.security.oauth2.TokenEndpointAuthMethod.CLIENT_SECRET_BASIC;
+import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestOAuth2WebUiAuthenticationFilterWithRefreshTokens
+{
+    protected static final Duration TTL_ACCESS_TOKEN_IN_SECONDS = Duration.ofSeconds(5);
+
+    protected static final String TRINO_CLIENT_ID = "trino-client";
+    protected static final String TRINO_CLIENT_SECRET = "trino-secret";
+    private static final String TRINO_AUDIENCE = TRINO_CLIENT_ID;
+    private static final String ADDITIONAL_AUDIENCE = "https://external-service.com";
+    protected static final String TRUSTED_CLIENT_ID = "trusted-client";
+
+    protected OkHttpClient httpClient;
+    protected TestingHydraIdentityProvider hydraIdP;
+    private TestingTrinoServer server;
+    private URI serverUri;
+    private URI uiUri;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel(OAuth2WebUiAuthenticationFilter.class.getName(), Level.DEBUG);
+        logging.setLevel(OAuth2Service.class.getName(), Level.DEBUG);
+
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
+        setupInsecureSsl(httpClientBuilder);
+        httpClientBuilder.followRedirects(false);
+        httpClient = httpClientBuilder.build();
+
+        hydraIdP = new TestingHydraIdentityProvider(TTL_ACCESS_TOKEN_IN_SECONDS, true, false);
+        hydraIdP.start();
+
+        String idpUrl = "https://localhost:" + hydraIdP.getAuthPort();
+
+        server = TestingTrinoServer.builder()
+                .setCoordinator(true)
+                .setAdditionalModule(new WebUiModule())
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("web-ui.enabled", "true")
+                        .put("web-ui.authentication.type", "oauth2")
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", Resources.getResource("cert/localhost.pem").getPath())
+                        .put("http-server.https.keystore.key", "")
+                        .put("http-server.authentication.oauth2.issuer", "https://localhost:4444/")
+                        .put("http-server.authentication.oauth2.auth-url", idpUrl + "/oauth2/auth")
+                        .put("http-server.authentication.oauth2.token-url", idpUrl + "/oauth2/token")
+                        .put("http-server.authentication.oauth2.end-session-url", idpUrl + "/oauth2/sessions/logout")
+                        .put("http-server.authentication.oauth2.jwks-url", idpUrl + "/.well-known/jwks.json")
+                        .put("http-server.authentication.oauth2.client-id", TRINO_CLIENT_ID)
+                        .put("http-server.authentication.oauth2.client-secret", TRINO_CLIENT_SECRET)
+                        .put("http-server.authentication.oauth2.additional-audiences", TRUSTED_CLIENT_ID)
+                        .put("http-server.authentication.oauth2.max-clock-skew", "0s")
+                        .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)(@.*)?")
+                        .put("http-server.authentication.oauth2.oidc.discovery", "false")
+                        .put("http-server.authentication.oauth2.scopes", "openid,offline")
+                        .put("http-server.authentication.oauth2.refresh-tokens", "true")
+                        .put("oauth2-jwk.http-client.trust-store-path", Resources.getResource("cert/localhost.pem").getPath())
+                        .buildOrThrow())
+                .build();
+        server.getInstance(Key.get(OAuth2Client.class)).load();
+        server.waitForNodeRefresh(Duration.ofSeconds(10));
+        serverUri = server.getHttpsBaseUrl();
+        uiUri = serverUri.resolve("/ui/");
+
+        hydraIdP.createClient(
+                TRINO_CLIENT_ID,
+                TRINO_CLIENT_SECRET,
+                CLIENT_SECRET_BASIC,
+                ImmutableList.of(TRINO_AUDIENCE, ADDITIONAL_AUDIENCE),
+                serverUri + "/oauth2/callback",
+                serverUri + "/ui/logout/logout.html");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        Logging logging = Logging.initialize();
+        logging.clearLevel(OAuth2WebUiAuthenticationFilter.class.getName());
+        logging.clearLevel(OAuth2Service.class.getName());
+
+        closeAll(
+                server,
+                hydraIdP,
+                () -> {
+                    httpClient.dispatcher().executorService().shutdown();
+                    httpClient.connectionPool().evictAll();
+                });
+        server = null;
+        hydraIdP = null;
+        httpClient = null;
+    }
+
+    @Test
+    public void testSuccessfulFlowWithRefreshedAccessToken()
+            throws Exception
+    {
+        // create a new HttpClient which follows redirects and give access to cookies
+        CookieManager cookieManager = new CookieManager();
+        CookieStore cookieStore = cookieManager.getCookieStore();
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient.Builder();
+        setupInsecureSsl(httpClientBuilder);
+        OkHttpClient httpClient = httpClientBuilder
+                .followRedirects(true)
+                .cookieJar(new JavaNetCookieJar(cookieManager))
+                .build();
+
+        assertThat(cookieStore.get(uiUri)).isEmpty();
+
+        accessUi(httpClient);
+
+        HttpCookie idTokenCookie = cookieStore.get(uiUri)
+                .stream()
+                .filter(cookie -> cookie.getName().equals(ID_TOKEN_COOKIE))
+                .findFirst()
+                .orElseThrow();
+
+        Thread.sleep(TTL_ACCESS_TOKEN_IN_SECONDS.plusSeconds(1).toMillis()); // wait for the token expiration = ttl of access token + 1 sec
+
+        // Access the UI after timeout
+        accessUi(httpClient);
+
+        HttpCookie newIdTokenCookie = cookieStore.get(uiUri)
+                .stream()
+                .filter(cookie -> cookie.getName().equals(ID_TOKEN_COOKIE))
+                .findFirst()
+                .orElseThrow();
+
+        // Post refresh of access token the id-token should remain same
+        assertThat(newIdTokenCookie.getValue()).isEqualTo(idTokenCookie.getValue());
+
+        // Check if the IDToken was expired
+        assertTokenIsExpired(newIdTokenCookie.getValue());
+
+        // Logout from the Trino
+        try (Response response = httpClient.newCall(
+                        new Request.Builder()
+                                .url(uiUri.resolve("logout").toURL())
+                                .get()
+                                .build())
+                .execute()) {
+            assertEquals(response.code(), SC_OK);
+            assertEquals(response.request().url().toString(), uiUri.resolve("logout/logout.html").toString());
+        }
+        assertThat(cookieStore.get(uiUri)).isEmpty();
+    }
+
+    protected void assertTokenIsExpired(String claimsJws)
+    {
+        assertThatThrownBy(() -> newJwtParserBuilder()
+                .setSigningKeyResolver(new JwkSigningKeyResolver(new JwkService(
+                        URI.create("https://localhost:" + hydraIdP.getAuthPort() + "/.well-known/jwks.json"),
+                        new JettyHttpClient(new HttpClientConfig()
+                                .setTrustStorePath(Resources.getResource("cert/localhost.pem").getPath())))))
+                .build()
+                .parseClaimsJws(claimsJws));
+    }
+
+    private void accessUi(OkHttpClient httpClient)
+            throws Exception
+    {
+        // access UI and follow redirects in order to get OAuth2 and IDToken cookie
+        try (Response response = httpClient.newCall(
+                        new Request.Builder()
+                                .url(uiUri.toURL())
+                                .get()
+                                .build())
+                .execute()) {
+            assertEquals(response.code(), SC_OK);
+            assertEquals(response.request().url().toString(), uiUri.toString());
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -62,7 +62,8 @@ public class TestOidcDiscovery
                     .put("http-server.authentication.oauth2.oidc.discovery", "false")
                     .put("http-server.authentication.oauth2.auth-url", issuer.resolve("/connect/authorize").toString())
                     .put("http-server.authentication.oauth2.token-url", issuer.resolve("/connect/token").toString())
-                    .put("http-server.authentication.oauth2.jwks-url", issuer.resolve("/jwks.json").toString());
+                    .put("http-server.authentication.oauth2.jwks-url", issuer.resolve("/jwks.json").toString())
+                    .put("http-server.authentication.oauth2.end-session-url", issuer.resolve("/connect/logout").toString());
             accessTokenIssuer.map(URI::toString).ifPresent(uri -> properties.put("http-server.authentication.oauth2.access-token-issuer", uri));
             userinfoUrl.map(URI::toString).ifPresent(uri -> properties.put("http-server.authentication.oauth2.userinfo-url", uri));
             try (TestingTrinoServer server = createServer(properties.buildOrThrow())) {

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -235,11 +235,11 @@ public class TestOidcDiscovery
                             .buildOrThrow())) {
                 assertComponents(server);
                 OAuth2ServerConfig config = server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
-                assertThat(config.getAccessTokenIssuer()).isEqualTo(Optional.of(accessTokenIssuer));
-                assertThat(config.getAuthUrl()).isEqualTo(authUrl);
-                assertThat(config.getTokenUrl()).isEqualTo(tokenUrl);
-                assertThat(config.getJwksUrl()).isEqualTo(jwksUrl);
-                assertThat(config.getUserinfoUrl()).isEqualTo(Optional.of(userinfoUrl));
+                assertThat(config.accessTokenIssuer()).isEqualTo(Optional.of(accessTokenIssuer));
+                assertThat(config.authUrl()).isEqualTo(authUrl);
+                assertThat(config.tokenUrl()).isEqualTo(tokenUrl);
+                assertThat(config.jwksUrl()).isEqualTo(jwksUrl);
+                assertThat(config.userinfoUrl()).isEqualTo(Optional.of(userinfoUrl));
             }
         }
     }
@@ -248,11 +248,11 @@ public class TestOidcDiscovery
     {
         assertComponents(server);
         OAuth2ServerConfig config = server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
-        assertThat(config.getAccessTokenIssuer()).isEqualTo(accessTokenIssuer.map(URI::toString));
-        assertThat(config.getAuthUrl()).isEqualTo(issuer.resolve("/connect/authorize"));
-        assertThat(config.getTokenUrl()).isEqualTo(issuer.resolve("/connect/token"));
-        assertThat(config.getJwksUrl()).isEqualTo(issuer.resolve("/jwks.json"));
-        assertThat(config.getUserinfoUrl()).isEqualTo(userinfoUrl);
+        assertThat(config.accessTokenIssuer()).isEqualTo(accessTokenIssuer.map(URI::toString));
+        assertThat(config.authUrl()).isEqualTo(issuer.resolve("/connect/authorize"));
+        assertThat(config.tokenUrl()).isEqualTo(issuer.resolve("/connect/token"));
+        assertThat(config.jwksUrl()).isEqualTo(issuer.resolve("/jwks.json"));
+        assertThat(config.userinfoUrl()).isEqualTo(userinfoUrl);
     }
 
     private static void assertComponents(TestingTrinoServer server)

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import com.google.common.net.InetAddresses;
 import com.google.inject.Key;
 import com.nimbusds.oauth2.sdk.GrantType;
 import io.airlift.http.server.HttpServerConfig;
@@ -26,6 +27,7 @@ import io.airlift.http.server.HttpServerInfo;
 import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.log.Level;
 import io.airlift.log.Logging;
+import io.airlift.node.NodeConfig;
 import io.airlift.node.NodeInfo;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
@@ -54,6 +56,7 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
@@ -219,7 +222,9 @@ public class TestingHydraIdentityProvider
     private TestingHttpServer createTestingLoginAndConsentServer()
             throws IOException
     {
-        NodeInfo nodeInfo = new NodeInfo("test");
+        NodeInfo nodeInfo = new NodeInfo(new NodeConfig()
+                .setEnvironment("test")
+                .setNodeInternalAddress(InetAddresses.toAddrString(InetAddress.getLocalHost())));
         HttpServerConfig config = new HttpServerConfig().setHttpPort(0);
         HttpServerInfo httpServerInfo = new HttpServerInfo(config, nodeInfo);
         return new TestingHttpServer(httpServerInfo, nodeInfo, config, new AcceptAllLoginsAndConsentsServlet(), ImmutableMap.of());

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraIdentityProvider.java
@@ -136,6 +136,7 @@ public class TestingHydraIdentityProvider
                 .withEnv("SERVE_TLS_KEY_PATH", "/tmp/certs/localhost.pem")
                 .withEnv("SERVE_TLS_CERT_PATH", "/tmp/certs/localhost.pem")
                 .withEnv("TTL_ACCESS_TOKEN", ttlAccessToken.getSeconds() + "s")
+                .withEnv("TTL_ID_TOKEN", ttlAccessToken.getSeconds() + "s")
                 .withEnv("STRATEGIES_ACCESS_TOKEN", useJwt ? "jwt" : null)
                 .withEnv("LOG_LEAK_SENSITIVE_VALUES", "true")
                 .withCommand("serve", "all")
@@ -162,7 +163,8 @@ public class TestingHydraIdentityProvider
             String clientSecret,
             TokenEndpointAuthMethod tokenEndpointAuthMethod,
             List<String> audiences,
-            String callbackUrl)
+            String callbackUrl,
+            String logoutCallbackUrl)
     {
         createHydraContainer()
                 .withCommand("clients", "create",
@@ -175,7 +177,8 @@ public class TestingHydraIdentityProvider
                         "--response-types", "token,code,id_token",
                         "--scope", "openid,offline",
                         "--token-endpoint-auth-method", tokenEndpointAuthMethod.getValue(),
-                        "--callbacks", callbackUrl)
+                        "--callbacks", callbackUrl,
+                        "--post-logout-callbacks", logoutCallbackUrl)
                 .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)))
                 .start();
     }
@@ -348,7 +351,8 @@ public class TestingHydraIdentityProvider
                     "trino-secret",
                     CLIENT_SECRET_BASIC,
                     ImmutableList.of("https://localhost:8443/ui"),
-                    "https://localhost:8443/oauth2/callback");
+                    "https://localhost:8443/oauth2/callback",
+                    "https://localhost:8443/ui/logout/logout.html");
             ImmutableMap.Builder<String, String> config = ImmutableMap.<String, String>builder()
                     .put("web-ui.enabled", "true")
                     .put("web-ui.authentication.type", "oauth2")

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -51,6 +51,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.UriBuilder;
 import okhttp3.FormBody;
 import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
@@ -106,6 +107,8 @@ import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.LOGIN_FORM;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGIN;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
+import static io.trino.server.ui.OAuthIdTokenCookie.ID_TOKEN_COOKIE;
+import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
@@ -115,11 +118,13 @@ import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static jakarta.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 @TestInstance(PER_CLASS)
@@ -662,7 +667,7 @@ public class TestWebUi
                         .setBinding()
                         .toInstance(oauthClient))
                 .build()) {
-            assertAuth2Authentication(server, oauthClient.getAccessToken(), false);
+            assertAuth2Authentication(server, oauthClient.getAccessToken(), oauthClient.getIdToken(), false, true);
         }
         finally {
             jwkServer.stop();
@@ -686,7 +691,7 @@ public class TestWebUi
                         .setBinding()
                         .toInstance(oauthClient))
                 .build()) {
-            assertAuth2Authentication(server, oauthClient.getAccessToken(), false);
+            assertAuth2Authentication(server, oauthClient.getAccessToken(), Optional.empty(), false, true);
         }
         finally {
             jwkServer.stop();
@@ -711,7 +716,7 @@ public class TestWebUi
                         .setBinding()
                         .toInstance(oauthClient))
                 .build()) {
-            assertAuth2Authentication(server, oauthClient.getAccessToken(), true);
+            assertAuth2Authentication(server, oauthClient.getAccessToken(), oauthClient.getIdToken(), true, true);
         }
         finally {
             jwkServer.stop();
@@ -812,6 +817,7 @@ public class TestWebUi
                         .put("preferred_username", "test-user@email.com")
                         .buildOrThrow(),
                 Duration.ofSeconds(5),
+                true,
                 true);
         TestingHttpServer jwkServer = createTestingJwkServer();
         jwkServer.start();
@@ -829,7 +835,7 @@ public class TestWebUi
                     jaxrsBinder(binder).bind(AuthenticatedIdentityCapturingFilter.class);
                 })
                 .build()) {
-            assertAuth2Authentication(server, oauthClient.getAccessToken(), false);
+            assertAuth2Authentication(server, oauthClient.getAccessToken(), oauthClient.getIdToken(), false, true);
             Identity identity = server.getInstance(Key.get(AuthenticatedIdentityCapturingFilter.class)).getAuthenticatedIdentity();
             assertThat(identity.getUser()).isEqualTo("test-user");
             assertThat(identity.getPrincipal()).isEqualTo(Optional.of(new BasicPrincipal("test-user@email.com")));
@@ -839,7 +845,31 @@ public class TestWebUi
         }
     }
 
-    private void assertAuth2Authentication(TestingTrinoServer server, String accessToken, boolean refreshTokensEnabled)
+    @Test
+    public void testOAuth2AuthenticatorWithoutEndSessionEndpoint()
+            throws Exception
+    {
+        OAuth2ClientStub oauthClient = new OAuth2ClientStub(ImmutableMap.of(), Duration.ofSeconds(5), false, false);
+        TestingHttpServer jwkServer = createTestingJwkServer();
+        jwkServer.start();
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(OAUTH2_PROPERTIES)
+                        .put("http-server.authentication.oauth2.jwks-url", jwkServer.getBaseUrl().toString())
+                        .put("http-server.authentication.oauth2.scopes", "")
+                        .buildOrThrow())
+                .setAdditionalModule(binder -> newOptionalBinder(binder, OAuth2Client.class)
+                        .setBinding()
+                        .toInstance(oauthClient))
+                .build()) {
+            assertAuth2Authentication(server, oauthClient.getAccessToken(), oauthClient.getIdToken(), false, false);
+        }
+        finally {
+            jwkServer.stop();
+        }
+    }
+
+    private void assertAuth2Authentication(TestingTrinoServer server, String accessToken, Optional<String> idToken, boolean refreshTokensEnabled, boolean supportsEndSessionEndpoint)
             throws Exception
     {
         CookieManager cookieManager = new CookieManager();
@@ -860,7 +890,7 @@ public class TestWebUi
         assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), UNAUTHORIZED.getStatusCode());
 
         loginWithCallbackEndpoint(client, baseUri);
-        HttpCookie cookie = getOnlyElement(cookieManager.getCookieStore().getCookies());
+        HttpCookie cookie = getCookie(cookieManager, OAUTH2_COOKIE);
         if (refreshTokensEnabled) {
             assertCookieWithRefreshToken(server, cookie, accessToken);
         }
@@ -872,6 +902,20 @@ public class TestWebUi
         assertEquals(cookie.getDomain(), baseUri.getHost());
         assertTrue(cookie.isHttpOnly());
 
+        if (idToken.isPresent()) {
+            HttpCookie idTokenCookie = getCookie(cookieManager, ID_TOKEN_COOKIE);
+            assertEquals(idTokenCookie.getValue(), idToken.get());
+            assertEquals(idTokenCookie.getPath(), "/ui/");
+            assertEquals(idTokenCookie.getDomain(), baseUri.getHost());
+            assertTrue(idTokenCookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
+            assertTrue(idTokenCookie.isHttpOnly());
+        }
+        else {
+            assertThatThrownBy(() -> getCookie(cookieManager, ID_TOKEN_COOKIE))
+                    // WebIDTokenCookie should not be set
+                    .hasMessageContaining("No value present");
+        }
+
         // authentication cookie is now set, so UI should work
         testRootRedirect(baseUri, client);
         assertOk(client, getUiLocation(baseUri));
@@ -881,8 +925,26 @@ public class TestWebUi
         assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), SC_NOT_FOUND);
 
         // logout
-        assertOk(client, getLogoutLocation(baseUri));
-        assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
+        Request request = new Request.Builder()
+                .url(uriBuilderFrom(baseUri)
+                        .replacePath("/ui/logout/")
+                        .toString())
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            String expectedRedirect = uriBuilderFrom(baseUri).replacePath("ui/logout/logout.html").toString();
+            if (supportsEndSessionEndpoint) {
+                UriBuilder uriBuilder = UriBuilder.fromUri("http://example.com/oauth2/v1/logout");
+                idToken.ifPresent(token -> uriBuilder.queryParam("id_token_hint", token));
+                uriBuilder.queryParam("post_logout_redirect_uri", expectedRedirect);
+                expectedRedirect = uriBuilder.build().toString();
+            }
+
+            assertEquals(response.code(), SC_SEE_OTHER);
+            String locationHeader = response.header(HttpHeaders.LOCATION);
+            assertNotNull(locationHeader);
+            assertEquals(locationHeader, expectedRedirect);
+            assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
+        }
         assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
     }
 
@@ -1217,6 +1279,7 @@ public class TestWebUi
         private final Duration accessTokenValidity;
         private final Optional<String> nonce;
         private final Optional<String> idToken;
+        private final boolean supportsEndsessionEndpoint;
 
         public OAuth2ClientStub()
         {
@@ -1225,10 +1288,10 @@ public class TestWebUi
 
         public OAuth2ClientStub(boolean issueIdToken, Duration accessTokenValidity)
         {
-            this(ImmutableMap.of(), accessTokenValidity, issueIdToken);
+            this(ImmutableMap.of(), accessTokenValidity, issueIdToken, true);
         }
 
-        public OAuth2ClientStub(Map<String, String> additionalClaims, Duration accessTokenValidity, boolean issueIdToken)
+        public OAuth2ClientStub(Map<String, String> additionalClaims, Duration accessTokenValidity, boolean issueIdToken, boolean supportsEndsessionEnpoint)
         {
             claims = new DefaultClaims(createClaims());
             claims.putAll(requireNonNull(additionalClaims, "additionalClaims is null"));
@@ -1246,6 +1309,7 @@ public class TestWebUi
                 nonce = Optional.empty();
                 idToken = Optional.empty();
             }
+            this.supportsEndsessionEndpoint = supportsEndsessionEnpoint;
         }
 
         @Override
@@ -1284,9 +1348,26 @@ public class TestWebUi
             throw new ChallengeFailedException("invalid refresh token");
         }
 
+        @Override
+        public Optional<URI> getLogoutEndpoint(Optional<String> idToken, URI callbackUrl)
+        {
+            if (supportsEndsessionEndpoint) {
+                UriBuilder builder = UriBuilder.fromUri("http://example.com/oauth2/v1/logout");
+                idToken.ifPresent(token -> builder.queryParam("id_token_hint", token));
+                builder.queryParam("post_logout_redirect_uri", callbackUrl);
+                return Optional.of(builder.build());
+            }
+            return Optional.empty();
+        }
+
         public String getAccessToken()
         {
             return accessToken;
+        }
+
+        public Optional<String> getIdToken()
+        {
+            return idToken;
         }
 
         private static String issueToken(Claims claims)
@@ -1338,5 +1419,13 @@ public class TestWebUi
         {
             return authenticatedIdentity;
         }
+    }
+
+    private static HttpCookie getCookie(CookieManager cookieManager, String cookieName)
+    {
+        return cookieManager.getCookieStore().getCookies().stream()
+                .filter(cookie -> cookie.getName().equals(cookieName))
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/docs/src/main/sphinx/security/oauth2.md
+++ b/docs/src/main/sphinx/security/oauth2.md
@@ -18,6 +18,10 @@ Set the callback/redirect URL to `https://<trino-coordinator-domain-name>/oauth2
 when configuring an OAuth 2.0 authorization server like an OpenID Connect (OIDC)
 provider.
 
+If Web UI is enabled, set the post-logout callback URL to 
+`https://<trino-coordinator-domain-name>/ui/logout/logout.html` when configuring 
+an OAuth 2.0 authentication server like an OpenID Connect (OIDC) provider.
+
 Using {doc}`TLS <tls>` and {doc}`a configured shared secret
 </security/internal-communication>` is required for OAuth 2.0 authentication.
 
@@ -33,6 +37,7 @@ values to set corresponding OAuth2 authentication configuration properties:
 - `jwks_uri` -> `http-server.authentication.oauth2.jwks-url`
 - `userinfo_endpoint` ->  `http-server.authentication.oauth2.userinfo-url`
 - `access_token_issuer` -> `http-server.authentication.oauth2.access-token-issuer`
+- `end_session_endpoint` -> `http-server.authentication.oauth2.end-session-url`
 
 :::{warning}
 If the authorization server is issuing JSON Web Tokens (JWTs) and the
@@ -157,6 +162,10 @@ The following configuration properties are available:
        validate the OAuth 2.0 access token, and retrieve any associated claims.
        This flag allows ignoring the value provided in the metadata document.
        Default is ``true``.
+   * - ``http-server.authentication.oauth2.end-session-url``
+     - The URL of the endpoint on the authorization server to which user's browser 
+       will be redirected to so that End-User will be logged out from the authorization 
+       server when logging out from Trino.
 ```
 
 (trino-oauth2-refresh-tokens)=


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When trying to logout from Trino WebUI, allows the user to be redirected to a specific end_session_endpoint thereby allowing user to logout from the IdP/OP.

Specification - https://openid.net/specs/openid-connect-rpinitiated-1_0.html

Will be sharing a video link on how it worked before and after this change. 

Fixes https://github.com/trinodb/trino/issues/13060

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Implement session logout when logging out from Trino WebUI . ({issue}`13060`)
```
