### PR TITLE
Extract environment setup from file system tests

### DIFF
--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -13,19 +13,9 @@
  */
 package io.trino.filesystem.azure;
 
-import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.blob.models.StorageAccountInfo;
-import com.azure.storage.common.StorageSharedKeyCredential;
-import com.azure.storage.file.datalake.DataLakeFileSystemClient;
-import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
-import com.azure.storage.file.datalake.models.PathItem;
-import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
-import io.trino.spi.security.ConnectorIdentity;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
+import io.trino.filesystem.azure.AzureFileSystemTestingEnvironment.AccountKind;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -34,12 +24,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import java.io.IOException;
 
-import static com.azure.storage.common.Utility.urlEncode;
-import static com.google.common.base.Preconditions.checkState;
-import static java.util.Locale.ROOT;
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public abstract class AbstractTestAzureFileSystem
@@ -50,124 +35,35 @@ public abstract class AbstractTestAzureFileSystem
         return requireNonNull(System.getenv(name), "Environment variable not set: " + name);
     }
 
-    enum AccountKind
-    {
-        HIERARCHICAL, FLAT, BLOB
-    }
-
-    private String account;
-    private StorageSharedKeyCredential credential;
-    private AccountKind accountKind;
-    private String containerName;
-    private Location rootLocation;
-    private BlobContainerClient blobContainerClient;
-    private TrinoFileSystem fileSystem;
+    private AzureFileSystemTestingEnvironment testingEnvironment;
 
     protected void initialize(String account, String accountKey, AccountKind expectedAccountKind)
             throws IOException
     {
-        this.account = account;
-        credential = new StorageSharedKeyCredential(account, accountKey);
-
-        String blobEndpoint = "https://%s.blob.core.windows.net".formatted(account);
-        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
-                .endpoint(blobEndpoint)
-                .credential(credential)
-                .buildClient();
-        accountKind = getAccountKind(blobServiceClient);
-        checkState(accountKind == expectedAccountKind, "Expected %s account, but found %s".formatted(expectedAccountKind, accountKind));
-
-        containerName = "test-%s-%s".formatted(accountKind.name().toLowerCase(ROOT), randomUUID());
-        rootLocation = Location.of("abfs://%s@%s.dfs.core.windows.net/".formatted(containerName, account));
-
-        blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
-        // this will fail if the container already exists, which is what we want
-        blobContainerClient.create();
-
-        fileSystem = new AzureFileSystemFactory(new AzureAuthAccessKey(accountKey), new AzureFileSystemConfig()).create(ConnectorIdentity.ofUser("test"));
-
-        cleanupFiles();
+        requireNonNull(account, "account is null");
+        requireNonNull(accountKey, "accountKey is null");
+        requireNonNull(expectedAccountKind, "expectedAccountKind is null");
+        testingEnvironment = new AzureFileSystemTestingEnvironment(account, accountKey, expectedAccountKind);
     }
 
-    private static AccountKind getAccountKind(BlobServiceClient blobServiceClient)
-            throws IOException
+    @Override
+    protected AbstractTrinoFileSystemTestingEnvironment testingEnvironment()
     {
-        StorageAccountInfo accountInfo = blobServiceClient.getAccountInfo();
-        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.STORAGE_V2) {
-            if (accountInfo.isHierarchicalNamespaceEnabled()) {
-                return AccountKind.HIERARCHICAL;
-            }
-            return AccountKind.FLAT;
-        }
-        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.BLOB_STORAGE) {
-            return AccountKind.BLOB;
-        }
-        throw new IOException("Unsupported account kind '%s'".formatted(accountInfo.getAccountKind()));
+        return testingEnvironment;
     }
 
     @AfterAll
     void tearDown()
     {
-        credential = null;
-        fileSystem = null;
-        if (blobContainerClient != null) {
-            blobContainerClient.deleteIfExists();
-            blobContainerClient = null;
+        if (testingEnvironment != null) {
+            testingEnvironment.close();
         }
     }
 
     @AfterEach
     void afterEach()
     {
-        cleanupFiles();
-    }
-
-    private void cleanupFiles()
-    {
-        if (accountKind == AccountKind.HIERARCHICAL) {
-            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClientBuilder()
-                    .endpoint("https://%s.dfs.core.windows.net".formatted(account))
-                    .fileSystemName(containerName)
-                    .credential(credential)
-                    .buildClient();
-
-            DataLakePathDeleteOptions deleteRecursiveOptions = new DataLakePathDeleteOptions().setIsRecursive(true);
-            for (PathItem pathItem : fileSystemClient.listPaths()) {
-                if (pathItem.isDirectory()) {
-                    fileSystemClient.deleteDirectoryIfExistsWithResponse(pathItem.getName(), deleteRecursiveOptions, null, null);
-                }
-                else {
-                    fileSystemClient.deleteFileIfExists(pathItem.getName());
-                }
-            }
-        }
-        else {
-            blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(urlEncode(item.getName())).deleteIfExists());
-        }
-    }
-
-    @Override
-    protected final boolean isHierarchical()
-    {
-        return accountKind == AccountKind.HIERARCHICAL;
-    }
-
-    @Override
-    protected final TrinoFileSystem getFileSystem()
-    {
-        return fileSystem;
-    }
-
-    @Override
-    protected final Location getRootLocation()
-    {
-        return rootLocation;
-    }
-
-    @Override
-    protected final void verifyFileSystemIsEmpty()
-    {
-        assertThat(blobContainerClient.listBlobs()).isEmpty();
+        testingEnvironment.cleanupFiles();
     }
 
     @Test

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AzureFileSystemTestingEnvironment.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AzureFileSystemTestingEnvironment.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.StorageAccountInfo;
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import com.azure.storage.file.datalake.models.PathItem;
+import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.spi.security.ConnectorIdentity;
+
+import java.io.IOException;
+
+import static com.azure.storage.common.Utility.urlEncode;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Locale.ROOT;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AzureFileSystemTestingEnvironment
+        extends AbstractTrinoFileSystemTestingEnvironment
+{
+    public enum AccountKind
+    {
+        HIERARCHICAL, FLAT, BLOB
+    }
+
+    private final String account;
+    private final StorageSharedKeyCredential credential;
+    private final AccountKind accountKind;
+    private final String containerName;
+    private final Location rootLocation;
+    private final BlobContainerClient blobContainerClient;
+    private final TrinoFileSystem fileSystem;
+
+    public AzureFileSystemTestingEnvironment(String account, String accountKey, AccountKind expectedAccountKind)
+            throws IOException
+    {
+        this.account = account;
+        credential = new StorageSharedKeyCredential(account, accountKey);
+
+        String blobEndpoint = "https://%s.blob.core.windows.net".formatted(account);
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
+                .endpoint(blobEndpoint)
+                .credential(credential)
+                .buildClient();
+        accountKind = getAccountKind(blobServiceClient);
+        checkState(accountKind == expectedAccountKind, "Expected %s account, but found %s".formatted(expectedAccountKind, accountKind));
+
+        containerName = "test-%s-%s".formatted(accountKind.name().toLowerCase(ROOT), randomUUID());
+        rootLocation = Location.of("abfs://%s@%s.dfs.core.windows.net/".formatted(containerName, account));
+
+        blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
+        // this will fail if the container already exists, which is what we want
+        blobContainerClient.create();
+
+        fileSystem = new AzureFileSystemFactory(new AzureAuthAccessKey(accountKey), new AzureFileSystemConfig()).create(ConnectorIdentity.ofUser("test"));
+
+        cleanupFiles();
+    }
+
+    private static AccountKind getAccountKind(BlobServiceClient blobServiceClient)
+            throws IOException
+    {
+        StorageAccountInfo accountInfo = blobServiceClient.getAccountInfo();
+        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.STORAGE_V2) {
+            if (accountInfo.isHierarchicalNamespaceEnabled()) {
+                return AccountKind.HIERARCHICAL;
+            }
+            return AccountKind.FLAT;
+        }
+        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.BLOB_STORAGE) {
+            return AccountKind.BLOB;
+        }
+        throw new IOException("Unsupported account kind '%s'".formatted(accountInfo.getAccountKind()));
+    }
+
+    public void cleanupFiles()
+    {
+        if (accountKind == AccountKind.HIERARCHICAL) {
+            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClientBuilder()
+                    .endpoint("https://%s.dfs.core.windows.net".formatted(account))
+                    .fileSystemName(containerName)
+                    .credential(credential)
+                    .buildClient();
+
+            DataLakePathDeleteOptions deleteRecursiveOptions = new DataLakePathDeleteOptions().setIsRecursive(true);
+            for (PathItem pathItem : fileSystemClient.listPaths()) {
+                if (pathItem.isDirectory()) {
+                    fileSystemClient.deleteDirectoryIfExistsWithResponse(pathItem.getName(), deleteRecursiveOptions, null, null);
+                }
+                else {
+                    fileSystemClient.deleteFileIfExists(pathItem.getName());
+                }
+            }
+        }
+        else {
+            blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(urlEncode(item.getName())).deleteIfExists());
+        }
+    }
+
+    public void close()
+    {
+        if (blobContainerClient != null) {
+            blobContainerClient.deleteIfExists();
+        }
+    }
+
+    @Override
+    protected final boolean isHierarchical()
+    {
+        return accountKind == AccountKind.HIERARCHICAL;
+    }
+
+    @Override
+    public final TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected final Location getRootLocation()
+    {
+        return rootLocation;
+    }
+
+    @Override
+    protected final void verifyFileSystemIsEmpty()
+    {
+        assertThat(blobContainerClient.listBlobs()).isEmpty();
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemBlob.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemBlob.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.io.IOException;
 
-import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.BLOB;
+import static io.trino.filesystem.azure.AzureFileSystemTestingEnvironment.AccountKind.BLOB;
 
 @EnabledIfEnvironmentVariable(named = "ABFS_BLOB_ACCOUNT", matches = ".+")
 @TestInstance(Lifecycle.PER_CLASS)

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.io.IOException;
 
-import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.FLAT;
+import static io.trino.filesystem.azure.AzureFileSystemTestingEnvironment.AccountKind.FLAT;
 
 @EnabledIfEnvironmentVariable(named = "ABFS_FLAT_ACCOUNT", matches = ".+")
 @TestInstance(Lifecycle.PER_CLASS)

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
 import java.io.IOException;
 
-import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.HIERARCHICAL;
+import static io.trino.filesystem.azure.AzureFileSystemTestingEnvironment.AccountKind.HIERARCHICAL;
 
 @EnabledIfEnvironmentVariable(named = "ABFS_ACCOUNT", matches = ".+")
 @TestInstance(Lifecycle.PER_CLASS)

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -15,21 +15,15 @@ package io.trino.filesystem.s3;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
-import io.airlift.log.Logging;
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
 import io.trino.filesystem.FileEntry;
 import io.trino.filesystem.FileIterator;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoInputStream;
-import io.trino.spi.security.ConnectorIdentity;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -42,26 +36,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class AbstractTestS3FileSystem
         extends AbstractTestTrinoFileSystem
 {
-    private S3FileSystemFactory fileSystemFactory;
-    private TrinoFileSystem fileSystem;
-
-    @BeforeAll
-    final void init()
+    @Override
+    protected AbstractTrinoFileSystemTestingEnvironment testingEnvironment()
     {
-        Logging.initialize();
-
-        initEnvironment();
-        fileSystemFactory = createS3FileSystemFactory();
-        fileSystem = fileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+        return s3TestingEnvironment();
     }
 
-    @AfterAll
-    final void cleanup()
-    {
-        fileSystem = null;
-        fileSystemFactory.destroy();
-        fileSystemFactory = null;
-    }
+    protected abstract S3FileSystemTestingEnvironment s3TestingEnvironment();
 
     /**
      * Tests same things as {@link #testFileWithTrailingWhitespace()} but with setup and assertions using {@link S3Client}.
@@ -70,22 +51,22 @@ public abstract class AbstractTestS3FileSystem
     public void testFileWithTrailingWhitespaceAgainstNativeClient()
             throws IOException
     {
-        try (S3Client s3Client = createS3Client()) {
+        try (S3Client s3Client = s3TestingEnvironment().createS3Client()) {
             String key = "foo/bar with whitespace ";
             byte[] contents = "abc foo bar".getBytes(UTF_8);
             s3Client.putObject(
-                    request -> request.bucket(bucket()).key(key),
+                    request -> request.bucket(s3TestingEnvironment().bucket()).key(key),
                     RequestBody.fromBytes(contents.clone()));
             try {
                 // Verify listing
-                List<FileEntry> listing = toList(fileSystem.listFiles(getRootLocation().appendPath("foo")));
+                List<FileEntry> listing = toList(getFileSystem().listFiles(getRootLocation().appendPath("foo")));
                 assertThat(listing).hasSize(1);
                 FileEntry fileEntry = getOnlyElement(listing);
                 assertThat(fileEntry.location()).isEqualTo(getRootLocation().appendPath(key));
                 assertThat(fileEntry.length()).isEqualTo(contents.length);
 
                 // Verify reading
-                TrinoInputFile inputFile = fileSystem.newInputFile(fileEntry.location());
+                TrinoInputFile inputFile = getFileSystem().newInputFile(fileEntry.location());
                 assertThat(inputFile.exists()).as("exists").isTrue();
                 try (TrinoInputStream inputStream = inputFile.newStream()) {
                     byte[] bytes = ByteStreams.toByteArray(inputStream);
@@ -94,76 +75,21 @@ public abstract class AbstractTestS3FileSystem
 
                 // Verify writing
                 byte[] newContents = "bar bar baz new content".getBytes(UTF_8);
-                try (OutputStream outputStream = fileSystem.newOutputFile(fileEntry.location()).createOrOverwrite()) {
+                try (OutputStream outputStream = getFileSystem().newOutputFile(fileEntry.location()).createOrOverwrite()) {
                     outputStream.write(newContents.clone());
                 }
-                assertThat(s3Client.getObjectAsBytes(request -> request.bucket(bucket()).key(key)).asByteArray())
+                assertThat(s3Client.getObjectAsBytes(request -> request.bucket(s3TestingEnvironment().bucket()).key(key)).asByteArray())
                         .isEqualTo(newContents);
 
                 // Verify deleting
-                fileSystem.deleteFile(fileEntry.location());
+                getFileSystem().deleteFile(fileEntry.location());
                 assertThat(inputFile.exists()).as("exists after delete").isFalse();
             }
             finally {
-                s3Client.deleteObject(delete -> delete.bucket(bucket()).key(key));
+                s3Client.deleteObject(delete -> delete.bucket(s3TestingEnvironment().bucket()).key(key));
             }
         }
     }
-
-    @Override
-    protected final boolean isHierarchical()
-    {
-        return false;
-    }
-
-    @Override
-    protected final TrinoFileSystem getFileSystem()
-    {
-        return fileSystem;
-    }
-
-    @Override
-    protected final Location getRootLocation()
-    {
-        return Location.of("s3://%s/".formatted(bucket()));
-    }
-
-    @Override
-    protected final boolean supportsCreateWithoutOverwrite()
-    {
-        return false;
-    }
-
-    @Override
-    protected final boolean supportsRenameFile()
-    {
-        return false;
-    }
-
-    @Override
-    protected final boolean deleteFileFailsIfNotExists()
-    {
-        return false;
-    }
-
-    @Override
-    protected final void verifyFileSystemIsEmpty()
-    {
-        try (S3Client client = createS3Client()) {
-            ListObjectsV2Request request = ListObjectsV2Request.builder()
-                    .bucket(bucket())
-                    .build();
-            assertThat(client.listObjectsV2(request).contents()).isEmpty();
-        }
-    }
-
-    protected void initEnvironment() {}
-
-    protected abstract String bucket();
-
-    protected abstract S3FileSystemFactory createS3FileSystemFactory();
-
-    protected abstract S3Client createS3Client();
 
     protected List<FileEntry> toList(FileIterator fileIterator)
             throws IOException

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/S3FileSystemTestingEnvironment.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/S3FileSystemTestingEnvironment.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.s3;
+
+import com.adobe.testing.s3mock.testcontainers.S3MockContainer;
+import io.airlift.log.Logging;
+import io.airlift.units.DataSize;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.spi.security.ConnectorIdentity;
+import io.trino.testing.containers.Minio;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class S3FileSystemTestingEnvironment
+        extends AbstractTrinoFileSystemTestingEnvironment
+{
+    private final S3FileSystemFactory fileSystemFactory;
+    private final TrinoFileSystem fileSystem;
+
+    public S3FileSystemTestingEnvironment()
+    {
+        Logging.initialize();
+        initEnvironment();
+        this.fileSystemFactory = createS3FileSystemFactory();
+        this.fileSystem = fileSystemFactory.create(ConnectorIdentity.ofUser("test"));
+    }
+
+    public void close()
+    {
+        fileSystemFactory.destroy();
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return false;
+    }
+
+    @Override
+    public TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("s3://%s/".formatted(bucket()));
+    }
+
+    @Override
+    protected final boolean supportsCreateWithoutOverwrite()
+    {
+        return false;
+    }
+
+    @Override
+    protected final boolean supportsRenameFile()
+    {
+        return false;
+    }
+
+    @Override
+    protected final boolean deleteFileFailsIfNotExists()
+    {
+        return false;
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        try (S3Client client = createS3Client()) {
+            ListObjectsV2Request request = ListObjectsV2Request.builder()
+                    .bucket(bucket())
+                    .build();
+            assertThat(client.listObjectsV2(request).contents()).isEmpty();
+        }
+    }
+
+    protected abstract void initEnvironment();
+
+    protected abstract String bucket();
+
+    protected abstract S3FileSystemFactory createS3FileSystemFactory();
+
+    protected abstract S3Client createS3Client();
+
+    public static class S3FileSystemTestingEnvironmentAwsS3
+            extends S3FileSystemTestingEnvironment
+    {
+        private String accessKey;
+        private String secretKey;
+        private String region;
+        private String bucket;
+
+        @Override
+        protected void initEnvironment()
+        {
+            accessKey = getRequiredEnvironmentVariable("AWS_ACCESS_KEY_ID");
+            secretKey = getRequiredEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
+            region = getRequiredEnvironmentVariable("AWS_REGION");
+            bucket = getRequiredEnvironmentVariable("S3_BUCKET");
+        }
+
+        @Override
+        protected String bucket()
+        {
+            return bucket;
+        }
+
+        @Override
+        protected S3Client createS3Client()
+        {
+            return S3Client.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                    .region(Region.of(region))
+                    .build();
+        }
+
+        @Override
+        protected S3FileSystemFactory createS3FileSystemFactory()
+        {
+            return new S3FileSystemFactory(new S3FileSystemConfig()
+                    .setAwsAccessKey(accessKey)
+                    .setAwsSecretKey(secretKey)
+                    .setRegion(region)
+                    .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+        }
+    }
+
+    public static class S3FileSystemTestingEnvironmentLocalStack
+            extends S3FileSystemTestingEnvironment
+    {
+        private static final String BUCKET = "test-bucket";
+
+        private LocalStackContainer localStack;
+
+        @Override
+        protected void initEnvironment()
+        {
+            localStack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.0.2"))
+                    .withServices(Service.S3);
+            localStack.start();
+            try (S3Client s3Client = createS3Client()) {
+                s3Client.createBucket(builder -> builder.bucket(BUCKET).build());
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            if (localStack != null) {
+                localStack.close();
+                localStack = null;
+            }
+            super.close();
+        }
+
+        @Override
+        protected String bucket()
+        {
+            return BUCKET;
+        }
+
+        @Override
+        protected S3Client createS3Client()
+        {
+            return S3Client.builder()
+                    .endpointOverride(localStack.getEndpointOverride(Service.S3))
+                    .region(Region.of(localStack.getRegion()))
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(localStack.getAccessKey(), localStack.getSecretKey())))
+                    .build();
+        }
+
+        @Override
+        protected S3FileSystemFactory createS3FileSystemFactory()
+        {
+            return new S3FileSystemFactory(new S3FileSystemConfig()
+                    .setAwsAccessKey(localStack.getAccessKey())
+                    .setAwsSecretKey(localStack.getSecretKey())
+                    .setEndpoint(localStack.getEndpointOverride(Service.S3).toString())
+                    .setRegion(localStack.getRegion())
+                    .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+        }
+    }
+
+    public static class S3FileSystemTestingEnvironmentMinIo
+            extends S3FileSystemTestingEnvironment
+    {
+        private final String bucket = "test-bucket-test-s3-file-system-minio";
+
+        private Minio minio;
+
+        @Override
+        protected void initEnvironment()
+        {
+            minio = Minio.builder().build();
+            minio.start();
+            minio.createBucket(bucket);
+        }
+
+        @Override
+        public void close()
+        {
+            if (minio != null) {
+                minio.close();
+                minio = null;
+            }
+            super.close();
+        }
+
+        @Override
+        protected String bucket()
+        {
+            return bucket;
+        }
+
+        @Override
+        protected S3Client createS3Client()
+        {
+            return S3Client.builder()
+                    .endpointOverride(URI.create(minio.getMinioAddress()))
+                    .region(Region.of(Minio.MINIO_REGION))
+                    .forcePathStyle(true)
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create(Minio.MINIO_ACCESS_KEY, Minio.MINIO_SECRET_KEY)))
+                    .build();
+        }
+
+        @Override
+        protected S3FileSystemFactory createS3FileSystemFactory()
+        {
+            return new S3FileSystemFactory(new S3FileSystemConfig()
+                    .setEndpoint(minio.getMinioAddress())
+                    .setRegion(Minio.MINIO_REGION)
+                    .setPathStyleAccess(true)
+                    .setAwsAccessKey(Minio.MINIO_ACCESS_KEY)
+                    .setAwsSecretKey(Minio.MINIO_SECRET_KEY)
+                    .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+        }
+    }
+
+    public static class S3FileSystemTestingEnvironmentS3Mock
+            extends S3FileSystemTestingEnvironment
+    {
+        private static final String BUCKET = "test-bucket";
+
+        private S3MockContainer s3Mock;
+
+        @Override
+        protected void initEnvironment()
+        {
+            s3Mock = new S3MockContainer("3.0.1")
+                    .withInitialBuckets(BUCKET);
+            s3Mock.start();
+        }
+
+        @Override
+        public void close()
+        {
+            if (s3Mock != null) {
+                s3Mock.close();
+                s3Mock = null;
+            }
+            super.close();
+        }
+
+        @Override
+        protected String bucket()
+        {
+            return BUCKET;
+        }
+
+        @Override
+        protected S3Client createS3Client()
+        {
+            return S3Client.builder()
+                    .credentialsProvider(StaticCredentialsProvider.create(
+                            AwsBasicCredentials.create("accesskey", "secretkey")))
+                    .endpointOverride(URI.create(s3Mock.getHttpEndpoint()))
+                    .region(Region.US_EAST_1)
+                    .forcePathStyle(true)
+                    .build();
+        }
+
+        @Override
+        protected S3FileSystemFactory createS3FileSystemFactory()
+        {
+            return new S3FileSystemFactory(new S3FileSystemConfig()
+                    .setAwsAccessKey("accesskey")
+                    .setAwsSecretKey("secretkey")
+                    .setEndpoint(s3Mock.getHttpEndpoint())
+                    .setRegion(Region.US_EAST_1.id())
+                    .setPathStyleAccess(true)
+                    .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+        }
+    }
+}

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemLocalStack.java
@@ -13,60 +13,33 @@
  */
 package io.trino.filesystem.s3;
 
-import io.airlift.units.DataSize;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.localstack.LocalStackContainer.Service;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.s3.S3Client;
+import io.trino.filesystem.s3.S3FileSystemTestingEnvironment.S3FileSystemTestingEnvironmentLocalStack;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-@Testcontainers
 public class TestS3FileSystemLocalStack
         extends AbstractTestS3FileSystem
 {
-    private static final String BUCKET = "test-bucket";
+    private S3FileSystemTestingEnvironmentLocalStack testingEnvironment;
 
-    @Container
-    private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:2.0.2"))
-            .withServices(Service.S3);
-
-    @Override
-    protected void initEnvironment()
+    @BeforeAll
+    public void setup()
     {
-        try (S3Client s3Client = createS3Client()) {
-            s3Client.createBucket(builder -> builder.bucket(BUCKET).build());
+        testingEnvironment = new S3FileSystemTestingEnvironmentLocalStack();
+    }
+
+    @AfterAll
+    public void cleanup()
+    {
+        if (testingEnvironment != null) {
+            testingEnvironment.close();
+            testingEnvironment = null;
         }
     }
 
     @Override
-    protected String bucket()
+    protected S3FileSystemTestingEnvironment s3TestingEnvironment()
     {
-        return BUCKET;
-    }
-
-    @Override
-    protected S3Client createS3Client()
-    {
-        return S3Client.builder()
-                .endpointOverride(LOCALSTACK.getEndpointOverride(Service.S3))
-                .region(Region.of(LOCALSTACK.getRegion()))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(LOCALSTACK.getAccessKey(), LOCALSTACK.getSecretKey())))
-                .build();
-    }
-
-    @Override
-    protected S3FileSystemFactory createS3FileSystemFactory()
-    {
-        return new S3FileSystemFactory(new S3FileSystemConfig()
-                .setAwsAccessKey(LOCALSTACK.getAccessKey())
-                .setAwsSecretKey(LOCALSTACK.getSecretKey())
-                .setEndpoint(LOCALSTACK.getEndpointOverride(Service.S3).toString())
-                .setRegion(LOCALSTACK.getRegion())
-                .setStreamingPartSize(DataSize.valueOf("5.5MB")));
+        return testingEnvironment;
     }
 }

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTrinoFileSystemTestingEnvironment.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTrinoFileSystemTestingEnvironment.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem;
+
+import com.google.common.io.Closer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class AbstractTrinoFileSystemTestingEnvironment
+{
+    protected static final String TEST_BLOB_CONTENT_PREFIX = "test blob content for ";
+
+    protected abstract boolean isHierarchical();
+
+    public abstract TrinoFileSystem getFileSystem();
+
+    protected abstract Location getRootLocation();
+
+    protected abstract void verifyFileSystemIsEmpty();
+
+    protected boolean supportsCreateWithoutOverwrite()
+    {
+        return true;
+    }
+
+    protected boolean supportsRenameFile()
+    {
+        return true;
+    }
+
+    protected boolean deleteFileFailsIfNotExists()
+    {
+        return true;
+    }
+
+    protected boolean normalizesListFilesResult()
+    {
+        return false;
+    }
+
+    protected boolean seekPastEndOfFileFails()
+    {
+        return true;
+    }
+
+    public static String getRequiredEnvironmentVariable(String name)
+    {
+        return requireNonNull(System.getenv(name), "Environment variable not set: " + name);
+    }
+
+    public Location createLocation(String path)
+    {
+        if (path.isEmpty()) {
+            return getRootLocation();
+        }
+        return getRootLocation().appendPath(path);
+    }
+
+    public String readLocation(Location path)
+    {
+        return readLocation(path, getFileSystem());
+    }
+
+    public static String readLocation(Location path, TrinoFileSystem trinoFileSystem)
+    {
+        try (InputStream inputStream = trinoFileSystem.newInputFile(path).newStream()) {
+            return new String(inputStream.readAllBytes(), UTF_8);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public Location createBlob(Closer closer, String path)
+    {
+        Location location = createLocation(path);
+        closer.register(new TempBlob(location, getFileSystem())).createOrOverwrite(TEST_BLOB_CONTENT_PREFIX + location.toString());
+        return location;
+    }
+
+    public TempBlob randomBlobLocation(String nameHint)
+    {
+        TempBlob tempBlob = new TempBlob(createLocation("%s/%s".formatted(nameHint, UUID.randomUUID())), getFileSystem());
+        assertThat(tempBlob.exists()).isFalse();
+        return tempBlob;
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TempBlob.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TempBlob.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+
+import static io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment.readLocation;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TempBlob
+        implements Closeable
+{
+    private final Location location;
+    private final TrinoFileSystem fileSystem;
+
+    public TempBlob(Location location, TrinoFileSystem fileSystem)
+    {
+        this.location = requireNonNull(location, "location is null");
+        this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
+    }
+
+    public Location location()
+    {
+        return location;
+    }
+
+    public boolean exists()
+    {
+        try {
+            return inputFile().exists();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public TrinoInputFile inputFile()
+    {
+        return fileSystem.newInputFile(location);
+    }
+
+    public TrinoOutputFile outputFile()
+    {
+        return fileSystem.newOutputFile(location);
+    }
+
+    public void createOrOverwrite(String data)
+    {
+        try (OutputStream outputStream = outputFile().createOrOverwrite()) {
+            outputStream.write(data.getBytes(UTF_8));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        assertThat(exists()).isTrue();
+    }
+
+    public String read()
+    {
+        return readLocation(location, fileSystem);
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            fileSystem.deleteFile(location);
+        }
+        catch (IOException ignored) {
+        }
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/LocalFileSystemTestingEnvironment.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/LocalFileSystemTestingEnvironment.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.local;
+
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import static java.util.function.Predicate.not;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalFileSystemTestingEnvironment
+        extends AbstractTrinoFileSystemTestingEnvironment
+{
+    private final Path tempDirectory;
+    private final LocalFileSystem fileSystem;
+
+    public LocalFileSystemTestingEnvironment()
+            throws IOException
+    {
+        tempDirectory = Files.createTempDirectory("test");
+        fileSystem = new LocalFileSystem(tempDirectory);
+    }
+
+    public void cleanupFiles()
+            throws IOException
+    {
+        // tests will leave directories
+        try (Stream<Path> walk = Files.walk(tempDirectory)) {
+            Iterator<Path> iterator = walk.sorted(Comparator.reverseOrder()).iterator();
+            while (iterator.hasNext()) {
+                Path path = iterator.next();
+                if (!path.equals(tempDirectory)) {
+                    Files.delete(path);
+                }
+            }
+        }
+    }
+
+    public void close()
+            throws IOException
+    {
+        Files.delete(tempDirectory);
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return true;
+    }
+
+    @Override
+    public TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("local://");
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        try {
+            try (Stream<Path> entries = Files.list(tempDirectory)) {
+                assertThat(entries.filter(not(tempDirectory::equals)).findFirst()).isEmpty();
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/TestLocalFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/local/TestLocalFileSystem.java
@@ -14,97 +14,49 @@
 package io.trino.filesystem.local;
 
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.stream.Stream;
 
-import static java.util.function.Predicate.not;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestLocalFileSystem
         extends AbstractTestTrinoFileSystem
 {
-    private LocalFileSystem fileSystem;
-    private Path tempDirectory;
+    private LocalFileSystemTestingEnvironment testingEnvironment;
 
     @BeforeAll
     void beforeAll()
             throws IOException
     {
-        tempDirectory = Files.createTempDirectory("test");
-        fileSystem = new LocalFileSystem(tempDirectory);
+        testingEnvironment = new LocalFileSystemTestingEnvironment();
     }
 
     @AfterEach
     void afterEach()
             throws IOException
     {
-        cleanupFiles();
+        testingEnvironment.cleanupFiles();
     }
 
     @AfterAll
     void afterAll()
             throws IOException
     {
-        Files.delete(tempDirectory);
-    }
-
-    private void cleanupFiles()
-            throws IOException
-    {
-        // tests will leave directories
-        try (Stream<Path> walk = Files.walk(tempDirectory)) {
-            Iterator<Path> iterator = walk.sorted(Comparator.reverseOrder()).iterator();
-            while (iterator.hasNext()) {
-                Path path = iterator.next();
-                if (!path.equals(tempDirectory)) {
-                    Files.delete(path);
-                }
-            }
+        if (testingEnvironment != null) {
+            testingEnvironment.close();
+            testingEnvironment = null;
         }
     }
 
     @Override
-    protected boolean isHierarchical()
+    protected AbstractTrinoFileSystemTestingEnvironment testingEnvironment()
     {
-        return true;
-    }
-
-    @Override
-    protected TrinoFileSystem getFileSystem()
-    {
-        return fileSystem;
-    }
-
-    @Override
-    protected Location getRootLocation()
-    {
-        return Location.of("local://");
-    }
-
-    @Override
-    protected void verifyFileSystemIsEmpty()
-    {
-        try {
-            try (Stream<Path> entries = Files.list(tempDirectory)) {
-                assertThat(entries.filter(not(tempDirectory::equals)).findFirst()).isEmpty();
-            }
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return testingEnvironment;
     }
 
     @Test

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/MemoryFileSystemTestingEnvironment.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/MemoryFileSystemTestingEnvironment.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.memory;
+
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MemoryFileSystemTestingEnvironment
+        extends AbstractTrinoFileSystemTestingEnvironment
+{
+    private final MemoryFileSystem fileSystem;
+
+    public MemoryFileSystemTestingEnvironment()
+    {
+        fileSystem = new MemoryFileSystem();
+    }
+
+    @Override
+    protected boolean isHierarchical()
+    {
+        return false;
+    }
+
+    @Override
+    public TrinoFileSystem getFileSystem()
+    {
+        return fileSystem;
+    }
+
+    @Override
+    protected Location getRootLocation()
+    {
+        return Location.of("memory://");
+    }
+
+    @Override
+    protected void verifyFileSystemIsEmpty()
+    {
+        assertThat(fileSystem.isEmpty()).isTrue();
+    }
+}

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
@@ -14,51 +14,30 @@
 package io.trino.filesystem.memory;
 
 import io.trino.filesystem.AbstractTestTrinoFileSystem;
-import io.trino.filesystem.Location;
-import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.AbstractTrinoFileSystemTestingEnvironment;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMemoryFileSystem
         extends AbstractTestTrinoFileSystem
 {
-    private MemoryFileSystem fileSystem;
+    private MemoryFileSystemTestingEnvironment testingEnvironment;
 
     @BeforeAll
     void setUp()
     {
-        fileSystem = new MemoryFileSystem();
+        testingEnvironment = new MemoryFileSystemTestingEnvironment();
     }
 
     @AfterAll
     void tearDown()
     {
-        fileSystem = null;
+        testingEnvironment = null;
     }
 
     @Override
-    protected boolean isHierarchical()
+    protected AbstractTrinoFileSystemTestingEnvironment testingEnvironment()
     {
-        return false;
-    }
-
-    @Override
-    protected TrinoFileSystem getFileSystem()
-    {
-        return fileSystem;
-    }
-
-    @Override
-    protected Location getRootLocation()
-    {
-        return Location.of("memory://");
-    }
-
-    @Override
-    protected void verifyFileSystemIsEmpty()
-    {
-        assertThat(fileSystem.isEmpty()).isTrue();
+        return testingEnvironment;
     }
 }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Extract the environment setup from tests that override AbstractTestTrinoFileSystem so that the environment can be reused for other tests. This makes it easier to create tests for the file systems since you don't have to duplicate the environment setup.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
