### PR TITLE
Distinguish SystemAccessControl methods not exposing query id

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -47,7 +47,6 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.SystemAccessControl;
 import io.trino.spi.security.SystemAccessControlFactory;
 import io.trino.spi.security.SystemAccessControlFactory.SystemAccessControlContext;
-import io.trino.spi.security.SystemSecurityContext;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
@@ -244,7 +243,7 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(userName, "userName is null");
 
-        systemAuthorizationCheck(control -> control.checkCanImpersonateUser(new SystemSecurityContext(identity, Optional.empty()), userName));
+        systemAuthorizationCheck(control -> control.checkCanImpersonateUser(identity, userName));
     }
 
     @Override
@@ -262,7 +261,7 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
 
-        systemAuthorizationCheck(control -> control.checkCanReadSystemInformation(new SystemSecurityContext(identity, Optional.empty())));
+        systemAuthorizationCheck(control -> control.checkCanReadSystemInformation(identity));
     }
 
     @Override
@@ -270,7 +269,7 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
 
-        systemAuthorizationCheck(control -> control.checkCanWriteSystemInformation(new SystemSecurityContext(identity, Optional.empty())));
+        systemAuthorizationCheck(control -> control.checkCanWriteSystemInformation(identity));
     }
 
     @Override
@@ -278,7 +277,7 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
 
-        systemAuthorizationCheck(control -> control.checkCanExecuteQuery(new SystemSecurityContext(identity, Optional.empty())));
+        systemAuthorizationCheck(control -> control.checkCanExecuteQuery(identity));
     }
 
     @Override
@@ -286,7 +285,7 @@ public class AccessControlManager
     {
         requireNonNull(identity, "identity is null");
 
-        systemAuthorizationCheck(control -> control.checkCanViewQueryOwnedBy(new SystemSecurityContext(identity, Optional.empty()), queryOwner));
+        systemAuthorizationCheck(control -> control.checkCanViewQueryOwnedBy(identity, queryOwner));
     }
 
     @Override
@@ -297,7 +296,7 @@ public class AccessControlManager
             return ImmutableSet.of();
         }
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
-            queryOwners = systemAccessControl.filterViewQueryOwnedBy(new SystemSecurityContext(identity, Optional.empty()), queryOwners);
+            queryOwners = systemAccessControl.filterViewQueryOwnedBy(identity, queryOwners);
         }
         return queryOwners;
     }
@@ -308,7 +307,7 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(queryOwner, "queryOwner is null");
 
-        systemAuthorizationCheck(control -> control.checkCanKillQueryOwnedBy(new SystemSecurityContext(identity, Optional.empty()), queryOwner));
+        systemAuthorizationCheck(control -> control.checkCanKillQueryOwnedBy(identity, queryOwner));
     }
 
     @Override
@@ -1067,7 +1066,7 @@ public class AccessControlManager
         requireNonNull(identity, "identity is null");
         requireNonNull(propertyName, "propertyName is null");
 
-        systemAuthorizationCheck(control -> control.checkCanSetSystemSessionProperty(new SystemSecurityContext(identity, Optional.empty()), propertyName));
+        systemAuthorizationCheck(control -> control.checkCanSetSystemSessionProperty(identity, propertyName));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/SecurityContext.java
+++ b/core/trino-main/src/main/java/io/trino/security/SecurityContext.java
@@ -20,7 +20,6 @@ import io.trino.spi.security.SystemSecurityContext;
 import io.trino.transaction.TransactionId;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -61,7 +60,7 @@ public class SecurityContext
 
     public SystemSecurityContext toSystemSecurityContext()
     {
-        return new SystemSecurityContext(identity, Optional.of(queryId));
+        return new SystemSecurityContext(identity, queryId);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -236,7 +236,7 @@ public class TestAccessControlManager
                         }
 
                         @Override
-                        public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+                        public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
                         {
                         }
                     };
@@ -520,7 +520,7 @@ public class TestAccessControlManager
                 return new SystemAccessControl()
                 {
                     @Override
-                    public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+                    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
                     {
                     }
 
@@ -588,7 +588,7 @@ public class TestAccessControlManager
                 }
 
                 @Override
-                public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+                public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
                 {
                     throw new UnsupportedOperationException();
                 }

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -43,7 +43,6 @@ import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.Identity;
-import io.trino.spi.security.SystemSecurityContext;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -1412,17 +1411,17 @@ public class TestResourceSecurity
         }
 
         @Override
-        public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+        public void checkCanImpersonateUser(Identity identity, String userName)
         {
             if (!allowImpersonation) {
-                denyImpersonateUser(context.getIdentity().getUser(), userName);
+                denyImpersonateUser(identity.getUser(), userName);
             }
         }
 
         @Override
-        public void checkCanReadSystemInformation(SystemSecurityContext context)
+        public void checkCanReadSystemInformation(Identity identity)
         {
-            if (!context.getIdentity().getUser().equals(MANAGEMENT_USER)) {
+            if (!identity.getUser().equals(MANAGEMENT_USER)) {
                 denyReadSystemInformationAccess();
             }
         }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -230,18 +230,6 @@
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
-                                    <ignore>true</ignore>
-                                    <code>java.class.removed</code>
-                                    <old>class io.trino.spi.connector.RelationColumnsMetadata</old>
-                                    <justification>False positive: the class is not removed, it's just marked @Experimental</justification>
-                                </item>
-                                <item>
-                                    <ignore>true</ignore>
-                                    <code>java.class.removed</code>
-                                    <old>class io.trino.spi.connector.RelationCommentMetadata</old>
-                                    <justification>False positive: the class is not removed, it's just marked @Experimental</justification>
-                                </item>
-                                <item>
                                     <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlockBuilder::copyPositions(int[], int, int)</old>
                                 </item>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -230,6 +230,66 @@
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanExecuteQuery(===io.trino.spi.security.SystemSecurityContext===)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanExecuteQuery(===io.trino.spi.security.Identity===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanImpersonateUser(===io.trino.spi.security.SystemSecurityContext===, java.lang.String)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanImpersonateUser(===io.trino.spi.security.Identity===, java.lang.String)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanKillQueryOwnedBy(===io.trino.spi.security.SystemSecurityContext===, io.trino.spi.security.Identity)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanKillQueryOwnedBy(===io.trino.spi.security.Identity===, io.trino.spi.security.Identity)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanReadSystemInformation(===io.trino.spi.security.SystemSecurityContext===)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanReadSystemInformation(===io.trino.spi.security.Identity===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanViewQueryOwnedBy(===io.trino.spi.security.SystemSecurityContext===, io.trino.spi.security.Identity)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanViewQueryOwnedBy(===io.trino.spi.security.Identity===, io.trino.spi.security.Identity)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanWriteSystemInformation(===io.trino.spi.security.SystemSecurityContext===)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanWriteSystemInformation(===io.trino.spi.security.Identity===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemAccessControl::checkCanSetSystemSessionProperty(===io.trino.spi.security.SystemSecurityContext===, java.lang.String)</old>
+                                    <new>parameter void io.trino.spi.security.SystemAccessControl::checkCanSetSystemSessionProperty(===io.trino.spi.security.Identity===, java.lang.String)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter java.util.Collection&lt;io.trino.spi.security.Identity&gt; io.trino.spi.security.SystemAccessControl::filterViewQueryOwnedBy(===io.trino.spi.security.SystemSecurityContext===, java.util.Collection&lt;io.trino.spi.security.Identity&gt;)</old>
+                                    <new>parameter java.util.Collection&lt;io.trino.spi.security.Identity&gt; io.trino.spi.security.SystemAccessControl::filterViewQueryOwnedBy(===io.trino.spi.security.Identity===, java.util.Collection&lt;io.trino.spi.security.Identity&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeChanged</code>
+                                    <old>parameter void io.trino.spi.security.SystemSecurityContext::&lt;init&gt;(io.trino.spi.security.Identity, ===java.util.Optional&lt;io.trino.spi.QueryId&gt;===)</old>
+                                    <new>parameter void io.trino.spi.security.SystemSecurityContext::&lt;init&gt;(io.trino.spi.security.Identity, ===io.trino.spi.QueryId===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeChanged</code>
+                                    <old>method java.util.Optional&lt;io.trino.spi.QueryId&gt; io.trino.spi.security.SystemSecurityContext::getQueryId()</old>
+                                    <new>method io.trino.spi.QueryId io.trino.spi.security.SystemSecurityContext::getQueryId()</new>
+                                </item>
+                                <item>
                                     <code>java.method.removed</code>
                                     <old>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlockBuilder::copyPositions(int[], int, int)</old>
                                 </item>

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -104,9 +104,9 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    default void checkCanImpersonateUser(Identity identity, String userName)
     {
-        denyImpersonateUser(context.getIdentity().getUser(), userName);
+        denyImpersonateUser(identity.getUser(), userName);
     }
 
     /**
@@ -126,7 +126,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanExecuteQuery(SystemSecurityContext context)
+    default void checkCanExecuteQuery(Identity identity)
     {
         denyExecuteQuery();
     }
@@ -137,7 +137,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanViewQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    default void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         denyViewQuery();
     }
@@ -146,7 +146,7 @@ public interface SystemAccessControl
      * Filter the list of users to those the identity view query owned by the user.  The method
      * will not be called with the current user in the set.
      */
-    default Collection<Identity> filterViewQueryOwnedBy(SystemSecurityContext context, Collection<Identity> queryOwners)
+    default Collection<Identity> filterViewQueryOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return emptySet();
     }
@@ -157,7 +157,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanKillQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    default void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         denyKillQuery();
     }
@@ -169,7 +169,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanReadSystemInformation(SystemSecurityContext context)
+    default void checkCanReadSystemInformation(Identity identity)
     {
         denyReadSystemInformationAccess();
     }
@@ -180,7 +180,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanWriteSystemInformation(SystemSecurityContext context)
+    default void checkCanWriteSystemInformation(Identity identity)
     {
         denyWriteSystemInformationAccess();
     }
@@ -190,7 +190,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    default void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    default void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
         denySetSystemSessionProperty(propertyName);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -64,6 +64,7 @@ import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivileg
 import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
 import static io.trino.spi.security.AccessDeniedException.denyInsertTable;
 import static io.trino.spi.security.AccessDeniedException.denyKillQuery;
+import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
 import static io.trino.spi.security.AccessDeniedException.denyRefreshMaterializedView;
 import static io.trino.spi.security.AccessDeniedException.denyRenameColumn;
 import static io.trino.spi.security.AccessDeniedException.denyRenameMaterializedView;
@@ -92,6 +93,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowTables;
 import static io.trino.spi.security.AccessDeniedException.denyTruncateTable;
 import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
+import static io.trino.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
 import static java.lang.String.format;
 import static java.util.Collections.emptySet;
 
@@ -169,7 +171,7 @@ public interface SystemAccessControl
      */
     default void checkCanReadSystemInformation(SystemSecurityContext context)
     {
-        AccessDeniedException.denyReadSystemInformationAccess();
+        denyReadSystemInformationAccess();
     }
 
     /**
@@ -180,7 +182,7 @@ public interface SystemAccessControl
      */
     default void checkCanWriteSystemInformation(SystemSecurityContext context)
     {
-        AccessDeniedException.denyWriteSystemInformationAccess();
+        denyWriteSystemInformationAccess();
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemSecurityContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemSecurityContext.java
@@ -15,16 +15,14 @@ package io.trino.spi.security;
 
 import io.trino.spi.QueryId;
 
-import java.util.Optional;
-
 import static java.util.Objects.requireNonNull;
 
 public class SystemSecurityContext
 {
     private final Identity identity;
-    private final Optional<QueryId> queryId;
+    private final QueryId queryId;
 
-    public SystemSecurityContext(Identity identity, Optional<QueryId> queryId)
+    public SystemSecurityContext(Identity identity, QueryId queryId)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -35,7 +33,7 @@ public class SystemSecurityContext
         return identity;
     }
 
-    public Optional<QueryId> getQueryId()
+    public QueryId getQueryId()
     {
         return queryId;
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -64,7 +64,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    public void checkCanImpersonateUser(Identity identity, String userName)
     {
     }
 
@@ -74,38 +74,38 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    public void checkCanReadSystemInformation(Identity identity)
     {
     }
 
     @Override
-    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    public void checkCanWriteSystemInformation(Identity identity)
     {
     }
 
     @Override
-    public void checkCanExecuteQuery(SystemSecurityContext context)
+    public void checkCanExecuteQuery(Identity identity)
     {
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
     }
 
     @Override
-    public Collection<Identity> filterViewQueryOwnedBy(SystemSecurityContext context, Collection<Identity> queryOwners)
+    public Collection<Identity> filterViewQueryOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return queryOwners;
     }
 
     @Override
-    public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/DefaultSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/DefaultSystemAccessControl.java
@@ -13,9 +13,9 @@
  */
 package io.trino.plugin.base.security;
 
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.SystemAccessControl;
 import io.trino.spi.security.SystemAccessControlFactory;
-import io.trino.spi.security.SystemSecurityContext;
 
 import java.util.Map;
 
@@ -52,13 +52,13 @@ public class DefaultSystemAccessControl
     }
 
     @Override
-    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    public void checkCanImpersonateUser(Identity identity, String userName)
     {
-        denyImpersonateUser(context.getIdentity().getUser(), userName);
+        denyImpersonateUser(identity.getUser(), userName);
     }
 
     @Override
-    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    public void checkCanWriteSystemInformation(Identity identity)
     {
         denyWriteSystemInformationAccess();
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -226,9 +226,8 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    public void checkCanImpersonateUser(Identity identity, String userName)
     {
-        Identity identity = context.getIdentity();
         if (impersonationRules.isEmpty()) {
             // if there are principal user match rules, we assume that impersonation checks are
             // handled there; otherwise, impersonation must be manually configured
@@ -281,37 +280,36 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanExecuteQuery(SystemSecurityContext context)
+    public void checkCanExecuteQuery(Identity identity)
     {
-        if (!canAccessQuery(context.getIdentity(), Optional.empty(), QueryAccessRule.AccessMode.EXECUTE)) {
+        if (!canAccessQuery(identity, Optional.empty(), QueryAccessRule.AccessMode.EXECUTE)) {
             denyViewQuery();
         }
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        if (!canAccessQuery(context.getIdentity(), Optional.of(queryOwner.getUser()), QueryAccessRule.AccessMode.VIEW)) {
+        if (!canAccessQuery(identity, Optional.of(queryOwner.getUser()), QueryAccessRule.AccessMode.VIEW)) {
             denyViewQuery();
         }
     }
 
     @Override
-    public Collection<Identity> filterViewQueryOwnedBy(SystemSecurityContext context, Collection<Identity> queryOwners)
+    public Collection<Identity> filterViewQueryOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         if (queryAccessRules.isEmpty()) {
             return queryOwners;
         }
-        Identity identity = context.getIdentity();
         return queryOwners.stream()
                 .filter(owner -> canAccessQuery(identity, Optional.of(owner.getUser()), QueryAccessRule.AccessMode.VIEW))
                 .collect(toImmutableSet());
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        if (!canAccessQuery(context.getIdentity(), Optional.of(queryOwner.getUser()), QueryAccessRule.AccessMode.KILL)) {
+        if (!canAccessQuery(identity, Optional.of(queryOwner.getUser()), QueryAccessRule.AccessMode.KILL)) {
             denyViewQuery();
         }
     }
@@ -331,17 +329,17 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    public void checkCanReadSystemInformation(Identity identity)
     {
-        if (!checkCanSystemInformation(context.getIdentity(), SystemInformationRule.AccessMode.READ)) {
+        if (!checkCanSystemInformation(identity, SystemInformationRule.AccessMode.READ)) {
             denyReadSystemInformationAccess();
         }
     }
 
     @Override
-    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    public void checkCanWriteSystemInformation(Identity identity)
     {
-        if (!checkCanSystemInformation(context.getIdentity(), SystemInformationRule.AccessMode.WRITE)) {
+        if (!checkCanSystemInformation(identity, SystemInformationRule.AccessMode.WRITE)) {
             denyWriteSystemInformationAccess();
         }
     }
@@ -358,9 +356,8 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
-        Identity identity = context.getIdentity();
         boolean allowed = sessionPropertyRules.stream()
                 .map(rule -> rule.match(identity.getUser(), identity.getEnabledRoles(), identity.getGroups(), propertyName))
                 .flatMap(Optional::stream)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -56,9 +56,9 @@ public abstract class ForwardingSystemAccessControl
     protected abstract SystemAccessControl delegate();
 
     @Override
-    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    public void checkCanImpersonateUser(Identity identity, String userName)
     {
-        delegate().checkCanImpersonateUser(context, userName);
+        delegate().checkCanImpersonateUser(identity, userName);
     }
 
     @Override
@@ -68,45 +68,45 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
-    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    public void checkCanReadSystemInformation(Identity identity)
     {
-        delegate().checkCanReadSystemInformation(context);
+        delegate().checkCanReadSystemInformation(identity);
     }
 
     @Override
-    public void checkCanWriteSystemInformation(SystemSecurityContext context)
+    public void checkCanWriteSystemInformation(Identity identity)
     {
-        delegate().checkCanWriteSystemInformation(context);
+        delegate().checkCanWriteSystemInformation(identity);
     }
 
     @Override
-    public void checkCanExecuteQuery(SystemSecurityContext context)
+    public void checkCanExecuteQuery(Identity identity)
     {
-        delegate().checkCanExecuteQuery(context);
+        delegate().checkCanExecuteQuery(identity);
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        delegate().checkCanViewQueryOwnedBy(context, queryOwner);
+        delegate().checkCanViewQueryOwnedBy(identity, queryOwner);
     }
 
     @Override
-    public Collection<Identity> filterViewQueryOwnedBy(SystemSecurityContext context, Collection<Identity> queryOwners)
+    public Collection<Identity> filterViewQueryOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
-        return delegate().filterViewQueryOwnedBy(context, queryOwners);
+        return delegate().filterViewQueryOwnedBy(identity, queryOwners);
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
-        delegate().checkCanKillQueryOwnedBy(context, queryOwner);
+        delegate().checkCanKillQueryOwnedBy(identity, queryOwner);
     }
 
     @Override
-    public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
-        delegate().checkCanSetSystemSessionProperty(context, propertyName);
+        delegate().checkCanSetSystemSessionProperty(identity, propertyName);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
@@ -65,23 +65,23 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public void checkCanExecuteQuery(SystemSecurityContext context)
+    public void checkCanExecuteQuery(Identity identity)
     {
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(SystemSecurityContext context, Identity queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
     }
 
     @Override
-    public Collection<Identity> filterViewQueryOwnedBy(SystemSecurityContext context, Collection<Identity> queryOwners)
+    public Collection<Identity> filterViewQueryOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return queryOwners;
     }
 
     @Override
-    public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+    public void checkCanSetSystemSessionProperty(Identity identity, String propertyName)
     {
     }
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -773,9 +773,9 @@ public abstract class BaseFileBasedSystemAccessControlTest
         SystemAccessControl accessControl = newFileBasedSystemAccessControl("file-based-system-access-table-mixed-groups.json");
 
         SystemSecurityContext userGroup1Group2 = new SystemSecurityContext(Identity.forUser("user_1_2")
-                .withGroups(ImmutableSet.of("group1", "group2")).build(), Optional.empty());
+                .withGroups(ImmutableSet.of("group1", "group2")).build(), queryId);
         SystemSecurityContext userGroup2 = new SystemSecurityContext(Identity.forUser("user_2")
-                .withGroups(ImmutableSet.of("group2")).build(), Optional.empty());
+                .withGroups(ImmutableSet.of("group2")).build(), queryId);
 
         assertEquals(
                 accessControl.getColumnMask(
@@ -794,9 +794,9 @@ public abstract class BaseFileBasedSystemAccessControlTest
                 new ViewExpression(Optional.empty(), Optional.of("some-catalog"), Optional.of("my_schema"), "'mask_a'"));
 
         SystemSecurityContext userGroup1Group3 = new SystemSecurityContext(Identity.forUser("user_1_3")
-                .withGroups(ImmutableSet.of("group1", "group3")).build(), Optional.empty());
+                .withGroups(ImmutableSet.of("group1", "group3")).build(), queryId);
         SystemSecurityContext userGroup3 = new SystemSecurityContext(Identity.forUser("user_3")
-                .withGroups(ImmutableSet.of("group3")).build(), Optional.empty());
+                .withGroups(ImmutableSet.of("group3")).build(), queryId);
 
         assertEquals(
                 accessControl.getRowFilters(
@@ -1005,23 +1005,23 @@ public abstract class BaseFileBasedSystemAccessControlTest
     {
         SystemAccessControl accessControlManager = newFileBasedSystemAccessControl("system-information.json");
 
-        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
-        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, queryId));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, queryId));
 
-        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, Optional.empty()));
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, queryId));
         assertAccessDenied(
-                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, Optional.empty())),
+                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, queryId)),
                 "Cannot write system information");
 
         assertAccessDenied(
-                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot read system information");
         assertAccessDenied(
-                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot write system information");
 
-        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(nonAsciiUser, Optional.empty()));
-        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(nonAsciiUser, Optional.empty()));
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(nonAsciiUser, queryId));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(nonAsciiUser, queryId));
     }
 
     @Test
@@ -1030,10 +1030,10 @@ public abstract class BaseFileBasedSystemAccessControlTest
         SystemAccessControl accessControlManager = newFileBasedSystemAccessControl("file-based-system-catalog.json");
 
         assertAccessDenied(
-                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot read system information");
         assertAccessDenied(
-                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot write system information");
     }
 
@@ -1043,19 +1043,19 @@ public abstract class BaseFileBasedSystemAccessControlTest
         File rulesFile = new File("../../docs/src/main/sphinx/security/system-information-access.json");
         SystemAccessControl accessControlManager = newFileBasedSystemAccessControl(rulesFile, ImmutableMap.of());
 
-        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
-        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, Optional.empty()));
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(admin, queryId));
+        accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(admin, queryId));
 
-        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, Optional.empty()));
+        accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(alice, queryId));
         assertAccessDenied(
-                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, Optional.empty())),
+                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(alice, queryId)),
                 "Cannot write system information");
 
         assertAccessDenied(
-                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanReadSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot read system information");
         assertAccessDenied(
-                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, Optional.empty())),
+                () -> accessControlManager.checkCanWriteSystemInformation(new SystemSecurityContext(bob, queryId)),
                 "Cannot write system information");
     }
 


### PR DESCRIPTION
## Description

Before the change, `SystemSecurityContext` was provided to every method in `SystemAccessControl`. This was problematic for implementations which need to be query-aware (e.g. for audit or caching purposes), because there was no type system support helping to determine whether ID is present or not. This commit makes `SystemSecurityContext.queryId` non-optional. For methods where query ID is not passed, simple `Identity` is now passed, since this is the only other field in the `SystemSecurityContext`. This is a breaking change because doing it in backwards compatible way would be quite laborious.
