### PR TITLE
Ignore external errors when listing table columns/comments

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
@@ -143,7 +143,7 @@ public class TableCommentSystemTable
                         }
                     }
                     catch (RuntimeException e) {
-                        LOG.warn(e, "Failed to get metadata for table: %s", name);
+                        LOG.warn(e, "Failed to get metadata for redirected table: %s", name);
                     }
                 }
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -397,7 +397,7 @@ public interface ConnectorMetadata
                     }
                     catch (RuntimeException e) {
                         // getTableHandle or getTableMetadata failed call may fail if table disappeared during listing or is unsupported.
-                        Helper.juliLogger.log(Level.WARNING, () -> "Failed to get metadata for table: " + tableName);
+                        Helper.juliLogger.log(Level.WARNING, e, () -> "Failed to get metadata for table: " + tableName);
                         // Since the getTableHandle did not return null (i.e. succeeded or failed), we assume the table would be returned by listTables
                         return RelationCommentMetadata.forRelation(tableName, Optional.empty());
                     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -441,6 +441,7 @@ public class TrinoGlueCatalog
             }
             catch (RuntimeException e) {
                 // Table may be concurrently deleted
+                // TODO detect file not found failure when reading metadata file and silently skip table in such case. Avoid logging warnings for legitimate situations.
                 LOG.warn(e, "Failed to get metadata for table: %s", tableName);
                 return;
             }
@@ -535,6 +536,7 @@ public class TrinoGlueCatalog
             }
             catch (RuntimeException e) {
                 // Table may be concurrently deleted
+                // TODO detect file not found failure when reading metadata file and silently skip table in such case. Avoid logging warnings for legitimate situations.
                 LOG.warn(e, "Failed to get metadata for table: %s", tableName);
                 return;
             }


### PR DESCRIPTION
Avoid logging for e.g. tables concurrently deleted.