### PR TITLE
Fix MAP and ARRAY flat write

### DIFF
--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerVarcharMapType.java
@@ -41,6 +41,7 @@ public class TestIntegerVarcharMapType
         BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(INTEGER, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(INTEGER, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
+        mapType.writeObject(blockBuilder, mapBlockOf(INTEGER, VARCHAR, ImmutableMap.of(1, "123456789012345", 2, "hello-world-hello-world-hello-world")));
         return blockBuilder.build();
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintVarcharMapType.java
@@ -41,6 +41,7 @@ public class TestSmallintVarcharMapType
         BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(SMALLINT, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(SMALLINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
+        mapType.writeObject(blockBuilder, mapBlockOf(SMALLINT, VARCHAR, ImmutableMap.of(1, "123456789012345", 2, "hello-world-hello-world-hello-world")));
         return blockBuilder.build();
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintVarcharMapType.java
@@ -41,6 +41,7 @@ public class TestTinyintVarcharMapType
         BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
         mapType.writeObject(blockBuilder, mapBlockOf(TINYINT, VARCHAR, ImmutableMap.of(1, "hi")));
         mapType.writeObject(blockBuilder, mapBlockOf(TINYINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
+        mapType.writeObject(blockBuilder, mapBlockOf(TINYINT, VARCHAR, ImmutableMap.of(1, "123456789012345", 2, "hello-world-hello-world-hello-world")));
         return blockBuilder.build();
     }
 

--- a/core/trino-main/src/test/java/io/trino/type/TestVarcharArrayType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVarcharArrayType.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.type;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.TypeSignature.arrayType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static io.trino.util.StructuralTestUtil.arrayBlockOf;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestVarcharArrayType
+        extends AbstractTestType
+{
+    public TestVarcharArrayType()
+    {
+        super(TESTING_TYPE_MANAGER.getType(arrayType(VARCHAR.getTypeSignature())), List.class, createTestBlock(TESTING_TYPE_MANAGER.getType(arrayType(VARCHAR.getTypeSignature()))));
+    }
+
+    public static Block createTestBlock(Type arrayType)
+    {
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, 4);
+        arrayType.writeObject(blockBuilder, arrayBlockOf(VARCHAR, "1", "2"));
+        arrayType.writeObject(blockBuilder, arrayBlockOf(VARCHAR, "the", "quick", "brown", "fox"));
+        arrayType.writeObject(blockBuilder, arrayBlockOf(VARCHAR, "one-two-three-four-five", "123456789012345", "the quick brown fox", "hello-world-hello-world-hello-world"));
+        return blockBuilder.build();
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        Block block = (Block) value;
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, block.getPositionCount() + 1);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            VARCHAR.appendTo(block, i, blockBuilder);
+        }
+        VARCHAR.writeSlice(blockBuilder, utf8Slice("_"));
+
+        return blockBuilder.build();
+    }
+
+    @Test
+    public void testRange()
+    {
+        assertThat(type.getRange())
+                .isEmpty();
+    }
+
+    @Test
+    public void testPreviousValue()
+    {
+        assertThat(type.getPreviousValue(getSampleValue()))
+                .isEmpty();
+    }
+
+    @Test
+    public void testNextValue()
+    {
+        assertThat(type.getNextValue(getSampleValue()))
+                .isEmpty();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/type/TestVarcharVarcharMapType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestVarcharVarcharMapType.java
@@ -21,27 +21,26 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.util.StructuralTestUtil.mapBlockOf;
 import static io.trino.util.StructuralTestUtil.mapType;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class TestBigintVarcharMapType
+public class TestVarcharVarcharMapType
         extends AbstractTestType
 {
-    public TestBigintVarcharMapType()
+    public TestVarcharVarcharMapType()
     {
-        super(mapType(BIGINT, VARCHAR), Map.class, createTestBlock(mapType(BIGINT, VARCHAR)));
+        super(mapType(VARCHAR, VARCHAR), Map.class, createTestBlock(mapType(VARCHAR, VARCHAR)));
     }
 
     public static Block createTestBlock(Type mapType)
     {
         BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 2);
-        mapType.writeObject(blockBuilder, mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(1, "hi")));
-        mapType.writeObject(blockBuilder, mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(1, "2", 2, "hello")));
-        mapType.writeObject(blockBuilder, mapBlockOf(BIGINT, VARCHAR, ImmutableMap.of(1, "123456789012345", 2, "hello-world-hello-world-hello-world")));
+        mapType.writeObject(blockBuilder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("hi", "there")));
+        mapType.writeObject(blockBuilder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("one", "1", "hello", "world")));
+        mapType.writeObject(blockBuilder, mapBlockOf(VARCHAR, VARCHAR, ImmutableMap.of("one-two-three-four-five", "123456789012345", "the quick brown fox", "hello-world-hello-world-hello-world")));
         return blockBuilder.build();
     }
 
@@ -61,16 +60,28 @@ public class TestBigintVarcharMapType
     @Test
     public void testPreviousValue()
     {
-        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Type is not orderable: " + type);
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getPreviousValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getPreviousValue(sampleValue))
+                .isEmpty();
     }
 
     @Test
     public void testNextValue()
     {
-        assertThatThrownBy(() -> type.getPreviousValue(getSampleValue()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Type is not orderable: " + type);
+        Object sampleValue = getSampleValue();
+        if (!type.isOrderable()) {
+            assertThatThrownBy(() -> type.getNextValue(sampleValue))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Type is not orderable: " + type);
+            return;
+        }
+        assertThat(type.getNextValue(sampleValue))
+                .isEmpty();
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ArrayType.java
@@ -271,6 +271,28 @@ public class ArrayType
         });
     }
 
+    // FLAT MEMORY LAYOUT
+    //
+    // All data of the array is stored in the variable width section. Within the variable width section,
+    // fixed data for all elements is stored first, followed by variable length data for all elements
+    // This simplifies the read implementation as we can simply step through the fixed section without
+    // knowing the variable length of each element, since each element stores the offset to its variable
+    // length data inside its fixed length data.
+    //
+    // In the current implementation, the element and null flag are stored in an interleaved flat record.
+    // This layout is not required by the format, and could be changed to a columnar if it is determined
+    // to be more efficient.
+    //
+    // Fixed:
+    //   int positionCount, int variableSizeOffset
+    // Variable:
+    //   byte element1Null, elementFixedSize element1FixedData
+    //   byte element2Null, elementFixedSize element2FixedData
+    //   ...
+    //   element1VariableSize element1VariableData
+    //   element2VariableSize element2VariableData
+    //   ...
+
     @Override
     public int getFlatFixedSize()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/MapType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/MapType.java
@@ -334,6 +334,29 @@ public class MapType
         });
     }
 
+    // FLAT MEMORY LAYOUT
+    //
+    // All data of the map is stored in the variable width section. Within the variable width section,
+    // fixed data for all keys and values are stored first, followed by variable length data for all keys
+    // and values. This simplifies the read implementation as we can simply step through the fixed
+    // section without knowing the variable length of each value, since each value stores the offset
+    // to its variable length data inside its fixed length data.
+    //
+    // In the current implementation, the keys and values are stored in an interleaved flat record along
+    // with null flags. This layout is not required by the format, and could be changed to a columnar
+    // if it is determined to be more efficient. Additionally, this layout allows for a null key, since
+    // non-null keys is not always enforced, and null keys may be allowed in the future.
+    //
+    // Fixed:
+    //   int positionCount, int variableSizeOffset
+    // Variable:
+    //   byte key1Null, keyFixedSize key1FixedData, byte value1Null, valueFixedSize value1FixedData
+    //   byte key2Null, keyFixedSize key2FixedData, byte value2Null, valueFixedSize value2FixedData
+    //   ...
+    //   key1VariableSize key1VariableData, value1VariableSize value1VariableData
+    //   key2VariableSize key2VariableData, value2VariableSize value2VariableData
+    //   ...
+
     @Override
     public int getFlatFixedSize()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -140,7 +140,7 @@ public class RowType
         // flat fixed size is one null byte for each field plus the sum of the field fixed sizes
         int fixedSize = fieldTypes.size();
         for (Type fieldType : fieldTypes) {
-            fixedSize += fieldType.getFlatFixedSize() + 4;
+            fixedSize += fieldType.getFlatFixedSize();
         }
         flatFixedSize = fixedSize;
 


### PR DESCRIPTION
## Description

The MAP and ARRAY types were incorrectly adjusting the pointer for the variable width data by the fixed width size of the type.  Since the variable width and fixed with data are kept in different sections of the flat record, the adjustment is not needed and causes failures.

Fixes #18863

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix index out of bounds exceptions in flat memory data structures using MAP and ARRAY types. ({issue}`18863`)
```
