### PR TITLE
Add view reference chain information to TableInfo

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
@@ -34,10 +34,19 @@ public class TableInfo
     private final List<String> filters;
     private final List<ColumnInfo> columns;
     private final boolean directlyReferenced;
+    private final List<TableInfo> viewReferenceChain;
 
     @JsonCreator
     @Unstable
-    public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns, boolean directlyReferenced)
+    public TableInfo(
+            String catalog,
+            String schema,
+            String table,
+            String authorization,
+            List<String> filters,
+            List<ColumnInfo> columns,
+            boolean directlyReferenced,
+            List<TableInfo> viewReferenceChain)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -46,6 +55,7 @@ public class TableInfo
         this.filters = List.copyOf(requireNonNull(filters, "filters is null"));
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.directlyReferenced = directlyReferenced;
+        this.viewReferenceChain = List.copyOf(requireNonNull(viewReferenceChain, "viewReferenceChain is null"));
     }
 
     @JsonProperty
@@ -88,5 +98,11 @@ public class TableInfo
     public boolean isDirectlyReferenced()
     {
         return directlyReferenced;
+    }
+
+    @JsonProperty
+    public List<TableInfo> getViewReferenceChain()
+    {
+        return viewReferenceChain;
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -375,26 +375,18 @@ public class TestEventListenerBasic
         assertThat(tables).hasSize(2);
 
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isFalse();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "tpch", "tiny", "nation", "user", false, 1, 0, 1);
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("nationkey");
         assertThat(column.getMask()).isEmpty();
 
+        TableInfo viewInfo = table.getViewReferenceChain().get(0);
+        assertTableInfoBasics(viewInfo, "mock", "default", "test_view", "user", true, 1, 0, 0);
+        assertThat(viewInfo.getColumns().get(0).getColumn()).isEqualTo("test_column");
+
         table = tables.get(1);
-        assertThat(table.getCatalog()).isEqualTo("mock");
-        assertThat(table.getSchema()).isEqualTo("default");
-        assertThat(table.getTable()).isEqualTo("test_view");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isTrue();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "mock", "default", "test_view", "user", true, 1, 0, 0);
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_column");
@@ -412,26 +404,18 @@ public class TestEventListenerBasic
         List<TableInfo> tables = event.getMetadata().getTables();
         assertThat(tables).hasSize(2);
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("alice");
-        assertThat(table.isDirectlyReferenced()).isFalse();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "tpch", "tiny", "nation", "alice", false, 1, 0, 1);
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("nationkey");
         assertThat(column.getMask()).isEmpty();
 
+        TableInfo viewInfo = table.getViewReferenceChain().get(0);
+        assertTableInfoBasics(viewInfo, "mock", "default", "test_materialized_view", "user", true, 1, 0, 0);
+        assertThat(viewInfo.getColumns().get(0).getColumn()).isEqualTo("test_column");
+
         table = tables.get(1);
-        assertThat(table.getCatalog()).isEqualTo("mock");
-        assertThat(table.getSchema()).isEqualTo("default");
-        assertThat(table.getTable()).isEqualTo("test_materialized_view");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isTrue();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "mock", "default", "test_materialized_view", "user", true, 1, 0, 0);
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_column");
@@ -460,13 +444,7 @@ public class TestEventListenerBasic
         assertThat(tables).hasSize(1);
 
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isTrue();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(4);
+        assertTableInfoBasics(table, "tpch", "tiny", "nation", "user", true, 4, 0, 0);
     }
 
     @Test
@@ -491,13 +469,7 @@ public class TestEventListenerBasic
         assertThat(tables).hasSize(1);
 
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isTrue();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(4);
+        assertTableInfoBasics(table, "tpch", "tiny", "nation", "user", true, 4, 0, 0);
     }
 
     @Test
@@ -512,26 +484,15 @@ public class TestEventListenerBasic
         assertThat(tables).hasSize(2);
 
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isFalse();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "tpch", "tiny", "nation", "user", false, 1, 0, 0);
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("name");
         assertThat(column.getMask()).isEmpty();
 
         table = tables.get(1);
-        assertThat(table.getCatalog()).isEqualTo("mock");
-        assertThat(table.getSchema()).isEqualTo("default");
-        assertThat(table.getTable()).isEqualTo("test_table_with_row_filter");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isTrue();
-        assertThat(table.getFilters()).hasSize(1);
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "mock", "default", "test_table_with_row_filter", "user", true, 1, 1, 0);
+        assertThat(table.getFilters().get(0)).isEqualToIgnoringWhitespace("(EXISTS (SELECT 1 FROM nation WHERE (name = test_varchar)))");
 
         column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("test_varchar");
@@ -560,13 +521,7 @@ public class TestEventListenerBasic
         assertThat(tables).hasSize(2);
 
         TableInfo table = tables.get(0);
-        assertThat(table.getCatalog()).isEqualTo("tpch");
-        assertThat(table.getSchema()).isEqualTo("tiny");
-        assertThat(table.getTable()).isEqualTo("orders");
-        assertThat(table.getAuthorization()).isEqualTo("user");
-        assertThat(table.isDirectlyReferenced()).isFalse();
-        assertThat(table.getFilters()).isEmpty();
-        assertThat(table.getColumns()).hasSize(1);
+        assertTableInfoBasics(table, "tpch", "tiny", "orders", "user", false, 1, 0, 0);
 
         ColumnInfo column = table.getColumns().get(0);
         assertThat(column.getColumn()).isEqualTo("orderkey");
@@ -1300,5 +1255,25 @@ public class TestEventListenerBasic
     private static String getQualifiedName(TableInfo tableInfo)
     {
         return tableInfo.getCatalog() + '.' + tableInfo.getSchema() + '.' + tableInfo.getTable();
+    }
+
+    private static void assertTableInfoBasics(
+            TableInfo tableInfo,
+            String catalog,
+            String schema,
+            String table,
+            String authorization,
+            boolean directlyReferenced,
+            int columnsSize,
+            int filtersSize,
+            int viewReferenceChainSize) {
+        assertThat(tableInfo.getCatalog()).isEqualTo(catalog);
+        assertThat(tableInfo.getSchema()).isEqualTo(schema);
+        assertThat(tableInfo.getTable()).isEqualTo(table);
+        assertThat(tableInfo.getAuthorization()).isEqualTo(authorization);
+        assertThat(tableInfo.isDirectlyReferenced()).isEqualTo(directlyReferenced);
+        assertThat(tableInfo.getColumns()).hasSize(columnsSize);
+        assertThat(tableInfo.getFilters()).hasSize(filtersSize);
+        assertThat(tableInfo.getViewReferenceChain()).hasSize(viewReferenceChainSize);
     }
 }


### PR DESCRIPTION
See #18871 for more context.

This is attempting to solve the same problem, but it is scoped only for views, and does not handle row filters or column masks. This makes the required changes much smaller, by reusing `TableInfo` for representing the views in the reference chain, since now they are all views (not filters/masks).

I lean towards preferring #18871, since it is a more generic solution, but implemented this view-specific approach first before identifying how the scope could be expanded to include row filters / column masks, so I figured I would share it here in case others have a preference for this simpler approach.