### PR TITLE
Fix hive ANALYZE when row count stats are missing

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHive.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHive.java
@@ -103,7 +103,7 @@ public class TestHive
             // used to ingest data into partitioned hive tables.
             testUpdatePartitionStatistics(
                     tableName,
-                    PartitionStatistics.empty(),
+                    EMPTY_ROWCOUNT_STATISTICS,
                     ImmutableList.of(BASIC_STATISTICS_1, BASIC_STATISTICS_2),
                     ImmutableList.of(BASIC_STATISTICS_2, BASIC_STATISTICS_1));
         }
@@ -124,7 +124,7 @@ public class TestHive
             // used to ingest data into partitioned hive tables.
             testUpdatePartitionStatistics(
                     tableName,
-                    PartitionStatistics.empty(),
+                    EMPTY_ROWCOUNT_STATISTICS,
                     ImmutableList.of(STATISTICS_1_1, STATISTICS_1_2, STATISTICS_2),
                     ImmutableList.of(STATISTICS_1_2, STATISTICS_1_1, STATISTICS_2));
         }
@@ -145,7 +145,7 @@ public class TestHive
             // used to ingest data into partitioned hive tables.
             testUpdatePartitionStatistics(
                     tableName,
-                    PartitionStatistics.empty(),
+                    EMPTY_ROWCOUNT_STATISTICS,
                     ImmutableList.of(STATISTICS_EMPTY_OPTIONAL_FIELDS),
                     ImmutableList.of(STATISTICS_EMPTY_OPTIONAL_FIELDS));
         }
@@ -161,7 +161,7 @@ public class TestHive
         // When the table has partitions, but row count statistics are set to zero, we treat this case as empty
         // statistics to avoid underestimation in the CBO. This scenario may be caused when other engines are
         // used to ingest data into partitioned hive tables.
-        testStorePartitionWithStatistics(STATISTICS_PARTITIONED_TABLE_COLUMNS, STATISTICS_1, STATISTICS_2, STATISTICS_1_1, PartitionStatistics.empty());
+        testStorePartitionWithStatistics(STATISTICS_PARTITIONED_TABLE_COLUMNS, STATISTICS_1, STATISTICS_2, STATISTICS_1_1, EMPTY_ROWCOUNT_STATISTICS);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveBasicStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveBasicStatistics.java
@@ -83,6 +83,11 @@ public class HiveBasicStatistics
         return onDiskDataSizeInBytes;
     }
 
+    public HiveBasicStatistics withEmptyRowCount()
+    {
+        return new HiveBasicStatistics(fileCount, OptionalLong.empty(), inMemoryDataSizeInBytes, onDiskDataSizeInBytes);
+    }
+
     @Override
     public boolean equals(Object o)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionStatistics.java
@@ -94,6 +94,11 @@ public class PartitionStatistics
         return new Builder();
     }
 
+    public PartitionStatistics withBasicStatistics(HiveBasicStatistics basicStatistics)
+    {
+        return new PartitionStatistics(basicStatistics, columnStatistics);
+    }
+
     public static class Builder
     {
         private HiveBasicStatistics basicStatistics = HiveBasicStatistics.createEmptyStatistics();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -333,8 +333,10 @@ public class GlueHiveMetastore
             // When the table has partitions, but row count statistics are set to zero, we treat this case as empty
             // statistics to avoid underestimation in the CBO. This scenario may be caused when other engines are
             // used to ingest data into partitioned hive tables.
-            partitionBasicStatistics = partitionBasicStatistics.keySet().stream()
-                    .map(key -> new SimpleEntry<>(key, PartitionStatistics.empty()))
+            partitionBasicStatistics = partitionBasicStatistics.entrySet().stream()
+                    .map(entry -> new SimpleEntry<>(
+                                entry.getKey(),
+                                entry.getValue().withBasicStatistics(entry.getValue().getBasicStatistics().withEmptyRowCount())))
                     .collect(toImmutableMap(SimpleEntry::getKey, SimpleEntry::getValue));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -399,8 +399,11 @@ public class ThriftHiveMetastore
             // When the table has partitions, but row count statistics are set to zero, we treat this case as empty
             // statistics to avoid underestimation in the CBO. This scenario may be caused when other engines are
             // used to ingest data into partitioned hive tables.
-            partitionBasicStatistics = partitionBasicStatistics.keySet().stream()
-                    .map(partitionName -> new SimpleEntry<>(partitionName, HiveBasicStatistics.createEmptyStatistics()))
+            // https://github.com/trinodb/trino/issues/18798 Hive Metastore assumes any new partition statistics to at least have all parameters that the partition used to have
+            partitionBasicStatistics = partitionBasicStatistics.entrySet().stream()
+                    .map(entry -> new SimpleEntry<>(
+                            entry.getKey(),
+                            entry.getValue().withEmptyRowCount()))
                     .collect(toImmutableMap(SimpleEntry::getKey, SimpleEntry::getValue));
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -543,6 +543,7 @@ public abstract class AbstractTestHive
             .build();
 
     protected static final PartitionStatistics ZERO_TABLE_STATISTICS = new PartitionStatistics(createZeroStatistics(), ImmutableMap.of());
+    protected static final PartitionStatistics EMPTY_ROWCOUNT_STATISTICS = ZERO_TABLE_STATISTICS.withBasicStatistics(ZERO_TABLE_STATISTICS.getBasicStatistics().withEmptyRowCount());
     protected static final PartitionStatistics BASIC_STATISTICS_1 = new PartitionStatistics(new HiveBasicStatistics(0, 20, 3, 0), ImmutableMap.of());
     protected static final PartitionStatistics BASIC_STATISTICS_2 = new PartitionStatistics(new HiveBasicStatistics(0, 30, 2, 0), ImmutableMap.of());
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -308,7 +308,7 @@ public class TestHiveGlueMetastore
             createDummyPartitionedTable(tableName, STATISTICS_PARTITIONED_TABLE_COLUMNS);
             testUpdatePartitionStatistics(
                     tableName,
-                    PartitionStatistics.empty(),
+                    EMPTY_ROWCOUNT_STATISTICS,
                     ImmutableList.of(BASIC_STATISTICS_1, BASIC_STATISTICS_2),
                     ImmutableList.of(BASIC_STATISTICS_2, BASIC_STATISTICS_1));
         }
@@ -329,7 +329,7 @@ public class TestHiveGlueMetastore
             // used to ingest data into partitioned hive tables.
             testUpdatePartitionStatistics(
                     tableName,
-                    PartitionStatistics.empty(),
+                    EMPTY_ROWCOUNT_STATISTICS,
                     ImmutableList.of(STATISTICS_1_1, STATISTICS_1_2, STATISTICS_2),
                     ImmutableList.of(STATISTICS_1_2, STATISTICS_1_1, STATISTICS_2));
         }
@@ -345,7 +345,7 @@ public class TestHiveGlueMetastore
         // When the table has partitions, but row count statistics are set to zero, we treat this case as empty
         // statistics to avoid underestimation in the CBO. This scenario may be caused when other engines are
         // used to ingest data into partitioned hive tables.
-        testStorePartitionWithStatistics(STATISTICS_PARTITIONED_TABLE_COLUMNS, BASIC_STATISTICS_1, BASIC_STATISTICS_2, BASIC_STATISTICS_1, PartitionStatistics.empty());
+        testStorePartitionWithStatistics(STATISTICS_PARTITIONED_TABLE_COLUMNS, BASIC_STATISTICS_1, BASIC_STATISTICS_2, BASIC_STATISTICS_1, EMPTY_ROWCOUNT_STATISTICS);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/18798

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The problem is specific to hive metastore and newer versions of HMS have fixed this https://issues.apache.org/jira/browse/HIVE-19254

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# Hive
* Fix failure in ANALYZE when row count stats are missing. ({issue}`18798`)
```