### PR TITLE
Remove split when finished

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -125,7 +125,12 @@ public class ThreadPerDriverTaskExecutor
 
             int splitId = entry.nextSplitId();
             ListenableFuture<Void> done = scheduler.submit(entry.group(), splitId, new VersionEmbedderBridge(versionEmbedder, new SplitProcessor(entry.taskId(), splitId, split, tracer)));
-            done.addListener(split::close, directExecutor());
+            done.addListener(
+                    () -> {
+                        split.close();
+                        entry.removeSplit(split);
+                    },
+                    directExecutor());
             futures.add(done);
         }
 
@@ -173,12 +178,19 @@ public class ThreadPerDriverTaskExecutor
             for (SplitRunner split : splits) {
                 split.close();
             }
+
+            splits.clear();
         }
 
         public synchronized void addSplit(SplitRunner split)
         {
             checkArgument(!destroyed, "Task already destroyed: %s", taskId);
             splits.add(split);
+        }
+
+        public void removeSplit(SplitRunner split)
+        {
+            splits.remove(split);
         }
 
         public int nextSplitId()


### PR DESCRIPTION
In the thread-per-driver executor, splits were being added but not removed upon completion.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
