### PR TITLE
Use 'contains' method in deletion vector tests

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
@@ -144,7 +144,8 @@ public class TestDeltaLakeDeleteCompatibility
             assertThat(onTrino().executeQuery("SHOW TABLES FROM delta.default"))
                     .contains(row(tableName));
             assertThat(onTrino().executeQuery("SELECT version, operation FROM delta.default.\"" + tableName + "$history\""))
-                    .containsOnly(row(0, "CREATE TABLE"), row(1, "WRITE"), row(2, "DELETE"));
+                    // Use 'contains' method because newer Databricks clusters execute OPTIMIZE statement in the background
+                    .contains(row(0, "CREATE TABLE"), row(1, "WRITE"), row(2, "DELETE"));
             assertThat(onTrino().executeQuery("SELECT comment FROM information_schema.columns WHERE table_schema = 'default' AND table_name = '" + tableName + "'"))
                     .hasNoRows();
             assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM delta.default." + tableName))


### PR DESCRIPTION
## Description

Fixes #18900

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
