### PR TITLE
Make some table definitions public

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -103,24 +103,29 @@ public class MaterializedViewSystemTable
         listCatalogNames(session, metadata, accessControl, catalogFilter).forEach(catalogName -> {
             QualifiedTablePrefix tablePrefix = tablePrefix(catalogName, schemaFilter, tableFilter);
 
-            getMaterializedViews(session, metadata, accessControl, tablePrefix).forEach((tableName, definition) -> {
-                QualifiedObjectName name = new QualifiedObjectName(tablePrefix.getCatalogName(), tableName.getSchemaName(), tableName.getTableName());
-                MaterializedViewFreshness freshness;
-
-                try {
-                    freshness = metadata.getMaterializedViewFreshness(session, name);
-                }
-                catch (MaterializedViewNotFoundException e) {
-                    // Ignore materialized view that was dropped during query execution (race condition)
-                    return;
-                }
-
-                Object[] materializedViewRow = createMaterializedViewRow(name, freshness, definition);
-                displayTable.addRow(materializedViewRow);
-            });
+            addMaterializedViewForCatalog(session, displayTable, tablePrefix);
         });
 
         return displayTable.build().cursor();
+    }
+
+    private void addMaterializedViewForCatalog(Session session, InMemoryRecordSet.Builder displayTable, QualifiedTablePrefix tablePrefix)
+    {
+        getMaterializedViews(session, metadata, accessControl, tablePrefix).forEach((tableName, definition) -> {
+            QualifiedObjectName name = new QualifiedObjectName(tablePrefix.getCatalogName(), tableName.getSchemaName(), tableName.getTableName());
+            MaterializedViewFreshness freshness;
+
+            try {
+                freshness = metadata.getMaterializedViewFreshness(session, name);
+            }
+            catch (MaterializedViewNotFoundException e) {
+                // Ignore materialized view that was dropped during query execution (race condition)
+                return;
+            }
+
+            Object[] materializedViewRow = createMaterializedViewRow(name, freshness, definition);
+            displayTable.addRow(materializedViewRow);
+        });
     }
 
     private static Object[] createMaterializedViewRow(


### PR DESCRIPTION
## Description

- Make table definitions public
- Extract materializedViewForCatalog() method so it can be reused
- Extract tableCommentForCatalog() so that it can be reused

## Additional context and related issues

n/a

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
