### PR TITLE
Allow re-using Oracle container in tests

### DIFF
--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -180,6 +180,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
@@ -20,8 +20,6 @@ import io.trino.testing.sql.SqlExecutor;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
@@ -54,7 +52,7 @@ public class TestOracleConnectorTest
 
     @AfterClass(alwaysRun = true)
     public final void destroy()
-            throws IOException
+            throws Exception
     {
         Closeables.closeAll(oracleServer);
         oracleServer = null;

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
@@ -18,8 +18,6 @@ import io.airlift.testing.Closeables;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.AfterClass;
 
-import java.io.IOException;
-
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 
@@ -47,7 +45,7 @@ public class TestOraclePoolConnectorSmokeTest
 
     @AfterClass(alwaysRun = true)
     public final void destroy()
-            throws IOException
+            throws Exception
     {
         Closeables.closeAll(oracleServer);
         oracleServer = null;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Ability to iterate faster on integration test development for Oracle by adding the support for TESTCONTAINERS_REUSE_ENABLE environment variable.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is based on previous commit 
https://github.com/trinodb/trino/commit/fbd1de01bba0c896e6e584f26d128452fdf35bc1
by @kokosing, which adds the feature and enables it for SQL Server and MySQL. Based on further comments from @kokosing, enablement of this feature for specific database tests needs to be tested one-by-one as not all test containers seem to digest that change without problems. This justifies adding it iteratively for selected databases based on a need-to-use basis.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
