### PR TITLE
Add view text and reference chain information to TableInfo

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -40,10 +40,16 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.eventlistener.BaseViewReferenceInfo;
 import io.trino.spi.eventlistener.ColumnDetail;
 import io.trino.spi.eventlistener.ColumnInfo;
+import io.trino.spi.eventlistener.ColumnMaskReferenceInfo;
+import io.trino.spi.eventlistener.MaterializedViewReferenceInfo;
 import io.trino.spi.eventlistener.RoutineInfo;
+import io.trino.spi.eventlistener.RowFilterReferenceInfo;
 import io.trino.spi.eventlistener.TableInfo;
+import io.trino.spi.eventlistener.TableReferenceInfo;
+import io.trino.spi.eventlistener.ViewReferenceInfo;
 import io.trino.spi.function.table.Argument;
 import io.trino.spi.function.table.ConnectorTableFunctionHandle;
 import io.trino.spi.security.Identity;
@@ -236,6 +242,8 @@ public class Analysis
 
     // for recursive view detection
     private final Deque<Table> tablesForView = new ArrayDeque<>();
+
+    private final Deque<TableReferenceInfo> referenceChain = new ArrayDeque<>();
 
     // row id field for update/delete queries
     private final Map<NodeRef<Table>, FieldReference> rowIdField = new LinkedHashMap<>();
@@ -638,7 +646,8 @@ public class Analysis
             Optional<TableHandle> handle,
             QualifiedObjectName name,
             String authorization,
-            Scope accessControlScope)
+            Scope accessControlScope,
+            Optional<String> viewText)
     {
         tables.put(
                 NodeRef.of(table),
@@ -649,7 +658,9 @@ public class Analysis
                         accessControlScope,
                         tablesForView.isEmpty() &&
                                 rowFilterScopes.isEmpty() &&
-                                columnMaskScopes.isEmpty()));
+                                columnMaskScopes.isEmpty(),
+                        viewText,
+                        referenceChain));
     }
 
     public Set<ResolvedFunction> getResolvedFunctions()
@@ -868,14 +879,23 @@ public class Analysis
         return Optional.ofNullable(expandableBaseScopes.get(NodeRef.of(node)));
     }
 
-    public void registerTableForView(Table tableReference)
+    public void registerTableForView(Table tableReference, QualifiedObjectName name, boolean isMaterializedView)
     {
         tablesForView.push(requireNonNull(tableReference, "tableReference is null"));
+        BaseViewReferenceInfo referenceInfo;
+        if (isMaterializedView) {
+            referenceInfo = new MaterializedViewReferenceInfo(name.getCatalogName(), name.getSchemaName(), name.getObjectName());
+        }
+        else {
+            referenceInfo = new ViewReferenceInfo(name.getCatalogName(), name.getSchemaName(), name.getObjectName());
+        }
+        referenceChain.push(referenceInfo);
     }
 
     public void unregisterTableForView()
     {
         tablesForView.pop();
+        referenceChain.pop();
     }
 
     public boolean hasTableInView(Table tableReference)
@@ -1089,14 +1109,16 @@ public class Analysis
         return rowFilterScopes.contains(new RowFilterScopeEntry(table, identity));
     }
 
-    public void registerTableForRowFiltering(QualifiedObjectName table, String identity)
+    public void registerTableForRowFiltering(QualifiedObjectName table, String identity, String filterExpression)
     {
         rowFilterScopes.add(new RowFilterScopeEntry(table, identity));
+        referenceChain.push(new RowFilterReferenceInfo(filterExpression, table.getCatalogName(), table.getSchemaName(), table.getObjectName()));
     }
 
     public void unregisterTableForRowFiltering(QualifiedObjectName table, String identity)
     {
         rowFilterScopes.remove(new RowFilterScopeEntry(table, identity));
+        referenceChain.pop();
     }
 
     public void addRowFilter(Table table, Expression filter)
@@ -1126,14 +1148,16 @@ public class Analysis
         return columnMaskScopes.contains(new ColumnMaskScopeEntry(table, column, identity));
     }
 
-    public void registerTableForColumnMasking(QualifiedObjectName table, String column, String identity)
+    public void registerTableForColumnMasking(QualifiedObjectName table, String column, String identity, String maskExpression)
     {
         columnMaskScopes.add(new ColumnMaskScopeEntry(table, column, identity));
+        referenceChain.push(new ColumnMaskReferenceInfo(maskExpression, table.getCatalogName(), table.getSchemaName(), table.getObjectName(), column));
     }
 
     public void unregisterTableForColumnMasking(QualifiedObjectName table, String column, String identity)
     {
         columnMaskScopes.remove(new ColumnMaskScopeEntry(table, column, identity));
+        referenceChain.pop();
     }
 
     public void addColumnMask(Table table, String column, Expression mask)
@@ -1178,7 +1202,9 @@ public class Analysis
                                     .map(Expression::toString)
                                     .collect(toImmutableList()),
                             columns,
-                            info.isDirectlyReferenced());
+                            info.isDirectlyReferenced(),
+                            info.getViewText(),
+                            info.getReferenceChain());
                 })
                 .collect(toImmutableList());
     }
@@ -1993,19 +2019,25 @@ public class Analysis
         private final String authorization;
         private final Scope accessControlScope; // synthetic scope for analysis of row filters and masks
         private final boolean directlyReferenced;
+        private final Optional<String> viewText;
+        private final List<TableReferenceInfo> referenceChain;
 
         public TableEntry(
                 Optional<TableHandle> handle,
                 QualifiedObjectName name,
                 String authorization,
                 Scope accessControlScope,
-                boolean directlyReferenced)
+                boolean directlyReferenced,
+                Optional<String> viewText,
+                Iterable<TableReferenceInfo> referenceChain)
         {
             this.handle = requireNonNull(handle, "handle is null");
             this.name = requireNonNull(name, "name is null");
             this.authorization = requireNonNull(authorization, "authorization is null");
             this.accessControlScope = requireNonNull(accessControlScope, "accessControlScope is null");
             this.directlyReferenced = directlyReferenced;
+            this.viewText = requireNonNull(viewText, "viewText is null");
+            this.referenceChain = ImmutableList.copyOf(requireNonNull(referenceChain, "referenceChain is null"));
         }
 
         public Optional<TableHandle> getHandle()
@@ -2018,11 +2050,6 @@ public class Analysis
             return name;
         }
 
-        public boolean isDirectlyReferenced()
-        {
-            return directlyReferenced;
-        }
-
         public String getAuthorization()
         {
             return authorization;
@@ -2031,6 +2058,21 @@ public class Analysis
         public Scope getAccessControlScope()
         {
             return accessControlScope;
+        }
+
+        public boolean isDirectlyReferenced()
+        {
+            return directlyReferenced;
+        }
+
+        public Optional<String> getViewText()
+        {
+            return viewText;
+        }
+
+        public List<TableReferenceInfo> getReferenceChain()
+        {
+            return referenceChain;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -607,7 +607,7 @@ class StatementAnalyzer
                     .build();
             analyzeFiltersAndMasks(insert.getTable(), targetTable, new RelationType(tableFields), accessControlScope);
             analyzeCheckConstraints(insert.getTable(), targetTable, accessControlScope, checkConstraints);
-            analysis.registerTable(insert.getTable(), targetTableHandle, targetTable, session.getIdentity().getUser(), accessControlScope);
+            analysis.registerTable(insert.getTable(), targetTableHandle, targetTable, session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             List<String> tableColumns = columns.stream()
                     .map(ColumnSchema::getName)
@@ -853,7 +853,7 @@ class StatementAnalyzer
                     .build();
             analyzeFiltersAndMasks(table, tableName, analysis.getScope(table).getRelationType(), accessControlScope);
             analyzeCheckConstraints(table, tableName, accessControlScope, tableSchema.getTableSchema().getCheckConstraints());
-            analysis.registerTable(table, Optional.of(handle), tableName, session.getIdentity().getUser(), accessControlScope);
+            analysis.registerTable(table, Optional.of(handle), tableName, session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             createMergeAnalysis(table, handle, tableSchema, tableScope, tableScope, ImmutableList.of());
 
@@ -2319,7 +2319,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(outputFields))
                     .build();
             analyzeFiltersAndMasks(table, targetTableName, new RelationType(outputFields), accessControlScope);
-            analysis.registerTable(table, tableHandle, targetTableName, session.getIdentity().getUser(), accessControlScope);
+            analysis.registerTable(table, tableHandle, targetTableName, session.getIdentity().getUser(), accessControlScope, Optional.empty());
 
             Scope tableScope = createAndAssignScope(table, scope, outputFields);
 
@@ -2483,7 +2483,8 @@ class StatementAnalyzer
                     view.getRunAsIdentity(),
                     view.getPath(),
                     view.getColumns(),
-                    storageTable);
+                    storageTable,
+                    true);
         }
 
         private Scope createScopeForView(Table table, QualifiedObjectName name, Optional<Scope> scope, ViewDefinition view)
@@ -2497,7 +2498,8 @@ class StatementAnalyzer
                     view.getRunAsIdentity(),
                     view.getPath(),
                     view.getColumns(),
-                    Optional.empty());
+                    Optional.empty(),
+                    false);
         }
 
         private Scope createScopeForView(
@@ -2510,7 +2512,8 @@ class StatementAnalyzer
                 Optional<Identity> owner,
                 List<CatalogSchemaName> path,
                 List<ViewColumn> columns,
-                Optional<TableHandle> storageTable)
+                Optional<TableHandle> storageTable,
+                boolean isMaterializedView)
         {
             Statement statement = analysis.getStatement();
             if (statement instanceof CreateView viewStatement) {
@@ -2535,7 +2538,7 @@ class StatementAnalyzer
                 throw semanticException(NOT_SUPPORTED, table, "View contains inline function: %s", name);
             }
 
-            analysis.registerTableForView(table);
+            analysis.registerTableForView(table, name, isMaterializedView);
             RelationType descriptor = analyzeView(query, name, catalog, schema, owner, path, table);
             analysis.unregisterTableForView();
 
@@ -2562,7 +2565,7 @@ class StatementAnalyzer
                         .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
                         .build();
                 analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
-                analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope);
+                analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
                 analysis.addRelationCoercion(table, viewFields.stream().map(Field::getType).toArray(Type[]::new));
                 // use storage table output fields as they contain ColumnHandles
                 return createAndAssignScope(table, scope, storageTableFields);
@@ -2572,7 +2575,7 @@ class StatementAnalyzer
                     .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
                     .build();
             analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
-            analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope);
+            analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
             viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
             analysis.registerNamedQuery(table, query);
             return createAndAssignScope(table, scope, viewFields);
@@ -3405,7 +3408,7 @@ class StatementAnalyzer
             Scope tableScope = analyzer.analyzeForUpdate(table, scope, UpdateKind.UPDATE);
             update.getWhere().ifPresent(where -> analyzeWhere(update, tableScope, where));
             analyzeCheckConstraints(table, tableName, tableScope, tableSchema.getTableSchema().getCheckConstraints());
-            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), tableScope);
+            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), tableScope, Optional.empty());
 
             ImmutableList.Builder<ExpressionAnalysis> analysesBuilder = ImmutableList.builder();
             ImmutableList.Builder<Type> expressionTypesBuilder = ImmutableList.builder();
@@ -3525,7 +3528,7 @@ class StatementAnalyzer
             Scope sourceTableScope = process(merge.getSource(), mergeScope);
             Scope joinScope = createAndAssignScope(merge, Optional.of(mergeScope), targetTableScope.getRelationType().joinWith(sourceTableScope.getRelationType()));
             analyzeCheckConstraints(table, tableName, targetTableScope, tableSchema.getTableSchema().getCheckConstraints());
-            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), targetTableScope);
+            analysis.registerTable(table, redirection.tableHandle(), tableName, session.getIdentity().getUser(), targetTableScope, Optional.empty());
 
             for (ColumnSchema column : dataColumnSchemas) {
                 if (accessControl.getColumnMask(session.toSecurityContext(), tableName, column.getName(), column.getType()).isPresent()) {
@@ -5074,7 +5077,7 @@ class StatementAnalyzer
                 throw new TrinoException(INVALID_ROW_FILTER, extractLocation(table), format("Invalid row filter for '%s': %s", name, e.getErrorMessage()), e);
             }
 
-            analysis.registerTableForRowFiltering(name, currentIdentity);
+            analysis.registerTableForRowFiltering(name, currentIdentity, expression.toString());
 
             verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, expression, format("Row filter for '%s'", name));
 
@@ -5193,7 +5196,7 @@ class StatementAnalyzer
             }
 
             ExpressionAnalysis expressionAnalysis;
-            analysis.registerTableForColumnMasking(tableName, column, currentIdentity);
+            analysis.registerTableForColumnMasking(tableName, column, currentIdentity, expression.toString());
 
             verifyNoAggregateWindowOrGroupingFunctions(session, functionResolver, accessControl, expression, format("Column mask for '%s.%s'", table.getName(), column));
 

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/BaseViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/BaseViewReferenceInfo.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public abstract class BaseViewReferenceInfo
+        implements TableReferenceInfo
+{
+    private final String catalogName;
+    private final String schemaName;
+    private final String viewName;
+
+    protected BaseViewReferenceInfo(String catalogName, String schemaName, String viewName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.viewName = requireNonNull(viewName, "viewName is null");
+    }
+
+    @JsonProperty
+    public String getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getViewName()
+    {
+        return viewName;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnMaskReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnMaskReferenceInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public class ColumnMaskReferenceInfo
+        extends FilterMaskReferenceInfo
+{
+    private final String columnName;
+
+    @JsonCreator
+    public ColumnMaskReferenceInfo(String maskExpression, String targetCatalogName, String targetSchemaName, String targetTableName, String targetColumnName)
+    {
+        super(maskExpression, targetCatalogName, targetSchemaName, targetTableName);
+        this.columnName = targetColumnName;
+    }
+
+    @JsonProperty
+    public String getTargetColumnName()
+    {
+        return columnName;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/FilterMaskReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/FilterMaskReferenceInfo.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public abstract class FilterMaskReferenceInfo
+        implements TableReferenceInfo
+{
+    private final String expression;
+    private final String targetCatalogName;
+    private final String targetSchemaName;
+    private final String targetTableName;
+
+    protected FilterMaskReferenceInfo(String expression, String targetCatalogName, String targetSchemaName, String targetTableName)
+    {
+        this.expression = expression;
+        this.targetCatalogName = targetCatalogName;
+        this.targetSchemaName = targetSchemaName;
+        this.targetTableName = targetTableName;
+    }
+
+    @JsonProperty
+    public String getExpression()
+    {
+        return expression;
+    }
+
+    @JsonProperty
+    public String getTargetCatalogName()
+    {
+        return targetCatalogName;
+    }
+
+    @JsonProperty
+    public String getTargetSchemaName()
+    {
+        return targetSchemaName;
+    }
+
+    @JsonProperty
+    public String getTargetTableName()
+    {
+        return targetTableName;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/MaterializedViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/MaterializedViewReferenceInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public class MaterializedViewReferenceInfo
+        extends BaseViewReferenceInfo
+{
+    @JsonCreator
+    public MaterializedViewReferenceInfo(String catalogName, String schemaName, String viewName)
+    {
+        super(catalogName, schemaName, viewName);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RowFilterReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RowFilterReferenceInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public class RowFilterReferenceInfo
+        extends FilterMaskReferenceInfo
+{
+    @JsonCreator
+    public RowFilterReferenceInfo(String filterExpression, String targetCatalogName, String targetSchemaName, String targetTableName)
+    {
+        super(filterExpression, targetCatalogName, targetSchemaName, targetTableName);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.Unstable;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,10 +35,21 @@ public class TableInfo
     private final List<String> filters;
     private final List<ColumnInfo> columns;
     private final boolean directlyReferenced;
+    private final Optional<String> viewText;
+    private final List<TableReferenceInfo> referenceChain;
 
     @JsonCreator
     @Unstable
-    public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns, boolean directlyReferenced)
+    public TableInfo(
+            String catalog,
+            String schema,
+            String table,
+            String authorization,
+            List<String> filters,
+            List<ColumnInfo> columns,
+            boolean directlyReferenced,
+            Optional<String> viewText,
+            List<TableReferenceInfo> referenceChain)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -46,6 +58,8 @@ public class TableInfo
         this.filters = List.copyOf(requireNonNull(filters, "filters is null"));
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.directlyReferenced = directlyReferenced;
+        this.viewText = requireNonNull(viewText, "viewText is null");
+        this.referenceChain = List.copyOf(requireNonNull(referenceChain, "referenceChain is null"));
     }
 
     @JsonProperty
@@ -88,5 +102,48 @@ public class TableInfo
     public boolean isDirectlyReferenced()
     {
         return directlyReferenced;
+    }
+
+    /**
+     * If this object refers to a view or materialized view, return the SQL text of the view.
+     *
+     * @return The SQL text of the view, or empty if this object does not refer to a view.
+     */
+    @JsonProperty
+    public Optional<String> getViewText()
+    {
+        return viewText;
+    }
+
+    /**
+     * Get the reference chain for this table. Contains entries for view-like expressions such as views, column masks, and row filters.
+     * Note that in contrast to {@link #getFilters()} and {@link #getColumns()}, this has information about the reference chain leading
+     * this table to be included in the query, rather than information about which filters/masks were applied to this table scan.
+     * <p>
+     * Let us assume the following setup, with default catalog "default" and default schema "db":
+     * <pre>
+     * CREATE TABLE t_base (a INT, b INT);
+     * CREATE VIEW v1 AS SELECT * FROM t_base;
+     * CREATE VIEW v2 AS SELECT * FROM v1;
+     *
+     * Row filter for t_base:      a NOT IN (SELECT * FROM t_filter)
+     * Column mask for t_base.b:   IF(b IN (SELECT * FROM t_mask), b, NULL)
+     * </pre>
+     * If we execute {@code SELECT * FROM v2}, we will see the following values for {@code referenceChain}:
+     * <pre>
+     * v2 -> []
+     * v1 -> [{"view", "default", "db", "v2"}]
+     * t_base -> [{"view", "default", "db", "v2"}, {"view", "default", "db", "v1"}]
+     * t_filter -> [{"view", "default", "db", "v2"}, {"view", "default", "db", "v1"}, {"rowFilter", "a NOT IN (SELECT * FROM t_filter)", "default", "db", "t_base"}]
+     * t_mask -> [{"view", "default", "db", "v2"}, {"view", "default", "db", "v1"}, {"columnMask", "IF(b IN SELECT * FROM t_mask, b, NULL)", "default", "db", "t_base"}]
+     * </pre>
+     * </p>
+     *
+     * @return The reference chain leading to this table, in order.
+     */
+    @JsonProperty
+    public List<TableReferenceInfo> getReferenceChain()
+    {
+        return referenceChain;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableReferenceInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ *
+ * @see TableInfo#getReferenceChain()
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ViewReferenceInfo.class, name = "view"),
+        @JsonSubTypes.Type(value = MaterializedViewReferenceInfo.class, name = "materializedView"),
+        @JsonSubTypes.Type(value = RowFilterReferenceInfo.class, name = "rowFilter"),
+        @JsonSubTypes.Type(value = ColumnMaskReferenceInfo.class, name = "columnMask")})
+public interface TableReferenceInfo
+{
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ViewReferenceInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
+public class ViewReferenceInfo
+        extends BaseViewReferenceInfo
+{
+    @JsonCreator
+    public ViewReferenceInfo(String catalogName, String schemaName, String viewName)
+    {
+        super(catalogName, schemaName, viewName);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/BaseViewReferenceInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/BaseViewReferenceInfoAssert.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.common.assertions;
+
+import io.trino.spi.eventlistener.BaseViewReferenceInfo;
+import org.assertj.core.api.AbstractAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BaseViewReferenceInfoAssert
+        extends AbstractAssert<BaseViewReferenceInfoAssert, BaseViewReferenceInfo>
+{
+    BaseViewReferenceInfoAssert(BaseViewReferenceInfo actual)
+    {
+        super(actual, BaseViewReferenceInfoAssert.class);
+    }
+
+    public BaseViewReferenceInfoAssert hasCatalogSchemaView(String catalogName, String schemaName, String viewName)
+    {
+        assertThat(actual.getCatalogName()).isEqualTo(catalogName);
+        assertThat(actual.getSchemaName()).isEqualTo(schemaName);
+        assertThat(actual.getViewName()).isEqualTo(viewName);
+        return this;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/FilterMaskReferenceInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/FilterMaskReferenceInfoAssert.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.common.assertions;
+
+import io.trino.spi.eventlistener.ColumnMaskReferenceInfo;
+import io.trino.spi.eventlistener.FilterMaskReferenceInfo;
+import org.assertj.core.api.AbstractAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FilterMaskReferenceInfoAssert
+        extends AbstractAssert<FilterMaskReferenceInfoAssert, FilterMaskReferenceInfo>
+{
+    FilterMaskReferenceInfoAssert(FilterMaskReferenceInfo actual)
+    {
+        super(actual, FilterMaskReferenceInfoAssert.class);
+    }
+
+    public FilterMaskReferenceInfoAssert hasExpression(String expression)
+    {
+        assertThat(actual.getExpression()).isEqualToIgnoringWhitespace(expression);
+        return this;
+    }
+
+    public FilterMaskReferenceInfoAssert hasTargetCatalogSchemaTable(String catalogName, String schemaName, String tableName)
+    {
+        assertThat(actual.getTargetCatalogName()).isEqualTo(catalogName);
+        assertThat(actual.getTargetSchemaName()).isEqualTo(schemaName);
+        assertThat(actual.getTargetTableName()).isEqualTo(tableName);
+        return this;
+    }
+
+    public FilterMaskReferenceInfoAssert hasTargetColumn(String maskedColumnName)
+    {
+        TrinoAssertions.assertThat(actual).isInstanceOfSatisfying(
+                ColumnMaskReferenceInfo.class,
+                columnMaskInfo -> assertThat(columnMaskInfo.getTargetColumnName()).isEqualTo(maskedColumnName));
+        return this;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/TableInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/TableInfoAssert.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.common.assertions;
+
+import io.trino.spi.eventlistener.ColumnInfo;
+import io.trino.spi.eventlistener.TableInfo;
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TableInfoAssert
+        extends AbstractAssert<TableInfoAssert, TableInfo>
+{
+    TableInfoAssert(TableInfo actual)
+    {
+        super(actual, TableInfoAssert.class);
+    }
+
+    public TableInfoAssert hasCatalogSchemaTable(String expectedCatalog, String expectedSchema, String expectedTable)
+    {
+        assertThat(actual.getCatalog()).isEqualTo(expectedCatalog);
+        assertThat(actual.getSchema()).isEqualTo(expectedSchema);
+        assertThat(actual.getTable()).isEqualTo(expectedTable);
+        return this;
+    }
+
+    public TableInfoAssert hasAuthorization(String expectedAuthorization)
+    {
+        assertThat(actual.getAuthorization()).isEqualTo(expectedAuthorization);
+        return this;
+    }
+
+    public TableInfoAssert isNotDirectlyReferenced()
+    {
+        assertThat(actual.isDirectlyReferenced()).isFalse();
+        return this;
+    }
+
+    public TableInfoAssert isDirectlyReferenced()
+    {
+        assertThat(actual.isDirectlyReferenced()).isTrue();
+        return this;
+    }
+
+    public TableInfoAssert hasColumnsWithoutMasking(String... columnNames)
+    {
+        assertThat(actual.getColumns()).extracting(ColumnInfo::getColumn).containsExactly(columnNames);
+        assertThat(actual.getColumns()).allSatisfy(columnInfo -> assertThat(columnInfo.getMask()).isEmpty());
+        return this;
+    }
+
+    public TableInfoAssert hasColumnNames(String... columnNames)
+    {
+        assertThat(actual.getColumns()).extracting(ColumnInfo::getColumn).containsExactly(columnNames);
+        return this;
+    }
+
+    /**
+     * Asserts that the table has the given column masks. Use 'null' to represent an empty mask.
+     */
+    public TableInfoAssert hasColumnMasks(String... columnMasks)
+    {
+        assertThat(actual.getColumns()).hasSize(columnMasks.length);
+        for (int i = 0; i < columnMasks.length; i++) {
+            String expectedMask = columnMasks[i];
+            Optional<String> actualMask = actual.getColumns().get(i).getMask();
+            if (expectedMask == null) {
+                assertThat(actualMask).isEmpty();
+            }
+            else {
+                assertThat(actualMask).hasValueSatisfying(maskText ->
+                        assertThat(maskText).isEqualToIgnoringWhitespace(expectedMask));
+            }
+        }
+        return this;
+    }
+
+    public TableInfoAssert hasNoRowFilters()
+    {
+        assertThat(actual.getFilters()).isEmpty();
+        return this;
+    }
+
+    public TableInfoAssert hasRowFilters(String... filterTexts)
+    {
+        assertThat(actual.getFilters()).hasSize(filterTexts.length);
+        for (int i = 0; i < filterTexts.length; i++) {
+            assertThat(actual.getFilters().get(i)).isEqualToIgnoringWhitespace(filterTexts[i]);
+        }
+        return this;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/TableInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/TableInfoAssert.java
@@ -15,9 +15,11 @@ package io.trino.common.assertions;
 
 import io.trino.spi.eventlistener.ColumnInfo;
 import io.trino.spi.eventlistener.TableInfo;
+import io.trino.spi.eventlistener.TableReferenceInfo;
 import org.assertj.core.api.AbstractAssert;
 
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -99,6 +101,28 @@ public class TableInfoAssert
         assertThat(actual.getFilters()).hasSize(filterTexts.length);
         for (int i = 0; i < filterTexts.length; i++) {
             assertThat(actual.getFilters().get(i)).isEqualToIgnoringWhitespace(filterTexts[i]);
+        }
+        return this;
+    }
+
+    public TableInfoAssert hasViewText(String viewText)
+    {
+        assertThat(actual.getViewText()).hasValueSatisfying(sql -> assertThat(sql).isEqualToIgnoringWhitespace(viewText));
+        return this;
+    }
+
+    public TableInfoAssert hasNoTableReferences()
+    {
+        assertThat(actual.getReferenceChain()).isEmpty();
+        return this;
+    }
+
+    @SafeVarargs
+    public final TableInfoAssert hasTableReferencesSatisfying(Consumer<TableReferenceInfo>... tableReferenceAssertions)
+    {
+        assertThat(actual.getReferenceChain()).hasSize(tableReferenceAssertions.length);
+        for (int i = 0; i < tableReferenceAssertions.length; i++) {
+            tableReferenceAssertions[i].accept(actual.getReferenceChain().get(i));
         }
         return this;
     }

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/TableReferenceInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/TableReferenceInfoAssert.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.common.assertions;
+
+import io.trino.spi.eventlistener.BaseViewReferenceInfo;
+import io.trino.spi.eventlistener.ColumnMaskReferenceInfo;
+import io.trino.spi.eventlistener.FilterMaskReferenceInfo;
+import io.trino.spi.eventlistener.MaterializedViewReferenceInfo;
+import io.trino.spi.eventlistener.RowFilterReferenceInfo;
+import io.trino.spi.eventlistener.TableReferenceInfo;
+import io.trino.spi.eventlistener.ViewReferenceInfo;
+import org.assertj.core.api.AbstractAssert;
+
+import static io.trino.common.assertions.TrinoAssertions.assertThat;
+
+public class TableReferenceInfoAssert
+        extends AbstractAssert<TableReferenceInfoAssert, TableReferenceInfo>
+{
+    TableReferenceInfoAssert(TableReferenceInfo actual)
+    {
+        super(actual, TableReferenceInfoAssert.class);
+    }
+
+    public BaseViewReferenceInfoAssert asViewInfo()
+    {
+        assertThat(actual).isInstanceOf(ViewReferenceInfo.class);
+        return new BaseViewReferenceInfoAssert((BaseViewReferenceInfo) actual);
+    }
+
+    public BaseViewReferenceInfoAssert asMaterializedViewInfo()
+    {
+        assertThat(actual).isInstanceOf(MaterializedViewReferenceInfo.class);
+        return new BaseViewReferenceInfoAssert((BaseViewReferenceInfo) actual);
+    }
+
+    public FilterMaskReferenceInfoAssert asRowFilterInfo()
+    {
+        assertThat(actual).isInstanceOf(RowFilterReferenceInfo.class);
+        return new FilterMaskReferenceInfoAssert((FilterMaskReferenceInfo) actual);
+    }
+
+    public FilterMaskReferenceInfoAssert asColumnMaskInfo()
+    {
+        assertThat(actual).isInstanceOf(ColumnMaskReferenceInfo.class);
+        return new FilterMaskReferenceInfoAssert((FilterMaskReferenceInfo) actual);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/TrinoAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/TrinoAssertions.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.common.assertions;
+
+import io.trino.spi.eventlistener.TableInfo;
+
+public class TrinoAssertions
+{
+    private TrinoAssertions() {}
+
+    public static TableInfoAssert assertThat(TableInfo actual)
+    {
+        return new TableInfoAssert(actual);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/TrinoAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/TrinoAssertions.java
@@ -13,7 +13,10 @@
  */
 package io.trino.common.assertions;
 
+import io.trino.spi.eventlistener.BaseViewReferenceInfo;
+import io.trino.spi.eventlistener.FilterMaskReferenceInfo;
 import io.trino.spi.eventlistener.TableInfo;
+import io.trino.spi.eventlistener.TableReferenceInfo;
 
 public class TrinoAssertions
 {
@@ -22,5 +25,20 @@ public class TrinoAssertions
     public static TableInfoAssert assertThat(TableInfo actual)
     {
         return new TableInfoAssert(actual);
+    }
+
+    public static TableReferenceInfoAssert assertThat(TableReferenceInfo actual)
+    {
+        return new TableReferenceInfoAssert(actual);
+    }
+
+    public static BaseViewReferenceInfoAssert assertThat(BaseViewReferenceInfo actual)
+    {
+        return new BaseViewReferenceInfoAssert(actual);
+    }
+
+    public static FilterMaskReferenceInfoAssert assertThat(FilterMaskReferenceInfo actual)
+    {
+        return new FilterMaskReferenceInfoAssert(actual);
     }
 }


### PR DESCRIPTION
In #7330, a flag `directlyReferenced` was added to `TableInfo` to indicate whether a given table or view was directly referenced, or indirectly referenced via a view/filter/mask. This is useful, but lacks the information necessary to understand what caused the indirect reference. Understanding the context can be useful for auditing purposes, as well as general lineage use cases.

As one motivating example, let us say we have have the following:
- table `foo` contains user data (PII)
- view `foo_sanitized` provides a view over `foo` with PII columns removed
- view `foo_dirty` defined as `SELECT * FROM foo`
- legal requirement that when reading user data for a certain use case `bar`, PII cannot be used

Auditing is one way to enforce that queries run for `bar` only make use of `foo_sanitized` rather than accessing `foo` directly. However currently we can only tell that `foo` was indirectly referenced, e.g. we don't know if it was accessed via `foo_dirty` or `foo_sanitized`, and thus cannot determine if the access met the requirement.

Similarly, let us envision that we want to notify all consumers of a table `foo` of some impending migration/deprecation. It's not sufficient to just know that `foo` was accessed by way of a view; we need to know _which_ view caused that access, so that we can identify the view owner to notify.

To achieve this, a new field `referenceChain` is added to `TableInfo`. This shows the chain of references leading from the direct reference to the view/table. For example assume we have the following:
```
CREATE TABLE foo;
CREATE VIEW foo1 AS SELECT * FROM foo;
CREATE VIEW foo2 AS SELECT * FROM foo1;

SELECT * FROM foo2;
```
For the `SELECT` query we will see the following values for `TableInfo#referenceChain`:
```
foo -> [foo2, foo1]
foo1 -> [foo2]
foo2 -> []
```
In this way we can clearly identify where the access originated from. This PR also proposes including the text of a view in the `TableInfo` entry for views, to make it easier to understand which transformations were applied.

This mainly focuses on views, but also accommodates column masks and row filters as part of the reference chain. Assuming the same setup as above, but also with a row filter applied on table `foo` like `userid IN (SELECT userid FROM allowed_users)`, we would see:
```
allowed_users -> [foo2, foo1, <foo, "userid IN (SELECT userid FROM allowed_users)">]
```
Since row filters / column masks aren't named, they are identified by their target table and the expression.

This creates a new interface `TableReferenceInfo` in the SPI to represent these entities that can reference other tables. There are concrete subclasses for views, column masks, and row filters.