### PR TITLE
Treat overflow error in DATE_ADD as user error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateAdd.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/DateAdd.java
@@ -14,6 +14,7 @@
 package io.trino.operator.scalar.timestamptz;
 
 import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
 import io.trino.spi.function.Description;
 import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
@@ -23,6 +24,7 @@ import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.StandardTypes;
 
 import static io.trino.operator.scalar.DateTimeFunctions.getTimestampField;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateTimeEncoding.updateMillisUtc;
 import static io.trino.type.DateTimes.round;
@@ -43,12 +45,17 @@ public class DateAdd
             @SqlType(StandardTypes.BIGINT) long value,
             @SqlType("timestamp(p) with time zone") long packedEpochMillis)
     {
-        long epochMillis = unpackMillisUtc(packedEpochMillis);
+        try {
+            long epochMillis = unpackMillisUtc(packedEpochMillis);
 
-        epochMillis = getTimestampField(unpackChronology(packedEpochMillis), unit).add(epochMillis, toIntExact(value));
-        epochMillis = round(epochMillis, (int) (3 - precision));
+            epochMillis = getTimestampField(unpackChronology(packedEpochMillis), unit).add(epochMillis, toIntExact(value));
+            epochMillis = round(epochMillis, (int) (3 - precision));
 
-        return updateMillisUtc(epochMillis, packedEpochMillis);
+            return updateMillisUtc(epochMillis, packedEpochMillis);
+        }
+        catch (IllegalArgumentException | ArithmeticException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage());
+        }
     }
 
     @LiteralParameters({"x", "p"})
@@ -58,8 +65,13 @@ public class DateAdd
             @SqlType(StandardTypes.BIGINT) long value,
             @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp)
     {
-        long epochMillis = getTimestampField(unpackChronology(timestamp.getTimeZoneKey()), unit).add(timestamp.getEpochMillis(), toIntExact(value));
+        try {
+            long epochMillis = getTimestampField(unpackChronology(timestamp.getTimeZoneKey()), unit).add(timestamp.getEpochMillis(), toIntExact(value));
 
-        return LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+            return LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, timestamp.getPicosOfMilli(), timestamp.getTimeZoneKey());
+        }
+        catch (IllegalArgumentException | ArithmeticException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## Description
Currently, overflow error in DATE_ADD is treated as internal error, but it should be treated as user error.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
