### PR TITLE
Remove Iceberg materialized view storage tables from metastores

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -20,6 +20,7 @@ import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
+import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -71,6 +72,7 @@ public class IcebergConfig
     // to avoid deleting those files if Trino is unable to check.
     private boolean deleteSchemaLocationsFallback;
     private double minimumAssignedSplitWeight = 0.05;
+    private boolean hideMaterializedViewStorageTable = true;
     private Optional<String> materializedViewsStorageSchema = Optional.empty();
     private boolean sortedWritingEnabled = true;
     private boolean queryPartitionFilterRequired;
@@ -342,6 +344,19 @@ public class IcebergConfig
         return minimumAssignedSplitWeight;
     }
 
+    public boolean isHideMaterializedViewStorageTable()
+    {
+        return hideMaterializedViewStorageTable;
+    }
+
+    @Config("iceberg.materialized-views.hide-storage-table")
+    @ConfigDescription("Hide materialized view storage tables in metastore")
+    public IcebergConfig setHideMaterializedViewStorageTable(boolean hideMaterializedViewStorageTable)
+    {
+        this.hideMaterializedViewStorageTable = hideMaterializedViewStorageTable;
+        return this;
+    }
+
     @NotNull
     public Optional<String> getMaterializedViewsStorageSchema()
     {
@@ -380,5 +395,11 @@ public class IcebergConfig
     public boolean isQueryPartitionFilterRequired()
     {
         return queryPartitionFilterRequired;
+    }
+
+    @AssertFalse(message = "iceberg.materialized-views.storage-schema may only be set when iceberg.materialized-views.hide-storage-table is set to false")
+    public boolean isStorageSchemaSetWhenHidingIsEnabled()
+    {
+        return hideMaterializedViewStorageTable && materializedViewsStorageSchema.isPresent();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -296,7 +296,7 @@ public class IcebergFileWriterFactory
                 .collect(toImmutableList());
 
         return new IcebergAvroFileWriter(
-                new ForwardingOutputFile(fileSystem, outputPath.toString()),
+                new ForwardingOutputFile(fileSystem, outputPath),
                 rollbackAction,
                 icebergSchema,
                 columnTypes,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -224,6 +224,9 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.isMergeManifestsO
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isQueryPartitionFilterRequired;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isStatisticsEnabled;
+import static io.trino.plugin.iceberg.IcebergTableName.isDataTable;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
+import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
@@ -265,6 +268,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.QUERY_REJECTED;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.FRESH;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.STALE;
 import static io.trino.spi.connector.MaterializedViewFreshness.Freshness.UNKNOWN;
@@ -384,7 +388,21 @@ public class IcebergMetadata
             throw new TrinoException(NOT_SUPPORTED, "Read table with start version is not supported");
         }
 
-        if (!IcebergTableName.isDataTable(tableName.getTableName())) {
+        if (isMaterializedViewStorage(tableName.getTableName())) {
+            verify(endVersion.isEmpty(), "Materialized views do not support versioned queries");
+
+            SchemaTableName materializedViewName = new SchemaTableName(tableName.getSchemaName(), tableNameFrom(tableName.getTableName()));
+            if (getMaterializedView(session, materializedViewName).isEmpty()) {
+                throw new TableNotFoundException(tableName);
+            }
+
+            BaseTable storageTable = catalog.getMaterializedViewStorageTable(session, materializedViewName)
+                    .orElseThrow(() -> new TrinoException(TABLE_NOT_FOUND, "Storage table metadata not found for materialized view " + tableName));
+
+            return tableHandleForCurrentSnapshot(tableName, storageTable);
+        }
+
+        if (!isDataTable(tableName.getTableName())) {
             // Pretend the table does not exist to produce better error message in case of table redirects to Hive
             return null;
         }
@@ -405,23 +423,36 @@ public class IcebergMetadata
             throw e;
         }
 
-        Optional<Long> tableSnapshotId;
-        Schema tableSchema;
-        Optional<PartitionSpec> partitionSpec;
         if (endVersion.isPresent()) {
             long snapshotId = getSnapshotIdFromVersion(session, table, endVersion.get());
-            tableSnapshotId = Optional.of(snapshotId);
-            tableSchema = schemaFor(table, snapshotId);
-            partitionSpec = Optional.empty();
+            return tableHandleForSnapshot(
+                    tableName,
+                    table,
+                    Optional.of(snapshotId),
+                    schemaFor(table, snapshotId),
+                    Optional.empty());
         }
-        else {
-            tableSnapshotId = Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId);
-            tableSchema = table.schema();
-            partitionSpec = Optional.of(table.spec());
-        }
+        return tableHandleForCurrentSnapshot(tableName, table);
+    }
 
+    private IcebergTableHandle tableHandleForCurrentSnapshot(SchemaTableName tableName, BaseTable table)
+    {
+        return tableHandleForSnapshot(
+                tableName,
+                table,
+                Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId),
+                table.schema(),
+                Optional.of(table.spec()));
+    }
+
+    private IcebergTableHandle tableHandleForSnapshot(
+            SchemaTableName tableName,
+            BaseTable table,
+            Optional<Long> tableSnapshotId,
+            Schema tableSchema,
+            Optional<PartitionSpec> partitionSpec)
+    {
         Map<String, String> tableProperties = table.properties();
-        String nameMappingJson = tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING);
         return new IcebergTableHandle(
                 trinoCatalogHandle,
                 tableName.getSchemaName(),
@@ -435,7 +466,7 @@ public class IcebergMetadata
                 TupleDomain.all(),
                 OptionalLong.empty(),
                 ImmutableSet.of(),
-                Optional.ofNullable(nameMappingJson),
+                Optional.ofNullable(tableProperties.get(TableProperties.DEFAULT_NAME_MAPPING)),
                 table.location(),
                 table.properties(),
                 false,
@@ -517,12 +548,12 @@ public class IcebergMetadata
 
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
-        if (IcebergTableName.isDataTable(tableName.getTableName())) {
+        if (isDataTable(tableName.getTableName()) || isMaterializedViewStorage(tableName.getTableName())) {
             return Optional.empty();
         }
 
         // Only when dealing with an actual system table proceed to retrieve the base table for the system table
-        String name = IcebergTableName.tableNameFrom(tableName.getTableName());
+        String name = tableNameFrom(tableName.getTableName());
         Table table;
         try {
             table = catalog.loadTable(session, new SchemaTableName(tableName.getSchemaName(), name));
@@ -549,6 +580,7 @@ public class IcebergMetadata
             case FILES -> Optional.of(new FilesTable(systemTableName, typeManager, table, getCurrentSnapshotId(table)));
             case PROPERTIES -> Optional.of(new PropertiesTable(systemTableName, table));
             case REFS -> Optional.of(new RefsTable(systemTableName, table));
+            case MATERIALIZED_VIEW_STORAGE -> throw new VerifyException("Unexpected MATERIALIZED_VIEW_STORAGE table type");
         };
     }
 
@@ -2902,9 +2934,12 @@ public class IcebergMetadata
                 .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + materializedViewName));
 
         Table icebergTable = catalog.loadTable(session, storageTableName);
-        String dependsOnTables = icebergTable.currentSnapshot().summary().getOrDefault(DEPENDS_ON_TABLES, "");
+        String dependsOnTables = Optional.ofNullable(icebergTable.currentSnapshot())
+                .map(snapshot -> snapshot.summary().getOrDefault(DEPENDS_ON_TABLES, ""))
+                .orElse("");
         if (dependsOnTables.isEmpty()) {
-            // Information missing. While it's "unknown" whether storage is stale, we return "stale": under no normal circumstances dependsOnTables should be missing.
+            // Information missing. While it's "unknown" whether storage is stale, we return "stale".
+            // Normally dependsOnTables may be missing only when there was no refresh yet.
             return new MaterializedViewFreshness(STALE, Optional.empty());
         }
         Instant refreshTime = Optional.ofNullable(icebergTable.currentSnapshot().summary().get(TRINO_QUERY_START_TIME))

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableName.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableName.java
@@ -20,6 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static io.trino.plugin.iceberg.TableType.DATA;
+import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -79,5 +80,11 @@ public final class IcebergTableName
         }
         String typeString = match.group("type");
         return typeString == null;
+    }
+
+    public static boolean isMaterializedViewStorage(String name)
+    {
+        Optional<TableType> tableType = tableTypeFrom(name);
+        return tableType.isPresent() && tableType.get() == MATERIALIZED_VIEW_STORAGE;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -644,7 +644,7 @@ public final class IcebergUtil
         return catalog.newCreateTableTransaction(session, schemaTableName, schema, partitionSpec, sortOrder, targetPath, createTableProperties(tableMetadata));
     }
 
-    private static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata)
+    public static Map<String, String> createTableProperties(ConnectorTableMetadata tableMetadata)
     {
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
         IcebergFileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
@@ -22,5 +22,6 @@ public enum TableType
     PARTITIONS,
     FILES,
     PROPERTIES,
-    REFS
+    REFS,
+    MATERIALIZED_VIEW_STORAGE,
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -48,6 +48,7 @@ import static io.trino.plugin.hive.util.HiveClassNames.FILE_OUTPUT_FORMAT_CLASS;
 import static io.trino.plugin.hive.util.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_MISSING_METADATA;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
 import static io.trino.plugin.iceberg.IcebergUtil.METADATA_FOLDER_NAME;
 import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
 import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
@@ -152,6 +153,11 @@ public abstract class AbstractIcebergTableOperations
             return;
         }
 
+        if (isMaterializedViewStorage(tableName)) {
+            commitMaterializedViewRefresh(base, metadata);
+            return;
+        }
+
         if (base == null) {
             if (PROVIDER_PROPERTY_VALUE.equals(metadata.properties().get(PROVIDER_PROPERTY_KEY))) {
                 // Assume this is a table executing migrate procedure
@@ -175,6 +181,8 @@ public abstract class AbstractIcebergTableOperations
     protected abstract void commitNewTable(TableMetadata metadata);
 
     protected abstract void commitToExistingTable(TableMetadata base, TableMetadata metadata);
+
+    protected abstract void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata);
 
     @Override
     public FileIO io()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -24,6 +24,7 @@ import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -167,6 +168,8 @@ public interface TrinoCatalog
     void dropMaterializedView(ConnectorSession session, SchemaTableName viewName);
 
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName);
+
+    Optional<BaseTable> getMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName);
 
     void renameMaterializedView(ConnectorSession session, SchemaTableName source, SchemaTableName target);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -835,8 +835,8 @@ public class TrinoGlueCatalog
             }
 
             try {
-                createMaterializedViewDefinition(session, schemaTableName, table)
-                        .ifPresent(materializedView -> materializedViewCache.put(schemaTableName, materializedView));
+                ConnectorMaterializedViewDefinition materializedView = createMaterializedViewDefinition(session, schemaTableName, table);
+                materializedViewCache.put(schemaTableName, materializedView);
             }
             catch (RuntimeException e) {
                 LOG.warn(e, "Failed to cache materialized view from %s", schemaTableName);
@@ -1261,10 +1261,10 @@ public class TrinoGlueCatalog
             return Optional.empty();
         }
 
-        return createMaterializedViewDefinition(session, viewName, table);
+        return Optional.of(createMaterializedViewDefinition(session, viewName, table));
     }
 
-    private Optional<ConnectorMaterializedViewDefinition> createMaterializedViewDefinition(
+    private ConnectorMaterializedViewDefinition createMaterializedViewDefinition(
             ConnectorSession session,
             SchemaTableName viewName,
             com.amazonaws.services.glue.model.Table table)
@@ -1293,11 +1293,11 @@ public class TrinoGlueCatalog
         if (viewOriginalText == null) {
             throw new TrinoException(ICEBERG_BAD_DATA, "Materialized view did not have original text " + viewName);
         }
-        return Optional.of(getMaterializedViewDefinition(
+        return getMaterializedViewDefinition(
                 icebergTable,
                 Optional.ofNullable(table.getOwner()),
                 viewOriginalText,
-                storageTableName));
+                storageTableName);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -53,6 +53,7 @@ import io.trino.plugin.iceberg.IcebergMetadata;
 import io.trino.plugin.iceberg.UnknownTableTypeException;
 import io.trino.plugin.iceberg.catalog.AbstractTrinoCatalog;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
@@ -821,14 +822,7 @@ public class TrinoGlueCatalog
             String metadataLocation = parameters.get(METADATA_LOCATION_PROP);
             try {
                 // Cache the TableMetadata while we have the Table retrieved anyway
-                TableOperations operations = tableOperationsProvider.createTableOperations(
-                        this,
-                        session,
-                        schemaTableName.getSchemaName(),
-                        schemaTableName.getTableName(),
-                        Optional.empty(),
-                        Optional.empty());
-                FileIO io = operations.io();
+                ForwardingFileIo io = new ForwardingFileIo(fileSystemFactory.create(session));
                 tableMetadataCache.put(schemaTableName, TableMetadataParser.read(io, io.newInputFile(metadataLocation)));
             }
             catch (RuntimeException e) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalogFactory.java
@@ -45,6 +45,7 @@ public class TrinoGlueCatalogFactory
     private final Optional<String> defaultSchemaLocation;
     private final AWSGlueAsync glueClient;
     private final boolean isUniqueTableLocation;
+    private final boolean hideMaterializedViewStorageTable;
     private final GlueMetastoreStats stats;
 
     @Inject
@@ -69,6 +70,7 @@ public class TrinoGlueCatalogFactory
         this.defaultSchemaLocation = glueConfig.getDefaultWarehouseDir();
         this.glueClient = requireNonNull(glueClient, "glueClient is null");
         this.isUniqueTableLocation = icebergConfig.isUniqueTableLocation();
+        this.hideMaterializedViewStorageTable = icebergConfig.isHideMaterializedViewStorageTable();
         this.stats = requireNonNull(stats, "stats is null");
     }
 
@@ -92,6 +94,7 @@ public class TrinoGlueCatalogFactory
                 glueClient,
                 stats,
                 defaultSchemaLocation,
-                isUniqueTableLocation);
+                isUniqueTableLocation,
+                hideMaterializedViewStorageTable);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/AbstractMetastoreTableOperations.java
@@ -38,6 +38,8 @@ import static io.trino.plugin.hive.ViewReaderUtil.isTrinoView;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergTableName.isMaterializedViewStorage;
+import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -71,14 +73,23 @@ public abstract class AbstractMetastoreTableOperations
         if (invalidateCaches) {
             metastore.invalidateTable(database, tableName);
         }
-        Table table = getTable();
 
-        if (isTrinoView(table) || isTrinoMaterializedView(table)) {
+        boolean isMaterializedViewStorageTable = isMaterializedViewStorage(tableName);
+
+        Table table;
+        if (isMaterializedViewStorageTable) {
+            table = getTable(database, tableNameFrom(tableName));
+        }
+        else {
+            table = getTable();
+        }
+
+        if (!isMaterializedViewStorageTable && (isTrinoView(table) || isTrinoMaterializedView(table))) {
             // this is a Hive view or Trino/Presto view, or Trino materialized view, hence not a table
             // TODO table operations should not be constructed for views (remove exception-driven code path)
             throw new TableNotFoundException(getSchemaTableName());
         }
-        if (!isIcebergTable(table)) {
+        if (!isMaterializedViewStorageTable && !isIcebergTable(table)) {
             throw new UnknownTableTypeException(getSchemaTableName());
         }
 
@@ -132,6 +143,11 @@ public abstract class AbstractMetastoreTableOperations
     }
 
     protected Table getTable()
+    {
+        return getTable(database, tableName);
+    }
+
+    protected Table getTable(String database, String tableName)
     {
         return metastore.getTable(database, tableName)
                 .orElseThrow(() -> new TableNotFoundException(getSchemaTableName()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -29,13 +29,16 @@ import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.io.FileIO;
 
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiTable;
+import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
 import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
+import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
 
 @NotThreadSafe
 public class HiveMetastoreTableOperations
@@ -61,15 +64,33 @@ public class HiveMetastoreTableOperations
     @Override
     protected void commitToExistingTable(TableMetadata base, TableMetadata metadata)
     {
-        String newMetadataLocation = writeNewMetadata(metadata, version.orElseThrow() + 1);
+        Table currentTable = getTable();
+        commitTableUpdate(currentTable, metadata, (table, newMetadataLocation) -> Table.builder(table)
+                .apply(builder -> updateMetastoreTable(builder, metadata, newMetadataLocation, Optional.of(currentMetadataLocation)))
+                .build());
+    }
 
+    @Override
+    protected final void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    {
+        Table materializedView = getTable(database, tableNameFrom(tableName));
+        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> Table.builder(table)
+                .apply(builder -> builder
+                        .setParameter(METADATA_LOCATION_PROP, newMetadataLocation)
+                        .setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation))
+                .build());
+    }
+
+    private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
+    {
+        String newMetadataLocation = writeNewMetadata(metadata, version.orElseThrow() + 1);
         long lockId = thriftMetastore.acquireTableExclusiveLock(
                 new AcidTransactionOwner(session.getUser()),
                 session.getQueryId(),
-                database,
-                tableName);
+                table.getDatabaseName(),
+                table.getTableName());
         try {
-            Table currentTable = fromMetastoreApiTable(thriftMetastore.getTable(database, tableName)
+            Table currentTable = fromMetastoreApiTable(thriftMetastore.getTable(database, table.getTableName())
                     .orElseThrow(() -> new TableNotFoundException(getSchemaTableName())));
 
             checkState(currentMetadataLocation != null, "No current metadata location for existing table");
@@ -79,14 +100,12 @@ public class HiveMetastoreTableOperations
                         currentMetadataLocation, metadataLocation, getSchemaTableName());
             }
 
-            Table table = Table.builder(currentTable)
-                    .apply(builder -> updateMetastoreTable(builder, metadata, newMetadataLocation, Optional.of(currentMetadataLocation)))
-                    .build();
+            Table updatedTable = tableUpdateFunction.apply(table, newMetadataLocation);
 
             // todo privileges should not be replaced for an alter
             PrincipalPrivileges privileges = table.getOwner().map(MetastoreUtil::buildInitialPrivilegeSet).orElse(NO_PRIVILEGES);
             try {
-                metastore.replaceTable(database, tableName, table, privileges);
+                metastore.replaceTable(table.getDatabaseName(), table.getTableName(), updatedTable, privileges);
             }
             catch (RuntimeException e) {
                 // Cannot determine whether the `replaceTable` operation was successful,
@@ -103,7 +122,7 @@ public class HiveMetastoreTableOperations
                 // So, that underlying iceberg API will not do the metadata cleanup, otherwise table will be in unusable state.
                 // If configured and supported, the unreleased lock will be automatically released by the metastore after not hearing a heartbeat for a while,
                 // or otherwise it might need to be manually deleted from the metastore backend storage.
-                log.error(e, "Failed to release lock %s when committing to table %s", lockId, tableName);
+                log.error(e, "Failed to release lock %s when committing to table %s", lockId, table.getTableName());
             }
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalogFactory.java
@@ -47,6 +47,7 @@ public class TrinoHiveCatalogFactory
     private final boolean isUniqueTableLocation;
     private final boolean isUsingSystemSecurity;
     private final boolean deleteSchemaLocationsFallback;
+    private final boolean hideMaterializedViewStorageTable;
 
     @Inject
     public TrinoHiveCatalogFactory(
@@ -68,6 +69,7 @@ public class TrinoHiveCatalogFactory
         this.isUniqueTableLocation = config.isUniqueTableLocation();
         this.isUsingSystemSecurity = securityConfig.getSecuritySystem() == SYSTEM;
         this.deleteSchemaLocationsFallback = config.isDeleteSchemaLocationsFallback();
+        this.hideMaterializedViewStorageTable = config.isHideMaterializedViewStorageTable();
     }
 
     @Override
@@ -83,6 +85,7 @@ public class TrinoHiveCatalogFactory
                 tableOperationsProvider,
                 isUniqueTableLocation,
                 isUsingSystemSecurity,
-                deleteSchemaLocationsFallback);
+                deleteSchemaLocationsFallback,
+                hideMaterializedViewStorageTable);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
@@ -67,4 +67,10 @@ public class IcebergJdbcTableOperations
         jdbcClient.alterTable(database, tableName, newMetadataLocation, currentMetadataLocation);
         shouldRefresh = true;
     }
+
+    @Override
+    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -91,7 +91,7 @@ public class TrinoJdbcCatalog
             boolean useUniqueTableLocation,
             String defaultWarehouseDir)
     {
-        super(catalogName, typeManager, tableOperationsProvider, useUniqueTableLocation);
+        super(catalogName, typeManager, tableOperationsProvider, fileSystemFactory, useUniqueTableLocation);
         this.jdbcCatalog = requireNonNull(jdbcCatalog, "jdbcCatalog is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
@@ -403,6 +403,12 @@ public class TrinoJdbcCatalog
     protected Optional<ConnectorMaterializedViewDefinition> doGetMaterializedView(ConnectorSession session, SchemaTableName schemaViewName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<BaseTable> getMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "The Iceberg JDBC catalog does not support materialized views");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
@@ -126,6 +126,12 @@ public class IcebergNessieTableOperations
         shouldRefresh = true;
     }
 
+    @Override
+    protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     private static ContentKey toKey(SchemaTableName tableName)
     {
         return ContentKey.of(Namespace.parse(tableName.getSchemaName()), tableName.getTableName());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -81,7 +81,7 @@ public class TrinoNessieCatalog
             String warehouseLocation,
             boolean useUniqueTableLocation)
     {
-        super(catalogName, typeManager, tableOperationsProvider, useUniqueTableLocation);
+        super(catalogName, typeManager, tableOperationsProvider, fileSystemFactory, useUniqueTableLocation);
         this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
         this.warehouseLocation = requireNonNull(warehouseLocation, "warehouseLocation is null");
         this.nessieClient = requireNonNull(nessieClient, "nessieClient is null");
@@ -394,6 +394,12 @@ public class TrinoNessieCatalog
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName schemaViewName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<BaseTable> getMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "The Iceberg Nessie catalog does not support materialized views");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -436,6 +436,12 @@ public class TrinoRestCatalog
     }
 
     @Override
+    public Optional<BaseTable> getMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "The Iceberg REST catalog does not support materialized views");
+    }
+
+    @Override
     public void renameMaterializedView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
     {
         throw new TrinoException(NOT_SUPPORTED, "renameMaterializedView is not supported for Iceberg REST catalog");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingFileIo.java
@@ -57,7 +57,7 @@ public class ForwardingFileIo
     @Override
     public OutputFile newOutputFile(String path)
     {
-        return new ForwardingOutputFile(fileSystem, path);
+        return new ForwardingOutputFile(fileSystem, Location.of(path));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingOutputFile.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/fileio/ForwardingOutputFile.java
@@ -33,10 +33,10 @@ public class ForwardingOutputFile
     private final TrinoFileSystem fileSystem;
     private final TrinoOutputFile outputFile;
 
-    public ForwardingOutputFile(TrinoFileSystem fileSystem, String path)
+    public ForwardingOutputFile(TrinoFileSystem fileSystem, Location location)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
-        this.outputFile = fileSystem.newOutputFile(Location.of(path));
+        this.outputFile = fileSystem.newOutputFile(location);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -6701,30 +6701,6 @@ public abstract class BaseIcebergConnectorTest
                 "WHEN MATCHED THEN UPDATE SET b = t.b * 50", tableName, sourceTableName)));
     }
 
-    @Test
-    public void testMaterializedViewSnapshotSummariesHaveTrinoQueryId()
-    {
-        String matViewName = "test_materialized_view_snapshot_query_ids" + randomNameSuffix();
-        String sourceTableName = "test_source_table_for_mat_view" + randomNameSuffix();
-        assertUpdate(format("CREATE TABLE %s (a bigint, b bigint)", sourceTableName));
-        assertUpdate(format("INSERT INTO %s VALUES (1, 1), (1, 4), (2, 2)", sourceTableName), 3);
-
-        // create a materialized view
-        QueryId matViewCreateQueryId = getDistributedQueryRunner()
-                .executeWithQueryId(getSession(), format("CREATE MATERIALIZED VIEW %s WITH (partitioning = ARRAY['a']) AS SELECT * FROM %s", matViewName, sourceTableName))
-                .getQueryId();
-
-        // fetch the underlying storage table name so we can inspect its snapshot summary after the REFRESH
-        // running queries against "materialized_view$snapshots" is not supported
-        String storageTable = (String) getDistributedQueryRunner()
-                .execute(getSession(), format("SELECT storage_table FROM system.metadata.materialized_views WHERE name = '%s'", matViewName))
-                .getOnlyValue();
-
-        assertQueryIdStored(storageTable, matViewCreateQueryId);
-
-        assertQueryIdStored(storageTable, executeWithQueryId(format("REFRESH MATERIALIZED VIEW %s", matViewName)));
-    }
-
     @Override
     protected OptionalInt maxTableNameLength()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -15,32 +15,32 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
-import io.trino.metadata.MaterializedViewDefinition;
-import io.trino.metadata.QualifiedObjectName;
-import io.trino.spi.connector.SchemaTableName;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.local.LocalFileSystem;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
+import io.trino.spi.QueryId;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.MaterializedRow;
-import io.trino.transaction.TransactionId;
-import io.trino.transaction.TransactionManager;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.assertj.core.api.Condition;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.SystemSessionProperties.LEGACY_MATERIALIZED_VIEW_GRACE_PERIOD;
 import static io.trino.testing.MaterializedResult.DEFAULT_PRECISION;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DELETE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_MATERIALIZED_VIEW;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.REFRESH_MATERIALIZED_VIEW;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_MATERIALIZED_VIEW;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
-import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.privilege;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
@@ -52,9 +52,9 @@ import static org.testng.Assert.assertEquals;
 public abstract class BaseIcebergMaterializedViewTest
         extends AbstractTestQueryFramework
 {
-    protected final String storageSchemaName = "testing_storage_schema_" + randomNameSuffix();
-
     protected abstract String getSchemaDirectory();
+
+    protected abstract String getStorageMetadataLocation(String materializedViewName);
 
     @BeforeClass
     public void setUp()
@@ -65,17 +65,13 @@ public abstract class BaseIcebergMaterializedViewTest
 
         assertUpdate("CREATE TABLE base_table2 (_varchar VARCHAR, _bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_bigint', '_date'])");
         assertUpdate("INSERT INTO base_table2 VALUES ('a', 0, DATE '2019-09-08'), ('a', 1, DATE '2019-09-08'), ('a', 0, DATE '2019-09-09')", 3);
-
-        assertUpdate("CREATE SCHEMA " + storageSchemaName);
     }
 
     @Test
     public void testShowTables()
     {
         assertUpdate("CREATE MATERIALIZED VIEW materialized_view_show_tables_test AS SELECT * FROM base_table1");
-        SchemaTableName storageTableName = getStorageTable("materialized_view_show_tables_test");
-
-        Set<String> expectedTables = ImmutableSet.of("base_table1", "base_table2", "materialized_view_show_tables_test", storageTableName.getTableName());
+        Set<String> expectedTables = ImmutableSet.of("base_table1", "base_table2", "materialized_view_show_tables_test");
         Set<String> actualTables = computeActual("SHOW TABLES").getOnlyColumnAsSet().stream()
                 .map(String.class::cast)
                 .collect(toImmutableSet());
@@ -106,20 +102,6 @@ public abstract class BaseIcebergMaterializedViewTest
 
         computeActual("CREATE TABLE small_region AS SELECT * FROM tpch.tiny.region LIMIT 1");
         computeActual(format("CREATE MATERIALIZED VIEW %s AS SELECT * FROM small_region LIMIT 1", materializedViewName));
-
-        // test storage table name
-        assertQuery(
-                format(
-                        "SELECT storage_catalog, storage_schema, CONCAT(storage_schema, '.', storage_table)" +
-                                "FROM system.metadata.materialized_views WHERE schema_name = '%s' AND name = '%s'",
-                        // TODO (https://github.com/trinodb/trino/issues/9039) remove redundant schema_name filter
-                        schemaName,
-                        materializedViewName),
-                format(
-                        "VALUES ('%s', '%s', '%s')",
-                        catalogName,
-                        schemaName,
-                        getStorageTable(catalogName, schemaName, materializedViewName)));
 
         // test freshness update
         assertQuery(
@@ -182,7 +164,7 @@ public abstract class BaseIcebergMaterializedViewTest
                                 "WITH (\n" +
                                 "   format = 'ORC',\n" +
                                 "   format_version = 2,\n" +
-                                "   location = '" + getSchemaDirectory() + "/st_\\E[0-9a-f]+-[0-9a-f]+\\Q',\n" +
+                                "   location = '" + getSchemaDirectory() + "/test_mv_show_create-\\E[0-9a-f]+\\Q',\n" +
                                 "   orc_bloom_filter_columns = ARRAY['_date'],\n" +
                                 "   orc_bloom_filter_fpp = 1E-1,\n" +
                                 "   partitioning = ARRAY['_date'],\n" +
@@ -267,22 +249,6 @@ public abstract class BaseIcebergMaterializedViewTest
                 privilege("materialized_view_refresh_deny", REFRESH_MATERIALIZED_VIEW));
 
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_refresh_deny");
-    }
-
-    @Test
-    public void testRefreshAllowedWithRestrictedStorageTable()
-    {
-        assertUpdate("CREATE MATERIALIZED VIEW materialized_view_refresh AS SELECT * FROM base_table1");
-        SchemaTableName storageTable = getStorageTable("materialized_view_refresh");
-
-        assertAccessAllowed(
-                "REFRESH MATERIALIZED VIEW materialized_view_refresh",
-                privilege(storageTable.getTableName(), INSERT_TABLE),
-                privilege(storageTable.getTableName(), DELETE_TABLE),
-                privilege(storageTable.getTableName(), UPDATE_TABLE),
-                privilege(storageTable.getTableName(), SELECT_COLUMN));
-
-        assertUpdate("DROP MATERIALIZED VIEW materialized_view_refresh");
     }
 
     @Test
@@ -524,7 +490,7 @@ public abstract class BaseIcebergMaterializedViewTest
                         "WITH (\n" +
                         "   format = 'PARQUET',\n" +
                         "   format_version = 2,\n" +
-                        "   location = '" + getSchemaDirectory() + "/st_\\E[0-9a-f]+-[0-9a-f]+\\Q',\n" +
+                        "   location = '" + getSchemaDirectory() + "/materialized_view_window-\\E[0-9a-f]+\\Q',\n" +
                         "   partitioning = ARRAY['_date'],\n" +
                         "   storage_schema = '" + schema + "'\n" +
                         ") AS\n" +
@@ -632,47 +598,6 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("DROP MATERIALIZED VIEW materialized_view_level2");
     }
 
-    @Test
-    public void testStorageSchemaProperty()
-    {
-        String schemaName = getSession().getSchema().orElseThrow();
-        String viewName = "storage_schema_property_test";
-        assertUpdate(
-                "CREATE MATERIALIZED VIEW " + viewName + " " +
-                        "WITH (storage_schema = '" + storageSchemaName + "') AS " +
-                        "SELECT * FROM base_table1");
-        SchemaTableName storageTable = getStorageTable(viewName);
-        assertThat(storageTable.getSchemaName()).isEqualTo(storageSchemaName);
-
-        assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 6);
-        assertThat(computeActual("SELECT * FROM " + viewName).getRowCount()).isEqualTo(6);
-        assertThat(getExplainPlan("SELECT * FROM " + viewName, ExplainType.Type.IO))
-                .doesNotContain("base_table1")
-                .contains(storageSchemaName);
-
-        assertThat((String) computeScalar("SHOW CREATE MATERIALIZED VIEW " + viewName))
-                .contains("storage_schema = '" + storageSchemaName + "'");
-
-        Set<String> storageSchemaTables = computeActual("SHOW TABLES IN " + storageSchemaName).getOnlyColumnAsSet().stream()
-                .map(String.class::cast)
-                .collect(toImmutableSet());
-        assertThat(storageSchemaTables).contains(storageTable.getTableName());
-
-        assertUpdate("DROP MATERIALIZED VIEW " + viewName);
-        storageSchemaTables = computeActual("SHOW TABLES IN " + storageSchemaName).getOnlyColumnAsSet().stream()
-                .map(String.class::cast)
-                .collect(toImmutableSet());
-        assertThat(storageSchemaTables).doesNotContain(storageTable.getTableName());
-
-        assertThatThrownBy(() -> query(
-                "CREATE MATERIALIZED VIEW " + viewName + " " +
-                        "WITH (storage_schema = 'non_existent') AS " +
-                        "SELECT * FROM base_table1"))
-                .hasMessageContaining("non_existent not found");
-        assertThatThrownBy(() -> query("DESCRIBE " + viewName))
-                .hasMessageContaining(format("'iceberg.%s.%s' does not exist", schemaName, viewName));
-    }
-
     @Test(dataProvider = "testBucketPartitioningDataProvider")
     public void testBucketPartitioning(String dataType, String exampleValue)
     {
@@ -683,9 +608,11 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE MATERIALIZED VIEW test_bucket_partitioning WITH (partitioning=ARRAY['bucket(col, 4)']) AS SELECT * FROM (VALUES CAST(NULL AS %s), %s) t(col)"
                 .formatted(dataType, exampleValue));
         try {
-            SchemaTableName storageTable = getStorageTable("test_bucket_partitioning");
-            assertThat((String) computeScalar("SHOW CREATE TABLE " + storageTable))
-                    .contains("partitioning = ARRAY['bucket(col, 4)']");
+            TableMetadata storageMetadata = getStorageTableMetadata( "test_bucket_partitioning");
+            assertThat(storageMetadata.spec().fields()).hasSize(1);
+            PartitionField bucketPartitionField = getOnlyElement(storageMetadata.spec().fields());
+            assertThat(bucketPartitionField.name()).isEqualTo("col_bucket");
+            assertThat(bucketPartitionField.transform().toString()).isEqualTo("bucket[4]");
 
             assertThat(query("SELECT * FROM test_bucket_partitioning WHERE col = " + exampleValue))
                     .matches("SELECT " + exampleValue);
@@ -724,9 +651,11 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE MATERIALIZED VIEW test_truncate_partitioning WITH (partitioning=ARRAY['truncate(col, 4)']) AS SELECT * FROM (VALUES CAST(NULL AS %s), %s) t(col)"
                 .formatted(dataType, exampleValue));
         try {
-            SchemaTableName storageTable = getStorageTable("test_truncate_partitioning");
-            assertThat((String) computeScalar("SHOW CREATE TABLE " + storageTable))
-                    .contains("partitioning = ARRAY['truncate(col, 4)']");
+            TableMetadata storageMetadata = getStorageTableMetadata("test_truncate_partitioning");
+            assertThat(storageMetadata.spec().fields()).hasSize(1);
+            PartitionField bucketPartitionField = getOnlyElement(storageMetadata.spec().fields());
+            assertThat(bucketPartitionField.name()).isEqualTo("col_trunc");
+            assertThat(bucketPartitionField.transform().toString()).isEqualTo("truncate[4]");
 
             assertThat(query("SELECT * FROM test_truncate_partitioning WHERE col = " + exampleValue))
                     .matches("SELECT " + exampleValue);
@@ -759,9 +688,11 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE MATERIALIZED VIEW test_temporal_partitioning WITH (partitioning=ARRAY['%s(col)']) AS SELECT * FROM (VALUES CAST(NULL AS %s), %s) t(col)"
                 .formatted(partitioning, dataType, exampleValue));
         try {
-            SchemaTableName storageTable = getStorageTable("test_temporal_partitioning");
-            assertThat((String) computeScalar("SHOW CREATE TABLE " + storageTable))
-                    .contains("partitioning = ARRAY['%s(col)']".formatted(partitioning));
+            TableMetadata storageMetadata = getStorageTableMetadata("test_temporal_partitioning");
+            assertThat(storageMetadata.spec().fields()).hasSize(1);
+            PartitionField bucketPartitionField = getOnlyElement(storageMetadata.spec().fields());
+            assertThat(bucketPartitionField.name()).isEqualTo("col_" + partitioning);
+            assertThat(bucketPartitionField.transform().toString()).isEqualTo(partitioning);
 
             assertThat(query("SELECT * FROM test_temporal_partitioning WHERE col = " + exampleValue))
                     .matches("SELECT " + exampleValue);
@@ -789,25 +720,40 @@ public abstract class BaseIcebergMaterializedViewTest
         };
     }
 
+    @Test
+    public void testMaterializedViewSnapshotSummariesHaveTrinoQueryId()
+    {
+        String materializedViewName = "test_materialized_view_snapshot_query_ids" + randomNameSuffix();
+        String sourceTableName = "test_source_table_for_mat_view" + randomNameSuffix();
+        assertUpdate(format("CREATE TABLE %s (a bigint, b bigint)", sourceTableName));
+        QueryId matViewCreateQueryId = getDistributedQueryRunner()
+                .executeWithQueryId(getSession(), format("CREATE MATERIALIZED VIEW %s WITH (partitioning = ARRAY['a']) AS SELECT * FROM %s", materializedViewName, sourceTableName))
+                .getQueryId();
+
+        try {
+            assertUpdate(format("INSERT INTO %s VALUES (1, 1), (1, 4), (2, 2)", sourceTableName), 3);
+
+            QueryId refreshQueryId = getDistributedQueryRunner()
+                    .executeWithQueryId(getSession(), format("REFRESH MATERIALIZED VIEW %s", materializedViewName))
+                    .getQueryId();
+            String savedQueryId = getStorageTableMetadata(materializedViewName).currentSnapshot().summary().get("trino_query_id");
+            assertThat(savedQueryId).isEqualTo(refreshQueryId.getId());
+        }
+        finally {
+            assertUpdate("DROP TABLE " + sourceTableName);
+            assertUpdate("DROP MATERIALIZED VIEW " + materializedViewName);
+        }
+    }
+
     protected String getColumnComment(String tableName, String columnName)
     {
         return (String) computeScalar("SELECT comment FROM information_schema.columns WHERE table_schema = '" + getSession().getSchema().orElseThrow() + "' AND table_name = '" + tableName + "' AND column_name = '" + columnName + "'");
     }
 
-    private SchemaTableName getStorageTable(String materializedViewName)
+    private TableMetadata getStorageTableMetadata(String materializedViewName)
     {
-        return getStorageTable(getSession().getCatalog().orElseThrow(), getSession().getSchema().orElseThrow(), materializedViewName);
-    }
-
-    private SchemaTableName getStorageTable(String catalogName, String schemaName, String materializedViewName)
-    {
-        TransactionManager transactionManager = getQueryRunner().getTransactionManager();
-        TransactionId transactionId = transactionManager.beginTransaction(false);
-        Session session = getSession().beginTransactionId(transactionId, transactionManager, getQueryRunner().getAccessControl());
-        Optional<MaterializedViewDefinition> materializedView = getQueryRunner().getMetadata()
-                .getMaterializedView(session, new QualifiedObjectName(catalogName, schemaName, materializedViewName));
-        assertThat(materializedView).isPresent();
-        return materializedView.get().getStorageTable().get().getSchemaTableName();
+        Location metadataLocation = Location.of(getStorageMetadataLocation(materializedViewName));
+        return TableMetadataParser.read(new ForwardingFileIo(new LocalFileSystem(Path.of(metadataLocation.parentDirectory().toString()))), "local:///" + metadataLocation);
     }
 
     private long getLatestSnapshotId(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -14,26 +14,40 @@
 package io.trino.plugin.iceberg;
 
 import io.trino.Session;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.Table;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
-import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
+import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergMaterializedView
         extends BaseIcebergMaterializedViewTest
 {
     private Session secondIceberg;
+    private String fileMetastoreDirectory;
+    private HiveMetastore metastore;
 
     @Override
     protected DistributedQueryRunner createQueryRunner()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createIcebergQueryRunner();
+        File metastoreDir = Files.createTempDirectory("test_iceberg_table_smoke_test").toFile();
+        metastoreDir.deleteOnExit();
+        this.fileMetastoreDirectory = metastoreDir.getAbsolutePath();
+        this.metastore = createTestingFileHiveMetastore(metastoreDir);
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
+                .setMetastoreDirectory(metastoreDir)
+                .build();
         try {
             queryRunner.createCatalog("iceberg2", "iceberg", Map.of(
                     "iceberg.catalog.type", "TESTING_FILE_METASTORE",
@@ -56,7 +70,14 @@ public class TestIcebergMaterializedView
     @Override
     protected String getSchemaDirectory()
     {
-        return getDistributedQueryRunner().getCoordinator().getBaseDataDir().resolve("iceberg_data/tpch").toString();
+        return Path.of(fileMetastoreDirectory, "tpch").toString();
+    }
+
+    @Override
+    protected String getStorageMetadataLocation(String materializedViewName)
+    {
+        Table table = metastore.getTable("tpch", materializedViewName).orElseThrow();
+        return table.getParameters().get(METADATA_LOCATION_PROP);
     }
 
     @Test
@@ -83,7 +104,7 @@ public class TestIcebergMaterializedView
         // After REFRESH, the MV is fresh
         assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_on_iceberg2", 1);
         assertThat(getExplainPlan("TABLE mv_on_iceberg2", ExplainType.Type.IO))
-                .contains("\"table\" : \"st_")
+                .contains("\"table\" : \"mv_on_iceberg2$materialized_view_storage")
                 .doesNotContain("common_base_table");
         assertThat(query("TABLE mv_on_iceberg2"))
                 .matches("VALUES BIGINT '10'");
@@ -91,7 +112,7 @@ public class TestIcebergMaterializedView
         // After INSERT to the base table, the MV is still fresh, because it currently does not detect changes to tables in other catalog.
         assertUpdate(secondIceberg, "INSERT INTO common_base_table VALUES 7", 1);
         assertThat(getExplainPlan("TABLE mv_on_iceberg2", ExplainType.Type.IO))
-                .contains("\"table\" : \"st_")
+                .contains("\"table\" : \"mv_on_iceberg2$materialized_view_storage")
                 .doesNotContain("common_base_table");
         assertThat(query("TABLE mv_on_iceberg2"))
                 .matches("VALUES BIGINT '10'");
@@ -99,7 +120,7 @@ public class TestIcebergMaterializedView
         // After REFRESH, the MV is fresh again
         assertUpdate(defaultIceberg, "REFRESH MATERIALIZED VIEW mv_on_iceberg2", 1);
         assertThat(getExplainPlan("TABLE mv_on_iceberg2", ExplainType.Type.IO))
-                .contains("\"table\" : \"st_")
+                .contains("\"table\" : \"mv_on_iceberg2$materialized_view_storage")
                 .doesNotContain("common_base_table");
         assertThat(query("TABLE mv_on_iceberg2"))
                 .matches("VALUES BIGINT '17'");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMergeAppend.java
@@ -62,7 +62,8 @@ public class TestIcebergMergeAppend
                 tableOperationsProvider,
                 false,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
 
         return queryRunner;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -107,7 +107,6 @@ public class TestIcebergMetadataListing
                         "iceberg_table1",
                         "iceberg_table2",
                         "iceberg_materialized_view",
-                        storageTable.getTableName(),
                         "iceberg_view",
                         "hive_table",
                         "hive_view");
@@ -118,7 +117,6 @@ public class TestIcebergMetadataListing
                         "'iceberg_table1', " +
                         "'iceberg_table2', " +
                         "'iceberg_materialized_view', " +
-                        "'" + storageTable.getTableName() + "', " +
                         "'iceberg_view', " +
                         "'hive_table', " +
                         "'hive_view'");
@@ -136,8 +134,6 @@ public class TestIcebergMetadataListing
                         "('iceberg_table2', '_double'), " +
                         "('iceberg_materialized_view', '_string'), " +
                         "('iceberg_materialized_view', '_integer'), " +
-                        "('" + storageTable.getTableName() + "', '_string'), " +
-                        "('" + storageTable.getTableName() + "', '_integer'), " +
                         "('iceberg_view', '_string'), " +
                         "('iceberg_view', '_integer'), " +
                         "('hive_view', '_double')");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -98,7 +98,8 @@ public class TestIcebergOrcMetricsCollection
                 tableOperationsProvider,
                 false,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
 
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -122,7 +122,8 @@ public class TestIcebergSplitSource
                 new FileMetastoreTableOperationsProvider(fileSystemFactory),
                 false,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
 
         return queryRunner;
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergV2.java
@@ -1036,7 +1036,8 @@ public class TestIcebergV2
                 tableOperationsProvider,
                 false,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
         return (BaseTable) loadIcebergTable(catalog, tableOperationsProvider, SESSION, new SchemaTableName("tpch", tableName));
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestTrinoHiveCatalogWithFileMetastore.java
@@ -18,6 +18,7 @@ import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.TrinoViewHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
+import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalog;
@@ -75,6 +76,7 @@ public class TestTrinoHiveCatalogWithFileMetastore
                 new FileMetastoreTableOperationsProvider(fileSystemFactory),
                 useUniqueTableLocations,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -52,6 +52,7 @@ import static io.trino.plugin.iceberg.TableType.DATA;
 import static io.trino.plugin.iceberg.TableType.FILES;
 import static io.trino.plugin.iceberg.TableType.HISTORY;
 import static io.trino.plugin.iceberg.TableType.MANIFESTS;
+import static io.trino.plugin.iceberg.TableType.MATERIALIZED_VIEW_STORAGE;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
 import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.REFS;
@@ -265,7 +266,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -283,7 +284,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("SELECT * FROM test_select_mview_where_view WHERE age = 2",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 3)
+                            .addCopies(GET_TABLE, 2)
                             .build());
         }
         finally {
@@ -301,7 +302,7 @@ public class TestIcebergGlueCatalogAccessOperations
 
             assertGlueMetastoreApiInvocations("REFRESH MATERIALIZED VIEW test_refresh_mview_view",
                     ImmutableMultiset.builder()
-                            .addCopies(GET_TABLE, 5)
+                            .addCopies(GET_TABLE, 4)
                             .addCopies(UPDATE_TABLE, 1)
                             .build());
         }
@@ -441,9 +442,12 @@ public class TestIcebergGlueCatalogAccessOperations
                             .addCopies(GET_TABLE, 1)
                             .build());
 
+            assertQueryFails("SELECT * FROM \"test_select_snapshots$materialized_view_storage\"",
+                    "Table '" + testSchema + ".test_select_snapshots\\$materialized_view_storage' not found");
+
             // This test should get updated if a new system table is added.
             assertThat(TableType.values())
-                    .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES, REFS);
+                    .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES, REFS, MATERIALIZED_VIEW_STORAGE);
         }
         finally {
             getQueryRunner().execute("DROP TABLE IF EXISTS test_select_snapshots");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -25,6 +25,7 @@ import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
 import io.trino.plugin.iceberg.CommitTaskData;
+import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergMetadata;
 import io.trino.plugin.iceberg.TableStatisticsWriter;
 import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
@@ -79,7 +80,8 @@ public class TestTrinoGlueCatalog
                 glueClient,
                 new GlueMetastoreStats(),
                 Optional.empty(),
-                useUniqueTableLocations);
+                useUniqueTableLocations,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
     }
 
     /**
@@ -157,7 +159,8 @@ public class TestTrinoGlueCatalog
                 glueClient,
                 new GlueMetastoreStats(),
                 Optional.of(tmpDirectory.toAbsolutePath().toString()),
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
 
         String namespace = "test_default_location_" + randomNameSuffix();
         String table = "tableName";

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -33,6 +33,7 @@ import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastore;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreFactory;
+import io.trino.plugin.iceberg.IcebergConfig;
 import io.trino.plugin.iceberg.IcebergSchemaProperties;
 import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
@@ -129,7 +130,8 @@ public class TestTrinoHiveCatalogWithHiveMetastore
                 }),
                 useUniqueTableLocations,
                 false,
-                false);
+                false,
+                new IcebergConfig().isHideMaterializedViewStorageTable());
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static com.google.common.collect.Iterators.getOnlyElement;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tests.product.TestGroups.HMS_ONLY;
 import static io.trino.tests.product.TestGroups.ICEBERG;
@@ -34,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestIcebergHiveMetadataListing
         extends ProductTest
 {
-    private String storageTable;
     private List<QueryAssert.Row> preexistingTables;
     private List<QueryAssert.Row> preexistingColumns;
 
@@ -55,11 +53,6 @@ public class TestIcebergHiveMetadataListing
         onTrino().executeQuery("CREATE TABLE iceberg.default.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
         onTrino().executeQuery("CREATE MATERIALIZED VIEW iceberg.default.iceberg_materialized_view AS " +
                 "SELECT * FROM iceberg.default.iceberg_table1");
-        storageTable = getOnlyElement(onTrino().executeQuery("SHOW TABLES FROM iceberg.default")
-                .column(1).stream()
-                .map(String.class::cast)
-                .filter(name -> name.startsWith("st_"))
-                .iterator());
 
         onTrino().executeQuery("CREATE TABLE hive.default.hive_table (_double DOUBLE)");
         onTrino().executeQuery("CREATE VIEW hive.default.hive_view AS SELECT * FROM hive.default.hive_table");
@@ -84,7 +77,6 @@ public class TestIcebergHiveMetadataListing
                             .addAll(preexistingTables)
                             .add(row("iceberg_table1"))
                             .add(row("iceberg_materialized_view"))
-                            .add(row(storageTable))
                             .add(row("iceberg_view"))
                             .add(row("hive_table"))
                             // Iceberg connector supports Trino views created via Hive connector
@@ -104,8 +96,6 @@ public class TestIcebergHiveMetadataListing
                         .add(row("iceberg_table1", "_integer"))
                         .add(row("iceberg_materialized_view", "_string"))
                         .add(row("iceberg_materialized_view", "_integer"))
-                        .add(row(storageTable, "_string"))
-                        .add(row(storageTable, "_integer"))
                         .add(row("iceberg_view", "_string"))
                         .add(row("iceberg_view", "_integer"))
                         .add(row("hive_view", "_double"))


### PR DESCRIPTION
## Description

Storage tables clutter the namespace, and do not need a separate metastore entry. The pointer to the current metadata file is instead stored in the materialized view properties.

This applies only to newly created materialized views, existing ones are not effected.

## Additional context and related issues

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Newly created Materialized Views will not create a separate entry in the metastore for a storage table.
```
