### PR TITLE
Add missing session to query_partition_filter_required test

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -443,9 +443,9 @@ public class TestDeltaLakeBasic
                 .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "query_partition_filter_required", "true")
                 .build();
 
-        assertQuery(format("SELECT * FROM %s WHERE \"part\" = 11", tableName), "VALUES (1, 11)");
-        assertQuery(format("SELECT * FROM %s WHERE \"PART\" = 11", tableName), "VALUES (1, 11)");
-        assertQuery(format("SELECT * FROM %s WHERE \"Part\" = 11", tableName), "VALUES (1, 11)");
+        assertQuery(session, format("SELECT * FROM %s WHERE \"part\" = 11", tableName), "VALUES (1, 11)");
+        assertQuery(session, format("SELECT * FROM %s WHERE \"PART\" = 11", tableName), "VALUES (1, 11)");
+        assertQuery(session, format("SELECT * FROM %s WHERE \"Part\" = 11", tableName), "VALUES (1, 11)");
 
         assertUpdate("DROP TABLE " + tableName);
     }


### PR DESCRIPTION
## Description

I was missing adding a session in https://github.com/trinodb/trino/commit/5ceb83d7f76edea7dd62a9ea7cf5135d4773b3fc

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.