### PR TITLE
Add support for writing timestamp_ntz type in Delta

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -302,6 +302,8 @@ this table:
     - ``BINARY``
   * - ``DATE``
     - ``DATE``
+  * - ``TIMESTAMP``
+    - ``TIMESTAMPNTZ`` (``TIMESTAMP_NTZ``)
   * - ``TIMESTAMP(3) WITH TIME ZONE``
     - ``TIMESTAMP``
   * - ``ARRAY``

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -131,6 +131,7 @@ import io.trino.spi.type.FixedWidthType;
 import io.trino.spi.type.HyperLogLogType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -146,6 +147,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -336,6 +338,8 @@ public class DeltaLakeMetadata
     private static final int CDF_SUPPORTED_WRITER_VERSION = 4;
     private static final int COLUMN_MAPPING_MODE_SUPPORTED_READER_VERSION = 2;
     private static final int COLUMN_MAPPING_MODE_SUPPORTED_WRITER_VERSION = 5;
+    private static final int TIMESTAMP_NTZ_SUPPORTED_READER_VERSION = 3;
+    private static final int TIMESTAMP_NTZ_SUPPORTED_WRITER_VERSION = 7;
 
     // Matches the dummy column Databricks stores in the metastore
     private static final List<Column> DUMMY_DATA_COLUMNS = ImmutableList.of(
@@ -879,10 +883,14 @@ public class DeltaLakeMetadata
                 ImmutableList.Builder<String> columnNames = ImmutableList.builderWithExpectedSize(tableMetadata.getColumns().size());
                 ImmutableMap.Builder<String, Object> columnTypes = ImmutableMap.builderWithExpectedSize(tableMetadata.getColumns().size());
                 ImmutableMap.Builder<String, Map<String, Object>> columnsMetadata = ImmutableMap.builderWithExpectedSize(tableMetadata.getColumns().size());
+                boolean containsTimestampType = false;
                 for (ColumnMetadata column : tableMetadata.getColumns()) {
                     columnNames.add(column.getName());
                     columnTypes.put(column.getName(), serializeColumnType(columnMappingMode, fieldId, column.getType()));
                     columnsMetadata.put(column.getName(), generateColumnMetadata(columnMappingMode, fieldId));
+                    if (!containsTimestampType) {
+                        containsTimestampType = containsTimestampType(column.getType());
+                    }
                 }
                 Map<String, String> columnComments = tableMetadata.getColumns().stream()
                         .filter(column -> column.getComment() != null)
@@ -909,7 +917,7 @@ public class DeltaLakeMetadata
                         CREATE_TABLE_OPERATION,
                         session,
                         tableMetadata.getComment(),
-                        protocolEntryForNewTable(tableMetadata.getProperties()));
+                        protocolEntryForNewTable(containsTimestampType, tableMetadata.getProperties()));
 
                 setRollback(() -> deleteRecursivelyIfExists(fileSystem, deltaLogDirectory));
                 transactionLogWriter.flush();
@@ -1009,6 +1017,7 @@ public class DeltaLakeMetadata
         setRollback(() -> deleteRecursivelyIfExists(fileSystemFactory.create(session), finalLocation));
 
         boolean usePhysicalName = columnMappingMode == ID || columnMappingMode == NAME;
+        boolean containsTimestampType = false;
         int columnSize = tableMetadata.getColumns().size();
         ImmutableList.Builder<String> columnNames = ImmutableList.builderWithExpectedSize(columnSize);
         ImmutableMap.Builder<String, Object> columnTypes = ImmutableMap.builderWithExpectedSize(columnSize);
@@ -1018,6 +1027,7 @@ public class DeltaLakeMetadata
         for (ColumnMetadata column : tableMetadata.getColumns()) {
             columnNames.add(column.getName());
             columnNullabilities.put(column.getName(), column.isNullable());
+            containsTimestampType |= containsTimestampType(column.getType());
 
             Object serializedType = serializeColumnType(columnMappingMode, fieldId, column.getType());
             Type physicalType = deserializeType(typeManager, serializedType, usePhysicalName);
@@ -1067,7 +1077,7 @@ public class DeltaLakeMetadata
                 schemaString,
                 columnMappingMode,
                 maxFieldId,
-                protocolEntryForNewTable(tableMetadata.getProperties()));
+                protocolEntryForNewTable(containsTimestampType, tableMetadata.getProperties()));
     }
 
     private Optional<String> getSchemaLocation(Database database)
@@ -1154,6 +1164,21 @@ public class DeltaLakeMetadata
         catch (IOException e) {
             LOG.warn(e, "IOException while trying to delete '%s'", path);
         }
+    }
+
+    private static boolean containsTimestampType(Type type)
+    {
+        if (type instanceof ArrayType arrayType) {
+            return containsTimestampType(arrayType.getElementType());
+        }
+        if (type instanceof MapType mapType) {
+            return containsTimestampType(mapType.getKeyType()) || containsTimestampType(mapType.getValueType());
+        }
+        if (type instanceof RowType rowType) {
+            return rowType.getFields().stream().anyMatch(field -> containsTimestampType(field.getType()));
+        }
+        checkArgument(type.getTypeParameters().isEmpty(), "Unexpected type parameters for type %s", type);
+        return type instanceof TimestampType;
     }
 
     @Override
@@ -2243,10 +2268,12 @@ public class DeltaLakeMetadata
         }
     }
 
-    private ProtocolEntry protocolEntryForNewTable(Map<String, Object> properties)
+    private ProtocolEntry protocolEntryForNewTable(boolean containsTimestampType, Map<String, Object> properties)
     {
         int readerVersion = DEFAULT_READER_VERSION;
         int writerVersion = DEFAULT_WRITER_VERSION;
+        Set<String> readerFeatures = new HashSet<>();
+        Set<String> writerFeatures = new HashSet<>();
         Optional<Boolean> changeDataFeedEnabled = getChangeDataFeedEnabled(properties);
         if (changeDataFeedEnabled.isPresent() && changeDataFeedEnabled.get()) {
             // Enabling cdf (change data feed) requires setting the writer version to 4
@@ -2258,7 +2285,17 @@ public class DeltaLakeMetadata
             readerVersion = max(readerVersion, COLUMN_MAPPING_MODE_SUPPORTED_READER_VERSION);
             writerVersion = max(writerVersion, COLUMN_MAPPING_MODE_SUPPORTED_WRITER_VERSION);
         }
-        return new ProtocolEntry(readerVersion, writerVersion, Optional.empty(), Optional.empty());
+        if (containsTimestampType) {
+            readerVersion = max(readerVersion, TIMESTAMP_NTZ_SUPPORTED_READER_VERSION);
+            writerVersion = max(writerVersion, TIMESTAMP_NTZ_SUPPORTED_WRITER_VERSION);
+            readerFeatures.add("timestampNtz");
+            writerFeatures.add("timestampNtz");
+        }
+        return new ProtocolEntry(
+                readerVersion,
+                writerVersion,
+                readerFeatures.isEmpty() ? Optional.empty() : Optional.of(readerFeatures),
+                writerFeatures.isEmpty() ? Optional.empty() : Optional.of(writerFeatures));
     }
 
     private void writeCheckpointIfNeeded(ConnectorSession session, SchemaTableName table, String tableLocation, Optional<Long> checkpointInterval, long newVersion)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemas.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeParquetSchemas.java
@@ -53,6 +53,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -265,6 +266,10 @@ public final class DeltaLakeParquetSchemas
                 // Spark / Delta Lake stores timestamps in UTC, but renders them in session time zone.
                 typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition).as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MILLIS));
                 trinoType = TIMESTAMP_MILLIS;
+            }
+            case "timestamp_ntz" -> {
+                typeBuilder = Types.primitive(PrimitiveType.PrimitiveTypeName.INT64, repetition).as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.MICROS));
+                trinoType = TIMESTAMP_MICROS;
             }
             default -> throw new TrinoException(NOT_SUPPORTED, format("Unsupported primitive type: %s", primitiveType));
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeSchemaSupport.java
@@ -35,6 +35,7 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -104,6 +105,7 @@ public final class DeltaLakeSchemaSupport
             .add("checkConstraints")
             .add("changeDataFeed")
             .add("columnMapping")
+            .add("timestampNtz")
             .build();
 
     public enum ColumnMappingMode
@@ -328,6 +330,9 @@ public final class DeltaLakeSchemaSupport
 
     private static Optional<String> serializeSupportedPrimitiveType(Type type)
     {
+        if (type instanceof TimestampType) {
+            return Optional.of("timestamp_ntz");
+        }
         if (type instanceof TimestampWithTimeZoneType) {
             return Optional.of("timestamp");
         }
@@ -374,6 +379,7 @@ public final class DeltaLakeSchemaSupport
     private static void validatePrimitiveType(Type type)
     {
         if (serializeSupportedPrimitiveType(type).isEmpty() ||
+                (type instanceof TimestampType && ((TimestampType) type).getPrecision() != 6) ||
                 (type instanceof TimestampWithTimeZoneType && ((TimestampWithTimeZoneType) type).getPrecision() != 3)) {
             throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Unsupported type: " + type);
         }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/DeltaLakeWriteUtils.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/DeltaLakeWriteUtils.java
@@ -44,6 +44,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
@@ -112,7 +113,7 @@ public final class DeltaLakeWriteUtils
         if (DATE.equals(type)) {
             return LocalDate.ofEpochDay(DATE.getInt(block, position)).format(DELTA_DATE_FORMATTER);
         }
-        if (TIMESTAMP_MILLIS.equals(type)) {
+        if (TIMESTAMP_MILLIS.equals(type) || TIMESTAMP_MICROS.equals(type)) {
             long epochMicros = type.getLong(block, position);
             long epochSeconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
             int nanosOfSecond = floorMod(epochMicros, MICROSECONDS_PER_SECOND) * NANOSECONDS_PER_MICROSECOND;

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -106,13 +106,13 @@ public class TestDeltaLakeBasic
     public void registerTables()
     {
         for (ResourceTable table : Iterables.concat(PERSON_TABLES, OTHER_TABLES)) {
-            String dataPath = getTableLocation(table.resourcePath()).toExternalForm();
+            String dataPath = getResourceLocation(table.resourcePath()).toExternalForm();
             getQueryRunner().execute(
                     format("CALL system.register_table('%s', '%s', '%s')", getSession().getSchema().orElseThrow(), table.tableName(), dataPath));
         }
     }
 
-    private URL getTableLocation(String resourcePath)
+    private URL getResourceLocation(String resourcePath)
     {
         return getClass().getClassLoader().getResource(resourcePath);
     }
@@ -656,7 +656,7 @@ public class TestDeltaLakeBasic
         // create a bad_person table which is based on person table in temporary location
         String tableName = "bad_person_" + randomNameSuffix();
         Path tableLocation = Files.createTempFile(tableName, null);
-        copyDirectoryContents(Path.of(getTableLocation("databricks73/person").toURI()), tableLocation);
+        copyDirectoryContents(Path.of(getResourceLocation("databricks73/person").toURI()), tableLocation);
         getQueryRunner().execute(
                 format("CALL system.register_table('%s', '%s', '%s')", getSession().getSchema().orElseThrow(), tableName, tableLocation));
         testCorruptedTableLocation(tableName, tableLocation, false);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -223,7 +223,6 @@ public class TestDeltaLakeConnectorTest
         if (typeName.equals("time") ||
                 typeName.equals("time(6)") ||
                 typeName.equals("timestamp") ||
-                typeName.equals("timestamp(6)") ||
                 typeName.equals("timestamp(6) with time zone") ||
                 typeName.equals("char(3)")) {
             return Optional.of(dataMappingTestSetup.asUnsupported());
@@ -530,6 +529,46 @@ public class TestDeltaLakeConnectorTest
                 "SELECT * FROM " + tableName + " WHERE t = TIMESTAMP '" + value + "'",
                 queryStats -> assertThat(queryStats.getProcessedInputDataSize().toBytes()).isGreaterThan(0),
                 results -> {});
+    }
+
+    @Test
+    public void testTimestampPartition()
+    {
+        String tableName = "test_timestamp_ntz_partition_" + randomNameSuffix();
+
+        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        assertUpdate("CREATE TABLE " + tableName + "(id INT, part TIMESTAMP(6)) WITH (partitioned_by = ARRAY['part'])");
+        assertUpdate(
+                "INSERT INTO " + tableName + " VALUES " +
+                "(1, NULL)," +
+                "(2, TIMESTAMP '0001-01-01 00:00:00.000')," +
+                "(3, TIMESTAMP '2023-07-20 01:02:03.9999999')," +
+                "(4, TIMESTAMP '9999-12-31 23:59:59.999999')",
+                4);
+
+        assertThat(query("SELECT * FROM " + tableName))
+                .matches("VALUES " +
+                         "(1, NULL)," +
+                         "(2, TIMESTAMP '0001-01-01 00:00:00.000000')," +
+                         "(3, TIMESTAMP '2023-07-20 01:02:04.000000')," +
+                         "(4, TIMESTAMP '9999-12-31 23:59:59.999999')");
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "VALUES " +
+                "('id', null, 4.0, 0.0, null, 1, 4)," +
+                "('part', null, 3.0, 0.25, null, null, null)," +
+                "(null, null, null, null, 4.0, null, null)");
+
+        assertThat((String) computeScalar("SELECT \"$path\" FROM " + tableName + " WHERE id = 1"))
+                .contains("/part=__HIVE_DEFAULT_PARTITION__/");
+        assertThat((String) computeScalar("SELECT \"$path\" FROM " + tableName + " WHERE id = 2"))
+                .contains("/part=0001-01-01 00%3A00%3A00/");
+        assertThat((String) computeScalar("SELECT \"$path\" FROM " + tableName + " WHERE id = 3"))
+                .contains("/part=2023-07-20 01%3A02%3A04/");
+        assertThat((String) computeScalar("SELECT \"$path\" FROM " + tableName + " WHERE id = 4"))
+                .contains("/part=9999-12-31 23%3A59%3A59.999999/");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksInsertCompatibility.java
@@ -34,6 +34,7 @@ import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_104;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_113;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_122;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_91;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.util.DatabricksVersion.DATABRICKS_104_RUNTIME_VERSION;
@@ -137,6 +138,42 @@ public class TestDeltaLakeDatabricksInsertCompatibility
         }
         finally {
             dropDeltaTableWithRetry("default." + tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_EXCLUDE_91, DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testTimestampInsertCompatibility()
+    {
+        String tableName = "test_dl_timestamp_ntz_insert_" + randomNameSuffix();
+
+        onTrino().executeQuery("" +
+                               "CREATE TABLE delta.default." + tableName +
+                               "(id INT, ts TIMESTAMP(6))" +
+                               "WITH (location = 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "')");
+        try {
+            onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES" +
+                                   "(1, TIMESTAMP '0001-01-01 00:00:00.000')," +
+                                   "(2, TIMESTAMP '2023-01-02 01:02:03.999')");
+            onTrino().executeQuery("INSERT INTO delta.default." + tableName + " VALUES" +
+                                   "(3, TIMESTAMP '2023-03-04 01:02:03.999')," +
+                                   "(4, TIMESTAMP '9999-12-31 23:59:59.999')");
+
+            assertThat(onDelta().executeQuery("SELECT id, date_format(ts, \"yyyy-MM-dd HH:mm:ss.SSS\") FROM default." + tableName))
+                    .containsOnly(
+                            row(1, databricksRuntimeVersion.isPresent() ? "0001-01-03 00:00:00.000" : "0001-01-01 00:00:00.000"), // Databricks returns incorrect results
+                            row(2, "2023-01-02 01:02:03.999"),
+                            row(3, "2023-03-04 01:02:03.999"),
+                            row(4, "9999-12-31 23:59:59.999"));
+            assertThat(onTrino().executeQuery("SELECT id, format_datetime(ts, 'yyyy-MM-dd HH:mm:ss.SSS') FROM delta.default." + tableName))
+                    .containsOnly(
+                            row(1, "0001-01-01 00:00:00.000"),
+                            row(2, "2023-01-02 01:02:03.999"),
+                            row(3, "2023-03-04 01:02:03.999"),
+                            row(4, "9999-12-31 23:59:59.999"));
+        }
+        finally {
+            onTrino().executeQuery("DROP TABLE delta.default." + tableName);
         }
     }
 


### PR DESCRIPTION
## Description

Add support for writing timestamp_ntz type in Delta

Fixes #16927

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for writing `timestamp` type. ({issue}`16927`)
```
