### PR TITLE
Avoid Slice allocations in decimal aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateSerializer.java
@@ -70,27 +70,26 @@ public class LongDecimalWithOverflowAndLongStateSerializer
     public void deserialize(Block block, int index, LongDecimalWithOverflowAndLongState state)
     {
         if (!block.isNull(index)) {
-            Slice slice = VARBINARY.getSlice(block, index);
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
 
-            int sliceLength = slice.length();
-            long low = slice.getLong(0);
+            int sliceLength = block.getSliceLength(index);
+            long low = block.getLong(index, 0);
             long high = 0;
             long overflow = 0;
             long count = 1;
 
             switch (sliceLength) {
                 case 4 * Long.BYTES:
-                    overflow = slice.getLong(Long.BYTES * 3);
-                    count = slice.getLong(Long.BYTES * 2);
+                    overflow = block.getLong(index, Long.BYTES * 3);
+                    count = block.getLong(index, Long.BYTES * 2);
                     // fall through
                 case 2 * Long.BYTES:
-                    high = slice.getLong(Long.BYTES);
+                    high = block.getLong(index, Long.BYTES);
                     break;
                 case 3 * Long.BYTES:
-                    overflow = slice.getLong(Long.BYTES * 2);
-                    count = slice.getLong(Long.BYTES);
+                    overflow = block.getLong(index, Long.BYTES * 2);
+                    count = block.getLong(index, Long.BYTES);
             }
 
             decimal[offset + 1] = low;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateSerializer.java
@@ -60,21 +60,20 @@ public class LongDecimalWithOverflowStateSerializer
     public void deserialize(Block block, int index, LongDecimalWithOverflowState state)
     {
         if (!block.isNull(index)) {
-            Slice slice = VARBINARY.getSlice(block, index);
             long[] decimal = state.getDecimalArray();
             int offset = state.getDecimalArrayOffset();
 
-            long low = slice.getLong(0);
-            int sliceLength = slice.length();
+            long low = block.getLong(index, 0);
+            int sliceLength = block.getSliceLength(index);
             long high = 0;
             long overflow = 0;
 
             switch (sliceLength) {
                 case 3 * Long.BYTES:
-                    overflow = slice.getLong(Long.BYTES * 2);
+                    overflow = block.getLong(index, Long.BYTES * 2);
                     // fall through
                 case 2 * Long.BYTES:
-                    high = slice.getLong(Long.BYTES);
+                    high = block.getLong(index, Long.BYTES);
             }
 
             decimal[offset + 1] = low;


### PR DESCRIPTION
## Description
Slice allocations in `Type#getSlice` cause significant CPU overhead on some decimal aggregation queries

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of decimal aggregations. ({issue}`18868`)
```
