### PR TITLE
Add causing exception to Hudi metadata parsing error

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
@@ -222,7 +222,7 @@ public class HudiTableFileSystemView
                                         Map.entry(new HudiFileGroupId(entry.getKey(), fileId), instant)));
                     }
                     catch (IOException e) {
-                        throw new TrinoException(HUDI_BAD_DATA, "error reading commit metadata for " + instant);
+                        throw new TrinoException(HUDI_BAD_DATA, "error reading commit metadata for " + instant, e);
                     }
                 })
                 .collect(toImmutableMap(Entry::getKey, Entry::getValue));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case of a Hudi metadata corruption during reading replace commits, the exact exception is not logged in the error message, making it difficult to diagnose the actual problem. This PR aims to fix that with a very small code extension.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

When the filesystem view for a Hudi table is assembled in the Trino Hudi connector, replace commits need to be collected so that data is not read multiple times by the system. During this operation Hudi metadata for these commits is accessed and when it is not readable, the error message does not tell the actual reason. This PR is aiming to fix that.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
