### PR TITLE
Eager speculative execution for final LIMIT stages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -906,51 +906,51 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_STANDARD_SPLIT_SIZE,
                         "Standard split size for a single fault tolerant task (split weight aware)",
                         queryManagerConfig.getFaultTolerantExecutionStandardSplitSize(),
-                        false),
+                        true),
                 integerProperty(
                         FAULT_TOLERANT_EXECUTION_MAX_TASK_SPLIT_COUNT,
                         "Maximal number of splits for a single fault tolerant task (count based)",
                         queryManagerConfig.getFaultTolerantExecutionMaxTaskSplitCount(),
-                        false),
+                        true),
                 dataSizeProperty(
                         FAULT_TOLERANT_EXECUTION_COORDINATOR_TASK_MEMORY,
                         "Estimated amount of memory a single coordinator task will use when task level retries are used; value is used when allocating nodes for tasks execution",
                         memoryManagerConfig.getFaultTolerantExecutionCoordinatorTaskMemory(),
-                        false),
+                        true),
                 dataSizeProperty(
                         FAULT_TOLERANT_EXECUTION_TASK_MEMORY,
                         "Estimated amount of memory a single task will use when task level retries are used; value is used when allocating nodes for tasks execution",
                         memoryManagerConfig.getFaultTolerantExecutionTaskMemory(),
-                        false),
+                        true),
                 doubleProperty(
                         FAULT_TOLERANT_EXECUTION_TASK_MEMORY_GROWTH_FACTOR,
                         "Factor by which estimated task memory is increased if task execution runs out of memory; value is used allocating nodes for tasks execution",
                         memoryManagerConfig.getFaultTolerantExecutionTaskMemoryGrowthFactor(),
-                        false),
+                        true),
                 doubleProperty(
                         FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE,
                         "What quantile of memory usage of completed tasks to look at when estimating memory usage for upcoming tasks",
                         memoryManagerConfig.getFaultTolerantExecutionTaskMemoryEstimationQuantile(),
                         value -> validateDoubleRange(value, FAULT_TOLERANT_EXECUTION_TASK_MEMORY_ESTIMATION_QUANTILE, 0.0, 1.0),
-                        false),
+                        true),
                 integerProperty(
                         FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT,
                         "Maximum number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled",
                         queryManagerConfig.getFaultTolerantExecutionMaxPartitionCount(),
                         value -> validateIntegerValue(value, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, 1, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT, false),
-                        false),
+                        true),
                 integerProperty(
                         FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT,
                         "Minimum number of partitions for distributed joins and aggregations executed with fault tolerant execution enabled",
                         queryManagerConfig.getFaultTolerantExecutionMinPartitionCount(),
                         value -> validateIntegerValue(value, FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, 1, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT, false),
-                        false),
+                        true),
                 integerProperty(
                         FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT_FOR_WRITE,
                         "Minimum number of partitions for distributed joins and aggregations in write queries executed with fault tolerant execution enabled",
                         queryManagerConfig.getFaultTolerantExecutionMinPartitionCountForWrite(),
                         value -> validateIntegerValue(value, FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT_FOR_WRITE, 1, FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT_LIMIT, false),
-                        false),
+                        true),
                 booleanProperty(
                         FAULT_TOLERANT_EXECUTION_RUNTIME_ADAPTIVE_PARTITIONING_ENABLED,
                         "Enables change of number of partitions at runtime when intermediate data size is large",
@@ -976,12 +976,12 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_SMALL_STAGE_ESTIMATION_ENABLED,
                         "Enable small stage estimation heuristic, used for more aggresive speculative stage scheduling",
                         queryManagerConfig.isFaultTolerantExecutionSmallStageEstimationEnabled(),
-                        false),
+                        true),
                 dataSizeProperty(
                         FAULT_TOLERANT_EXECUTION_SMALL_STAGE_ESTIMATION_THRESHOLD,
                         "Threshold until which stage is considered small",
                         queryManagerConfig.getFaultTolerantExecutionSmallStageEstimationThreshold(),
-                        false),
+                        true),
                 doubleProperty(
                         FAULT_TOLERANT_EXECUTION_SMALL_STAGE_SOURCE_SIZE_MULTIPLIER,
                         "Multiplier used for heuristic estimation is stage is small; the bigger the more conservative estimation is",
@@ -993,12 +993,12 @@ public final class SystemSessionProperties
                                         format("%s must be greater than or equal to 1.0: %s", FAULT_TOLERANT_EXECUTION_SMALL_STAGE_SOURCE_SIZE_MULTIPLIER, value));
                             }
                         },
-                        false),
+                        true),
                 booleanProperty(
                         FAULT_TOLERANT_EXECUTION_SMALL_STAGE_REQUIRE_NO_MORE_PARTITIONS,
                         "Is it required for all stage partitions (tasks) to be enumerated for stage to be used in heuristic to determine if parent stage is small",
                         queryManagerConfig.isFaultTolerantExecutionSmallStageRequireNoMorePartitions(),
-                        false),
+                        true),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
                         "When enabled, partial aggregation might be adaptively turned off when it does not provide any performance gain",

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -195,6 +195,7 @@ public final class SystemSessionProperties
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_ESTIMATION_THRESHOLD = "fault_tolerant_execution_small_stage_estimation_threshold";
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_SOURCE_SIZE_MULTIPLIER = "fault_tolerant_execution_small_stage_source_size_multiplier";
     private static final String FAULT_TOLERANT_EXECUTION_SMALL_STAGE_REQUIRE_NO_MORE_PARTITIONS = "fault_tolerant_execution_small_stage_require_no_more_partitions";
+    private static final String FAULT_TOLERANT_EXECUTION_STAGE_ESTIMATION_FOR_EAGER_PARENT_ENABLED = "fault_tolerant_execution_stage_estimation_for_eager_parent_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_ENABLED = "adaptive_partial_aggregation_enabled";
     public static final String ADAPTIVE_PARTIAL_AGGREGATION_UNIQUE_ROWS_RATIO_THRESHOLD = "adaptive_partial_aggregation_unique_rows_ratio_threshold";
     public static final String REMOTE_TASK_ADAPTIVE_UPDATE_REQUEST_SIZE_ENABLED = "remote_task_adaptive_update_request_size_enabled";
@@ -998,6 +999,11 @@ public final class SystemSessionProperties
                         FAULT_TOLERANT_EXECUTION_SMALL_STAGE_REQUIRE_NO_MORE_PARTITIONS,
                         "Is it required for all stage partitions (tasks) to be enumerated for stage to be used in heuristic to determine if parent stage is small",
                         queryManagerConfig.isFaultTolerantExecutionSmallStageRequireNoMorePartitions(),
+                        true),
+                booleanProperty(
+                        FAULT_TOLERANT_EXECUTION_STAGE_ESTIMATION_FOR_EAGER_PARENT_ENABLED,
+                        "Enable aggressive stage output size estimation heuristic for children of stages to be executed eagerly",
+                        queryManagerConfig.isFaultTolerantExecutionStageEstimationForEagerParentEnabled(),
                         true),
                 booleanProperty(
                         ADAPTIVE_PARTIAL_AGGREGATION_ENABLED,
@@ -1841,6 +1847,11 @@ public final class SystemSessionProperties
     public static boolean isFaultTolerantExecutionSmallStageRequireNoMorePartitions(Session session)
     {
         return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_SMALL_STAGE_REQUIRE_NO_MORE_PARTITIONS, Boolean.class);
+    }
+
+    public static boolean isFaultTolerantExecutionStageEstimationForEagerParentEnabled(Session session)
+    {
+        return session.getSystemProperty(FAULT_TOLERANT_EXECUTION_STAGE_ESTIMATION_FOR_EAGER_PARENT_ENABLED, Boolean.class);
     }
 
     public static boolean isAdaptivePartialAggregationEnabled(Session session)

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -144,6 +144,7 @@ public class QueryManagerConfig
     private DataSize faultTolerantExecutionSmallStageEstimationThreshold = DataSize.of(20, GIGABYTE);
     private double faultTolerantExecutionSmallStageSourceSizeMultiplier = 1.2;
     private boolean faultTolerantExecutionSmallStageRequireNoMorePartitions;
+    private boolean faultTolerantExecutionStageEstimationForEagerParentEnabled = true;
 
     @Min(1)
     public int getScheduleSplitBatchSize()
@@ -1074,6 +1075,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setFaultTolerantExecutionSmallStageRequireNoMorePartitions(boolean faultTolerantExecutionSmallStageRequireNoMorePartitions)
     {
         this.faultTolerantExecutionSmallStageRequireNoMorePartitions = faultTolerantExecutionSmallStageRequireNoMorePartitions;
+        return this;
+    }
+
+    public boolean isFaultTolerantExecutionStageEstimationForEagerParentEnabled()
+    {
+        return faultTolerantExecutionStageEstimationForEagerParentEnabled;
+    }
+
+    @Config("fault-tolerant-execution-stage-estimation-for-eager-parent-enabled")
+    @ConfigDescription("Enable aggressive stage output size estimation heuristic for children of stages to be executed eagerly")
+    public QueryManagerConfig setFaultTolerantExecutionStageEstimationForEagerParentEnabled(boolean faultTolerantExecutionStageEstimationForEagerParentEnabled)
+    {
+        this.faultTolerantExecutionStageEstimationForEagerParentEnabled = faultTolerantExecutionStageEstimationForEagerParentEnabled;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -411,7 +411,7 @@ public class BinPackingNodeAllocatorService
         public void setExecutionClass(TaskExecutionClass newExecutionClass)
         {
             TaskExecutionClass changedFrom = this.executionClass.getAndUpdate(oldExecutionClass -> {
-                checkArgument(newExecutionClass != SPECULATIVE, "cannot make non-speculative task speculative");
+                checkArgument(oldExecutionClass.canTransitionTo(newExecutionClass), "cannot change execution class from %s to %s", oldExecutionClass, newExecutionClass);
                 return newExecutionClass;
             });
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -422,7 +422,7 @@ public class BinPackingNodeAllocatorService
 
         public boolean isSpeculative()
         {
-            return executionClass.get() == SPECULATIVE;
+            return executionClass.get().isSpeculative();
         }
 
         public TaskExecutionClass getExecutionClass()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1221,14 +1221,14 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private void scheduleTasks()
         {
-            long speculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
-                    .filter(context -> !context.getNodeLease().getNode().isDone())
-                    .filter(context -> context.getExecutionClass() == SPECULATIVE)
-                    .count();
-
             long nonSpeculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
                     .filter(context -> !context.getNodeLease().getNode().isDone())
                     .filter(context -> context.getExecutionClass() == STANDARD)
+                    .count();
+
+            long speculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
+                    .filter(context -> !context.getNodeLease().getNode().isDone())
+                    .filter(context -> context.getExecutionClass() == SPECULATIVE)
                     .count();
 
             while (!schedulingQueue.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1339,7 +1339,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             ExchangeSinkInstanceHandle sinkInstanceHandle = sinkInstanceHandleAcquiredEvent.getSinkInstanceHandle();
             StageExecution stageExecution = getStageExecution(stageId);
 
-            Optional<RemoteTask> remoteTask = stageExecution.schedule(partitionId, sinkInstanceHandle, attempt, nodeLease, context.getExecutionClass() == SPECULATIVE);
+            Optional<RemoteTask> remoteTask = stageExecution.schedule(partitionId, sinkInstanceHandle, attempt, nodeLease, context.getExecutionClass().isSpeculative());
             remoteTask.ifPresent(task -> {
                 task.addStateChangeListener(createExchangeSinkInstanceHandleUpdateRequiredListener());
                 task.addStateChangeListener(taskStatus -> {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -2956,7 +2956,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         public void setExecutionClass(TaskExecutionClass executionClass)
         {
-            checkArgument(executionClass == STANDARD || this.executionClass == SPECULATIVE, "cannot change execution class from %s to %s", this.executionClass, executionClass);
+            checkArgument(this.executionClass.canTransitionTo(executionClass), "cannot change execution class from %s to %s", this.executionClass, executionClass);
             this.executionClass = executionClass;
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -2312,11 +2312,6 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.remainingAttempts = maxTaskExecutionAttempts;
         }
 
-        public int getPartitionId()
-        {
-            return partitionId;
-        }
-
         public ExchangeSinkHandle getExchangeSinkHandle()
         {
             return exchangeSinkHandle;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1221,7 +1221,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private void scheduleTasks()
         {
-            long nonSpeculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
+            long standardTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
                     .filter(context -> !context.getNodeLease().getNode().isDone())
                     .filter(context -> context.getExecutionClass() == STANDARD)
                     .count();
@@ -1232,13 +1232,13 @@ public class EventDrivenFaultTolerantQueryScheduler
                     .count();
 
             while (!schedulingQueue.isEmpty()) {
-                if (nonSpeculativeTasksWaitingForNode >= maxTasksWaitingForNode) {
+                if (standardTasksWaitingForNode >= maxTasksWaitingForNode) {
                     break;
                 }
 
                 PrioritizedScheduledTask scheduledTask = schedulingQueue.peekOrThrow();
 
-                if (scheduledTask.getExecutionClass() == SPECULATIVE && nonSpeculativeTasksWaitingForNode > 0) {
+                if (scheduledTask.getExecutionClass() == SPECULATIVE && standardTasksWaitingForNode > 0) {
                     // do not handle any speculative tasks if there are non-speculative waiting
                     break;
                 }
@@ -1269,7 +1269,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                     speculativeTasksWaitingForNode++;
                 }
                 else {
-                    nonSpeculativeTasksWaitingForNode++;
+                    standardTasksWaitingForNode++;
                 }
             }
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1019,16 +1019,9 @@ public class EventDrivenFaultTolerantQueryScheduler
                 }
 
                 switch (result.orElseThrow().getStatus()) {
-                    case ESTIMATED_BY_PROGRESS -> {
-                        estimatedByProgressSourcesCount++;
-                    }
-                    case ESTIMATED_BY_SMALL_INPUT -> {
-                        estimatedBySmallInputSourcesCount++;
-                    }
-                    default -> {
-                        // FINISHED handled above
-                        throw new IllegalStateException(format("unexpected status %s", result.orElseThrow().getStatus()));
-                    }
+                    case ESTIMATED_BY_PROGRESS -> estimatedByProgressSourcesCount++;
+                    case ESTIMATED_BY_SMALL_INPUT -> estimatedBySmallInputSourcesCount++;
+                    default -> throw new IllegalStateException(format("unexpected status %s", result.orElseThrow().getStatus())); // FINISHED handled above
                 }
 
                 sourceOutputSizeEstimates.put(sourceStageExecution.getStageId(), result.orElseThrow().getOutputDataSizeEstimate());

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1080,7 +1080,11 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             for (SubPlan source : subPlan.getChildren()) {
                 StageExecution sourceStageExecution = stageExecutions.get(getStageId(source.getFragment().getId()));
-                if (sourceStageExecution != null) {
+                if (sourceStageExecution != null && sourceStageExecution.getState().isDone()) {
+                    // Only close source exchange if source stage writing to it is already done.
+                    // It could be that closeSourceExchanges was called because downstream stage already
+                    // finished while some upstream stages are still running.
+                    // E.g this may happen in case of early limit termination.
                     sourceStageExecution.closeExchange();
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1443,7 +1443,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             boolean schedulingQueueIsFull = schedulingQueue.getTaskCount(STANDARD) >= maxTasksWaitingForExecution;
             for (StageExecution stageExecution : stageExecutions.values()) {
-                if (!schedulingQueueIsFull || stageExecution.hasOpenTaskRunning()) {
+                if (!schedulingQueueIsFull || stageExecution.hasOpenTaskRunning() || stageExecution.isEager()) {
                     stageExecution.loadMoreTaskDescriptors().ifPresent(future -> Futures.addCallback(future, new FutureCallback<>()
                     {
                         @Override
@@ -1903,6 +1903,11 @@ public class EventDrivenFaultTolerantQueryScheduler
                 runningPartitions.add(partitionId);
             });
             return task;
+        }
+
+        public boolean isEager()
+        {
+            return eager;
         }
 
         public boolean hasOpenTaskRunning()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1700,9 +1700,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 partition.setTaskScheduled(true);
                 return Optional.of(PrioritizedScheduledTask.createSpeculative(stage.getStageId(), partitionId, schedulingPriority));
             }
-            else {
-                return Optional.empty();
-            }
+            return Optional.empty();
         }
 
         public Optional<PrioritizedScheduledTask> sealPartition(int partitionId)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -967,8 +967,8 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private IsReadyForExecutionResult isReadyForExecution(SubPlan subPlan)
         {
-            boolean nonSpeculativeTasksInQueue = schedulingQueue.getTaskCount(STANDARD) > 0;
-            boolean nonSpeculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
+            boolean standardTasksInQueue = schedulingQueue.getTaskCount(STANDARD) > 0;
+            boolean standardTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
                     .anyMatch(task -> task.getExecutionClass() == STANDARD && !task.getNodeLease().getNode().isDone());
 
             // Do not start a speculative stage if there is non-speculative work still to be done.
@@ -976,7 +976,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             // by progress, repartition tasks will produce very uneven output for different output partitions, which
             // will result in very bad task bin-packing results; also the fact that runtime adaptive partitioning
             // happened already suggests that there is plenty work ahead.
-            boolean canScheduleSpeculative = !nonSpeculativeTasksInQueue && !nonSpeculativeTasksWaitingForNode && !runtimeAdaptivePartitioningApplied;
+            boolean canScheduleSpeculative = !standardTasksInQueue && !standardTasksWaitingForNode && !runtimeAdaptivePartitioningApplied;
             boolean speculative = false;
             int finishedSourcesCount = 0;
             int estimatedByProgressSourcesCount = 0;

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -2612,7 +2612,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         @Override
         public String toString()
         {
-            return "" + task.stageId() + "/" + task.partitionId() + "[" + priority + "]";
+            return task.stageId() + "/" + task.partitionId() + "[" + priority + "]";
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -1221,15 +1221,8 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private void scheduleTasks()
         {
-            long standardTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
-                    .filter(context -> !context.getNodeLease().getNode().isDone())
-                    .filter(context -> context.getExecutionClass() == STANDARD)
-                    .count();
-
-            long speculativeTasksWaitingForNode = preSchedulingTaskContexts.values().stream()
-                    .filter(context -> !context.getNodeLease().getNode().isDone())
-                    .filter(context -> context.getExecutionClass() == SPECULATIVE)
-                    .count();
+            long standardTasksWaitingForNode = getWaitingForNodeTasksCount(STANDARD);
+            long speculativeTasksWaitingForNode = getWaitingForNodeTasksCount(SPECULATIVE);
 
             while (!schedulingQueue.isEmpty()) {
                 if (standardTasksWaitingForNode >= maxTasksWaitingForNode) {
@@ -1272,6 +1265,14 @@ public class EventDrivenFaultTolerantQueryScheduler
                     standardTasksWaitingForNode++;
                 }
             }
+        }
+
+        private long getWaitingForNodeTasksCount(TaskExecutionClass executionClass)
+        {
+            return preSchedulingTaskContexts.values().stream()
+                    .filter(context -> !context.getNodeLease().getNode().isDone())
+                    .filter(context -> context.getExecutionClass() == executionClass)
+                    .count();
         }
 
         private void processNodeAcquisitions()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -526,8 +526,6 @@ public class EventDrivenFaultTolerantQueryScheduler
         private final PartitionMemoryEstimatorFactory memoryEstimatorFactory;
         private final FaultTolerantPartitioningSchemeFactory partitioningSchemeFactory;
         private final ExchangeManager exchangeManager;
-        private final DataSize smallSizePartitionSizeEstimate;
-        private final boolean smallStageRequireNoMorePartitions;
         private final int maxTaskExecutionAttempts;
         private final int maxTasksWaitingForNode;
         private final int maxTasksWaitingForExecution;
@@ -544,6 +542,8 @@ public class EventDrivenFaultTolerantQueryScheduler
         private final boolean smallStageEstimationEnabled;
         private final DataSize smallStageEstimationThreshold;
         private final double smallStageSourceSizeMultiplier;
+        private final DataSize smallSizePartitionSizeEstimate;
+        private final boolean smallStageRequireNoMorePartitions;
 
         private final BlockingQueue<Event> eventQueue = new LinkedBlockingQueue<>();
         private final List<Event> eventBuffer = new ArrayList<>(EVENT_BUFFER_CAPACITY);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAllocator.java
@@ -29,7 +29,7 @@ public interface NodeAllocator
      *
      * It is obligatory for the calling party to release all the leases they obtained via {@link NodeLease#release()}.
      */
-    NodeLease acquire(NodeRequirements nodeRequirements, DataSize memoryRequirement, boolean speculative);
+    NodeLease acquire(NodeRequirements nodeRequirements, DataSize memoryRequirement, TaskExecutionClass executionClass);
 
     @Override
     void close();
@@ -40,7 +40,7 @@ public interface NodeAllocator
 
         default void attachTaskId(TaskId taskId) {}
 
-        void setSpeculative(boolean speculative);
+        void setExecutionClass(TaskExecutionClass executionClass);
 
         void release();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+public enum TaskExecutionClass
+{
+    // Tasks from stages with all upstream stages finished
+    STANDARD,
+
+    // Tasks from stages with some upstream stages still running.
+    // To be scheduled only if no STANDARD tasks can fit.
+    // Picked to kill if worker runs out of memory to prevent deadlock.
+    SPECULATIVE,
+    /**/;
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
@@ -23,4 +23,12 @@ public enum TaskExecutionClass
     // Picked to kill if worker runs out of memory to prevent deadlock.
     SPECULATIVE,
     /**/;
+
+    boolean canTransitionTo(TaskExecutionClass targetExecutionClass)
+    {
+        return switch (this) {
+            case STANDARD -> targetExecutionClass == STANDARD;
+            case SPECULATIVE -> targetExecutionClass == SPECULATIVE || targetExecutionClass == STANDARD;
+        };
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TaskExecutionClass.java
@@ -31,4 +31,12 @@ public enum TaskExecutionClass
             case SPECULATIVE -> targetExecutionClass == SPECULATIVE || targetExecutionClass == STANDARD;
         };
     }
+
+    boolean isSpeculative()
+    {
+        return switch (this) {
+            case STANDARD -> false;
+            case SPECULATIVE -> true;
+        };
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryManagerConfig.java
@@ -45,6 +45,7 @@ public class MemoryManagerConfig
     private LowMemoryQueryKillerPolicy lowMemoryQueryKillerPolicy = LowMemoryQueryKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private LowMemoryTaskKillerPolicy lowMemoryTaskKillerPolicy = LowMemoryTaskKillerPolicy.TOTAL_RESERVATION_ON_BLOCKED_NODES;
     private boolean faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled = true;
+    private DataSize faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit = DataSize.of(20, GIGABYTE);
 
     /**
      * default value is overwritten for fault tolerant execution in {@link #applyFaultTolerantExecutionDefaults()}}
@@ -201,6 +202,18 @@ public class MemoryManagerConfig
     public MemoryManagerConfig setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(boolean faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled)
     {
         this.faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled = faultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled;
+        return this;
+    }
+
+    public DataSize getFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit()
+    {
+        return faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit;
+    }
+
+    @Config("fault-tolerant-execution-eager-speculative-tasks-node_memory-overcommit")
+    public MemoryManagerConfig setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit)
+    {
+        this.faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit = faultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -107,6 +107,7 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionSmallStageEstimationThreshold(DataSize.of(20, GIGABYTE))
                 .setFaultTolerantExecutionSmallStageSourceSizeMultiplier(1.2)
                 .setFaultTolerantExecutionSmallStageRequireNoMorePartitions(false)
+                .setFaultTolerantExecutionStageEstimationForEagerParentEnabled(true)
                 .setMaxWriterTasksCount(100));
     }
 
@@ -182,6 +183,7 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-small-stage-estimation-threshold", "6GB")
                 .put("fault-tolerant-execution-small-stage-source-size-multiplier", "1.6")
                 .put("fault-tolerant-execution-small-stage-require-no-more-partitions", "true")
+                .put("fault-tolerant-execution-stage-estimation-for-eager-parent-enabled", "false")
                 .buildOrThrow();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -252,6 +254,7 @@ public class TestQueryManagerConfig
                 .setFaultTolerantExecutionSmallStageEstimationThreshold(DataSize.of(6, GIGABYTE))
                 .setFaultTolerantExecutionSmallStageSourceSizeMultiplier(1.6)
                 .setFaultTolerantExecutionSmallStageRequireNoMorePartitions(true)
+                .setFaultTolerantExecutionStageEstimationForEagerParentEnabled(false)
                 .setMaxWriterTasksCount(101);
 
         assertFullMapping(properties, expected);

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -43,6 +43,8 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.trino.execution.scheduler.TaskExecutionClass.SPECULATIVE;
+import static io.trino.execution.scheduler.TaskExecutionClass.STANDARD;
 import static io.trino.testing.TestingHandles.createTestCatalogHandle;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.time.temporal.ChronoUnit.MINUTES;
@@ -150,19 +152,19 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first two allocations should not block
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
 
             // same for subsequent two allocation (each task requires 32GB and we have 2 nodes with 64GB each)
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire3, NODE_1);
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_2);
 
             // 5th allocation should block
-            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire5);
 
             // release acquire2 which uses
@@ -174,7 +176,7 @@ public class TestBinPackingNodeAllocator
             });
 
             // try to acquire one more node (should block)
-            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire6);
 
             // add new node
@@ -198,25 +200,25 @@ public class TestBinPackingNodeAllocator
         setupNodeAllocatorService(nodeManager);
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire3, NODE_1);
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_2);
-            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire5, NODE_1);
-            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire6, NODE_2);
             // each of the nodes is filled in with 32+16+16
 
             // try allocate 32 and 16
-            NodeAllocator.NodeLease acquire7 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire7 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire7);
 
-            NodeAllocator.NodeLease acquire8 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire8 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertNotAcquired(acquire8);
 
             // free 16MB on NODE_1;
@@ -244,25 +246,25 @@ public class TestBinPackingNodeAllocator
         setupNodeAllocatorService(nodeManager);
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire3, NODE_1);
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_2);
-            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire5, NODE_1);
-            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire6, NODE_2);
             // each of the nodes is filled in with 32+16+16
 
             // try to allocate 32 and 16
-            NodeAllocator.NodeLease acquire7 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire7 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire7);
 
-            NodeAllocator.NodeLease acquire8 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire8 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertNotAcquired(acquire8);
 
             // free 32MB on NODE_2;
@@ -285,15 +287,15 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first two allocations should not block
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_1);
 
             // another two should block
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire3);
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire4);
 
             // releasing a blocked one should not unblock anything
@@ -314,7 +316,7 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // request a node with specific catalog (not present)
-            NodeAllocator.NodeLease acquireNoMatching = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNoMatching = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), STANDARD);
             assertNotAcquired(acquireNoMatching);
             ticker.increment(59, TimeUnit.SECONDS); // still below timeout
             nodeAllocatorService.processPendingAcquires();
@@ -328,11 +330,11 @@ public class TestBinPackingNodeAllocator
             nodeManager.addNodes(NODE_2);
 
             // we should be able to acquire the node now
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_2);
 
             // acquiring one more should block (only one acquire fits a node as we request 64GB)
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), STANDARD);
             assertNotAcquired(acquire2);
 
             // remove node with catalog
@@ -360,8 +362,8 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // request a node with specific catalog (not present)
-            NodeAllocator.NodeLease acquireNoMatching1 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), false);
-            NodeAllocator.NodeLease acquireNoMatching2 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNoMatching1 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), STANDARD);
+            NodeAllocator.NodeLease acquireNoMatching2 = nodeAllocator.acquire(REQ_CATALOG_1, DataSize.of(64, GIGABYTE), STANDARD);
             assertNotAcquired(acquireNoMatching1);
             assertNotAcquired(acquireNoMatching2);
 
@@ -407,7 +409,7 @@ public class TestBinPackingNodeAllocator
         setupNodeAllocatorService(nodeManager);
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
 
             // remove acquired node
@@ -426,17 +428,17 @@ public class TestBinPackingNodeAllocator
         setupNodeAllocatorService(nodeManager);
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_2);
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
 
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NODE_2, DataSize.of(32, GIGABYTE), STANDARD);
             // no more place on NODE_2
             assertNotAcquired(acquire3);
 
             // requests for other node are still good
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NODE_1, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NODE_1, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_1);
 
             // release some space on NODE_2
@@ -454,7 +456,7 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first allocation is fine
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
 
@@ -465,27 +467,27 @@ public class TestBinPackingNodeAllocator
             nodeAllocatorService.refreshNodePoolMemoryInfos();
 
             // second allocation of 32GB should go to another node
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
             acquire2.attachTaskId(taskId(2));
 
             // third allocation of 32GB should also use NODE_2 as there is not enough runtime memory on NODE_1
             // second allocation of 32GB should go to another node
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire3, NODE_2);
             acquire3.attachTaskId(taskId(3));
 
             // fourth allocation of 16 should fit on NODE_1
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_1);
             acquire4.attachTaskId(taskId(4));
 
             // fifth allocation of 16 should no longer fit on NODE_1. There is 16GB unreserved but only 15GB taking runtime usage into account
-            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertNotAcquired(acquire5);
 
             // even tiny allocations should not fit now
-            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire6 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), STANDARD);
             assertNotAcquired(acquire6);
 
             // if memory usage decreases on NODE_1 the pending 16GB allocation should complete
@@ -511,7 +513,7 @@ public class TestBinPackingNodeAllocator
         // test when global memory usage on node is greater than per task usage
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first allocation is fine
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
 
@@ -522,7 +524,7 @@ public class TestBinPackingNodeAllocator
             nodeAllocatorService.refreshNodePoolMemoryInfos();
 
             // global (greater) memory usage should take precedence
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire2);
         }
 
@@ -530,7 +532,7 @@ public class TestBinPackingNodeAllocator
         // test when global memory usage on node is smaller than per task usage
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first allocation is fine
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
 
@@ -541,7 +543,7 @@ public class TestBinPackingNodeAllocator
             nodeAllocatorService.refreshNodePoolMemoryInfos();
 
             // per-task (greater) memory usage should take precedence
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire2);
         }
 
@@ -549,7 +551,7 @@ public class TestBinPackingNodeAllocator
         // test when per-task memory usage not present at all
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // first allocation is fine
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
 
@@ -558,7 +560,7 @@ public class TestBinPackingNodeAllocator
             nodeAllocatorService.refreshNodePoolMemoryInfos();
 
             // global memory usage should be used (not per-task usage)
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire2);
         }
     }
@@ -572,10 +574,10 @@ public class TestBinPackingNodeAllocator
         // test when global memory usage on node is greater than per task usage
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // reserve 32GB on NODE_1 and 16GB on NODE_2
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquire2, NODE_2);
             acquire2.attachTaskId(taskId(2));
 
@@ -591,11 +593,11 @@ public class TestBinPackingNodeAllocator
             // try to allocate 32GB task
             // it will not fit on neither of nodes. space should be reserved on NODE_2 as it has more memory available
             // when you do not take runtime memory into account
-            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire3);
 
             // to check that is the case try to allocate 20GB; NODE_1 should be picked
-            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(20, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(20, GIGABYTE), STANDARD);
             assertAcquired(acquire4, NODE_1);
             acquire4.attachTaskId(taskId(2));
         }
@@ -610,7 +612,7 @@ public class TestBinPackingNodeAllocator
         // test when global memory usage on node is greater than per task usage
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // allocated 32GB
-            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquire1, NODE_1);
             acquire1.attachTaskId(taskId(1));
 
@@ -621,7 +623,7 @@ public class TestBinPackingNodeAllocator
             nodeAllocatorService.refreshNodePoolMemoryInfos();
 
             // including overhead node runtime usage is 30+4 = 34GB so another 32GB task will not fit
-            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquire2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquire2);
 
             // decrease runtime usage to 28GB
@@ -645,7 +647,7 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             for (int i = 0; i < 10_000_000; ++i) {
-                NodeAllocator.NodeLease lease = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+                NodeAllocator.NodeLease lease = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
                 lease.release();
             }
         }
@@ -659,23 +661,23 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // allocate two speculative tasks
-            NodeAllocator.NodeLease acquireSpeculative1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), true);
+            NodeAllocator.NodeLease acquireSpeculative1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), SPECULATIVE);
             assertAcquired(acquireSpeculative1, NODE_1);
-            NodeAllocator.NodeLease acquireSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), true);
+            NodeAllocator.NodeLease acquireSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), SPECULATIVE);
             assertAcquired(acquireSpeculative2, NODE_2);
 
             // non-speculative tasks should still get node
-            NodeAllocator.NodeLease acquireNonSpeculative1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNonSpeculative1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD);
             assertAcquired(acquireNonSpeculative1, NODE_2);
-            NodeAllocator.NodeLease acquireNonSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNonSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquireNonSpeculative2, NODE_1);
 
             // new speculative task will not fit (even tiny one)
-            NodeAllocator.NodeLease acquireSpeculative3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), true);
+            NodeAllocator.NodeLease acquireSpeculative3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), SPECULATIVE);
             assertNotAcquired(acquireSpeculative3);
 
             // if you switch it to non-speculative it will schedule
-            acquireSpeculative3.setSpeculative(false);
+            acquireSpeculative3.setExecutionClass(STANDARD);
             assertAcquired(acquireSpeculative3, NODE_1);
 
             // release all speculative tasks
@@ -684,15 +686,15 @@ public class TestBinPackingNodeAllocator
             acquireSpeculative3.release();
 
             // we have 32G free on NODE_1 now
-            NodeAllocator.NodeLease acquireNonSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNonSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertAcquired(acquireNonSpeculative4, NODE_1);
 
             // no place for speculative task
-            NodeAllocator.NodeLease acquireSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), true);
+            NodeAllocator.NodeLease acquireSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), SPECULATIVE);
             assertNotAcquired(acquireSpeculative4);
 
             // no place for another non-speculative task
-            NodeAllocator.NodeLease acquireNonSpeculative5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireNonSpeculative5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
             assertNotAcquired(acquireNonSpeculative5);
 
             // release acquireNonSpeculative4 - a non-speculative task should be scheduled before speculative one
@@ -714,19 +716,19 @@ public class TestBinPackingNodeAllocator
 
         try (NodeAllocator nodeAllocator = nodeAllocatorService.getNodeAllocator(SESSION)) {
             // allocate speculative task
-            NodeAllocator.NodeLease acquireSpeculative = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), true);
+            NodeAllocator.NodeLease acquireSpeculative = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), SPECULATIVE);
             assertAcquired(acquireSpeculative, NODE_1);
 
             // check if standard task can fit and release - it should fit
-            NodeAllocator.NodeLease acquireStandard1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireStandard1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertAcquired(acquireStandard1, NODE_1);
             acquireStandard1.release();
 
             // switch acquireSpeculative to standard
-            acquireSpeculative.setSpeculative(false);
+            acquireSpeculative.setExecutionClass(STANDARD);
 
             // extra standard task should no longer fit
-            NodeAllocator.NodeLease acquireStandard2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), false);
+            NodeAllocator.NodeLease acquireStandard2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(16, GIGABYTE), STANDARD);
             assertNotAcquired(acquireStandard2);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestBinPackingNodeAllocator.java
@@ -666,17 +666,17 @@ public class TestBinPackingNodeAllocator
             NodeAllocator.NodeLease acquireSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), SPECULATIVE);
             assertAcquired(acquireSpeculative2, NODE_2);
 
-            // non-speculative tasks should still get node
-            NodeAllocator.NodeLease acquireNonSpeculative1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD);
-            assertAcquired(acquireNonSpeculative1, NODE_2);
-            NodeAllocator.NodeLease acquireNonSpeculative2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
-            assertAcquired(acquireNonSpeculative2, NODE_1);
+            // standard tasks should still get node
+            NodeAllocator.NodeLease acquireStandard1 = nodeAllocator.acquire(REQ_NONE, DataSize.of(64, GIGABYTE), STANDARD);
+            assertAcquired(acquireStandard1, NODE_2);
+            NodeAllocator.NodeLease acquireStandard2 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
+            assertAcquired(acquireStandard2, NODE_1);
 
             // new speculative task will not fit (even tiny one)
             NodeAllocator.NodeLease acquireSpeculative3 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), SPECULATIVE);
             assertNotAcquired(acquireSpeculative3);
 
-            // if you switch it to non-speculative it will schedule
+            // if you switch it to standard it will schedule
             acquireSpeculative3.setExecutionClass(STANDARD);
             assertAcquired(acquireSpeculative3, NODE_1);
 
@@ -686,24 +686,24 @@ public class TestBinPackingNodeAllocator
             acquireSpeculative3.release();
 
             // we have 32G free on NODE_1 now
-            NodeAllocator.NodeLease acquireNonSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
-            assertAcquired(acquireNonSpeculative4, NODE_1);
+            NodeAllocator.NodeLease acquireStandard4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
+            assertAcquired(acquireStandard4, NODE_1);
 
             // no place for speculative task
             NodeAllocator.NodeLease acquireSpeculative4 = nodeAllocator.acquire(REQ_NONE, DataSize.of(1, GIGABYTE), SPECULATIVE);
             assertNotAcquired(acquireSpeculative4);
 
-            // no place for another non-speculative task
-            NodeAllocator.NodeLease acquireNonSpeculative5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
-            assertNotAcquired(acquireNonSpeculative5);
+            // no place for another standard task
+            NodeAllocator.NodeLease acquireStandard5 = nodeAllocator.acquire(REQ_NONE, DataSize.of(32, GIGABYTE), STANDARD);
+            assertNotAcquired(acquireStandard5);
 
-            // release acquireNonSpeculative4 - a non-speculative task should be scheduled before speculative one
-            acquireNonSpeculative4.release();
-            assertAcquired(acquireNonSpeculative5);
+            // release acquireStandard4 - a standard task should be scheduled before speculative one
+            acquireStandard4.release();
+            assertAcquired(acquireStandard5);
             assertNotAcquired(acquireSpeculative4);
 
             // on subsequent release speculative task will get node
-            acquireNonSpeculative5.release();
+            acquireStandard5.release();
             assertAcquired(acquireSpeculative4);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestExponentialGrowthPartitionMemoryEstimator.java
@@ -54,6 +54,7 @@ public class TestExponentialGrowthPartitionMemoryEstimator
                 true,
                 Duration.of(1, MINUTES),
                 DataSize.ofBytes(0),
+                DataSize.ofBytes(0),
                 Ticker.systemTicker());
         nodeAllocatorService.refreshNodePoolMemoryInfos();
         PartitionMemoryEstimator estimator = nodeAllocatorService.createPartitionMemoryEstimator();

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryManagerConfig.java
@@ -46,7 +46,8 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(1, GIGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(3.0)
                 .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.9)
-                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(true));
+                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(true)
+                .setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize.of(20, GIGABYTE)));
     }
 
     @Test
@@ -64,6 +65,7 @@ public class TestMemoryManagerConfig
                 .put("fault-tolerant-execution-task-memory-growth-factor", "17.3")
                 .put("fault-tolerant-execution-task-memory-estimation-quantile", "0.7")
                 .put("fault-tolerant-execution.memory-requirement-increase-on-worker-crash-enabled", "false")
+                .put("fault-tolerant-execution-eager-speculative-tasks-node_memory-overcommit", "21GB")
                 .buildOrThrow();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
@@ -77,7 +79,8 @@ public class TestMemoryManagerConfig
                 .setFaultTolerantExecutionTaskRuntimeMemoryEstimationOverhead(DataSize.of(300, MEGABYTE))
                 .setFaultTolerantExecutionTaskMemoryGrowthFactor(17.3)
                 .setFaultTolerantExecutionTaskMemoryEstimationQuantile(0.7)
-                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(false);
+                .setFaultTolerantExecutionMemoryRequirementIncreaseOnWorkerCrashEnabled(false)
+                .setFaultTolerantExecutionEagerSpeculativeTasksNodeMemoryOvercommit(DataSize.of(21, GIGABYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/Exchange.java
@@ -20,10 +20,15 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 @ThreadSafe
-@Experimental(eta = "2023-09-01")
+@Experimental(eta = "2024-03-01")
 public interface Exchange
         extends Closeable
 {
+    enum SourceHandlesDeliveryMode {
+        STANDARD,
+        EAGER
+    }
+
     /**
      * Get id of this exchange
      */
@@ -93,6 +98,23 @@ public interface Exchange
      * worker that is needed to create an {@link ExchangeSource} using {@link ExchangeManager#createSource()}
      */
     ExchangeSourceHandleSource getSourceHandles();
+
+    /**
+     * Change {@link ExchangeSourceHandleSource} delivery mode.
+     * <p>
+     * In {@link SourceHandlesDeliveryMode#STANDARD} mode the handles are delivered at
+     * pace optimized for throughput.
+     * <p>
+     * In {@link SourceHandlesDeliveryMode#EAGER} the handles are delivered as soon as possible even if that would mean
+     * each handle corresponds to smaller amount of data, which may be not optimal from throughput.
+     * <p>
+     * There are no strict constraints regarding when this method can be called. When called, the newly selected delivery mode
+     * will apply to all {@link ExchangeSourceHandleSource} instances already obtained via {@link #getSourceHandles()} method.
+     * As well as to those yet to be obtained.
+     * <p>
+     * Support for this method is optional and best-effort.
+     */
+    default void setSourceHandlesDeliveryMode(SourceHandlesDeliveryMode sourceHandlesDeliveryMode) {}
 
     @Override
     void close();


### PR DESCRIPTION

It is quite common to use
```
  SELECT .... LIMIT N
```
queries for date exploration.
Currently such queries when run in FTE mode require completion of all (or almost) all
tasks which read source data, even though most of the time final answer
could be obtained much sooner.

This commit enables EAGER_SPECULATIVE tasks execution mode for stages
which have FINAL LIMIT operator. This will allow for returning final
results to user much faster (assuming exchange plugin in use supports
concurrent read and write)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
