### PR TITLE
Fix column lineage for UPDATE statements with subqueries

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1078,6 +1078,65 @@ public class TestEventListenerBasic
     }
 
     @Test
+    public void testOutputColumnsForUpdatingColumnWithSelectQuery()
+            throws Exception
+    {
+        QueryEvents queryEvents = runQueryAndWaitForEvents("UPDATE mock.default.table_for_output SET test_varchar = (SELECT name from nation LIMIT 1)").getQueryEvents();
+        QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "name"))));
+    }
+
+    @Test
+    public void testOutputColumnsForUpdatingColumnWithSelectQueryWithAliasedField()
+            throws Exception
+    {
+        QueryEvents queryEvents = runQueryAndWaitForEvents("UPDATE mock.default.table_for_output SET test_varchar = (SELECT name AS aliased_name from nation LIMIT 1)").getQueryEvents();
+        QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "name"))));
+    }
+
+    @Test
+    public void testOutputColumnsForUpdatingColumnsWithSelectQueries()
+            throws Exception
+    {
+        QueryEvents queryEvents = runQueryAndWaitForEvents("""
+                UPDATE mock.default.table_for_output SET test_varchar = (SELECT name AS aliased_name from nation LIMIT 1), test_bigint = (SELECT nationkey FROM nation LIMIT 1)
+                """).getQueryEvents();
+        QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactlyInAnyOrder(
+                        new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "name"))),
+                        new OutputColumnMetadata("test_bigint", BIGINT_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "nationkey"))));
+    }
+
+    @Test
+    public void testOutputColumnsForUpdatingColumnsWithSelectQueryAndRawValue()
+            throws Exception
+    {
+        QueryEvents queryEvents = runQueryAndWaitForEvents("""
+                UPDATE mock.default.table_for_output SET test_varchar = (SELECT name AS aliased_name from nation LIMIT 1), test_bigint = 1
+                """).getQueryEvents();
+        QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactlyInAnyOrder(
+                        new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "name"))),
+                        new OutputColumnMetadata("test_bigint", BIGINT_TYPE, ImmutableSet.of()));
+    }
+
+    @Test
+    public void testOutputColumnsForUpdatingColumnWithSelectQueryAndWhereClauseWithOuterColumn()
+            throws Exception
+    {
+        QueryEvents queryEvents = runQueryAndWaitForEvents("""
+                UPDATE mock.default.table_for_output SET test_varchar = (SELECT name from nation WHERE test_bigint = nationkey)""").getQueryEvents();
+        QueryCompletedEvent event = queryEvents.getQueryCompletedEvent();
+        assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
+                .containsExactly(new OutputColumnMetadata("test_varchar", VARCHAR_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "name"))));
+    }
+
+    @Test
     public void testCreateTable()
             throws Exception
     {


### PR DESCRIPTION
## Description
- This PR fixes an issue where the query output columns were incorrectly not returning source columns for UPDATE statements with subqueries. For example:

```
UPDATE catalog.schema.test_table SET output_column = (SELECT test_column FROM catalog.schema.test_alt_table)
```

This query should set `test_alt_table.test_column` as a source column of `test_table.output_column`

## Additional context and related issues


## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix event listener to capture source columns for UPDATE statements with subqueries.
```
