### PR TITLE
Fix incorrect symbol resolution during predicate pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LookupSymbolResolver.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LookupSymbolResolver.java
@@ -19,7 +19,6 @@ import io.trino.spi.predicate.NullableValue;
 
 import java.util.Map;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class LookupSymbolResolver
@@ -41,9 +40,8 @@ public class LookupSymbolResolver
     public Object getValue(Symbol symbol)
     {
         ColumnHandle column = assignments.get(symbol);
-        checkArgument(column != null, "Missing column assignment for %s", symbol);
 
-        if (!bindings.containsKey(column)) {
+        if (column == null || !bindings.containsKey(column)) {
             return symbol.toSymbolReference();
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -14,6 +14,9 @@
 package io.trino.plugin.hive;
 
 import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.testing.TestingNames.randomNameSuffix;
 
 public class TestHiveConnectorTest
         extends BaseHiveConnectorTest
@@ -23,5 +26,30 @@ public class TestHiveConnectorTest
             throws Exception
     {
         return createHiveQueryRunner(HiveQueryRunner.builder());
+    }
+
+    @Test
+    public void testPredicatePushdownWithLambdaExpression()
+    {
+        String table = "test_predicate_pushdown_" + randomNameSuffix();
+
+        assertUpdate("""
+            CREATE TABLE %s (v, k)
+            WITH (partitioned_by = ARRAY['k'])
+            AS (VALUES ('value', 'key'))
+            """.formatted(table),
+                1);
+
+        try {
+            assertQuery("""
+                            SELECT *
+                            FROM %s
+                            WHERE k = 'key' AND regexp_replace(v, '(.*)', x -> x[1]) IS NOT NULL
+                            """.formatted(table),
+                    "VALUES ('value', 'key')");
+        }
+        finally {
+            assertUpdate("DROP TABLE " + table);
+        }
     }
 }


### PR DESCRIPTION
When the expression evaluated by LayoutConstraintEvaluator contains a lambda expression, it's incorrect to attempt to resolve a reference to a lambda expression argument as if it were a column.

Fixes #18865 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix failure when querying partitioned tables and the `WHERE` clause contains lambda expressions. ({issue}`18865`)
```
