### PR TITLE
Remove deprecated `ConnectorMetadata.dropSchema` method from SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -348,15 +348,6 @@ public class TracingConnectorMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
-    {
-        Span span = startSpan("dropSchema", schemaName);
-        try (var ignored = scopedSpan(span)) {
-            delegate.dropSchema(session, schemaName);
-        }
-    }
-
-    @Override
     public void renameSchema(ConnectorSession session, String source, String target)
     {
         Span span = startSpan("renameSchema", source);

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -499,7 +499,7 @@ public class MockConnector
         public void setSchemaAuthorization(ConnectorSession session, String schemaName, TrinoPrincipal principal) {}
 
         @Override
-        public void dropSchema(ConnectorSession session, String schemaName) {}
+        public void dropSchema(ConnectorSession session, String schemaName, boolean cascade) {}
 
         @Override
         public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -439,21 +439,6 @@ public interface ConnectorMetadata
      */
     default void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
-        if (!cascade) {
-            dropSchema(session, schemaName);
-            return;
-        }
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas with CASCADE option");
-    }
-
-    /**
-     * Drops the specified schema.
-     *
-     * @deprecated use {@link #dropSchema(ConnectorSession, String, boolean)}
-     */
-    @Deprecated
-    default void dropSchema(ConnectorSession session, String schemaName)
-    {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas");
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -399,14 +399,6 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
-    {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropSchema(session, schemaName);
-        }
-    }
-
-    @Override
     public void renameSchema(ConnectorSession session, String source, String target)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
@@ -89,8 +89,11 @@ public class AccumuloMetadata
     }
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
+    public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
+        if (cascade) {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping schemas with CASCADE option");
+        }
         client.dropSchema(schemaName);
     }
 


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# SPI
* Remove deprecated `io.trino.spi.connector.ConnectorMetadata#dropSchema(ConnectorSession session, String schemaName)` method. ({issue}`18839`)
```
