### PR TITLE
[WIP] Fix synthetic column names for Oracle

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -603,6 +603,12 @@ public class CachingJdbcClient
         onDataChanged(handle.getRequiredNamedRelation().getSchemaTableName());
     }
 
+    @Override
+    public OptionalInt getMaximumIdentifierLength()
+    {
+        return delegate.getMaximumIdentifierLength();
+    }
+
     @Managed
     public void flushCache()
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -113,11 +113,22 @@ public class DefaultJdbcMetadata
 
     private final AtomicReference<Runnable> rollbackAction = new AtomicReference<>();
 
+    private final SyntheticColumnBuilder syntheticColumnBuilder;
+
     public DefaultJdbcMetadata(JdbcClient jdbcClient, boolean precalculateStatisticsForPushdown, Set<JdbcQueryEventListener> jdbcQueryEventListeners)
+    {
+        this(jdbcClient, precalculateStatisticsForPushdown, jdbcQueryEventListeners, new SyntheticColumnBuilder());
+    }
+
+    public DefaultJdbcMetadata(JdbcClient jdbcClient,
+            boolean precalculateStatisticsForPushdown,
+            Set<JdbcQueryEventListener> jdbcQueryEventListeners,
+            SyntheticColumnBuilder syntheticColumnBuilder)
     {
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.precalculateStatisticsForPushdown = precalculateStatisticsForPushdown;
         this.jdbcQueryEventListeners = ImmutableSet.copyOf(requireNonNull(jdbcQueryEventListeners, "queryEventListeners is null"));
+        this.syntheticColumnBuilder = requireNonNull(syntheticColumnBuilder, "syntheticColumnBuilder is null");
     }
 
     @Override
@@ -453,22 +464,17 @@ public class DefaultJdbcMetadata
 
         ImmutableMap.Builder<JdbcColumnHandle, JdbcColumnHandle> newLeftColumnsBuilder = ImmutableMap.builder();
         for (JdbcColumnHandle column : jdbcClient.getColumns(session, leftHandle)) {
-            newLeftColumnsBuilder.put(column, JdbcColumnHandle.builderFrom(column)
-                    .setColumnName(column.getColumnName() + "_" + nextSyntheticColumnId)
-                    .build());
+            newLeftColumnsBuilder.put(column, syntheticColumnBuilder.aliasForColumn(column, jdbcClient.getMaximumIdentifierLength(), nextSyntheticColumnId));
             nextSyntheticColumnId++;
         }
         Map<JdbcColumnHandle, JdbcColumnHandle> newLeftColumns = newLeftColumnsBuilder.buildOrThrow();
 
         ImmutableMap.Builder<JdbcColumnHandle, JdbcColumnHandle> newRightColumnsBuilder = ImmutableMap.builder();
         for (JdbcColumnHandle column : jdbcClient.getColumns(session, rightHandle)) {
-            newRightColumnsBuilder.put(column, JdbcColumnHandle.builderFrom(column)
-                    .setColumnName(column.getColumnName() + "_" + nextSyntheticColumnId)
-                    .build());
+            newRightColumnsBuilder.put(column, syntheticColumnBuilder.aliasForColumn(column, jdbcClient.getMaximumIdentifierLength(), nextSyntheticColumnId));
             nextSyntheticColumnId++;
         }
         Map<JdbcColumnHandle, JdbcColumnHandle> newRightColumns = newRightColumnsBuilder.buildOrThrow();
-
         ImmutableList.Builder<JdbcJoinCondition> jdbcJoinConditions = ImmutableList.builder();
         for (JoinCondition joinCondition : joinConditions) {
             Optional<JdbcColumnHandle> leftColumn = getVariableColumnHandle(leftAssignments, joinCondition.getLeftExpression());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -438,4 +438,10 @@ public abstract class ForwardingJdbcClient
     {
         return delegate().getMaxWriteParallelism(session);
     }
+
+    @Override
+    public OptionalInt getMaximumIdentifierLength()
+    {
+        return delegate().getMaximumIdentifierLength();
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -232,4 +232,9 @@ public interface JdbcClient
     void truncateTable(ConnectorSession session, JdbcTableHandle handle);
 
     OptionalInt getMaxWriteParallelism(ConnectorSession session);
+
+    default OptionalInt getMaximumIdentifierLength()
+    {
+        return OptionalInt.empty();
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SyntheticColumnBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SyntheticColumnBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import java.util.OptionalInt;
+
+import static com.google.common.base.Verify.verify;
+
+public class SyntheticColumnBuilder
+{
+    private static final String SEPARATOR = "_";
+    private static final int SEPARATOR_LENGTH = SEPARATOR.length();
+
+    public JdbcColumnHandle aliasForColumn(JdbcColumnHandle column, OptionalInt maximumIdentifierLength, int nextSyntheticColumnId)
+    {
+        if (maximumIdentifierLength.isEmpty()) {
+            // No identifier length limit
+            return syntheticColumnHandle(column, nextSyntheticColumnId);
+        }
+
+        String nextColumnId = String.valueOf(nextSyntheticColumnId);
+        int nextColumnIdLength = nextColumnId.length();
+
+        int maximumLength = maximumIdentifierLength.getAsInt();
+        int columnLength = column.getColumnName().length();
+
+        int totalLength = columnLength + nextColumnIdLength + SEPARATOR_LENGTH;
+        verify(nextColumnIdLength <= maximumLength, "Maximum allowed identifier length is %s but synthetic column has length %s", maximumLength, nextColumnIdLength);
+
+        if (nextColumnIdLength == maximumLength) {
+            return JdbcColumnHandle.builderFrom(column)
+                    .setColumnName(nextColumnId)
+                    .build();
+        }
+
+        if (totalLength > maximumLength) {
+            String strippedColumnName = column.getColumnName().substring(0, columnLength - (totalLength - maximumLength));
+            return JdbcColumnHandle.builderFrom(column)
+                    .setColumnName(strippedColumnName + SEPARATOR + nextColumnId)
+                    .build();
+        }
+
+        return syntheticColumnHandle(column, nextSyntheticColumnId);
+    }
+
+    private static JdbcColumnHandle syntheticColumnHandle(JdbcColumnHandle column, int nextSyntheticColumnId)
+    {
+        return JdbcColumnHandle.builderFrom(column)
+                .setColumnName(column.getColumnName() + SEPARATOR + nextSyntheticColumnId)
+                .build();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -458,4 +458,10 @@ public final class StatisticsAwareJdbcClient
     {
         return delegate().getMaxWriteParallelism(session);
     }
+
+    @Override
+    public OptionalInt getMaximumIdentifierLength()
+    {
+        return delegate().getMaximumIdentifierLength();
+    }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestSyntheticColumnBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestSyntheticColumnBuilder.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.base.VerifyException;
+import org.testng.annotations.Test;
+
+import java.util.OptionalInt;
+
+import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestSyntheticColumnBuilder
+{
+    private static final SyntheticColumnBuilder FORMATTER = new SyntheticColumnBuilder();
+    private static final int MAX_SYNTHETIC_ID_LENGTH = String.valueOf(Integer.MAX_VALUE).length();
+
+    @Test
+    public void columnNameShorterThanMaximum()
+    {
+        int maximumLength = 30;
+        String columnName = "a".repeat(maximumLength - 4);
+
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName(columnName)
+                .build();
+
+        JdbcColumnHandle result = FORMATTER.aliasForColumn(column, OptionalInt.of(maximumLength), 456);
+        assertThat(result.getColumnName()).isEqualTo(columnName + "_456");
+    }
+
+    @Test
+    public void columnNameLongerThanMaximum()
+    {
+        int maximumLength = 30;
+        String columnName = "a".repeat(maximumLength);
+
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName(columnName)
+                .build();
+
+        JdbcColumnHandle result = FORMATTER.aliasForColumn(column, OptionalInt.of(maximumLength), 123);
+        assertThat(result.getColumnName()).isEqualTo("a".repeat(maximumLength - 4) + "_123");
+    }
+
+    @Test
+    public void syntheticIdEqualsTheMaximum()
+    {
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName("aaaa")
+                .build();
+
+        JdbcColumnHandle result = FORMATTER.aliasForColumn(column, OptionalInt.of(MAX_SYNTHETIC_ID_LENGTH), Integer.MAX_VALUE);
+        assertThat(result.getColumnName()).isEqualTo(String.valueOf(Integer.MAX_VALUE));
+    }
+
+    @Test
+    public void syntheticWithSeparatorIdEqualsTheMaximum()
+    {
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName("aaaa")
+                .build();
+
+        JdbcColumnHandle result = FORMATTER.aliasForColumn(column, OptionalInt.of(MAX_SYNTHETIC_ID_LENGTH + 1), Integer.MAX_VALUE);
+        assertThat(result.getColumnName()).isEqualTo("_" + Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void syntheticWithSeparatorSmallerThanMaximum()
+    {
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName("abcd")
+                .build();
+
+        JdbcColumnHandle result = FORMATTER.aliasForColumn(column, OptionalInt.of(MAX_SYNTHETIC_ID_LENGTH + 2), Integer.MAX_VALUE);
+        assertThat(result.getColumnName()).isEqualTo("a_" + Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void syntheticIdLongerThanMaximum()
+    {
+        JdbcColumnHandle column = getDefaultColumnHandleBuilder()
+                .setColumnName("a")
+                .build();
+
+        assertThatThrownBy(() -> FORMATTER.aliasForColumn(column, OptionalInt.of(MAX_SYNTHETIC_ID_LENGTH - 1), Integer.MAX_VALUE))
+                .isInstanceOf(VerifyException.class)
+                        .hasMessage("Maximum allowed identifier length is 9 but synthetic column has length 10");
+    }
+
+    private static JdbcColumnHandle.Builder getDefaultColumnHandleBuilder()
+    {
+        return JdbcColumnHandle.builder()
+                .setJdbcTypeHandle(JDBC_VARCHAR)
+                .setColumnType(VARCHAR);
+    }
+}

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.oracle;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -89,6 +90,7 @@ import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -157,6 +159,9 @@ import static java.util.concurrent.TimeUnit.DAYS;
 public class OracleClient
         extends BaseJdbcClient
 {
+    @VisibleForTesting
+    public static final int ORACLE_MAXIMUM_IDENTIFIER_LENGTH = 30;
+
     public static final int ORACLE_MAX_LIST_EXPRESSIONS = 1000;
 
     private static final int MAX_ORACLE_TIMESTAMP_PRECISION = 9;
@@ -250,6 +255,12 @@ public class OracleClient
                         .add(new ImplementCovarianceSamp())
                         .add(new ImplementCovariancePop())
                         .build());
+    }
+
+    @Override
+    public OptionalInt getMaximumIdentifierLength()
+    {
+        return OptionalInt.of(ORACLE_MAXIMUM_IDENTIFIER_LENGTH);
     }
 
     @Override


### PR DESCRIPTION
Oracle 11 has a maximum identifier length of 32 which causes problem when the actual column name has the length that when suffixed with the nextSyntheticColumnId will cause synthetic column name identifier to exceed this limit.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
