### PR TITLE
Coerce column type varchar0 to varchar1 for hive table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -124,6 +124,7 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarcharType;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.apache.hadoop.fs.Path;
@@ -3423,6 +3424,15 @@ public class HiveMetadata
                         .addAll(partitionedBy)
                         .build(),
                 multipleWritersPerPartitionSupported));
+    }
+
+    @Override
+    public Optional<Type> getSupportedType(ConnectorSession session, Type type)
+    {
+        if (type instanceof VarcharType varcharType && !varcharType.isUnbounded() && varcharType.getBoundedLength() == 0) {
+            return Optional.of(VarcharType.createVarcharType(1));
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -7965,6 +7965,41 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testCoercingVarchar0ToVarchar1()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_coercion_create_table_varchar",
+                "(var_column_0 varchar(0), var_column_1 varchar(1), var_column_10 varchar(10))")) {
+            assertEquals(getColumnType(testTable.getName(), "var_column_0"), "varchar(1)");
+            assertEquals(getColumnType(testTable.getName(), "var_column_1"), "varchar(1)");
+            assertEquals(getColumnType(testTable.getName(), "var_column_10"), "varchar(10)");
+        }
+    }
+
+    @Test
+    public void testCoercingVarchar0ToVarchar1WithCTAS()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_coercion_ctas_varchar",
+                "AS SELECT '' AS var_column")) {
+            assertEquals(getColumnType(testTable.getName(), "var_column"), "varchar(1)");
+        }
+    }
+
+    @Test
+    public void testCoercingVarchar0ToVarchar1WithCTASNoData()
+    {
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_coercion_ctas_nd_varchar",
+                "AS SELECT '' AS var_column WITH NO DATA")) {
+            assertEquals(getColumnType(testTable.getName(), "var_column"), "varchar(1)");
+        }
+    }
+
+    @Test
     public void testOptimize()
     {
         String tableName = "test_optimize_" + randomNameSuffix();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The goal of the PR is to auto-adjust column type from varchar(0) to varchar(1) for Hive connector.
The min len of the Trino SPI's VarchartType is 0 whereas the min len of Hive's varchar type is 1.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) Release notes are required, with the following suggested text:
```
# Hive connector
* Automatic type coercion from varchar(0) to varchar(1) for columns within Hive connector.
```