### PR TITLE
Reduce FileSystem calls in LinePageSourceFactory

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputStream.java
@@ -139,14 +139,8 @@ final class S3InputStream
             return;
         }
 
-        if (length == null) {
-            seekStream();
-            super.skipNBytes(n);
-            return;
-        }
-
         long position = nextReadPosition + n;
-        if ((position < 0) || (position > length)) {
+        if ((position < 0) || (length != null && position > length)) {
             throw new EOFException("Unable to skip %s bytes (position=%s, fileSize=%s): %s".formatted(n, nextReadPosition, length, location));
         }
         nextReadPosition = position;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/line/LinePageSourceFactory.java
@@ -55,7 +55,6 @@ import static io.trino.plugin.hive.util.HiveUtil.getDeserializerClassName;
 import static io.trino.plugin.hive.util.HiveUtil.getFooterCount;
 import static io.trino.plugin.hive.util.HiveUtil.getHeaderCount;
 import static io.trino.plugin.hive.util.HiveUtil.splitError;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public abstract class LinePageSourceFactory
@@ -128,35 +127,26 @@ public abstract class LinePageSourceFactory
                     Maps.fromProperties(schema));
         }
 
-        // buffer file if small
+        // Skip empty inputs
+        if (length == 0) {
+            return Optional.of(noProjectionAdaptation(new EmptyPageSource()));
+        }
+
         TrinoFileSystem trinoFileSystem = fileSystemFactory.create(session.getIdentity());
         TrinoInputFile inputFile = trinoFileSystem.newInputFile(path);
         try {
-            length = min(inputFile.length() - start, length);
-            if (!inputFile.exists()) {
-                throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, "File does not exist");
-            }
+            // buffer file if small
             if (estimatedFileSize < SMALL_FILE_SIZE.toBytes()) {
                 try (InputStream inputStream = inputFile.newStream()) {
                     byte[] data = inputStream.readAllBytes();
                     inputFile = new MemoryInputFile(path, Slices.wrappedBuffer(data));
                 }
             }
-        }
-        catch (TrinoException e) {
-            throw e;
-        }
-        catch (Exception e) {
-            throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
-        }
-
-        // Split may be empty now that the correct file size is known
-        if (length <= 0) {
-            return Optional.of(noProjectionAdaptation(new EmptyPageSource()));
-        }
-
-        try {
             LineReader lineReader = lineReaderFactory.createLineReader(inputFile, start, length, headerCount, footerCount);
+            // Split may be empty after discovering the real file size and skipping headers
+            if (lineReader.isClosed()) {
+                return Optional.of(noProjectionAdaptation(new EmptyPageSource()));
+            }
             LinePageSource pageSource = new LinePageSource(lineReader, lineDeserializer, lineReaderFactory.createLineBuffer(), path);
             return Optional.of(new ReaderPageSource(pageSource, readerProjections));
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Avoids calling `exists()` and `length()` on `TrinoInputFile` inside of `LinePageSourceFactory`, both of which will map to some API metadata lookups like S3's HeadObject which is unnecessary since:

1. Opening the stream will throw `FileNotFoundException` anyway if the file does not exist and issuing a `HeadObject` eagerly doesn't guarantee the object will still exist for a subsequent `GetObject` call
2. Adjusting the split length based on the exact file size doesn't prevent data corruption, since the file may change size between the two calls anyway and for line based text inputs, you can simply open the stream and read until an EOF is encountered without a separate call to lookup the size.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Improve performance of Trino native text format readers
```
