### PR TITLE
IpAddressFunctions.contains should return False

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
@@ -83,10 +83,11 @@ public final class IpAddressFunctions
         catch (UnknownHostException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid IP address");
         }
-
+        // CIDR prefix works similiarly for ipv4 and ipv6 
+        // If the length of the CIDR address does not match the length of the comparison IP
+        // the prefixes cannot match.
         if (base.length != ipAddress.length) {
             return false;
-            //throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "IP address version should be the same");
         }
 
         if (prefixLength == 0) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
@@ -83,7 +83,7 @@ public final class IpAddressFunctions
         catch (UnknownHostException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Invalid IP address");
         }
-        // CIDR prefix works similiarly for ipv4 and ipv6 
+        // CIDR prefix works similiarly for ipv4 and ipv6
         // If the length of the CIDR address does not match the length of the comparison IP
         // the prefixes cannot match.
         if (base.length != ipAddress.length) {

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/IpAddressFunctions.java
@@ -85,7 +85,8 @@ public final class IpAddressFunctions
         }
 
         if (base.length != ipAddress.length) {
-            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "IP address version should be the same");
+            return false;
+            //throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "IP address version should be the same");
         }
 
         if (prefixLength == 0) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
@@ -75,7 +75,7 @@ public class TestIpAddressFunctions
         assertThat(assertions.function("contains", "'0.0.0.0/4'", "IPADDRESS '0.0.0.0'"))
                 .isEqualTo(true);
         assertThat(assertions.function("contains", "'16.0.0.0/4'", "IPADDRESS '16.0.0.0'"))
-                .isEqualTo(true);
+                        .isEqualTo(true);
         assertThat(assertions.function("contains", "'240.0.0.0/4'", "IPADDRESS '240.0.0.0'"))
                 .isEqualTo(true);
 
@@ -362,6 +362,12 @@ public class TestIpAddressFunctions
         assertThat(assertions.function("contains", "'2001:abcd:ef01:2345:6789:abcd:ef01:234/60'", "IPADDRESS '2001::'"))
                 .isEqualTo(false);
         assertThat(assertions.function("contains", "'2001:abcd:ef01:2345:6789:abcd:ef01:234/60'", "IPADDRESS '2002::'"))
+                .isEqualTo(false);
+
+        // conflicting IP address versions
+        assertThat(assertions.function("contains", "'127.0.0.1/32'", "IPADDRESS '64:ff9a:f:f:f:f:f:f'"))
+                .isEqualTo(false);
+        assertThat(assertions.function("contains", "'2001:abcd:ef01:2345:6789:abcd:ef01:234/60'", "IPADDRESS '127.0.0.0'"))
                 .isEqualTo(false);
 
         // NULL argument

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestIpAddressFunctions.java
@@ -75,7 +75,7 @@ public class TestIpAddressFunctions
         assertThat(assertions.function("contains", "'0.0.0.0/4'", "IPADDRESS '0.0.0.0'"))
                 .isEqualTo(true);
         assertThat(assertions.function("contains", "'16.0.0.0/4'", "IPADDRESS '16.0.0.0'"))
-                        .isEqualTo(true);
+                .isEqualTo(true);
         assertThat(assertions.function("contains", "'240.0.0.0/4'", "IPADDRESS '240.0.0.0'"))
                 .isEqualTo(true);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes #18497 

Have IpAddressFunctions.contains reutrn false instead of throwing an exception.  This fixes an issue where the data is potentially a dynamic set of data containing both ipv4 and ipv6 data. 
There was no test case for this either.

This was the easiest option.  I could also see just not checking the length and allowing the final prefix check to fail to return false.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Given a table with the following column:
```
                 initiator_ip                   
------------------------------------------------
00 00 00 00 00 00 00 00 00 00 ff ff 0a 01 03 b9 
fe 80 00 00 00 00 00 00 05 ae ea 5e 70 9c bd 32
```
checking if the column is contained in a given cidr will thrown an exception when it processes the other version of IP(4 vs 6).  This makes columns storing both and the converted to IPADDRESS fail.  

SELECT contains('10.0.0.0/8', cast(initiator_ip as IPADDRESS))
This throws an exception instead of returning false.  


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
(  ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* return false instead of throwing exception. [Issue 18497](#18497)
```
