### PR TITLE
Update testing ClickHouse server versions

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.md
+++ b/docs/src/main/sphinx/connector/clickhouse.md
@@ -19,7 +19,7 @@ from different catalogs accessing ClickHouse or any other supported data source.
 
 To connect to a ClickHouse server, you need:
 
-- ClickHouse (version 21.8 or higher) or Altinity (version 20.8 or higher).
+- ClickHouse (version 22.8 or higher) or Altinity (version 21.3 or higher).
 - Network access from the Trino coordinator and workers to the ClickHouse
   server. Port 8123 is the default port.
 

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/TrinoToClickHouseWriteChecker.java
@@ -13,8 +13,6 @@
  */
 package io.trino.plugin.clickhouse;
 
-import com.clickhouse.data.ClickHouseVersion;
-import com.google.common.collect.ImmutableList;
 import io.trino.spi.TrinoException;
 
 import java.math.BigDecimal;
@@ -23,90 +21,66 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
-import java.util.List;
-import java.util.function.Predicate;
 
-import static com.google.common.base.Predicates.alwaysTrue;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class TrinoToClickHouseWriteChecker<T>
 {
-    // Different versions of ClickHouse may support different min/max values for the
-    // same data type, you can refer to the table below:
-    //
     // | version | column type | min value           | max value            |
     // |---------|-------------|---------------------|----------------------|
     // | any     | UInt8       | 0                   | 255                  |
     // | any     | UInt16      | 0                   | 65535                |
     // | any     | UInt32      | 0                   | 4294967295           |
     // | any     | UInt64      | 0                   | 18446744073709551615 |
-    // | < 21.4  | Date        | 1970-01-01          | 2106-02-07           |
-    // | < 21.4  | DateTime    | 1970-01-01 00:00:00 | 2106-02-06 06:28:15  |
-    // | >= 21.4 | Date        | 1970-01-01          | 2149-06-06           |
-    // | >= 21.4 | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15  |
+    // | any     | Date        | 1970-01-01          | 2149-06-06           |
+    // | any     | DateTime    | 1970-01-01 00:00:00 | 2106-02-07 06:28:15  |
     //
-    // And when the value written to ClickHouse is out of range, ClickHouse will store
+    // When the value written to ClickHouse is out of range, ClickHouse will store
     // the incorrect result, so we need to check the range of the written value to
     // prevent ClickHouse from storing the incorrect value.
 
-    public static final TrinoToClickHouseWriteChecker<Long> UINT8 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 255L))));
-    public static final TrinoToClickHouseWriteChecker<Long> UINT16 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 65535L))));
-    public static final TrinoToClickHouseWriteChecker<Long> UINT32 = new TrinoToClickHouseWriteChecker<>(ImmutableList.of(new LongWriteValueChecker(alwaysTrue(), new Range<>(0L, 4294967295L))));
+    public static final TrinoToClickHouseWriteChecker<Long> UINT8 = new TrinoToClickHouseWriteChecker<>(new LongWriteValueChecker(new Range<>(0L, 255L)));
+    public static final TrinoToClickHouseWriteChecker<Long> UINT16 = new TrinoToClickHouseWriteChecker<>(new LongWriteValueChecker(new Range<>(0L, 65535L)));
+    public static final TrinoToClickHouseWriteChecker<Long> UINT32 = new TrinoToClickHouseWriteChecker<>(new LongWriteValueChecker(new Range<>(0L, 4294967295L)));
     public static final TrinoToClickHouseWriteChecker<BigDecimal> UINT64 = new TrinoToClickHouseWriteChecker<>(
-            ImmutableList.of(new BigDecimalWriteValueChecker(alwaysTrue(), new Range<>(BigDecimal.ZERO, new BigDecimal("18446744073709551615")))));
+            new BigDecimalWriteValueChecker(new Range<>(BigDecimal.ZERO, new BigDecimal("18446744073709551615"))));
     public static final TrinoToClickHouseWriteChecker<LocalDate> DATE = new TrinoToClickHouseWriteChecker<>(
-            ImmutableList.of(
-                    new DateWriteValueChecker(version -> version.isOlderThan("21.4"), new Range<>(LocalDate.parse("1970-01-01"), LocalDate.parse("2106-02-07"))),
-                    new DateWriteValueChecker(version -> version.isNewerOrEqualTo("21.4"), new Range<>(LocalDate.parse("1970-01-01"), LocalDate.parse("2149-06-06")))));
+            new DateWriteValueChecker(new Range<>(LocalDate.parse("1970-01-01"), LocalDate.parse("2149-06-06"))));
     public static final TrinoToClickHouseWriteChecker<LocalDateTime> DATETIME = new TrinoToClickHouseWriteChecker<>(
-            ImmutableList.of(
-                    new TimestampWriteValueChecker(
-                            version -> version.isOlderThan("21.4"),
-                            new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-06T06:28:15"))),
-                    new TimestampWriteValueChecker(
-                            version -> version.isNewerOrEqualTo("21.4"),
-                            new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-07T06:28:15")))));
+            new TimestampWriteValueChecker(new Range<>(LocalDateTime.parse("1970-01-01T00:00:00"), LocalDateTime.parse("2106-02-07T06:28:15"))));
 
-    private final List<Checker<T>> checkers;
+    private final Checker<T> checker;
 
-    private TrinoToClickHouseWriteChecker(List<Checker<T>> checkers)
+    private TrinoToClickHouseWriteChecker(Checker<T> checker)
     {
-        this.checkers = ImmutableList.copyOf(requireNonNull(checkers, "checkers is null"));
+        this.checker = requireNonNull(checker, "checker is null");
     }
 
-    public void validate(ClickHouseVersion version, T value)
+    public void validate(T value)
     {
-        for (Checker<T> checker : checkers) {
-            checker.validate(version, value);
-        }
+        checker.validate(value);
     }
 
     private interface Checker<T>
     {
-        void validate(ClickHouseVersion version, T value);
+        void validate(T value);
     }
 
     private static class LongWriteValueChecker
             implements Checker<Long>
     {
-        private final Predicate<ClickHouseVersion> predicate;
         private final Range<Long> range;
 
-        public LongWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<Long> range)
+        public LongWriteValueChecker(Range<Long> range)
         {
-            this.predicate = requireNonNull(predicate, "predicate is null");
             this.range = requireNonNull(range, "range is null");
         }
 
         @Override
-        public void validate(ClickHouseVersion version, Long value)
+        public void validate(Long value)
         {
-            if (!predicate.test(version)) {
-                return;
-            }
-
             if (value >= range.getMin() && value <= range.getMax()) {
                 return;
             }
@@ -118,22 +92,16 @@ public class TrinoToClickHouseWriteChecker<T>
     private static class BigDecimalWriteValueChecker
             implements Checker<BigDecimal>
     {
-        private final Predicate<ClickHouseVersion> predicate;
         private final Range<BigDecimal> range;
 
-        public BigDecimalWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<BigDecimal> range)
+        public BigDecimalWriteValueChecker(Range<BigDecimal> range)
         {
-            this.predicate = requireNonNull(predicate, "predicate is null");
             this.range = requireNonNull(range, "range is null");
         }
 
         @Override
-        public void validate(ClickHouseVersion version, BigDecimal value)
+        public void validate(BigDecimal value)
         {
-            if (!predicate.test(version)) {
-                return;
-            }
-
             if (value.compareTo(range.getMin()) >= 0 && value.compareTo(range.getMax()) <= 0) {
                 return;
             }
@@ -145,22 +113,16 @@ public class TrinoToClickHouseWriteChecker<T>
     private static class DateWriteValueChecker
             implements Checker<LocalDate>
     {
-        private final Predicate<ClickHouseVersion> predicate;
         private final Range<LocalDate> range;
 
-        public DateWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<LocalDate> range)
+        public DateWriteValueChecker(Range<LocalDate> range)
         {
-            this.predicate = requireNonNull(predicate, "predicate is null");
             this.range = requireNonNull(range, "range is null");
         }
 
         @Override
-        public void validate(ClickHouseVersion version, LocalDate value)
+        public void validate(LocalDate value)
         {
-            if (!predicate.test(version)) {
-                return;
-            }
-
             if (value.isBefore(range.getMin()) || value.isAfter(range.getMax())) {
                 throw new TrinoException(INVALID_ARGUMENTS, format("Date must be between %s and %s in ClickHouse: %s", range.getMin(), range.getMax(), value));
             }
@@ -170,22 +132,16 @@ public class TrinoToClickHouseWriteChecker<T>
     private static class TimestampWriteValueChecker
             implements Checker<LocalDateTime>
     {
-        private final Predicate<ClickHouseVersion> predicate;
         private final Range<LocalDateTime> range;
 
-        public TimestampWriteValueChecker(Predicate<ClickHouseVersion> predicate, Range<LocalDateTime> range)
+        public TimestampWriteValueChecker(Range<LocalDateTime> range)
         {
-            this.predicate = requireNonNull(predicate, "predicate is null");
             this.range = requireNonNull(range, "range is null");
         }
 
         @Override
-        public void validate(ClickHouseVersion version, LocalDateTime value)
+        public void validate(LocalDateTime value)
         {
-            if (!predicate.test(version)) {
-                return;
-            }
-
             if (value.isBefore(range.getMin()) || value.isAfter(range.getMax())) {
                 DateTimeFormatter formatter = new DateTimeFormatterBuilder()
                         .appendPattern("uuuu-MM-dd HH:mm:ss")

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -387,11 +387,7 @@ public abstract class BaseClickHouseTypeMapping
                 .addRoundTrip("double", "3.1415926835", DOUBLE, "DOUBLE '3.1415926835'")
                 .addRoundTrip("double", "1.79769E308", DOUBLE, "DOUBLE '1.79769E308'")
                 .addRoundTrip("double", "2.225E-307", DOUBLE, "DOUBLE '2.225E-307'")
-
-                .execute(getQueryRunner(), clickhouseCreateAndInsert("tpch.test_double"))
-
                 .addRoundTrip("double", "NULL", DOUBLE, "CAST(NULL AS DOUBLE)")
-
                 .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_double"));
 
         SqlDataTypeTest.create()

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestAltinityConnectorSmokeTest.java
@@ -15,11 +15,9 @@ package io.trino.plugin.clickhouse;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
-import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 import static io.trino.plugin.clickhouse.TestingClickHouseServer.ALTINITY_DEFAULT_IMAGE;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestAltinityConnectorSmokeTest
         extends BaseClickHouseConnectorSmokeTest
@@ -33,14 +31,5 @@ public class TestAltinityConnectorSmokeTest
                 ImmutableMap.of(),
                 ImmutableMap.of("clickhouse.map-string-as-varchar", "true"), // To handle string types in TPCH tables as varchar instead of varbinary
                 REQUIRED_TPCH_TABLES);
-    }
-
-    @Test
-    @Override
-    public void testRenameSchema()
-    {
-        // Override because RENAME DATABASE statement isn't supported in Altinity 20.8
-        assertThatThrownBy(super::testRenameSchema)
-                .hasMessageContaining("RENAME DATABASE is not supported");
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -440,7 +440,9 @@ public class TestClickHouseConnectorTest
         assertUpdate("DROP TABLE " + tableName);
 
         // the column refers by order by must be not null
-        assertQueryFails("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id', 'x'])", ".* Sorting key cannot contain nullable columns.*\\n.*");
+        assertQueryFails(
+                "CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id', 'x'])",
+                "(?s).* Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled.*");
 
         assertUpdate("CREATE TABLE " + tableName + " (id int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['id'], primary_key = ARRAY['id'])");
         assertThat((String) computeScalar("SHOW CREATE TABLE " + tableName))

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseTypeMapping.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.clickhouse;
 
 import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.testng.annotations.Test;
 
 import static io.trino.plugin.clickhouse.ClickHouseQueryRunner.createClickHouseQueryRunner;
 
@@ -26,5 +28,15 @@ public class TestClickHouseTypeMapping
     {
         clickhouseServer = closeAfterClass(new TestingClickHouseServer());
         return createClickHouseQueryRunner(clickhouseServer);
+    }
+
+    @Test
+    public void testDoubleCorrectness()
+    {
+        try (TestTable table = new TestTable(onRemoteDatabase(), "tpch.test_correct_double", "(d double) ENGINE=Log")) {
+            onRemoteDatabase().execute("INSERT INTO " + table.getName() + " VALUES (CAST('2.225E-307' AS double))");
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES CAST('2.225E-307' AS double)");
+            assertQuery("SELECT true FROM " + table.getName() + " WHERE d = CAST('2.225E-307' AS double)", "VALUES true");
+        }
     }
 }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -28,14 +28,14 @@ import static org.testcontainers.utility.MountableFile.forClasspathResource;
 public class TestingClickHouseServer
         implements Closeable
 {
-    private static final DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("yandex/clickhouse-server");
-    public static final DockerImageName CLICKHOUSE_LATEST_IMAGE = CLICKHOUSE_IMAGE.withTag("21.11.10.1");
-    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("21.8.14.5"); // EOL is 31 Aug 2022
+    private static final DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("clickhouse/clickhouse-server");
+    public static final DockerImageName CLICKHOUSE_LATEST_IMAGE = CLICKHOUSE_IMAGE.withTag("23.3.13.6");
+    public static final DockerImageName CLICKHOUSE_DEFAULT_IMAGE = CLICKHOUSE_IMAGE.withTag("22.8.20.11"); // EOL is 31 Aug 2023
 
     // Altinity Stable Builds Life-Cycle Table https://docs.altinity.com/altinitystablebuilds/#altinity-stable-builds-life-cycle-table
-    private static final DockerImageName ALTINITY_IMAGE = DockerImageName.parse("altinity/clickhouse-server").asCompatibleSubstituteFor("yandex/clickhouse-server");
-    public static final DockerImageName ALTINITY_LATEST_IMAGE = ALTINITY_IMAGE.withTag("21.8.13.1.altinitystable");
-    public static final DockerImageName ALTINITY_DEFAULT_IMAGE = ALTINITY_IMAGE.withTag("20.8.4.11_aes"); // EOL is 02 December 2022
+    private static final DockerImageName ALTINITY_IMAGE = DockerImageName.parse("altinity/clickhouse-server").asCompatibleSubstituteFor("clickhouse/clickhouse-server");
+    public static final DockerImageName ALTINITY_LATEST_IMAGE = ALTINITY_IMAGE.withTag("23.3.8.22.altinitystable");
+    public static final DockerImageName ALTINITY_DEFAULT_IMAGE = ALTINITY_IMAGE.withTag("21.3.20.2.altinitystable"); // EOL is 31 Mar 2024
 
     private static final Integer HTTP_PORT = 8123;
 

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.clickhouse;
 
 import io.trino.testing.ResourcePresence;
-import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.Closeable;
@@ -23,7 +23,6 @@ import java.sql.DriverManager;
 import java.sql.Statement;
 
 import static java.lang.String.format;
-import static org.testcontainers.containers.ClickHouseContainer.HTTP_PORT;
 import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public class TestingClickHouseServer
@@ -37,6 +36,8 @@ public class TestingClickHouseServer
     private static final DockerImageName ALTINITY_IMAGE = DockerImageName.parse("altinity/clickhouse-server").asCompatibleSubstituteFor("yandex/clickhouse-server");
     public static final DockerImageName ALTINITY_LATEST_IMAGE = ALTINITY_IMAGE.withTag("21.8.13.1.altinitystable");
     public static final DockerImageName ALTINITY_DEFAULT_IMAGE = ALTINITY_IMAGE.withTag("20.8.4.11_aes"); // EOL is 02 December 2022
+
+    private static final Integer HTTP_PORT = 8123;
 
     private final ClickHouseContainer dockerContainer;
 


### PR DESCRIPTION
## Description

Update testing ClickHouse server versions because the current versions already reached EOL. 

## Release notes

( ) Release notes are required, with the following suggested text:

```markdown
# ClickHouse
* Upgrade minimum required Clickhouse version to 22.8. ({issue}`issuenumber`)
```
