### PR TITLE
Cleanup scheduled tasks on completion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ThreadPerDriverTaskExecutor.java
@@ -188,7 +188,7 @@ public class ThreadPerDriverTaskExecutor
             splits.add(split);
         }
 
-        public void removeSplit(SplitRunner split)
+        public synchronized void removeSplit(SplitRunner split)
         {
             splits.remove(split);
         }

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/BlockingSchedulingQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/BlockingSchedulingQueue.java
@@ -13,6 +13,7 @@
  */
 package io.trino.execution.executor.scheduler;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 
@@ -46,6 +47,21 @@ final class BlockingSchedulingQueue<G, T>
         lock.lock();
         try {
             return queue.finishGroup(group);
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
+    public Set<T> getTasks(G group)
+    {
+        lock.lock();
+        try {
+            if (!queue.containsGroup(group)) {
+                return ImmutableSet.of();
+            }
+
+            return queue.getTasks(group);
         }
         finally {
             lock.unlock();

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/BlockingSchedulingQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/BlockingSchedulingQueue.java
@@ -134,6 +134,22 @@ final class BlockingSchedulingQueue<G, T>
         }
     }
 
+    public boolean finish(G group, T task)
+    {
+        lock.lock();
+        try {
+            if (!queue.containsGroup(group)) {
+                return false;
+            }
+
+            queue.finish(group, task);
+            return true;
+        }
+        finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -183,6 +183,7 @@ public final class FairScheduler
             if (task.getState() == TaskControl.State.RUNNING) {
                 concurrencyControl.release(task);
             }
+            queue.finish(task.group(), task);
             task.transitionToFinished();
         }
     }

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/FairScheduler.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -142,6 +143,13 @@ public final class FairScheduler
         for (TaskControl task : tasks) {
             task.cancel();
         }
+    }
+
+    public Set<Integer> getTasks(Group group)
+    {
+        return queue.getTasks(group).stream()
+                .map(TaskControl::id)
+                .collect(toImmutableSet());
     }
 
     public synchronized ListenableFuture<Void> submit(Group group, int id, Schedulable runner)

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/SchedulingQueue.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/SchedulingQueue.java
@@ -138,6 +138,12 @@ final class SchedulingQueue<G, T>
         return groups.containsKey(group);
     }
 
+    public Set<T> getTasks(G group)
+    {
+        checkArgument(groups.containsKey(group), "Unknown group: %s", group);
+        return groups.get(group).tasks();
+    }
+
     public Set<T> finishAll()
     {
         Set<G> groups = ImmutableSet.copyOf(this.groups.keySet());

--- a/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/TaskControl.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/scheduler/TaskControl.java
@@ -69,6 +69,11 @@ final class TaskControl
         this.periodStart = ticker.read();
     }
 
+    public int id()
+    {
+        return id;
+    }
+
     public void setThread(Thread thread)
     {
         this.thread = thread;

--- a/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/scheduler/TestFairScheduler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -197,6 +198,25 @@ public class TestFairScheduler
 
             scheduler.removeGroup(group);
             task1.get();
+        }
+    }
+
+    @Test
+    public void testCleanupAfterFinish()
+            throws InterruptedException, ExecutionException
+    {
+        TestingTicker ticker = new TestingTicker();
+        try (FairScheduler scheduler = FairScheduler.newInstance(1, ticker)) {
+            Group group = scheduler.createGroup("G");
+
+            AtomicInteger counter = new AtomicInteger();
+            ListenableFuture<Void> task1 = scheduler.submit(group, 1, context -> {
+                counter.incrementAndGet();
+            });
+
+            task1.get();
+            assertThat(counter.get()).isEqualTo(1);
+            assertThat(scheduler.getTasks(group)).isEmpty();
         }
     }
 


### PR DESCRIPTION
Tasks were not being removed from the FairScheduler scheduling queue upon completion. They were only being removed when the scheduling group was terminated.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
