### PR TITLE
Allow writing to externally provided JDK

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/TarDownloadingJdkProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/TarDownloadingJdkProvider.java
@@ -122,7 +122,7 @@ public abstract class TarDownloadingJdkProvider
                     binds[binds.length - 1] = new Bind(
                             javaHomePath.toAbsolutePath().toString(),
                             new Volume(javaHome),
-                            AccessMode.ro);
+                            AccessMode.rw);
                     cmd.getHostConfig().setBinds(binds);
                 })
                 .withEnv("JAVA_HOME", javaHome);


### PR DESCRIPTION
Some product test environments can import certificates to cacerts, which will fail if the externally provided JDK is mounted read-only.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
