### PR TITLE
Increase default response/request buffer size for OAuth2 client

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.units.DataSize;
 import io.trino.server.ui.OAuth2WebUiInstalled;
 
 import java.time.Duration;
@@ -29,6 +30,7 @@ import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.server.security.oauth2.TokenPairSerializer.ACCESS_TOKEN_ONLY_SERIALIZER;
 
 public class OAuth2ServiceModule
@@ -50,7 +52,11 @@ public class OAuth2ServiceModule
                 .in(Scopes.SINGLETON);
         install(conditionalModule(OAuth2Config.class, OAuth2Config::isEnableDiscovery, this::bindOidcDiscovery, this::bindStaticConfiguration));
         install(conditionalModule(OAuth2Config.class, OAuth2Config::isEnableRefreshTokens, this::enableRefreshTokens, this::disableRefreshTokens));
-        httpClientBinder(binder).bindHttpClient("oauth2-jwk", ForOAuth2.class);
+        httpClientBinder(binder)
+                .bindHttpClient("oauth2-jwk", ForOAuth2.class)
+                .withConfigDefaults(clientConfig -> clientConfig
+                        .setRequestBufferSize(DataSize.of(32, KILOBYTE))
+                        .setResponseBufferSize(DataSize.of(32, KILOBYTE)));
     }
 
     private void enableRefreshTokens(Binder binder)


### PR DESCRIPTION
For some of the identity providers the default buffer sizes are too small to work out of the box, when authentication tokens size exceeds the default request buffer size of 4KB.

In these cases the default configuration will fail with:

```
io.trino.server.security.oauth2.NimbusAirliftHttpClient Received bad response from endpoint java.lang.IllegalArgumentException: Request header too large
    at org.eclipse.jetty.client.http.HttpSenderOverHTTP$HeadersCallback.process(HttpSenderOverHTTP.java:182)
    at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:232)
    at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:214)
    at org.eclipse.jetty.client.http.HttpSenderOverHTTP.sendHeaders(HttpSenderOverHTTP.java:79)
    at org.eclipse.jetty.client.HttpSender$ContentConsumer.onContent(HttpSender.java:496)
    at org.eclipse.jetty.client.util.AbstractRequestContent$AbstractSubscription.notifyContent(AbstractRequestContent.java:207)
    at org.eclipse.jetty.client.util.AbstractRequestContent$AbstractSubscription.processContent(AbstractRequestContent.java:181)
    at org.eclipse.jetty.client.util.BytesRequestContent$SubscriptionImpl.produceContent(BytesRequestContent.java:83)
    at org.eclipse.jetty.client.util.AbstractRequestContent$AbstractSubscription.produce(AbstractRequestContent.java:117)
    at org.eclipse.jetty.client.util.AbstractRequestContent$AbstractSubscription.demand(AbstractRequestContent.java:93)
    at org.eclipse.jetty.client.HttpSender.demand(HttpSender.java:237)
    at org.eclipse.jetty.client.HttpSender.send(HttpSender.java:83)
    at org.eclipse.jetty.client.http.HttpChannelOverHTTP.send(HttpChannelOverHTTP.java:80)
    at org.eclipse.jetty.client.HttpChannel.send(HttpChannel.java:122)
    at org.eclipse.jetty.client.HttpConnection.send(HttpConnection.java:111)
    at org.eclipse.jetty.client.http.HttpConnectionOverHTTP$Delegate.send(HttpConnectionOverHTTP.java:301)
    at org.eclipse.jetty.client.http.HttpConnectionOverHTTP.send(HttpConnectionOverHTTP.java:146)
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:440)
    at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:416)
    at org.eclipse.jetty.client.HttpDestination.process(HttpDestination.java:371)
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:354)
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:348)
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:325)
    at org.eclipse.jetty.client.HttpDestination.send(HttpDestination.java:304)
    at org.eclipse.jetty.client.HttpClient.send(HttpClient.java:591)
    at org.eclipse.jetty.client.HttpRequest.sendAsync(HttpRequest.java:819)
    at org.eclipse.jetty.client.HttpRequest.send(HttpRequest.java:807)
    at io.airlift.http.client.jetty.JettyHttpClient.execute(JettyHttpClient.java:578)
    at io.trino.server.security.oauth2.NimbusAirliftHttpClient.execute(NimbusAirliftHttpClient.java:102)
    at io.trino.server.security.oauth2.NimbusOAuth2Client.queryUserInfo(NimbusOAuth2Client.java:379)
    at io.trino.server.security.oauth2.NimbusOAuth2Client.getJWTClaimsSet(NimbusOAuth2Client.java:371)
    at io.trino.server.security.oauth2.NimbusOAuth2Client$OAuth2WithOidcExtensionsCodeFlow.toResponse(NimbusOAuth2Client.java:303)
    at io.trino.server.security.oauth2.NimbusOAuth2Client$OAuth2WithOidcExtensionsCodeFlow.getOAuth2Response(NimbusOAuth2Client.java:285)
    at io.trino.server.security.oauth2.NimbusOAuth2Client.getOAuth2Response(NimbusOAuth2Client.java:168)
    at io.trino.server.security.oauth2.OAuth2Service.finishOAuth2Challenge(OAuth2Service.java:169)
    at io.trino.server.security.oauth2.OAuth2CallbackResource.callback(OAuth2CallbackResource.java:71)
```

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
