### PR TITLE
Allow tests to choose builtin access control factory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -232,16 +232,6 @@ public class AccessControlManager
     }
 
     @VisibleForTesting
-    public void addSystemAccessControl(SystemAccessControl systemAccessControl)
-    {
-        systemAccessControls.updateAndGet(currentControls ->
-                ImmutableList.<SystemAccessControl>builder()
-                        .addAll(currentControls)
-                        .add(systemAccessControl)
-                        .build());
-    }
-
-    @VisibleForTesting
     public void setSystemAccessControls(List<SystemAccessControl> systemAccessControls)
     {
         checkState(this.systemAccessControls.compareAndSet(null, systemAccessControls), "System access control already initialized");

--- a/core/trino-main/src/main/java/io/trino/server/testing/FactoryConfiguration.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/FactoryConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.testing;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record FactoryConfiguration(String factoryName, Map<String, String> configuration)
+{
+    public FactoryConfiguration
+    {
+        requireNonNull(factoryName, "factoryName is null");
+        configuration = ImmutableMap.copyOf(requireNonNull(configuration, "configuration is null"));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -744,6 +744,11 @@ public class TestingTrinoServer
             return this;
         }
 
+        public Builder setSystemAccessControl(SystemAccessControl systemAccessControl)
+        {
+            return setSystemAccessControls(ImmutableList.of(requireNonNull(systemAccessControl, "systemAccessControl is null")));
+        }
+
         public Builder setSystemAccessControls(List<SystemAccessControl> systemAccessControls)
         {
             this.systemAccessControls = ImmutableList.copyOf(requireNonNull(systemAccessControls, "systemAccessControls is null"));

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -123,6 +123,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -221,7 +222,8 @@ public class TestingTrinoServer
             Optional<URI> discoveryUri,
             Module additionalModule,
             Optional<Path> baseDataDir,
-            List<SystemAccessControl> systemAccessControls,
+            Optional<FactoryConfiguration> systemAccessControlConfiguration,
+            Optional<List<SystemAccessControl>> systemAccessControls,
             List<EventListener> eventListeners)
     {
         this.coordinator = coordinator;
@@ -380,7 +382,12 @@ public class TestingTrinoServer
         failureInjector = injector.getInstance(FailureInjector.class);
         exchangeManagerRegistry = injector.getInstance(ExchangeManagerRegistry.class);
 
-        accessControl.setSystemAccessControls(systemAccessControls);
+        systemAccessControlConfiguration.ifPresentOrElse(
+                configuration -> {
+                    checkArgument(systemAccessControls.isEmpty(), "systemAccessControlConfiguration and systemAccessControls cannot be both present");
+                    accessControl.loadSystemAccessControl(configuration.factoryName(), configuration.configuration());
+                },
+                () -> accessControl.setSystemAccessControls(systemAccessControls.orElseThrow()));
 
         EventListenerManager eventListenerManager = injector.getInstance(EventListenerManager.class);
         eventListeners.forEach(eventListenerManager::addEventListener);
@@ -705,7 +712,8 @@ public class TestingTrinoServer
         private Optional<URI> discoveryUri = Optional.empty();
         private Module additionalModule = EMPTY_MODULE;
         private Optional<Path> baseDataDir = Optional.empty();
-        private List<SystemAccessControl> systemAccessControls = ImmutableList.of();
+        private Optional<FactoryConfiguration> systemAccessControlConfiguration = Optional.empty();
+        private Optional<List<SystemAccessControl>> systemAccessControls = Optional.of(ImmutableList.of());
         private List<EventListener> eventListeners = ImmutableList.of();
 
         public Builder setCoordinator(boolean coordinator)
@@ -744,14 +752,20 @@ public class TestingTrinoServer
             return this;
         }
 
-        public Builder setSystemAccessControl(SystemAccessControl systemAccessControl)
+        public Builder setSystemAccessControlConfiguration(Optional<FactoryConfiguration> systemAccessControlConfiguration)
         {
-            return setSystemAccessControls(ImmutableList.of(requireNonNull(systemAccessControl, "systemAccessControl is null")));
+            this.systemAccessControlConfiguration = requireNonNull(systemAccessControlConfiguration, "systemAccessControlConfiguration is null");
+            return this;
         }
 
-        public Builder setSystemAccessControls(List<SystemAccessControl> systemAccessControls)
+        public Builder setSystemAccessControl(SystemAccessControl systemAccessControl)
         {
-            this.systemAccessControls = ImmutableList.copyOf(requireNonNull(systemAccessControls, "systemAccessControls is null"));
+            return setSystemAccessControls(Optional.of(ImmutableList.of(requireNonNull(systemAccessControl, "systemAccessControl is null"))));
+        }
+
+        public Builder setSystemAccessControls(Optional<List<SystemAccessControl>> systemAccessControls)
+        {
+            this.systemAccessControls = systemAccessControls.map(ImmutableList::copyOf);
             return this;
         }
 
@@ -770,6 +784,7 @@ public class TestingTrinoServer
                     discoveryUri,
                     additionalModule,
                     baseDataDir,
+                    systemAccessControlConfiguration,
                     systemAccessControls,
                     eventListeners);
         }

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -32,7 +32,6 @@ import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtParser;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AccessControl;
-import io.trino.security.AccessControlManager;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.ProtocolConfig;
 import io.trino.server.protocol.PreparedStatementEncoder;
@@ -196,8 +195,8 @@ public class TestResourceSecurity
     {
         try (TestingTrinoServer server = TestingTrinoServer.builder()
                 .setProperties(ImmutableMap.of("http-server.authentication.insecure.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN))
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertInsecureAuthentication(httpServerInfo.getHttpUri());
         }
@@ -209,8 +208,8 @@ public class TestResourceSecurity
     {
         try (TestingTrinoServer server = TestingTrinoServer.builder()
                 .setProperties(SECURE_PROPERTIES)
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertInsecureAuthentication(httpServerInfo.getHttpUri());
             assertInsecureAuthentication(httpServerInfo.getHttpsUri());
@@ -226,8 +225,8 @@ public class TestResourceSecurity
                         .putAll(SECURE_PROPERTIES)
                         .put("http-server.authentication.allow-insecure-over-http", "false")
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
             assertInsecureAuthentication(httpServerInfo.getHttpsUri());
@@ -245,9 +244,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "password")
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
             assertPasswordAuthentication(httpServerInfo.getHttpsUri());
@@ -265,9 +264,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "password")
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate, TestResourceSecurity::authenticate2);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
             assertPasswordAuthentication(httpServerInfo.getHttpsUri(), TEST_PASSWORD, TEST_PASSWORD2);
@@ -285,9 +284,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "password")
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate, TestResourceSecurity::authenticate2);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             Request request = new Request.Builder()
                     .url(getAuthorizedUserLocation(httpServerInfo.getHttpsUri()))
@@ -312,9 +311,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
                 .setAdditionalModule(binder -> jaxrsBinder(binder).bind(TestResource.class))
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             // Test sets basic auth user and X-Trino-User, and the authenticator is performing user mapping.
@@ -345,9 +344,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.allow-insecure-over-http", "true")
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertInsecureAuthentication(httpServerInfo.getHttpUri());
             assertPasswordAuthentication(httpServerInfo.getHttpsUri());
@@ -367,9 +366,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .put("management.user", MANAGEMENT_USER)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
 
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertFixedManagementUser(httpServerInfo.getHttpUri(), true);
@@ -390,9 +389,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .put("management.user", MANAGEMENT_USER)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
 
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertResponseCode(client, getPublicLocation(httpServerInfo.getHttpUri()), SC_OK);
@@ -417,9 +416,9 @@ public class TestResourceSecurity
                         .put("management.user", MANAGEMENT_USER)
                         .put("management.user.https-enabled", "true")
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.WITH_IMPERSONATION);
 
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
             assertFixedManagementUser(httpServerInfo.getHttpUri(), true);
@@ -438,8 +437,8 @@ public class TestResourceSecurity
                         .put("http-server.https.truststore.path", LOCALHOST_KEYSTORE)
                         .put("http-server.https.truststore.key", "")
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -480,8 +479,8 @@ public class TestResourceSecurity
                         .put("http-server.authentication.jwt.principal-field", principalField.orElse("sub"))
                         .put("http-server.authentication.jwt.required-audience", TRINO_AUDIENCE)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -526,8 +525,8 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "jwt")
                         .put("http-server.authentication.jwt.key-file", jwkServer.getBaseUrl().toString())
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -562,8 +561,8 @@ public class TestResourceSecurity
                         .put("http-server.authentication.jwt.key-file", HMAC_KEY)
                         .put("http-server.authentication.jwt.required-audience", TRINO_AUDIENCE)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             SecretKey hmac = hmacShaKeyFor(Base64.getDecoder().decode(Files.readString(Paths.get(HMAC_KEY)).trim()));
@@ -596,8 +595,8 @@ public class TestResourceSecurity
                         .put("http-server.authentication.type", "jwt")
                         .put("http-server.authentication.jwt.key-file", HMAC_KEY)
                         .buildOrThrow())
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -653,8 +652,8 @@ public class TestResourceSecurity
                                 .put("http-server.authentication.oauth2.refresh-tokens", String.valueOf(refreshTokensEnabled))
                                 .buildOrThrow())
                         .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                         .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -787,8 +786,8 @@ public class TestResourceSecurity
                                 .put("deprecated.http-server.authentication.oauth2.groups-field", GROUPS_CLAIM)
                                 .buildOrThrow())
                         .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                         .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             String accessToken = tokenServer.issueAccessToken(groups);
@@ -873,8 +872,8 @@ public class TestResourceSecurity
                                         .put("web-ui.enabled", "true")
                                         .buildOrThrow())
                         .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                         .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -932,8 +931,8 @@ public class TestResourceSecurity
                                         .put("web-ui.enabled", "true")
                                         .buildOrThrow())
                         .setAdditionalModule(oauth2Module(tokenServer))
+                        .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                         .build()) {
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             assertAuthenticationDisabled(httpServerInfo.getHttpUri());
@@ -966,9 +965,9 @@ public class TestResourceSecurity
                         .put("http-server.authentication.password.user-mapping.pattern", ALLOWED_USER_MAPPING_PATTERN)
                         .buildOrThrow())
                 .setAdditionalModule(binder -> jaxrsBinder(binder).bind(TestResource.class))
+                .setSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION)
                 .build()) {
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
-            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(TestSystemAccessControl.NO_IMPERSONATION);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
             // Authenticated user TEST_USER_LOGIN impersonates impersonated-user by passing request header X-Trino-Authorization-User

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestSetSessionAuthorization.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestSetSessionAuthorization.java
@@ -25,12 +25,14 @@ import io.trino.testing.QueryRunner;
 import okhttp3.OkHttpClient;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.io.Resources.getResource;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.client.StatementClientFactory.newStatementClient;
 import static io.trino.spi.StandardErrorCode.GENERIC_USER_ERROR;
@@ -46,14 +48,9 @@ public class TestSetSessionAuthorization
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION)
-                .setSystemAccessControl("file", Map.of("security.config-file", getResourcePath("set_session_authorization_permissions.json")))
+                .setSystemAccessControl("file", Map.of("security.config-file", new File(getResource("set_session_authorization_permissions.json").toURI()).getPath()))
                 .build();
         return queryRunner;
-    }
-
-    private String getResourcePath(String resourceName)
-    {
-        return this.getClass().getClassLoader().getResource(resourceName).getPath();
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestSetSessionAuthorization.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestSetSessionAuthorization.java
@@ -14,14 +14,11 @@
 package io.trino.execution;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 import io.trino.client.ClientSession;
 import io.trino.client.QueryData;
 import io.trino.client.StatementClient;
-import io.trino.plugin.base.security.FileBasedSystemAccessControl;
 import io.trino.spi.ErrorCode;
-import io.trino.spi.security.SystemAccessControl;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -31,6 +28,7 @@ import org.testng.annotations.Test;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -48,19 +46,9 @@ public class TestSetSessionAuthorization
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION)
-                .setSystemAccessControl(newFileBasedSystemAccessControl("set_session_authorization_permissions.json"))
+                .setSystemAccessControl("file", Map.of("security.config-file", getResourcePath("set_session_authorization_permissions.json")))
                 .build();
         return queryRunner;
-    }
-
-    private SystemAccessControl newFileBasedSystemAccessControl(String resourceName)
-    {
-        return newFileBasedSystemAccessControl(ImmutableMap.of("security.config-file", getResourcePath(resourceName)));
-    }
-
-    private SystemAccessControl newFileBasedSystemAccessControl(ImmutableMap<String, String> config)
-    {
-        return new FileBasedSystemAccessControl.Factory().create(config);
     }
 
     private String getResourcePath(String resourceName)

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Nullable;
 import okhttp3.OkHttpClient;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.time.ZoneId;
 import java.util.Locale;
 import java.util.Map;
@@ -47,7 +48,7 @@ public class TestUserImpersonationAccessControl
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        String securityConfigFile = getResource("access_control_rules.json").getPath();
+        String securityConfigFile = new File(getResource("access_control_rules.json").toURI()).getPath();
         QueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION)
                 .setNodeCount(1)
                 .setSystemAccessControl("file", Map.of(SECURITY_CONFIG_FILE, securityConfigFile))

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
@@ -18,9 +18,7 @@ import io.airlift.units.Duration;
 import io.trino.client.ClientSession;
 import io.trino.client.QueryError;
 import io.trino.client.StatementClient;
-import io.trino.plugin.base.security.FileBasedSystemAccessControl;
 import io.trino.plugin.tpch.TpchPlugin;
-import io.trino.spi.security.SystemAccessControl;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
@@ -30,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.time.ZoneId;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.io.Resources.getResource;
@@ -49,10 +48,9 @@ public class TestUserImpersonationAccessControl
             throws Exception
     {
         String securityConfigFile = getResource("access_control_rules.json").getPath();
-        SystemAccessControl accessControl = new FileBasedSystemAccessControl.Factory().create(ImmutableMap.of(SECURITY_CONFIG_FILE, securityConfigFile));
         QueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION)
                 .setNodeCount(1)
-                .setSystemAccessControl(accessControl)
+                .setSystemAccessControl("file", Map.of(SECURITY_CONFIG_FILE, securityConfigFile))
                 .build();
 
         queryRunner.installPlugin(new TpchPlugin());

--- a/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
@@ -13,22 +13,20 @@
  */
 package io.trino.security;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.TestingTableFunctions;
-import io.trino.plugin.base.security.FileBasedSystemAccessControl;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.spi.connector.TableFunctionApplicationResult;
 import io.trino.spi.security.Identity;
-import io.trino.spi.security.SystemAccessControl;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.io.Resources.getResource;
@@ -47,13 +45,12 @@ public class TestFunctionsInViewsWithFileBasedSystemAccessControl
             throws Exception
     {
         String securityConfigFile = getResource("file-based-system-functions-access.json").getPath();
-        SystemAccessControl accessControl = new FileBasedSystemAccessControl.Factory().create(ImmutableMap.of(SECURITY_CONFIG_FILE, securityConfigFile));
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
                         .setCatalog(Optional.empty())
                         .setSchema(Optional.empty())
                         .build())
                 .setNodeCount(1)
-                .setSystemAccessControl(accessControl)
+                .setSystemAccessControl("file", Map.of(SECURITY_CONFIG_FILE, securityConfigFile))
                 .build();
         queryRunner.installPlugin(new BlackHolePlugin());
         queryRunner.createCatalog("blackhole", "blackhole");

--- a/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestFunctionsInViewsWithFileBasedSystemAccessControl.java
@@ -26,6 +26,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.testng.annotations.Test;
 
+import java.io.File;
 import java.util.Map;
 import java.util.Optional;
 
@@ -44,7 +45,7 @@ public class TestFunctionsInViewsWithFileBasedSystemAccessControl
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        String securityConfigFile = getResource("file-based-system-functions-access.json").getPath();
+        String securityConfigFile = new File(getResource("file-based-system-functions-access.json").toURI()).getPath();
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
                         .setCatalog(Optional.empty())
                         .setSchema(Optional.empty())


### PR DESCRIPTION
Provide tests with ability to use AccessControlManager's built-in access
control factory by its name. This provides coverage for factory
registration (otherwise possible only in product tests), and also allow
factories to take injected dependencies (e.g. for tracing).