### PR TITLE
Disable function deprecation checks on workers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1313,12 +1313,19 @@ public class ExpressionAnalyzer
 
             resolvedFunctions.put(NodeRef.of(node), function);
 
-            FunctionMetadata functionMetadata = plannerContext.getMetadata().getFunctionMetadata(session, function);
-            if (functionMetadata.isDeprecated()) {
-                warningCollector.add(new TrinoWarning(DEPRECATED_FUNCTION,
-                        format("Use of deprecated function: %s: %s",
-                                functionMetadata.getSignature().getName(),
-                                functionMetadata.getDescription())));
+            // FunctionMetadata should only be fetched on the coordinator, as workers do not have FunctionMetadata for all functions
+            // Since warning collector is also only set on the coordinator, this check is sufficient
+            // TODO remove this when workers no longer reanalyze expressions
+            if (warningCollector != WarningCollector.NOOP) {
+                FunctionMetadata functionMetadata = plannerContext.getMetadata().getFunctionMetadata(session, function);
+                if (functionMetadata.isDeprecated()) {
+                    warningCollector.add(new TrinoWarning(
+                            DEPRECATED_FUNCTION,
+                            format(
+                                    "Use of deprecated function: %s: %s",
+                                    functionMetadata.getSignature().getName(),
+                                    functionMetadata.getDescription())));
+                }
             }
 
             Type type = signature.getReturnType();


### PR DESCRIPTION
## Description

FunctionMetadata should only be fetched on the coordinator, as workers do not have FunctionMetadata for all functions.  The ExpressionAnalyzer issues warnings for deprecated functions, but this creates problems since the expression analyzer is also run on worker.  The PR works around this problem by only checking for deprecation when the `WarningCollector` is not the `NOOP` implementation.  Since the worker exclusively uses the `NOOP` collector, this effectively disables the code on workers.

 Fixes #17661 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
