### PR TITLE
Fix return value from SortedRangeSet.buildFromUnsortedRanges

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -1077,7 +1077,7 @@ public final class SortedRangeSet
             writeRange(type, blockBuilder, inclusive, rangeIndex, range);
         }
 
-        return new SortedRangeSet(type, inclusive, blockBuilder);
+        return new SortedRangeSet(type, inclusive, blockBuilder.build());
     }
 
     private static void writeRange(Type type, BlockBuilder blockBuilder, boolean[] inclusive, int rangeIndex, Range range)


### PR DESCRIPTION
## Description
`SortedRangeSet.buildFromUnsortedRanges` constructs and returns instance of `SortedRangeSet` where field `sortedRanges` is an instance of `BlockBuilder`. Change this field to be instance of `Block`.

## Release notes

(*) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
