### PR TITLE
Recommend Eclipse Temurin as Java runtime

### DIFF
--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -39,10 +39,10 @@ Trino requires a 64-bit version of Java 17, with a minimum required version of 1
 Earlier major versions such as Java 8 or Java 11 do not work.
 Newer major versions such as Java 18 or 19, are not supported -- they may work, but are not tested.
 
-We recommend using [Azul Zulu](https://www.azul.com/downloads/zulu-community/)
-as the JDK for Trino, as Trino is tested against that distribution.
-Zulu is also the JDK used by the
-[Trino Docker image](https://hub.docker.com/r/trinodb/trino).
+We recommend using the Eclipse Temurin OpenJDK distribution from
+[Adoptium](https://adoptium.net/) as the JDK for Trino, as Trino is tested
+against that distribution. Eclipse Temurin is also the JDK used by the [Trino
+Docker image](https://hub.docker.com/r/trinodb/trino).
 
 If you are using Java 17 or 18, the JVM must be configured to use UTF-8 as the default charset by
 adding `-Dfile.encoding=UTF-8` to `etc/jvm.config`. Starting with Java 19, the Java default 


### PR DESCRIPTION
## Description

CI and Docker recently changed and documentation was accidentally left unchanged.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* https://github.com/trinodb/trino/pull/17685
* https://github.com/trinodb/trino/blob/398b64671cc2ecc1c23556d80eb20f29c4eca5eb/core/docker/Dockerfile#L17


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Change recommended Java runtime distribution to Eclipse Temurin. ({issue}`18886`)
```
