### PR TITLE
Add FlatSet for semi join

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BigintGroupByHash.java
@@ -163,32 +163,6 @@ public class BigintGroupByHash
     }
 
     @Override
-    public boolean contains(int position, Page page)
-    {
-        Block block = page.getBlock(0);
-        if (block.isNull(position)) {
-            return nullGroupId >= 0;
-        }
-
-        long value = BIGINT.getLong(block, position);
-        int hashPosition = getHashPosition(value, mask);
-
-        // look for an empty slot or a slot containing this key
-        while (true) {
-            int groupId = groupIds[hashPosition];
-            if (groupId == -1) {
-                return false;
-            }
-            if (value == values[hashPosition]) {
-                return true;
-            }
-
-            // increment position and mask to handle wrap around
-            hashPosition = (hashPosition + 1) & mask;
-        }
-    }
-
-    @Override
     public long getRawHash(int groupId)
     {
         return BigintType.hash(valuesByGroupId[groupId]);

--- a/core/trino-main/src/main/java/io/trino/operator/ChannelSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ChannelSet.java
@@ -13,37 +13,37 @@
  */
 package io.trino.operator;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import io.trino.memory.context.LocalMemoryContext;
-import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
-import io.trino.sql.gen.JoinCompiler;
 
-import static io.trino.operator.GroupByHash.createGroupByHash;
-import static io.trino.type.UnknownType.UNKNOWN;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.FLAT;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FLAT_RETURN;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
 public class ChannelSet
 {
-    private final GroupByHash hash;
-    private final boolean containsNull;
+    private final FlatSet set;
 
-    private ChannelSet(GroupByHash hash, boolean containsNull)
+    private ChannelSet(FlatSet set)
     {
-        this.hash = hash;
-        this.containsNull = containsNull;
+        this.set = set;
     }
 
     public long getEstimatedSizeInBytes()
     {
-        return hash.getEstimatedSize();
+        return set.getEstimatedSize();
     }
 
     public int size()
     {
-        return hash.getGroupCount();
+        return set.size();
     }
 
     public boolean isEmpty()
@@ -53,67 +53,67 @@ public class ChannelSet
 
     public boolean containsNull()
     {
-        return containsNull;
+        return set.containsNull();
     }
 
-    public boolean contains(int position, Page page)
+    public boolean contains(Block valueBlock, int position)
     {
-        return hash.contains(position, page);
+        return set.contains(valueBlock, position);
     }
 
-    public boolean contains(int position, Page page, long rawHash)
+    public boolean contains(Block valueBlock, int position, long rawHash)
     {
-        return hash.contains(position, page, rawHash);
+        return set.contains(valueBlock, position, rawHash);
     }
 
     public static class ChannelSetBuilder
     {
-        private final Type type;
-        private final OperatorContext operatorContext;
-        private final LocalMemoryContext localMemoryContext;
-        private final GroupByHash hash;
+        private final LocalMemoryContext memoryContext;
+        private final FlatSet set;
 
-        public ChannelSetBuilder(Type type, boolean hasPrecomputedHash, int expectedPositions, OperatorContext operatorContext, JoinCompiler joinCompiler, TypeOperators typeOperators)
+        public ChannelSetBuilder(Type type, TypeOperators typeOperators, LocalMemoryContext memoryContext)
         {
-            this.type = requireNonNull(type, "type is null");
-            this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-            this.localMemoryContext = operatorContext.localUserMemoryContext();
-            this.hash = createGroupByHash(
-                    operatorContext.getSession(),
-                    ImmutableList.of(type),
-                    hasPrecomputedHash,
-                    expectedPositions,
-                    joinCompiler,
-                    typeOperators,
-                    this::updateMemoryReservation);
+            set = new FlatSet(
+                    type,
+                    typeOperators.getReadValueOperator(type, simpleConvention(FLAT_RETURN, BLOCK_POSITION_NOT_NULL)),
+                    typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, FLAT)),
+                    typeOperators.getDistinctFromOperator(type, simpleConvention(FAIL_ON_NULL, FLAT, BLOCK_POSITION_NOT_NULL)),
+                    typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION_NOT_NULL)));
+            this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+            this.memoryContext.setBytes(set.getEstimatedSize());
         }
 
         public ChannelSet build()
         {
-            Page nullBlockPage = new Page(type.createBlockBuilder(null, 1, UNKNOWN.getFixedSize()).appendNull().build());
-            boolean containsNull = hash.contains(0, nullBlockPage);
-            return new ChannelSet(hash, containsNull);
+            return new ChannelSet(set);
         }
 
-        public Work<?> addPage(Page page)
+        public void addAll(Block valueBlock, Block hashBlock)
         {
-            // Just add the page to the pending work, which will be processed later.
-            return hash.addPage(page);
-        }
+            if (valueBlock.getPositionCount() == 0) {
+                return;
+            }
 
-        public boolean updateMemoryReservation()
-        {
-            // If memory is not available, once we return, this operator will be blocked until memory is available.
-            localMemoryContext.setBytes(hash.getEstimatedSize());
+            if (valueBlock instanceof RunLengthEncodedBlock rleBlock) {
+                if (hashBlock != null) {
+                    set.add(rleBlock.getValue(), 0, BIGINT.getLong(hashBlock, 0));
+                }
+                else {
+                    set.add(rleBlock.getValue(), 0);
+                }
+            }
+            else if (hashBlock != null) {
+                for (int position = 0; position < valueBlock.getPositionCount(); position++) {
+                    set.add(valueBlock, position, BIGINT.getLong(hashBlock, position));
+                }
+            }
+            else {
+                for (int position = 0; position < valueBlock.getPositionCount(); position++) {
+                    set.add(valueBlock, position);
+                }
+            }
 
-            // If memory is not available, inform the caller that we cannot proceed for allocation.
-            return operatorContext.isWaitingForMemory().isDone();
-        }
-
-        @VisibleForTesting
-        public int getCapacity()
-        {
-            return hash.getCapacity();
+            memoryContext.setBytes(set.getEstimatedSize());
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatGroupByHash.java
@@ -161,32 +161,6 @@ public class FlatGroupByHash
         return new GetNonDictionaryGroupIdsWork(blocks);
     }
 
-    @Override
-    public boolean contains(int position, Page page)
-    {
-        return flatHash.contains(getBlocksForContainsPage(page), position);
-    }
-
-    @Override
-    public boolean contains(int position, Page page, long hash)
-    {
-        return flatHash.contains(getBlocksForContainsPage(page), position, hash);
-    }
-
-    private Block[] getBlocksForContainsPage(Page page)
-    {
-        // contains page only has the group by channels as the optional hash is passed directly
-        checkArgument(page.getChannelCount() == groupByChannelCount);
-        Block[] blocks = currentBlocks;
-        for (int i = 0; i < page.getChannelCount(); i++) {
-            blocks[i] = page.getBlock(i);
-        }
-        if (hasPrecomputedHash) {
-            blocks[blocks.length - 1] = null;
-        }
-        return blocks;
-    }
-
     @VisibleForTesting
     @Override
     public int getCapacity()
@@ -442,7 +416,7 @@ public class FlatGroupByHash
         {
             for (int i = 0; i < blocks.length; i++) {
                 // GroupBy blocks are guaranteed to be RLE, but hash block might not be an RLE due to bugs
-                // use getSingleValueBlock here which for RLE is a no-op, but will still work if hash block is not RLE
+                // use getSingleValueBlock here, which for RLE is a no-op, but will still work if hash block is not RLE
                 blocks[i] = blocks[i].getSingleValueBlock(0);
             }
             this.blocks = blocks;
@@ -639,7 +613,7 @@ public class FlatGroupByHash
             positionCount = blocks[0].getPositionCount();
             for (int i = 0; i < blocks.length; i++) {
                 // GroupBy blocks are guaranteed to be RLE, but hash block might not be an RLE due to bugs
-                // use getSingleValueBlock here which for RLE is a no-op, but will still work if hash block is not RLE
+                // use getSingleValueBlock here, which for RLE is a no-op, but will still work if hash block is not RLE
                 blocks[i] = blocks[i].getSingleValueBlock(0);
             }
             this.blocks = blocks;

--- a/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FlatSet.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.base.Throwables;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+import static io.airlift.slice.SizeOf.instanceSize;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.operator.VariableWidthData.EMPTY_CHUNK;
+import static io.trino.operator.VariableWidthData.POINTER_SIZE;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
+import static java.lang.Math.multiplyExact;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
+import static java.util.Objects.requireNonNull;
+
+final class FlatSet
+{
+    private static final int INSTANCE_SIZE = instanceSize(FlatSet.class);
+
+    // See jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH for an explanation
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+    // Hash table capacity must be a power of two and at least VECTOR_LENGTH
+    private static final int INITIAL_CAPACITY = 16;
+
+    private static final int RECORDS_PER_GROUP_SHIFT = 10;
+    private static final int RECORDS_PER_GROUP = 1 << RECORDS_PER_GROUP_SHIFT;
+    private static final int RECORDS_PER_GROUP_MASK = RECORDS_PER_GROUP - 1;
+
+    private static final int VECTOR_LENGTH = Long.BYTES;
+    private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, LITTLE_ENDIAN);
+
+    private final Type type;
+    private final MethodHandle writeFlat;
+    private final MethodHandle hashFlat;
+    private final MethodHandle distinctFlatBlock;
+    private final MethodHandle hashBlock;
+
+    private final int recordSize;
+    private final int recordValueOffset;
+
+    private boolean hasNull;
+
+    private int capacity;
+    private int mask;
+
+    private byte[] control;
+    private byte[][] recordGroups;
+    private final VariableWidthData variableWidthData;
+
+    private int size;
+    private int maxFill;
+
+    public FlatSet(
+            Type type,
+            MethodHandle writeFlat,
+            MethodHandle hashFlat,
+            MethodHandle distinctFlatBlock,
+            MethodHandle hashBlock)
+    {
+        this.type = requireNonNull(type, "type is null");
+
+        this.writeFlat = requireNonNull(writeFlat, "writeFlat is null");
+        this.hashFlat = requireNonNull(hashFlat, "hashFlat is null");
+        this.distinctFlatBlock = requireNonNull(distinctFlatBlock, "distinctFlatBlock is null");
+        this.hashBlock = requireNonNull(hashBlock, "hashBlock is null");
+
+        capacity = INITIAL_CAPACITY;
+        maxFill = calculateMaxFill(capacity);
+        mask = capacity - 1;
+        control = new byte[capacity + VECTOR_LENGTH];
+
+        boolean variableWidth = type.isFlatVariableWidth();
+        variableWidthData = variableWidth ? new VariableWidthData() : null;
+
+        recordValueOffset = (variableWidth ? POINTER_SIZE : 0);
+        recordSize = recordValueOffset + type.getFlatFixedSize();
+        recordGroups = createRecordGroups(capacity, recordSize);
+    }
+
+    private static byte[][] createRecordGroups(int capacity, int recordSize)
+    {
+        if (capacity < RECORDS_PER_GROUP) {
+            return new byte[][]{new byte[multiplyExact(capacity, recordSize)]};
+        }
+
+        byte[][] groups = new byte[(capacity + 1) >> RECORDS_PER_GROUP_SHIFT][];
+        for (int i = 0; i < groups.length; i++) {
+            groups[i] = new byte[multiplyExact(RECORDS_PER_GROUP, recordSize)];
+        }
+        return groups;
+    }
+
+    public long getEstimatedSize()
+    {
+        return INSTANCE_SIZE +
+                sizeOf(control) +
+                (sizeOf(recordGroups[0]) * recordGroups.length) +
+                (variableWidthData == null ? 0 : variableWidthData.getRetainedSizeBytes());
+    }
+
+    public int size()
+    {
+        return size + (hasNull ? 1 : 0);
+    }
+
+    public boolean containsNull()
+    {
+        return hasNull;
+    }
+
+    public boolean contains(Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return hasNull;
+        }
+        return getIndex(block, position, valueHashCode(block, position)) >= 0;
+    }
+
+    public boolean contains(Block block, int position, long hash)
+    {
+        if (block.isNull(position)) {
+            return hasNull;
+        }
+        return getIndex(block, position, hash) >= 0;
+    }
+
+    public void add(Block block, int position)
+    {
+        if (block.isNull(position)) {
+            hasNull = true;
+            return;
+        }
+        addNonNull(block, position, valueHashCode(block, position));
+    }
+
+    public void add(Block block, int position, long hash)
+    {
+        if (block.isNull(position)) {
+            hasNull = true;
+            return;
+        }
+        addNonNull(block, position, hash);
+    }
+
+    private void addNonNull(Block block, int position, long hash)
+    {
+        int index = getIndex(block, position, hash);
+        if (index >= 0) {
+            return;
+        }
+
+        index = -index - 1;
+        insert(index, block, position, hash);
+        size++;
+        if (size >= maxFill) {
+            rehash();
+        }
+    }
+
+    private int getIndex(Block block, int position, long hash)
+    {
+        byte hashPrefix = (byte) (hash & 0x7F | 0x80);
+        int bucket = bucket((int) (hash >> 7));
+
+        int step = 1;
+        long repeated = repeat(hashPrefix);
+
+        while (true) {
+            final long controlVector = (long) LONG_HANDLE.get(control, bucket);
+
+            int matchIndex = matchInVector(block, position, bucket, repeated, controlVector);
+            if (matchIndex >= 0) {
+                return matchIndex;
+            }
+
+            int emptyIndex = findEmptyInVector(controlVector, bucket);
+            if (emptyIndex >= 0) {
+                return -emptyIndex - 1;
+            }
+
+            bucket = bucket(bucket + step);
+            step += VECTOR_LENGTH;
+        }
+    }
+
+    private int matchInVector(Block block, int position, int vectorStartBucket, long repeated, long controlVector)
+    {
+        long controlMatches = match(controlVector, repeated);
+        while (controlMatches != 0) {
+            int bucket = bucket(vectorStartBucket + (Long.numberOfTrailingZeros(controlMatches) >>> 3));
+            if (valueNotDistinctFrom(bucket, block, position)) {
+                return bucket;
+            }
+
+            controlMatches = controlMatches & (controlMatches - 1);
+        }
+        return -1;
+    }
+
+    private int findEmptyInVector(long vector, int vectorStartBucket)
+    {
+        long controlMatches = match(vector, 0x00_00_00_00_00_00_00_00L);
+        if (controlMatches == 0) {
+            return -1;
+        }
+        int slot = Long.numberOfTrailingZeros(controlMatches) >>> 3;
+        return bucket(vectorStartBucket + slot);
+    }
+
+    private void insert(int index, Block block, int position, long hash)
+    {
+        setControl(index, (byte) (hash & 0x7F | 0x80));
+
+        byte[] records = getRecords(index);
+        int recordOffset = getRecordOffset(index);
+
+        // write value
+        byte[] variableWidthChunk = EMPTY_CHUNK;
+        int variableWidthChunkOffset = 0;
+        if (variableWidthData != null) {
+            int variableWidthLength = type.getFlatVariableWidthSize(block, position);
+            variableWidthChunk = variableWidthData.allocate(records, recordOffset, variableWidthLength);
+            variableWidthChunkOffset = VariableWidthData.getChunkOffset(records, recordOffset);
+        }
+
+        try {
+            writeFlat.invokeExact(block, position, records, recordOffset + recordValueOffset, variableWidthChunk, variableWidthChunkOffset);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    private void setControl(int index, byte hashPrefix)
+    {
+        control[index] = hashPrefix;
+        if (index < VECTOR_LENGTH) {
+            control[index + capacity] = hashPrefix;
+        }
+    }
+
+    private void rehash()
+    {
+        int oldCapacity = capacity;
+        byte[] oldControl = control;
+        byte[][] oldRecordGroups = recordGroups;
+
+        long newCapacityLong = capacity * 2L;
+        if (newCapacityLong > MAX_ARRAY_SIZE) {
+            throw new TrinoException(GENERIC_INSUFFICIENT_RESOURCES, "Size of hash table cannot exceed 1 billion entries");
+        }
+
+        capacity = (int) newCapacityLong;
+        maxFill = calculateMaxFill(capacity);
+        mask = capacity - 1;
+
+        control = new byte[capacity + VECTOR_LENGTH];
+        recordGroups = createRecordGroups(capacity, recordSize);
+
+        for (int oldIndex = 0; oldIndex < oldCapacity; oldIndex++) {
+            if (oldControl[oldIndex] != 0) {
+                byte[] oldRecords = oldRecordGroups[oldIndex >> RECORDS_PER_GROUP_SHIFT];
+                int oldRecordOffset = getRecordOffset(oldIndex);
+
+                long hash = valueHashCode(oldRecords, oldIndex);
+                byte hashPrefix = (byte) (hash & 0x7F | 0x80);
+                int bucket = bucket((int) (hash >> 7));
+
+                int step = 1;
+                while (true) {
+                    final long controlVector = (long) LONG_HANDLE.get(control, bucket);
+                    // values are already distinct, so just find the first empty slot
+                    int emptyIndex = findEmptyInVector(controlVector, bucket);
+                    if (emptyIndex >= 0) {
+                        setControl(emptyIndex, hashPrefix);
+
+                        // copy full record including groupId and count
+                        byte[] records = getRecords(emptyIndex);
+                        int recordOffset = getRecordOffset(emptyIndex);
+                        System.arraycopy(oldRecords, oldRecordOffset, records, recordOffset, recordSize);
+                        break;
+                    }
+
+                    bucket = bucket(bucket + step);
+                    step += VECTOR_LENGTH;
+                }
+            }
+        }
+    }
+
+    private int bucket(int hash)
+    {
+        return hash & mask;
+    }
+
+    private byte[] getRecords(int index)
+    {
+        return recordGroups[index >> RECORDS_PER_GROUP_SHIFT];
+    }
+
+    private int getRecordOffset(int index)
+    {
+        return (index & RECORDS_PER_GROUP_MASK) * recordSize;
+    }
+
+    private long valueHashCode(byte[] records, int index)
+    {
+        int recordOffset = getRecordOffset(index);
+
+        try {
+            byte[] variableWidthChunk = EMPTY_CHUNK;
+            if (variableWidthData != null) {
+                variableWidthChunk = variableWidthData.getChunk(records, recordOffset);
+            }
+
+            return (long) hashFlat.invokeExact(
+                    records,
+                    recordOffset + recordValueOffset,
+                    variableWidthChunk);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    private long valueHashCode(Block right, int rightPosition)
+    {
+        try {
+            return (long) hashBlock.invokeExact(right, rightPosition);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    private boolean valueNotDistinctFrom(int leftPosition, Block right, int rightPosition)
+    {
+        byte[] leftRecords = getRecords(leftPosition);
+        int leftRecordOffset = getRecordOffset(leftPosition);
+
+        byte[] leftVariableWidthChunk = EMPTY_CHUNK;
+        if (variableWidthData != null) {
+            leftVariableWidthChunk = variableWidthData.getChunk(leftRecords, leftRecordOffset);
+        }
+
+        try {
+            return !(boolean) distinctFlatBlock.invokeExact(
+                    leftRecords,
+                    leftRecordOffset + recordValueOffset,
+                    leftVariableWidthChunk,
+                    right,
+                    rightPosition);
+        }
+        catch (Throwable throwable) {
+            Throwables.throwIfUnchecked(throwable);
+            throw new RuntimeException(throwable);
+        }
+    }
+
+    private static long repeat(byte value)
+    {
+        return ((value & 0xFF) * 0x01_01_01_01_01_01_01_01L);
+    }
+
+    private static long match(long vector, long repeatedValue)
+    {
+        // HD 6-1
+        long comparison = vector ^ repeatedValue;
+        return (comparison - 0x01_01_01_01_01_01_01_01L) & ~comparison & 0x80_80_80_80_80_80_80_80L;
+    }
+
+    private static int calculateMaxFill(int capacity)
+    {
+        // The hash table uses a load factory of 15/16
+        return (capacity / 16) * 15;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.Session;
+import io.trino.annotation.NotThreadSafe;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
@@ -27,6 +28,7 @@ import static io.trino.SystemSessionProperties.isDictionaryAggregationEnabled;
 import static io.trino.SystemSessionProperties.isFlatGroupByHash;
 import static io.trino.spi.type.BigintType.BIGINT;
 
+@NotThreadSafe
 public interface GroupByHash
 {
     static GroupByHash createGroupByHash(

--- a/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByHash.java
@@ -79,13 +79,6 @@ public interface GroupByHash
      */
     Work<int[]> getGroupIds(Page page);
 
-    boolean contains(int position, Page page);
-
-    default boolean contains(int position, Page page, long rawHash)
-    {
-        return contains(position, page);
-    }
-
     long getRawHash(int groupId);
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
@@ -174,7 +174,7 @@ public class HashSemiJoinOperator
 
             if (channelSet == null) {
                 if (!channelSetFuture.isDone()) {
-                    // This will materialize page but it shouldn't matter for the first page
+                    // This will materialize page, but it shouldn't matter for the first page
                     localMemoryContext.setBytes(inputPage.getSizeInBytes());
                     return blocked(asVoid(channelSetFuture));
                 }
@@ -182,20 +182,20 @@ public class HashSemiJoinOperator
                 channelSet = getFutureValue(channelSetFuture);
                 localMemoryContext.setBytes(0);
             }
-            // use an effectively-final local variable instead of the non-final instance field inside of the loop
+            // use an effectively-final local variable instead of the non-final instance field inside the loop
             ChannelSet channelSet = requireNonNull(this.channelSet, "channelSet is null");
 
             // create the block builder for the new boolean column
             // we know the exact size required for the block
             BlockBuilder blockBuilder = BOOLEAN.createFixedSizeBlockBuilder(inputPage.getPositionCount());
 
-            Page probeJoinPage = inputPage.getLoadedPage(probeJoinChannel);
-            Block probeJoinNulls = probeJoinPage.getBlock(0).mayHaveNull() ? probeJoinPage.getBlock(0) : null;
-            Block hashBlock = probeHashChannel >= 0 ? inputPage.getBlock(probeHashChannel) : null;
+            Block probeBlock = inputPage.getBlock(probeJoinChannel).copyRegion(0, inputPage.getPositionCount());
+            boolean probeMayHaveNull = probeBlock.mayHaveNull();
+            Block hashBlock = probeHashChannel >= 0 ? inputPage.getBlock(probeHashChannel).copyRegion(0, inputPage.getPositionCount()) : null;
 
             // update hashing strategy to use probe cursor
             for (int position = 0; position < inputPage.getPositionCount(); position++) {
-                if (probeJoinNulls != null && probeJoinNulls.isNull(position)) {
+                if (probeMayHaveNull && probeBlock.isNull(position)) {
                     if (channelSet.isEmpty()) {
                         BOOLEAN.writeBoolean(blockBuilder, false);
                     }
@@ -207,10 +207,10 @@ public class HashSemiJoinOperator
                     boolean contains;
                     if (hashBlock != null) {
                         long rawHash = BIGINT.getLong(hashBlock, position);
-                        contains = channelSet.contains(position, probeJoinPage, rawHash);
+                        contains = channelSet.contains(probeBlock, position, rawHash);
                     }
                     else {
-                        contains = channelSet.contains(position, probeJoinPage);
+                        contains = channelSet.contains(probeBlock, position);
                     }
                     if (!contains && channelSet.containsNull()) {
                         blockBuilder.appendNull();

--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -219,31 +219,6 @@ public class MultiChannelGroupByHash
         return new GetNonDictionaryGroupIdsWork(page);
     }
 
-    @Override
-    public boolean contains(int position, Page page)
-    {
-        long rawHash = hashStrategy.hashRow(position, page);
-        return contains(position, page, rawHash);
-    }
-
-    @Override
-    public boolean contains(int position, Page page, long rawHash)
-    {
-        int hashPosition = getHashPosition(rawHash, mask);
-
-        // look for a slot containing this key
-        while (groupIdsByHash[hashPosition] != -1) {
-            if (positionNotDistinctFromCurrentRow(groupIdsByHash[hashPosition], hashPosition, position, page, (byte) rawHash, channels)) {
-                // found an existing slot for this key
-                return true;
-            }
-            // increment position and mask to handle wrap around
-            hashPosition = (hashPosition + 1) & mask;
-        }
-
-        return false;
-    }
-
     @VisibleForTesting
     @Override
     public int getCapacity()

--- a/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/NoChannelGroupByHash.java
@@ -59,12 +59,6 @@ public class NoChannelGroupByHash
     }
 
     @Override
-    public boolean contains(int position, Page page)
-    {
-        throw new UnsupportedOperationException("NoChannelGroupByHash does not support getHashCollisions");
-    }
-
-    @Override
     public long getRawHash(int groupId)
     {
         throw new UnsupportedOperationException("NoChannelGroupByHash does not support getHashCollisions");

--- a/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/CyclingGroupByHash.java
@@ -72,12 +72,6 @@ public class CyclingGroupByHash
     }
 
     @Override
-    public boolean contains(int position, Page page)
-    {
-        throw new UnsupportedOperationException("Not yet supported");
-    }
-
-    @Override
     public long getRawHash(int groupId)
     {
         throw new UnsupportedOperationException("Not yet supported");


### PR DESCRIPTION
## Description
Convert ChannelSet used in SemiJoinOperator from GroupByHash to the new FlatSet.  The FlatSet is deisgned for the single write, multi-threaded read that ChannelSet uses. The FlatSet is much simpler as it only needs to hold a single column, and only needs to support a contains check, which vastly simplifies the implementation. 

This effectivly splits the use cases of GroupByHash, so the contains methods can be used.

Fixes #18752

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
