### PR TITLE
Introduce QueryDataProducer abstraction and pluggable QueryData formats

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -106,6 +106,18 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-terminal-jna</artifactId>
             <version>${dep.jline.version}</version>

--- a/client/trino-cli/src/main/java/io/trino/cli/OutputHandler.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/OutputHandler.java
@@ -14,6 +14,7 @@
 package io.trino.cli;
 
 import io.airlift.units.Duration;
+import io.trino.client.QueryData;
 import io.trino.client.StatementClient;
 
 import java.io.Closeable;
@@ -64,9 +65,9 @@ public final class OutputHandler
         BlockingQueue<List<?>> rowQueue = new ArrayBlockingQueue<>(MAX_QUEUED_ROWS);
         CompletableFuture<Void> readerFuture = CompletableFuture.runAsync(() -> {
             while (client.isRunning()) {
-                Iterable<List<Object>> data = client.currentData().getData();
-                if (data != null) {
-                    for (List<Object> row : data) {
+                QueryData data = client.currentData();
+                if (data.isPresent()) {
+                    for (List<Object> row : data.getData()) {
                         putOrThrow(rowQueue, row);
                     }
                 }

--- a/client/trino-cli/src/main/java/io/trino/cli/Query.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Query.java
@@ -210,7 +210,7 @@ public class Query
 
     private void processInitialStatusUpdates(WarningsPrinter warningsPrinter)
     {
-        while (client.isRunning() && (client.currentData().getData() == null)) {
+        while (client.isRunning() && client.currentData().isEmpty()) {
             warningsPrinter.print(client.currentStatusInfo().getWarnings(), true, false);
             try {
                 client.advance();

--- a/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/StatusPrinter.java
@@ -103,7 +103,7 @@ Spilled: 20GB
             while (client.isRunning()) {
                 try {
                     // exit status loop if there is pending output
-                    if (client.currentData().getData() != null) {
+                    if (client.currentData().isPresent()) {
                         return;
                     }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/TableNameCompleter.java
@@ -87,7 +87,7 @@ public class TableNameCompleter
         try (StatementClient client = queryRunner.startInternalQuery(query)) {
             while (client.isRunning() && !Thread.currentThread().isInterrupted()) {
                 QueryData results = client.currentData();
-                if (results.getData() != null) {
+                if (results.isPresent()) {
                     for (List<Object> row : results.getData()) {
                         cache.add((String) row.get(0));
                     }

--- a/client/trino-client/src/main/java/io/trino/client/FixJsonDataUtils.java
+++ b/client/trino-client/src/main/java/io/trino/client/FixJsonDataUtils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.transform;
 import static io.trino.client.ClientStandardTypes.ARRAY;
 import static io.trino.client.ClientStandardTypes.BIGINT;
 import static io.trino.client.ClientStandardTypes.BING_TILE;
@@ -57,14 +58,10 @@ final class FixJsonDataUtils
 {
     private FixJsonDataUtils() {}
 
-    public static Iterable<List<Object>> fixData(List<Column> columns, List<List<Object>> data)
+    public static Iterable<List<Object>> fixData(List<Column> columns, Iterable<List<Object>> data)
     {
-        if (data == null) {
-            return null;
-        }
         ColumnTypeHandler[] typeHandlers = createTypeHandlers(columns);
-        ImmutableList.Builder<List<Object>> rows = ImmutableList.builderWithExpectedSize(data.size());
-        for (List<Object> row : data) {
+        return transform(data, row -> {
             if (row.size() != typeHandlers.length) {
                 throw new IllegalArgumentException("row/column size mismatch");
             }
@@ -77,9 +74,8 @@ final class FixJsonDataUtils
                 newRow.add(value);
                 column++;
             }
-            rows.add(unmodifiableList(newRow)); // allow nulls in list
-        }
-        return rows.build();
+            return unmodifiableList(newRow); // allow nulls in list
+        });
     }
 
     private static ColumnTypeHandler[] createTypeHandlers(List<Column> columns)

--- a/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
@@ -49,6 +50,11 @@ public class JsonCodec<T>
     public static <T> JsonCodec<T> jsonCodec(Class<T> type)
     {
         return new JsonCodec<>(OBJECT_MAPPER_SUPPLIER.get(), type);
+    }
+
+    public static <T> JsonCodec<T> jsonCodec(Class<T> type, Module... extraModules)
+    {
+        return new JsonCodec<>(OBJECT_MAPPER_SUPPLIER.get().registerModules(extraModules), type);
     }
 
     private final ObjectMapper mapper;
@@ -90,6 +96,16 @@ public class JsonCodec<T>
             T value = mapper.readerFor(javaType).readValue(parser);
             checkArgument(parser.nextToken() == null, "Found characters after the expected end of input");
             return value;
+        }
+    }
+
+    public String toJson(T instance)
+    {
+        try {
+            return mapper.writerFor(javaType).writeValueAsString(instance);
+        }
+        catch (IOException exception) {
+            throw new IllegalArgumentException(String.format("%s could not be converted to JSON", instance.getClass().getName()), exception);
         }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/JsonInlineQueryData.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonInlineQueryData.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import java.util.List;
+
+import static com.google.common.collect.Iterables.unmodifiableIterable;
+import static io.trino.client.NoQueryData.NO_DATA;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class represents QueryData serialized to JSON array of arrays of objects.
+ * It has custom handling and representation in the QueryData (de)serializer.
+ */
+@QueryDataFormat(formatName = "json-inlined")
+public class JsonInlineQueryData
+        implements QueryData
+{
+    private final Iterable<List<Object>> values;
+    private final boolean hasValues;
+
+    JsonInlineQueryData(Iterable<List<Object>> values, boolean hasValues)
+    {
+        this.values = unmodifiableIterable(requireNonNull(values, "values is null"));
+        this.hasValues = hasValues;
+    }
+
+    @Override
+    public Iterable<List<Object>> getData()
+    {
+        return values;
+    }
+
+    @Override
+    public boolean isPresent()
+    {
+        return hasValues;
+    }
+
+    public static QueryData create(Iterable<List<Object>> values, boolean hasValues)
+    {
+        if (values == null) {
+            return NO_DATA;
+        }
+
+        return new JsonInlineQueryData(values, hasValues);
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/NoQueryData.java
+++ b/client/trino-client/src/main/java/io/trino/client/NoQueryData.java
@@ -15,20 +15,23 @@ package io.trino.client;
 
 import java.util.List;
 
-/**
- * QueryData implementations are shared between the client and the server.
- * Implementing class is responsible for transferring result data over the wire (through @JsonProperty)
- * and deserializing incoming result data (through @JsonCreator) accordingly.
- * {@link JsonInlineQueryData} is an exception to the above as it is entirely handled by the {@link QueryDataJsonSerializationModule} .
- */
-public interface QueryData
+@QueryDataFormat(formatName = "no-data")
+public class NoQueryData
+        implements QueryData
 {
-    Iterable<List<Object>> getData();
+    public static final QueryData NO_DATA = new NoQueryData();
 
-    boolean isPresent();
+    private NoQueryData() {}
 
-    default boolean isEmpty()
+    @Override
+    public Iterable<List<Object>> getData()
     {
-        return !isPresent();
+        throw new UnsupportedOperationException("NullQueryData.getData() called");
+    }
+
+    @Override
+    public boolean isPresent()
+    {
+        return false;
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
+++ b/client/trino-client/src/main/java/io/trino/client/ProtocolHeaders.java
@@ -52,6 +52,7 @@ public final class ProtocolHeaders
     private final String responseDeallocatedPrepare;
     private final String responseStartedTransactionId;
     private final String responseClearTransactionId;
+    private final String supportedQueryDataFormats;
 
     public static ProtocolHeaders createProtocolHeaders(String name)
     {
@@ -95,6 +96,7 @@ public final class ProtocolHeaders
         responseDeallocatedPrepare = prefix + "Deallocated-Prepare";
         responseStartedTransactionId = prefix + "Started-Transaction-Id";
         responseClearTransactionId = prefix + "Clear-Transaction-Id";
+        supportedQueryDataFormats = prefix + "Query-Data-Formats";
     }
 
     public String getProtocolName()
@@ -235,6 +237,11 @@ public final class ProtocolHeaders
     public String responseClearTransactionId()
     {
         return responseClearTransactionId;
+    }
+
+    public String supportedQueryDataFormats()
+    {
+        return supportedQueryDataFormats;
     }
 
     public static ProtocolHeaders detectProtocol(Optional<String> alternateHeaderName, Set<String> headerNames)

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataFormat.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataFormat.java
@@ -13,22 +13,15 @@
  */
 package io.trino.client;
 
-import java.util.List;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-/**
- * QueryData implementations are shared between the client and the server.
- * Implementing class is responsible for transferring result data over the wire (through @JsonProperty)
- * and deserializing incoming result data (through @JsonCreator) accordingly.
- * {@link JsonInlineQueryData} is an exception to the above as it is entirely handled by the {@link QueryDataJsonSerializationModule} .
- */
-public interface QueryData
+import static java.lang.annotation.ElementType.TYPE;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(TYPE)
+public @interface QueryDataFormat
 {
-    Iterable<List<Object>> getData();
-
-    boolean isPresent();
-
-    default boolean isEmpty()
-    {
-        return !isPresent();
-    }
+    String formatName();
 }

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataFormatResolver.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataFormatResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.UnaryOperator.identity;
+
+public class QueryDataFormatResolver
+{
+    private final Map<String, Class<? extends QueryData>> formats;
+
+    public QueryDataFormatResolver(List<Class<? extends QueryData>> dataFormats)
+    {
+        this.formats = dataFormats.stream()
+                // This will throw an exception if there are two queryFormats with the same name
+                .collect(toImmutableMap(QueryDataFormatResolver::formatNameForClass, identity()));
+    }
+
+    public static QueryDataFormatResolver defaultResolver()
+    {
+        // Can be empty, JsonInlineQueryData has a special handling in the deserializer/serializer
+        return new QueryDataFormatResolver(ImmutableList.of());
+    }
+
+    public Class<?> getClassByFormatName(String formatName)
+    {
+        return formats.get(formatName);
+    }
+
+    public Set<String> supportedFormats()
+    {
+        return formats.keySet();
+    }
+
+    public static String formatNameForClass(Class<?> clazz)
+    {
+        String className = clazz.getSimpleName();
+        checkArgument(className.matches("^[a-zA-Z\\-]+QueryData$"), "Name of %s should end with 'QueryData'", clazz);
+        return requireNonNull(clazz.getAnnotation(QueryDataFormat.class), format("@QueryDataFormat is missing on %s", clazz)).formatName();
+    }
+
+    public String formatNameFromObject(Object object)
+    {
+        return formatNameForClass(object.getClass());
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataFormats.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataFormats.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+public class QueryDataFormats
+{
+    private static final Splitter SPLITTER = Splitter.on(",");
+    private static final Joiner JOINER = Joiner.on(",");
+
+    private QueryDataFormats() {}
+
+    public static String toHeaderValue(Set<String> supportedQueryDataFormats)
+    {
+        return JOINER.join(supportedQueryDataFormats);
+    }
+
+    public static Set<String> fromHeaderValue(String headerValue)
+    {
+        if (headerValue == null) {
+            return ImmutableSet.of();
+        }
+        return ImmutableSet.copyOf(SPLITTER.splitToList(headerValue));
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/QueryDataJsonSerializationModule.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryDataJsonSerializationModule.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.impl.AsPropertyTypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.BeanSerializerFactory;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class QueryDataJsonSerializationModule
+        extends SimpleModule
+{
+    private static final TypeReference<Iterable<List<Object>>> INLINE_JSON_FORMAT_REFERENCE = new TypeReference<Iterable<List<Object>>>(){};
+
+    private static final String FORMAT_PROPERTY = "format";
+
+    public QueryDataJsonSerializationModule(QueryDataFormatResolver formatResolver)
+    {
+        super(QueryData.class.getSimpleName() + "Module", Version.unknownVersion());
+
+        TypeIdResolver typeResolver = new InternalTypeResolver(formatResolver::formatNameFromObject, formatResolver::getClassByFormatName);
+        addSerializer(QueryData.class, new InternalTypeSerializer(typeResolver));
+        addDeserializer(QueryData.class, new InternalTypeDeserializer(typeResolver));
+    }
+
+    private static class InternalTypeDeserializer
+            extends StdDeserializer<QueryData>
+    {
+        private final TypeDeserializer typeDeserializer;
+
+        public InternalTypeDeserializer(TypeIdResolver typeIdResolver)
+        {
+            super(QueryData.class);
+            this.typeDeserializer = new AsPropertyTypeDeserializer(
+                    TypeFactory.defaultInstance().constructType(QueryData.class),
+                    typeIdResolver,
+                    FORMAT_PROPERTY,
+                    false,
+                    TypeFactory.defaultInstance().constructType(JsonInlineQueryData.class));
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public QueryData deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+                throws IOException
+        {
+            // If this is JSON_ARRAY we are dealing with inline JSON response, otherwise it will be custom type
+            if (jsonParser.currentToken().equals(JsonToken.START_ARRAY)) {
+                JsonLocation valueStartLocation = jsonParser.currentLocation();
+                Iterable<List<Object>> values = jsonParser.readValueAs(INLINE_JSON_FORMAT_REFERENCE);
+                JsonLocation valueEndLocation = jsonParser.currentLocation();
+                // we don't want to peek into iterable to check whether we actually have values so let's determine it while deserializing
+                boolean hasValues = (valueEndLocation.getColumnNr() - valueStartLocation.getColumnNr()) > 1;
+                return JsonInlineQueryData.create(values, hasValues);
+            }
+            return (QueryData) typeDeserializer.deserializeTypedFromAny(jsonParser, deserializationContext);
+        }
+    }
+
+    private static class InternalTypeSerializer
+            extends StdSerializer<QueryData>
+    {
+        private final TypeSerializer typeSerializer;
+
+        public InternalTypeSerializer(TypeIdResolver typeIdResolver)
+        {
+            super(QueryData.class);
+            this.typeSerializer = new AsPropertyTypeSerializer(typeIdResolver, null, FORMAT_PROPERTY);
+        }
+
+        @Override
+        public void serialize(QueryData value, JsonGenerator generator, SerializerProvider provider)
+                throws IOException
+        {
+            if (value == null || value instanceof NoQueryData) {
+                provider.defaultSerializeNull(generator);
+                return;
+            }
+
+            if (value instanceof JsonInlineQueryData) {
+                // Backward compatible json inline data serialization
+                JsonInlineQueryData jsonData = (JsonInlineQueryData) value;
+                provider.defaultSerializeValue(jsonData.getData(), generator);
+                return;
+            }
+
+            Class<?> type = value.getClass();
+            JsonSerializer<QueryData> serializer = createSerializer(provider, type);
+            serializer.serializeWithType(value, generator, provider, typeSerializer);
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <T> JsonSerializer<T> createSerializer(SerializerProvider provider, Class<?> type)
+                throws JsonMappingException
+        {
+            JavaType javaType = provider.constructType(type);
+            return (JsonSerializer<T>) BeanSerializerFactory.instance.createSerializer(provider, javaType);
+        }
+    }
+
+    private static class InternalTypeResolver
+            extends TypeIdResolverBase
+    {
+        private final Function<Object, String> nameResolver;
+        private final Function<String, Class<?>> classResolver;
+
+        public InternalTypeResolver(Function<Object, String> nameResolver, Function<String, Class<?>> classResolver)
+        {
+            this.nameResolver = requireNonNull(nameResolver, "nameResolver is null");
+            this.classResolver = requireNonNull(classResolver, "classResolver is null");
+        }
+
+        @Override
+        public String idFromValue(Object value)
+        {
+            return idFromValueAndType(value, value.getClass());
+        }
+
+        @Override
+        public String idFromValueAndType(Object value, Class<?> suggestedType)
+        {
+            requireNonNull(value, "value is null");
+            return nameResolver.apply(value);
+        }
+
+        @Override
+        public JavaType typeFromId(DatabindContext context, String id)
+        {
+            requireNonNull(id, "id is null");
+            Class<?> typeClass = classResolver.apply(id);
+            checkArgument(typeClass != null, "Unknown type ID: %s", id);
+            return context.getTypeFactory().constructType(typeClass);
+        }
+
+        @Override
+        public JsonTypeInfo.Id getMechanism()
+        {
+            return JsonTypeInfo.Id.NAME;
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/QueryResults.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryResults.java
@@ -14,6 +14,7 @@
 package io.trino.client;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
@@ -25,20 +26,21 @@ import java.util.List;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.unmodifiableIterable;
 import static io.trino.client.FixJsonDataUtils.fixData;
+import static io.trino.client.NoQueryData.NO_DATA;
+import static io.trino.client.QueryDataFormatResolver.formatNameForClass;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
 public class QueryResults
-        implements QueryStatusInfo, QueryData
+        implements QueryStatusInfo
 {
     private final String id;
     private final URI infoUri;
     private final URI partialCancelUri;
     private final URI nextUri;
     private final List<Column> columns;
-    private final Iterable<List<Object>> data;
+    private final QueryData data;
     private final StatementStats stats;
     private final QueryError error;
     private final List<Warning> warnings;
@@ -52,50 +54,23 @@ public class QueryResults
             @JsonProperty("partialCancelUri") URI partialCancelUri,
             @JsonProperty("nextUri") URI nextUri,
             @JsonProperty("columns") List<Column> columns,
-            @JsonProperty("data") List<List<Object>> data,
+            @JsonProperty("data") QueryData data,
             @JsonProperty("stats") StatementStats stats,
             @JsonProperty("error") QueryError error,
             @JsonProperty("warnings") List<Warning> warnings,
             @JsonProperty("updateType") String updateType,
             @JsonProperty("updateCount") Long updateCount)
     {
-        this(
-                id,
-                infoUri,
-                partialCancelUri,
-                nextUri,
-                columns,
-                fixData(columns, data),
-                stats,
-                error,
-                firstNonNull(warnings, ImmutableList.of()),
-                updateType,
-                updateCount);
-    }
-
-    public QueryResults(
-            String id,
-            URI infoUri,
-            URI partialCancelUri,
-            URI nextUri,
-            List<Column> columns,
-            Iterable<List<Object>> data,
-            StatementStats stats,
-            QueryError error,
-            List<Warning> warnings,
-            String updateType,
-            Long updateCount)
-    {
         this.id = requireNonNull(id, "id is null");
         this.infoUri = requireNonNull(infoUri, "infoUri is null");
         this.partialCancelUri = partialCancelUri;
         this.nextUri = nextUri;
         this.columns = (columns != null) ? ImmutableList.copyOf(columns) : null;
-        this.data = (data != null) ? unmodifiableIterable(data) : null;
-        checkArgument(data == null || columns != null, "data present without columns");
+        this.data = firstNonNull(data, NO_DATA);
+        checkArgument(this.data.isEmpty() || columns != null, "data present without columns");
         this.stats = requireNonNull(stats, "stats is null");
         this.error = error;
-        this.warnings = ImmutableList.copyOf(requireNonNull(warnings, "warnings is null"));
+        this.warnings = ImmutableList.copyOf(firstNonNull(warnings, ImmutableList.of()));
         this.updateType = updateType;
         this.updateCount = updateCount;
     }
@@ -138,10 +113,20 @@ public class QueryResults
         return columns;
     }
 
-    @Nullable
-    @JsonProperty
-    @Override
-    public Iterable<List<Object>> getData()
+    @JsonIgnore
+    public QueryData getData()
+    {
+        if (data instanceof JsonInlineQueryData) {
+            // JSON-serialized data doesn't keep type information, so we need to "fix" the data
+            // before returning it to the caller. This is done lazily while iterating.
+            return new JsonInlineQueryData(fixData(columns, data.getData()), data.isPresent());
+        }
+
+        return data;
+    }
+
+    @JsonProperty("data")
+    public QueryData getRawData()
     {
         return data;
     }
@@ -193,11 +178,12 @@ public class QueryResults
                 .add("partialCancelUri", partialCancelUri)
                 .add("nextUri", nextUri)
                 .add("columns", columns)
-                .add("hasData", data != null)
+                .add("hasData", data.isPresent())
                 .add("stats", stats)
                 .add("error", error)
                 .add("updateType", updateType)
                 .add("updateCount", updateCount)
+                .add("format", formatNameForClass(data.getClass()))
                 .toString();
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientFactory.java
@@ -32,4 +32,9 @@ public final class StatementClientFactory
     {
         return new StatementClientV1((Call.Factory) httpClient, session, query, clientCapabilities);
     }
+
+    public static StatementClient newStatementClient(Call.Factory httpCallFactory, QueryDataFormatResolver handlerResolver, ClientSession session, String query, Optional<Set<String>> clientCapabilities)
+    {
+        return new StatementClientV1(httpCallFactory, handlerResolver, session, query, clientCapabilities);
+    }
 }

--- a/client/trino-client/src/test/java/io/trino/client/TestQueryDataSerialization.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestQueryDataSerialization.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalDouble;
+
+import static io.trino.client.ClientStandardTypes.BIGINT;
+import static io.trino.client.NoQueryData.NO_DATA;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestQueryDataSerialization
+{
+    @Test
+    public void testNullDataSerialization()
+    {
+        testRoundTrip(NO_DATA, "null");
+        testRoundTrip(JsonInlineQueryData.create(null, false), "null");
+    }
+
+    @Test
+    public void testEmptyArraySerialization()
+    {
+        testRoundTrip(JsonInlineQueryData.create(ImmutableList.of(), false), "[]");
+    }
+
+    @Test
+    public void testValuesSerialization()
+    {
+        Iterable<List<Object>> values = ImmutableList.of(ImmutableList.of(1L), ImmutableList.of(5L));
+        testRoundTrip(JsonInlineQueryData.create(values, true), "[[1],[5]]");
+    }
+
+    @QueryDataFormat(formatName = "json-download-uris")
+    public static class CustomQueryData
+            implements QueryData
+    {
+        private List<String> dataUris;
+
+        @JsonCreator
+        public CustomQueryData(@JsonProperty("data-uris") List<String> dataUris)
+        {
+            this.dataUris = ImmutableList.copyOf(dataUris);
+        }
+
+        @JsonProperty("data-uris")
+        public List<String> getDataUris()
+        {
+            return dataUris;
+        }
+
+        @Override
+        public Iterable<List<Object>> getData()
+        {
+            return ImmutableList.of(ImmutableList.of("some", "fake", "data"));
+        }
+
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+    }
+
+    @Test
+    public void testCustomFormatSerialization()
+    {
+        testRoundTrip(new CustomQueryData(ImmutableList.of("link1", "link2", "link3")), "{\"format\":\"json-download-uris\",\"data-uris\":[\"link1\",\"link2\",\"link3\"]}", CustomQueryData.class);
+
+        assertThatThrownBy(() -> testRoundTrip(new CustomQueryData(ImmutableList.of("link1", "link2", "link3")), "{\"format\":\"json-download-uris\",\"data-uris\":[\"link1\",\"link2\",\"link3\"]}"))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown type ID: json-download-uris");
+
+        assertThatThrownBy(() -> deserialize(queryResultsJson("{\"format\":\"unknown-download-uris\",\"data-uris\":[\"link1\",\"link2\",\"link3\"]}")))
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown type ID: unknown-download-uris");
+
+        assertThatThrownBy(() -> deserialize(queryResultsJson("{\"data-uris\":[\"link1\",\"link2\",\"link3\"]}")))
+                .hasRootCauseInstanceOf(InvalidDefinitionException.class)
+                .hasMessageContaining("Cannot construct instance of `io.trino.client.JsonInlineQueryData`");
+    }
+
+    private void testRoundTrip(QueryData queryData, String expectedDataRepresentation, Class<? extends QueryData>... formats)
+    {
+        assertThat(serialize(queryData, formats))
+                .isEqualTo(queryResultsJson(expectedDataRepresentation));
+
+        assertValues(deserialize(serialize(queryData, formats), formats), queryData);
+    }
+
+    private String queryResultsJson(String expectedDataField)
+    {
+        return format("{\"id\":\"20160128_214710_00012_rk68b\",\"infoUri\":\"http://coordinator/query.html?20160128_214710_00012_rk68b\",\"partialCancelUri\":null," +
+                "\"nextUri\":null,\"columns\":[{\"name\":\"_col0\",\"type\":\"bigint\",\"typeSignature\":{\"rawType\":\"bigint\",\"arguments\":[]}}],\"data\":%s," +
+                "\"stats\":{\"state\":\"FINISHED\",\"queued\":false,\"scheduled\":false,\"progressPercentage\":null,\"runningPercentage\":null,\"nodes\":0," +
+                "\"totalSplits\":0,\"queuedSplits\":0,\"runningSplits\":0,\"completedSplits\":0,\"cpuTimeMillis\":0,\"wallTimeMillis\":0,\"queuedTimeMillis\":0," +
+                "\"elapsedTimeMillis\":0,\"processedRows\":0,\"processedBytes\":0,\"physicalInputBytes\":0,\"physicalWrittenBytes\":0,\"peakMemoryBytes\":0," +
+                "\"spilledBytes\":0,\"rootStage\":null},\"error\":null,\"warnings\":[],\"updateType\":null,\"updateCount\":null}", expectedDataField);
+    }
+
+    private static boolean assertValues(QueryData left, QueryData right)
+    {
+        if (!left.getClass().equals(right.getClass())) {
+            throw new AssertionError(format("%s class is different than %s class", left.getClass(), right.getClass()));
+        }
+
+        if (left.isPresent() != right.isPresent()) {
+            throw new AssertionError("mismatch with the isPresent check");
+        }
+
+        if (left.isEmpty() != right.isEmpty()) {
+            throw new AssertionError("mismatch with the isEmpty check");
+        }
+
+        if (left instanceof JsonInlineQueryData) {
+            assertThat(left.getData()).hasSameElementsAs(right.getData());
+        }
+
+        return true;
+    }
+
+    private static QueryData deserialize(String serialized, Class<? extends QueryData>... formats)
+    {
+        JsonCodec<QueryResults> codec = codec(formats);
+        try {
+            return codec.fromJson(serialized).getData();
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String serialize(QueryData data, Class<? extends QueryData>... formats)
+    {
+        JsonCodec<QueryResults> codec = codec(formats);
+        return codec.toJson(new QueryResults(
+                "20160128_214710_00012_rk68b",
+                URI.create("http://coordinator/query.html?20160128_214710_00012_rk68b"),
+                null,
+                null,
+                ImmutableList.of(new Column("_col0", BIGINT, new ClientTypeSignature(BIGINT))),
+                data,
+                StatementStats.builder()
+                        .setState("FINISHED")
+                        .setProgressPercentage(OptionalDouble.empty())
+                        .setRunningPercentage(OptionalDouble.empty())
+                        .build(),
+                null,
+                ImmutableList.of(),
+                null,
+                null));
+    }
+
+    private static JsonCodec<QueryResults> codec(Class<? extends QueryData>... formats)
+    {
+        return JsonCodec.jsonCodec(QueryResults.class, new QueryDataJsonSerializationModule(new QueryDataFormatResolver(Arrays.asList(formats))));
+    }
+}

--- a/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
@@ -13,18 +13,19 @@
  */
 package io.trino.client;
 
-import io.airlift.json.JsonCodec;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.testng.annotations.Test;
 
-import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.client.JsonCodec.jsonCodec;
 import static org.testng.Assert.assertEquals;
 
 public class TestQueryResults
 {
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class, new QueryDataJsonSerializationModule(QueryDataFormatResolver.defaultResolver()));
 
     @Test
     public void testCompatibility()
+            throws JsonProcessingException
     {
         String goldenValue = "{\n" +
                 "  \"id\" : \"20160128_214710_00012_rk68b\",\n" +

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>test</scope>

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.trino.client.Column;
+import io.trino.client.QueryData;
 import io.trino.client.QueryStatusInfo;
 import io.trino.client.StatementClient;
 
@@ -272,7 +273,7 @@ public class TrinoResultSet
                 QueryStatusInfo results = client.currentStatusInfo();
                 progressCallback.accept(QueryStats.create(results.getId(), results.getStats()));
                 warningsManager.addWarnings(results.getWarnings());
-                Iterable<List<Object>> data = client.currentData().getData();
+                QueryData data = client.currentData();
 
                 try {
                     client.advance();
@@ -281,8 +282,8 @@ public class TrinoResultSet
                     throw e;
                 }
 
-                if (data != null) {
-                    return data;
+                if (data.isPresent()) {
+                    return data.getData();
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -279,6 +279,7 @@ public class QueuedStatementResource
             Duration queuedTime)
     {
         QueryState state = queryError.map(error -> FAILED).orElse(QUEUED);
+
         return new QueryResults(
                 queryId.toString(),
                 getQueryInfoUri(queryInfoUrl, queryId, uriInfo),

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -91,6 +91,7 @@ import io.trino.operator.ForScheduler;
 import io.trino.operator.OperatorStats;
 import io.trino.server.protocol.ExecutingStatementResource;
 import io.trino.server.protocol.QueryInfoUrlFactory;
+import io.trino.server.protocol.data.QueryDataFormatsModule;
 import io.trino.server.remotetask.RemoteTaskStats;
 import io.trino.server.ui.WebUiModule;
 import io.trino.server.ui.WorkerResource;
@@ -142,6 +143,7 @@ public class CoordinatorModule
     protected void setup(Binder binder)
     {
         install(new WebUiModule());
+        install(new QueryDataFormatsModule());
 
         // coordinator announcement
         discoveryBinder(binder).bindHttpAnnouncement("trino-coordinator");

--- a/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/ExecutingStatementResource.java
@@ -23,11 +23,13 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.client.ProtocolHeaders;
+import io.trino.client.QueryDataFormats;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.QueryManager;
 import io.trino.operator.DirectExchangeClientSupplier;
 import io.trino.server.ForStatementResource;
 import io.trino.server.ServerConfig;
+import io.trino.server.protocol.data.QueryDataProducerFactory;
 import io.trino.server.security.ResourceSecurity;
 import io.trino.spi.QueryId;
 import io.trino.spi.block.BlockEncodingSerde;
@@ -42,6 +44,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.ResponseBuilder;
@@ -50,6 +53,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.net.URLEncoder;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -79,6 +83,7 @@ public class ExecutingStatementResource
     private static final DataSize MAX_TARGET_RESULT_SIZE = DataSize.of(128, MEGABYTE);
 
     private final QueryManager queryManager;
+    private final QueryDataProducerFactory queryDataProducerFactory;
     private final DirectExchangeClientSupplier directExchangeClientSupplier;
     private final ExchangeManagerRegistry exchangeManagerRegistry;
     private final BlockEncodingSerde blockEncodingSerde;
@@ -94,6 +99,7 @@ public class ExecutingStatementResource
     @Inject
     public ExecutingStatementResource(
             QueryManager queryManager,
+            QueryDataProducerFactory queryDataProducerFactory,
             DirectExchangeClientSupplier directExchangeClientSupplier,
             ExchangeManagerRegistry exchangeManagerRegistry,
             BlockEncodingSerde blockEncodingSerde,
@@ -104,6 +110,7 @@ public class ExecutingStatementResource
             ServerConfig serverConfig)
     {
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.queryDataProducerFactory = requireNonNull(queryDataProducerFactory, "queryDataProducerFactory is null");
         this.directExchangeClientSupplier = requireNonNull(directExchangeClientSupplier, "directExchangeClientSupplier is null");
         this.exchangeManagerRegistry = requireNonNull(exchangeManagerRegistry, "exchangeManagerRegistry is null");
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
@@ -161,13 +168,14 @@ public class ExecutingStatementResource
             @QueryParam("maxWait") Duration maxWait,
             @QueryParam("targetResultSize") DataSize targetResultSize,
             @Context UriInfo uriInfo,
+            @Context HttpHeaders httpHeaders,
             @Suspended AsyncResponse asyncResponse)
     {
-        Query query = getQuery(queryId, slug, token);
+        Query query = getQuery(queryId, slug, token, uriInfo, httpHeaders);
         asyncQueryResults(query, token, maxWait, targetResultSize, uriInfo, asyncResponse);
     }
 
-    protected Query getQuery(QueryId queryId, String slug, long token)
+    protected Query getQuery(QueryId queryId, String slug, long token, UriInfo uriInfo, HttpHeaders httpHeaders)
     {
         Query query = queries.get(queryId);
         if (query != null) {
@@ -191,10 +199,12 @@ public class ExecutingStatementResource
             throw queryNotFound();
         }
 
+        Set<String> supportedDataFormats = QueryDataFormats.fromHeaderValue(httpHeaders.getHeaderString(session.getProtocolHeaders().supportedQueryDataFormats()));
         query = queries.computeIfAbsent(queryId, id -> Query.create(
                 session,
                 querySlug,
                 queryManager,
+                queryDataProducerFactory.create(session, queryId, supportedDataFormats, uriInfo),
                 queryInfoUrlFactory.getQueryInfoUrl(queryId),
                 directExchangeClientSupplier,
                 exchangeManagerRegistry,
@@ -313,9 +323,11 @@ public class ExecutingStatementResource
             @PathParam("queryId") QueryId queryId,
             @PathParam("stage") int stage,
             @PathParam("slug") String slug,
-            @PathParam("token") long token)
+            @PathParam("token") long token,
+            @Context UriInfo uriInfo,
+            @Context HttpHeaders httpHeaders)
     {
-        Query query = getQuery(queryId, slug, token);
+        Query query = getQuery(queryId, slug, token, uriInfo, httpHeaders);
         query.partialCancel(stage);
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -45,6 +45,7 @@ import io.trino.execution.buffer.PageDeserializer;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.memory.context.SimpleLocalMemoryContext;
 import io.trino.operator.DirectExchangeClientSupplier;
+import io.trino.server.protocol.data.QueryDataProducer;
 import io.trino.spi.ErrorCode;
 import io.trino.spi.Page;
 import io.trino.spi.QueryId;
@@ -103,6 +104,10 @@ class Query
 
     @GuardedBy("this")
     private final ExchangeDataSource exchangeDataSource;
+
+    @GuardedBy("this")
+    private final QueryDataProducer resultSetProducer;
+
     @GuardedBy("this")
     private ListenableFuture<Void> exchangeDataSourceBlocked;
 
@@ -170,6 +175,7 @@ class Query
             Session session,
             Slug slug,
             QueryManager queryManager,
+            QueryDataProducer queryDataProducer,
             Optional<URI> queryInfoUrl,
             DirectExchangeClientSupplier directExchangeClientSupplier,
             ExchangeManagerRegistry exchangeManagerRegistry,
@@ -186,8 +192,7 @@ class Query
                 getRetryPolicy(session),
                 exchangeManagerRegistry);
 
-        Query result = new Query(session, slug, queryManager, queryInfoUrl, exchangeDataSource, dataProcessorExecutor, timeoutExecutor, blockEncodingSerde);
-
+        Query result = new Query(session, slug, queryManager, queryDataProducer, queryInfoUrl, exchangeDataSource, dataProcessorExecutor, timeoutExecutor, blockEncodingSerde);
         result.queryManager.setOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
 
         result.queryManager.addStateChangeListener(result.getQueryId(), state -> {
@@ -206,6 +211,7 @@ class Query
             Session session,
             Slug slug,
             QueryManager queryManager,
+            QueryDataProducer resultSetProducer,
             Optional<URI> queryInfoUrl,
             ExchangeDataSource exchangeDataSource,
             Executor resultsProcessorExecutor,
@@ -215,6 +221,7 @@ class Query
         requireNonNull(session, "session is null");
         requireNonNull(slug, "slug is null");
         requireNonNull(queryManager, "queryManager is null");
+        requireNonNull(resultSetProducer, "resultSetProducer is null");
         requireNonNull(queryInfoUrl, "queryInfoUrl is null");
         requireNonNull(exchangeDataSource, "exchangeDataSource is null");
         requireNonNull(resultsProcessorExecutor, "resultsProcessorExecutor is null");
@@ -222,6 +229,7 @@ class Query
         requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
 
         this.queryManager = queryManager;
+        this.resultSetProducer = resultSetProducer;
         this.queryId = session.getQueryId();
         this.session = session;
         this.slug = slug;
@@ -485,7 +493,7 @@ class Query
                 partialCancelUri,
                 nextResultsUri,
                 resultRows.getColumns().orElse(null),
-                resultRows.isEmpty() ? null : resultRows, // client excepts null that indicates "no data"
+                resultSetProducer.create(session, resultRows, nextToken.isEmpty(), this::handleSerializationException), // client excepts null that will be represented as NoQueryData
                 toStatementStats(queryInfo),
                 toQueryError(queryInfo, typeSerializationException),
                 mappedCopy(queryInfo.getWarnings(), ProtocolUtil::toClientWarning),
@@ -531,7 +539,6 @@ class Query
         QueryResultRows.Builder resultBuilder = queryResultRowsBuilder(session)
                 // Intercept serialization exceptions and fail query if it's still possible.
                 // Put serialization exception aside to return failed query result.
-                .withExceptionConsumer(this::handleSerializationException)
                 .withColumnsAndTypes(columns, types);
 
         try {

--- a/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/QueryResultRows.java
@@ -14,72 +14,40 @@
 package io.trino.server.protocol;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import io.trino.Session;
-import io.trino.client.ClientCapabilities;
 import io.trino.client.Column;
 import io.trino.spi.Page;
-import io.trino.spi.TrinoException;
-import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.type.ArrayType;
-import io.trino.spi.type.MapType;
-import io.trino.spi.type.RowType;
-import io.trino.spi.type.SqlTime;
-import io.trino.spi.type.SqlTimeWithTimeZone;
-import io.trino.spi.type.SqlTimestamp;
-import io.trino.spi.type.SqlTimestampWithTimeZone;
-import io.trino.spi.type.TimeType;
-import io.trino.spi.type.TimeWithTimeZoneType;
-import io.trino.spi.type.TimestampType;
-import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import jakarta.annotation.Nullable;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.spi.StandardErrorCode.SERIALIZATION_ERROR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static java.lang.String.format;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 public class QueryResultRows
-        implements Iterable<List<Object>>
 {
     private final ConnectorSession session;
     private final Optional<List<ColumnAndType>> columns;
     private final List<Page> pages;
-    private final Optional<Consumer<Throwable>> exceptionConsumer;
     private final long totalRows;
-    private final boolean supportsParametricDateTime;
 
-    private QueryResultRows(Session session, Optional<List<ColumnAndType>> columns, List<Page> pages, Consumer<Throwable> exceptionConsumer)
+    private QueryResultRows(Session session, Optional<List<ColumnAndType>> columns, List<Page> pages)
     {
         this.session = session.toConnectorSession();
         this.columns = requireNonNull(columns, "columns is null");
         this.pages = ImmutableList.copyOf(pages);
-        this.exceptionConsumer = Optional.ofNullable(exceptionConsumer);
         this.totalRows = countRows(pages);
-        this.supportsParametricDateTime = session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString());
 
         verify(totalRows == 0 || (totalRows > 0 && columns.isPresent()), "data present without columns and types");
     }
@@ -89,11 +57,21 @@ public class QueryResultRows
         return totalRows == 0;
     }
 
+    public Optional<List<ColumnAndType>> getColumnsAndTypes()
+    {
+        return this.columns;
+    }
+
     public Optional<List<Column>> getColumns()
     {
         return columns.map(columns -> columns.stream()
                 .map(ColumnAndType::getColumn)
                 .collect(toImmutableList()));
+    }
+
+    public List<Page> getPages()
+    {
+        return this.pages;
     }
 
     /**
@@ -124,12 +102,6 @@ public class QueryResultRows
         return Optional.ofNullable(value).map(Number::longValue);
     }
 
-    @Override
-    public Iterator<List<Object>> iterator()
-    {
-        return new ResultsIterator(this);
-    }
-
     private static long countRows(List<Page> pages)
     {
         long rows = 0;
@@ -151,7 +123,7 @@ public class QueryResultRows
 
     public static QueryResultRows empty(Session session)
     {
-        return new QueryResultRows(session, Optional.empty(), ImmutableList.of(), null);
+        return new QueryResultRows(session, Optional.empty(), ImmutableList.of());
     }
 
     public static Builder queryResultRowsBuilder(Session session)
@@ -164,7 +136,6 @@ public class QueryResultRows
         private final Session session;
         private ImmutableList.Builder<Page> pages = ImmutableList.builder();
         private Optional<List<ColumnAndType>> columns = Optional.empty();
-        private Consumer<Throwable> exceptionConsumer;
 
         public Builder(Session session)
         {
@@ -202,19 +173,12 @@ public class QueryResultRows
             return this;
         }
 
-        public Builder withExceptionConsumer(Consumer<Throwable> exceptionConsumer)
-        {
-            this.exceptionConsumer = exceptionConsumer;
-            return this;
-        }
-
         public QueryResultRows build()
         {
             return new QueryResultRows(
                     session,
                     columns,
-                    pages.build(),
-                    exceptionConsumer);
+                    pages.build());
         }
 
         private static List<ColumnAndType> combine(@Nullable List<Column> columns, @Nullable List<Type> types)
@@ -232,7 +196,7 @@ public class QueryResultRows
         }
     }
 
-    private static class ColumnAndType
+    public static class ColumnAndType
     {
         private final int position;
         private final Column column;
@@ -268,160 +232,6 @@ public class QueryResultRows
                     .add("type", type)
                     .add("position", position)
                     .toString();
-        }
-    }
-
-    private static class ResultsIterator
-            extends AbstractIterator<List<Object>>
-    {
-        private final Deque<Page> queue;
-        private final QueryResultRows results;
-        private Page currentPage;
-        private int rowPosition = -1;
-        private int inPageIndex = -1;
-
-        public ResultsIterator(QueryResultRows results)
-        {
-            this.queue = new ArrayDeque<>(results.pages);
-            this.results = results;
-            this.currentPage = queue.pollFirst();
-        }
-
-        @Override
-        protected List<Object> computeNext()
-        {
-            while (true) {
-                if (currentPage == null) {
-                    return endOfData();
-                }
-
-                inPageIndex++;
-
-                if (inPageIndex >= currentPage.getPositionCount()) {
-                    currentPage = queue.pollFirst();
-
-                    if (currentPage == null) {
-                        return endOfData();
-                    }
-
-                    inPageIndex = 0;
-                }
-
-                rowPosition++;
-
-                List<Object> row = getRowValues();
-                if (row != null) {
-                    // row is not skipped, return it
-                    return row;
-                }
-            }
-        }
-
-        @Nullable
-        private List<Object> getRowValues()
-        {
-            // types are present if data is present
-            List<ColumnAndType> columns = results.columns.orElseThrow();
-            Object[] row = new Object[currentPage.getChannelCount()];
-
-            for (int channel = 0; channel < currentPage.getChannelCount(); channel++) {
-                ColumnAndType column = columns.get(channel);
-                Type type = column.getType();
-                Block block = currentPage.getBlock(channel);
-
-                try {
-                    Object value = type.getObjectValue(results.session, block, inPageIndex);
-                    if (!results.supportsParametricDateTime) {
-                        value = getLegacyValue(value, type);
-                    }
-                    row[channel] = value;
-                }
-                catch (Throwable throwable) {
-                    propagateException(rowPosition, column, throwable);
-                    // skip row as it contains non-serializable value
-                    return null;
-                }
-            }
-
-            return unmodifiableList(Arrays.asList(row));
-        }
-
-        private Object getLegacyValue(Object value, Type type)
-        {
-            if (value == null) {
-                return null;
-            }
-
-            if (!results.supportsParametricDateTime) {
-                // for legacy clients we need to round timestamp and timestamp with timezone to default precision (3)
-
-                if (type instanceof TimestampType) {
-                    return ((SqlTimestamp) value).roundTo(3);
-                }
-
-                if (type instanceof TimestampWithTimeZoneType) {
-                    return ((SqlTimestampWithTimeZone) value).roundTo(3);
-                }
-
-                if (type instanceof TimeType) {
-                    return ((SqlTime) value).roundTo(3);
-                }
-
-                if (type instanceof TimeWithTimeZoneType) {
-                    return ((SqlTimeWithTimeZone) value).roundTo(3);
-                }
-            }
-
-            if (type instanceof ArrayType) {
-                Type elementType = ((ArrayType) type).getElementType();
-
-                if (!(elementType instanceof TimestampType || elementType instanceof TimestampWithTimeZoneType)) {
-                    return value;
-                }
-
-                List<Object> listValue = (List<Object>) value;
-                List<Object> legacyValues = new ArrayList<>(listValue.size());
-                for (Object element : listValue) {
-                    legacyValues.add(getLegacyValue(element, elementType));
-                }
-
-                return unmodifiableList(legacyValues);
-            }
-
-            if (type instanceof MapType) {
-                Type keyType = ((MapType) type).getKeyType();
-                Type valueType = ((MapType) type).getValueType();
-
-                Map<Object, Object> mapValue = (Map<Object, Object>) value;
-                Map<Object, Object> result = Maps.newHashMapWithExpectedSize(mapValue.size());
-                mapValue.forEach((key, val) -> result.put(getLegacyValue(key, keyType), getLegacyValue(val, valueType)));
-                return unmodifiableMap(result);
-            }
-
-            if (type instanceof RowType) {
-                List<RowType.Field> fields = ((RowType) type).getFields();
-                List<Object> values = (List<Object>) value;
-
-                List<Object> result = new ArrayList<>(values.size());
-                for (int i = 0; i < values.size(); i++) {
-                    result.add(getLegacyValue(values.get(i), fields.get(i).getType()));
-                }
-                return unmodifiableList(result);
-            }
-
-            return value;
-        }
-
-        private void propagateException(int row, ColumnAndType column, Throwable cause)
-        {
-            // columns and rows are 0-indexed
-            String message = format("Could not serialize column '%s' of type '%s' at position %d:%d",
-                    column.getColumn().getName(),
-                    column.getType(),
-                    row + 1,
-                    column.getPosition() + 1);
-
-            results.exceptionConsumer.ifPresent(consumer -> consumer.accept(new TrinoException(SERIALIZATION_ERROR, message, cause)));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/protocol/data/DefaultQueryDataProducerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/data/DefaultQueryDataProducerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.data;
+
+import io.trino.Session;
+import io.trino.spi.QueryId;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Set;
+
+public class DefaultQueryDataProducerFactory
+        implements QueryDataProducerFactory
+{
+    @Override
+    public QueryDataProducer create(Session session, QueryId queryId, Set<String> supportedFormats, UriInfo uriInfo)
+    {
+        // Always return data as inlined JSON-serialized array of arrays of values
+        return new InlineJsonQueryDataProducer();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/data/InlineJsonQueryDataProducer.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/data/InlineJsonQueryDataProducer.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.data;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import io.trino.Session;
+import io.trino.client.ClientCapabilities;
+import io.trino.client.JsonInlineQueryData;
+import io.trino.client.QueryData;
+import io.trino.server.protocol.QueryResultRows;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SqlTime;
+import io.trino.spi.type.SqlTimeWithTimeZone;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlTimestampWithTimeZone;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static io.trino.client.NoQueryData.NO_DATA;
+import static io.trino.server.protocol.data.InlineJsonQueryDataProducer.JsonArrayIterator.toIterableList;
+import static io.trino.spi.StandardErrorCode.SERIALIZATION_ERROR;
+import static java.lang.String.format;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This QueryDataProducer that represents existing protocol semantics.
+ * Streams partial result as JSON-serialized list of lists of objects on every available set of pages.
+ */
+public class InlineJsonQueryDataProducer
+        implements QueryDataProducer
+{
+    @Override
+    public QueryData create(Session session, QueryResultRows rows, boolean completed, Consumer<Throwable> exceptionHandler)
+    {
+        if (rows.isEmpty()) {
+            return NO_DATA;
+        }
+
+        // We are passing whether data is present as we don't want to peek into iterable
+        return JsonInlineQueryData.create(toIterableList(session, rows, exceptionHandler), !rows.isEmpty());
+    }
+
+    @Override
+    public Class<? extends QueryData> produces()
+    {
+        return JsonInlineQueryData.class;
+    }
+
+    static class JsonArrayIterator
+            extends AbstractIterator<List<Object>>
+            implements Iterable<List<Object>>
+    {
+        private final Deque<Page> queue;
+        private final ConnectorSession session;
+        private final ImmutableList<Page> pages;
+        private final List<QueryResultRows.ColumnAndType> columns;
+        private final boolean supportsParametricDateTime;
+        private final Consumer<Throwable> exceptionConsumer;
+
+        private Page currentPage;
+        private int rowPosition = -1;
+        private int inPageIndex = -1;
+
+        public JsonArrayIterator(ConnectorSession session, List<Page> pages, List<QueryResultRows.ColumnAndType> columns, boolean supportsParametricDateTime, Consumer<Throwable> exceptionConsumer)
+        {
+            this.pages = ImmutableList.copyOf(pages);
+            this.queue = new ArrayDeque<>(pages);
+            this.session = requireNonNull(session, "session is null");
+            this.columns = requireNonNull(columns, "columns is null");
+            this.supportsParametricDateTime = supportsParametricDateTime;
+            this.exceptionConsumer = requireNonNull(exceptionConsumer, "exceptionConsumer is null");
+            this.currentPage = queue.pollFirst();
+        }
+
+        public static Iterable<List<Object>> toIterableList(Session session, QueryResultRows rows, Consumer<Throwable> exceptionConsumer)
+        {
+            return new JsonArrayIterator(
+                    session.toConnectorSession(),
+                    rows.getPages(),
+                    rows.getColumnsAndTypes().orElseThrow(),
+                    session.getClientCapabilities().contains(ClientCapabilities.PARAMETRIC_DATETIME.toString()),
+                    exceptionConsumer);
+        }
+
+        @Override
+        protected List<Object> computeNext()
+        {
+            while (true) {
+                if (currentPage == null) {
+                    return endOfData();
+                }
+
+                inPageIndex++;
+
+                if (inPageIndex >= currentPage.getPositionCount()) {
+                    currentPage = queue.pollFirst();
+
+                    if (currentPage == null) {
+                        return endOfData();
+                    }
+
+                    inPageIndex = 0;
+                }
+
+                rowPosition++;
+
+                List<Object> row = getRowValues();
+                if (row != null) {
+                    // row is not skipped, return it
+                    return row;
+                }
+            }
+        }
+
+        @Nullable
+        private List<Object> getRowValues()
+        {
+            Object[] row = new Object[currentPage.getChannelCount()];
+
+            for (int channel = 0; channel < currentPage.getChannelCount(); channel++) {
+                QueryResultRows.ColumnAndType column = columns.get(channel);
+                Type type = column.getType();
+                Block block = currentPage.getBlock(channel);
+
+                try {
+                    Object value = type.getObjectValue(session, block, inPageIndex);
+                    if (!supportsParametricDateTime) {
+                        value = getLegacyValue(value, type);
+                    }
+                    row[channel] = value;
+                }
+                catch (Throwable throwable) {
+                    propagateException(rowPosition, column, throwable);
+                    // skip row as it contains non-serializable value
+                    return null;
+                }
+            }
+
+            return unmodifiableList(Arrays.asList(row));
+        }
+
+        private Object getLegacyValue(Object value, Type type)
+        {
+            if (value == null) {
+                return null;
+            }
+
+            if (!supportsParametricDateTime) {
+                // for legacy clients we need to round timestamp and timestamp with timezone to default precision (3)
+
+                if (type instanceof TimestampType) {
+                    return ((SqlTimestamp) value).roundTo(3);
+                }
+
+                if (type instanceof TimestampWithTimeZoneType) {
+                    return ((SqlTimestampWithTimeZone) value).roundTo(3);
+                }
+
+                if (type instanceof TimeType) {
+                    return ((SqlTime) value).roundTo(3);
+                }
+
+                if (type instanceof TimeWithTimeZoneType) {
+                    return ((SqlTimeWithTimeZone) value).roundTo(3);
+                }
+            }
+
+            if (type instanceof ArrayType) {
+                Type elementType = ((ArrayType) type).getElementType();
+
+                if (!(elementType instanceof TimestampType || elementType instanceof TimestampWithTimeZoneType)) {
+                    return value;
+                }
+
+                List<Object> listValue = (List<Object>) value;
+                List<Object> legacyValues = new ArrayList<>(listValue.size());
+                for (Object element : listValue) {
+                    legacyValues.add(getLegacyValue(element, elementType));
+                }
+
+                return unmodifiableList(legacyValues);
+            }
+
+            if (type instanceof MapType) {
+                Type keyType = ((MapType) type).getKeyType();
+                Type valueType = ((MapType) type).getValueType();
+
+                Map<Object, Object> mapValue = (Map<Object, Object>) value;
+                Map<Object, Object> result = Maps.newHashMapWithExpectedSize(mapValue.size());
+                mapValue.forEach((key, val) -> result.put(getLegacyValue(key, keyType), getLegacyValue(val, valueType)));
+                return unmodifiableMap(result);
+            }
+
+            if (type instanceof RowType) {
+                List<RowType.Field> fields = ((RowType) type).getFields();
+                List<Object> values = (List<Object>) value;
+
+                List<Object> result = new ArrayList<>(values.size());
+                for (int i = 0; i < values.size(); i++) {
+                    result.add(getLegacyValue(values.get(i), fields.get(i).getType()));
+                }
+                return unmodifiableList(result);
+            }
+
+            return value;
+        }
+
+        private void propagateException(int row, QueryResultRows.ColumnAndType column, Throwable cause)
+        {
+            // columns and rows are 0-indexed
+            String message = format("Could not serialize column '%s' of type '%s' at position %d:%d",
+                    column.getColumn().getName(),
+                    column.getType(),
+                    row + 1,
+                    column.getPosition() + 1);
+
+            exceptionConsumer.accept(new TrinoException(SERIALIZATION_ERROR, message, cause));
+        }
+
+        @NotNull
+        @Override
+        public Iterator<List<Object>> iterator()
+        {
+            // Iterator needs to be idempotent
+            return new JsonArrayIterator(session, pages, columns, supportsParametricDateTime, exceptionConsumer);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataFormatsModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataFormatsModule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.data;
+
+import com.fasterxml.jackson.databind.Module;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.multibindings.ProvidesIntoSet;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.client.QueryData;
+import io.trino.client.QueryDataFormatResolver;
+import io.trino.client.QueryDataJsonSerializationModule;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+
+public class QueryDataFormatsModule
+        extends AbstractConfigurationAwareModule
+{
+    @ProvidesIntoSet
+    @Singleton
+    public static Module queryDataSerializationModule(QueryDataFormatResolver formatResolver)
+    {
+        return new QueryDataJsonSerializationModule(formatResolver);
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        newSetBinder(binder, QueryDataProducer.class).addBinding()
+                .to(InlineJsonQueryDataProducer.class)
+                .in(Scopes.SINGLETON);
+
+        newOptionalBinder(binder, QueryDataProducerFactory.class)
+                .setDefault()
+                .to(DefaultQueryDataProducerFactory.class)
+                .in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    private QueryDataFormatResolver getResultSetProducers(Set<QueryDataProducer> handlers)
+    {
+        List<Class<? extends QueryData>> classes = handlers.stream()
+                .map(QueryDataProducer::produces)
+                .collect(Collectors.toList());
+        return new QueryDataFormatResolver(classes);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataProducer.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataProducer.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.data;
+
+import io.trino.Session;
+import io.trino.client.QueryData;
+import io.trino.server.protocol.QueryResultRows;
+
+import java.util.function.Consumer;
+
+/**
+ * QueryDataProducer is responsible for serializing result data according to a given format and returning it as QueryResults data field.
+ */
+public interface QueryDataProducer
+{
+    QueryData create(Session session, QueryResultRows rows, boolean completed, Consumer<Throwable> handleSerializationException);
+
+    Class<? extends QueryData> produces();
+}

--- a/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataProducerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/data/QueryDataProducerFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.protocol.data;
+
+import io.trino.Session;
+import io.trino.spi.QueryId;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Set;
+
+/**
+ * QueryDataProducerFactory is used to negotiate the {@link QueryDataProducer} between the server implementation and the client
+ */
+public interface QueryDataProducerFactory
+{
+    QueryDataProducer create(Session session, QueryId queryId, Set<String> supportedFormats, UriInfo uriInfo);
+}

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryResource.java
@@ -13,16 +13,23 @@
  */
 package io.trino.server;
 
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.airlift.bootstrap.Bootstrap;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.UnexpectedResponseException;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
 import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.JsonModule;
+import io.trino.client.JsonInlineQueryData;
 import io.trino.client.QueryResults;
 import io.trino.execution.QueryInfo;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.protocol.data.QueryDataFormatsModule;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.QueryId;
 import org.testng.annotations.AfterMethod;
@@ -40,7 +47,7 @@ import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.Request.Builder.preparePut;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
-import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.execution.QueryState.FAILED;
@@ -66,6 +73,7 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestQueryResource
 {
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_JSON_CODEC = queryResultsCodec();
     private static final JsonCodec<List<BasicQueryInfo>> BASIC_QUERY_INFO_CODEC = tracingJsonCodecFactory().listJsonCodec(BasicQueryInfo.class);
 
     private HttpClient client;
@@ -100,7 +108,7 @@ public class TestQueryResource
                 .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
                 .build();
 
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         URI uri = queryResults.getNextUri();
         while (uri != null) {
             QueryResults attempt1 = client.execute(
@@ -108,16 +116,23 @@ public class TestQueryResource
                             .setHeader(TRINO_HEADERS.requestUser(), "user")
                             .setUri(uri)
                             .build(),
-                    createJsonResponseHandler(jsonCodec(QueryResults.class)));
+                    createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
 
             QueryResults attempt2 = client.execute(
                     prepareGet()
                             .setHeader(TRINO_HEADERS.requestUser(), "user")
                             .setUri(uri)
                             .build(),
-                    createJsonResponseHandler(jsonCodec(QueryResults.class)));
+                    createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
 
-            assertThat(attempt2.getData()).isEqualTo(attempt1.getData());
+            if (attempt1.getData() instanceof JsonInlineQueryData) {
+                // We need to materialize lazy iterables in order to compare these
+                assertThat(ImmutableList.copyOf(attempt2.getData().getData()))
+                        .isEqualTo(ImmutableList.copyOf(attempt1.getData().getData()));
+            }
+            else {
+                assertThat(attempt1.getData()).isEqualTo(attempt2.getData());
+            }
 
             uri = attempt1.getNextUri();
         }
@@ -252,13 +267,13 @@ public class TestQueryResource
                 .setUri(uri)
                 .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
                 .build();
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         while (queryResults.getNextUri() != null) {
             request = prepareGet()
                     .setHeader(TRINO_HEADERS.requestUser(), "user")
                     .setUri(queryResults.getNextUri())
                     .build();
-            queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+            queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         }
         return queryResults.getId();
     }
@@ -271,13 +286,13 @@ public class TestQueryResource
                 .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
                 .setHeader(TRINO_HEADERS.requestUser(), "user")
                 .build();
-        QueryResults queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         while (queryResults.getNextUri() != null && !queryResults.getStats().getState().equals(RUNNING.toString())) {
             request = prepareGet()
                     .setHeader(TRINO_HEADERS.requestUser(), "user")
                     .setUri(queryResults.getNextUri())
                     .build();
-            queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+            queryResults = client.execute(request, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         }
         return queryResults.getId();
     }
@@ -356,5 +371,15 @@ public class TestQueryResource
                 .setHeader(TRINO_HEADERS.requestUser(), "unknown")
                 .build();
         return client.execute(request, createStatusResponseHandler()).getStatusCode();
+    }
+
+    public static JsonCodec<QueryResults> queryResultsCodec()
+    {
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new QueryDataFormatsModule(), binder -> jsonCodecBinder(binder).bindJsonCodec(QueryResults.class)
+        ).initialize();
+
+        return injector.getInstance(Key.get(new TypeLiteral<>(){}));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQueryStateInfoResource.java
@@ -14,14 +14,20 @@
 package io.trino.server;
 
 import com.google.common.io.Closer;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.airlift.bootstrap.Bootstrap;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.Request;
 import io.airlift.http.client.UnexpectedResponseException;
 import io.airlift.http.client.jetty.JettyHttpClient;
 import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonModule;
 import io.airlift.units.Duration;
 import io.trino.client.QueryResults;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.protocol.data.QueryDataFormatsModule;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.ErrorCode;
 import org.testng.annotations.AfterClass;
@@ -39,6 +45,7 @@ import static io.airlift.http.client.Request.Builder.preparePost;
 import static io.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.airlift.json.JsonCodec.listJsonCodec;
+import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.execution.QueryState.FAILED;
 import static io.trino.execution.QueryState.RUNNING;
@@ -57,7 +64,7 @@ import static org.testng.Assert.assertTrue;
 public class TestQueryStateInfoResource
 {
     private static final String LONG_LASTING_QUERY = "SELECT * FROM tpch.sf1.lineitem";
-    private static final JsonCodec<QueryResults> QUERY_RESULTS_JSON_CODEC = jsonCodec(QueryResults.class);
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_JSON_CODEC = queryResultsCodec();
     private static final JsonCodec<List<BasicQueryInfo>> BASIC_QUERY_INFO_CODEC = tracingJsonCodecFactory().listJsonCodec(BasicQueryInfo.class);
 
     private TestingTrinoServer server;
@@ -85,7 +92,7 @@ public class TestQueryStateInfoResource
                 .setBodyGenerator(createStaticBodyGenerator(LONG_LASTING_QUERY, UTF_8))
                 .setHeader(TRINO_HEADERS.requestUser(), "user2")
                 .build();
-        QueryResults queryResults2 = client.execute(request2, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        QueryResults queryResults2 = client.execute(request2, createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
         client.execute(prepareGet().setUri(queryResults2.getNextUri()).build(), createJsonResponseHandler(QUERY_RESULTS_JSON_CODEC));
 
         // queries are started in the background, so they may not all be immediately visible
@@ -240,5 +247,15 @@ public class TestQueryStateInfoResource
                 createJsonResponseHandler(jsonCodec(QueryStateInfo.class))))
                 .isInstanceOf(UnexpectedResponseException.class)
                 .hasMessageMatching("Expected response code .*, but was 404");
+    }
+
+    public static JsonCodec<QueryResults> queryResultsCodec()
+    {
+        Injector injector = new Bootstrap(
+                new JsonModule(),
+                new QueryDataFormatsModule(), binder -> jsonCodecBinder(binder).bindJsonCodec(QueryResults.class)
+        ).initialize();
+
+        return injector.getInstance(Key.get(new TypeLiteral<>(){}));
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchLoader.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchLoader.java
@@ -83,7 +83,7 @@ public class ElasticsearchLoader
                 types.set(getTypes(statusInfo.getColumns()));
             }
 
-            if (data.getData() == null) {
+            if (data.isEmpty()) {
                 return;
             }
             checkState(types.get() != null, "Type information is missing");

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisLoader.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/util/RedisLoader.java
@@ -102,7 +102,7 @@ public class RedisLoader
                 types.set(getTypes(statusInfo.getColumns()));
             }
 
-            if (data.getData() != null) {
+            if (data.isPresent()) {
                 checkState(types.get() != null, "Data without types received!");
                 List<Column> columns = statusInfo.getColumns();
                 for (List<Object> fields : data.getData()) {

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
@@ -162,7 +162,7 @@ public class TestingTrinoClient
                 columnNames.set(getNames(statusInfo.getColumns()));
             }
 
-            if (data.getData() != null) {
+            if (data.isPresent()) {
                 checkState(types.get() != null, "data received without types");
                 rows.addAll(mappedCopy(data.getData(), dataToRow(types.get())));
             }


### PR DESCRIPTION
This extends existing v1 protocol with the ability to transfer other query data representations then JSON-serialized list of list of objects. New "query data formats" are pluggable on the client and server side (see `QueryData`).

Currently only `JsonInlineQueryData` is implemented which has the same semantics as existing protocol (streaming JSON inlined response).

Other formats can add arbitrary fields to the `QueryResults` data field represented as `QueryData` interface, and the information about the current format is represented by the `format` field.

Other formats are negotiated by the pluggable `QueryDataProducerFactory` on the server side.

This change is backward and forward-compatible:

- new server with additional result set formats used by the old client will return result in `json` format (current protocol)
- new server with additional result set formats supported by the new client will return result in the negotiated format
- old server used by the new client supporting additional formats will return `json` format (current protocol)


Alternative to https://github.com/trinodb/trino/pull/18452 without introducing separate `QueryResults` implementations.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
