### PR TITLE
Allow different synthetic column name length limits in JDBC connectors

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -560,6 +560,12 @@ public class CachingJdbcClient
         return delegate.getMaxWriteParallelism(session);
     }
 
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return delegate.getMaxColumnNameLength(session);
+    }
+
     public void onDataChanged(SchemaTableName table)
     {
         invalidateAllIf(statisticsCache, key -> key.mayReference(table));

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -460,14 +460,14 @@ public class DefaultJdbcMetadata
 
         ImmutableMap.Builder<JdbcColumnHandle, JdbcColumnHandle> newLeftColumnsBuilder = ImmutableMap.builder();
         for (JdbcColumnHandle column : jdbcClient.getColumns(session, leftHandle)) {
-            newLeftColumnsBuilder.put(column, createSyntheticColumn(column, nextSyntheticColumnId));
+            newLeftColumnsBuilder.put(column, createSyntheticJoinProjectionColumn(column, nextSyntheticColumnId));
             nextSyntheticColumnId++;
         }
         Map<JdbcColumnHandle, JdbcColumnHandle> newLeftColumns = newLeftColumnsBuilder.buildOrThrow();
 
         ImmutableMap.Builder<JdbcColumnHandle, JdbcColumnHandle> newRightColumnsBuilder = ImmutableMap.builder();
         for (JdbcColumnHandle column : jdbcClient.getColumns(session, rightHandle)) {
-            newRightColumnsBuilder.put(column, createSyntheticColumn(column, nextSyntheticColumnId));
+            newRightColumnsBuilder.put(column, createSyntheticJoinProjectionColumn(column, nextSyntheticColumnId));
             nextSyntheticColumnId++;
         }
         Map<JdbcColumnHandle, JdbcColumnHandle> newRightColumns = newRightColumnsBuilder.buildOrThrow();
@@ -525,7 +525,7 @@ public class DefaultJdbcMetadata
     }
 
     @VisibleForTesting
-    static JdbcColumnHandle createSyntheticColumn(JdbcColumnHandle column, int nextSyntheticColumnId)
+    static JdbcColumnHandle createSyntheticJoinProjectionColumn(JdbcColumnHandle column, int nextSyntheticColumnId)
     {
         verify(nextSyntheticColumnId >= 0, "nextSyntheticColumnId rolled over and is not monotonically increasing any more");
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -450,4 +450,10 @@ public abstract class ForwardingJdbcClient
     {
         return delegate().getMaxWriteParallelism(session);
     }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return delegate().getMaxColumnNameLength(session);
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -239,4 +239,9 @@ public interface JdbcClient
     OptionalLong update(ConnectorSession session, JdbcTableHandle handle);
 
     OptionalInt getMaxWriteParallelism(ConnectorSession session);
+
+    default OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return OptionalInt.empty();
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -470,4 +470,10 @@ public final class StatisticsAwareJdbcClient
     {
         return delegate().getMaxWriteParallelism(session);
     }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return delegate().getMaxColumnNameLength(session);
+    }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -44,7 +44,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.plugin.jdbc.DefaultJdbcMetadata.createSyntheticColumn;
+import static io.trino.plugin.jdbc.DefaultJdbcMetadata.createSyntheticJoinProjectionColumn;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -402,11 +402,11 @@ public class TestDefaultJdbcMetadata
     @Test
     public void testColumnAliasTruncation()
     {
-        assertThat(createSyntheticColumn(column("column_0"), 999).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_0"), 999).getColumnName())
                 .isEqualTo("column_0_999");
-        assertThat(createSyntheticColumn(column("column_with_over_twenty_characters"), 100).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), 100).getColumnName())
                 .isEqualTo("column_with_over_twenty_ch_100");
-        assertThat(createSyntheticColumn(column("column_with_over_twenty_characters"), Integer.MAX_VALUE).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), Integer.MAX_VALUE).getColumnName())
                 .isEqualTo("column_with_over_tw_2147483647");
     }
 
@@ -415,7 +415,7 @@ public class TestDefaultJdbcMetadata
     {
         JdbcColumnHandle column = column("column_0");
 
-        assertThatThrownBy(() -> createSyntheticColumn(column, -2147483648)).isInstanceOf(VerifyException.class);
+        assertThatThrownBy(() -> createSyntheticJoinProjectionColumn(column, -2147483648)).isInstanceOf(VerifyException.class);
     }
 
     private static JdbcColumnHandle column(String columnName)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.Function;
 
 import static io.airlift.slice.Slices.utf8Slice;
@@ -403,11 +404,11 @@ public class TestDefaultJdbcMetadata
     @Test
     public void testColumnAliasTruncation()
     {
-        assertThat(createSyntheticJoinProjectionColumn(column("column_0"), 999).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_0"), 999, OptionalInt.of(30)).getColumnName())
                 .isEqualTo("column_0_999");
-        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), 100).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), 100, OptionalInt.of(30)).getColumnName())
                 .isEqualTo("column_with_over_twenty_ch_100");
-        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), Integer.MAX_VALUE).getColumnName())
+        assertThat(createSyntheticJoinProjectionColumn(column("column_with_over_twenty_characters"), Integer.MAX_VALUE, OptionalInt.of(30)).getColumnName())
                 .isEqualTo("column_with_over_tw_2147483647");
     }
 
@@ -416,7 +417,7 @@ public class TestDefaultJdbcMetadata
     {
         JdbcColumnHandle column = column("column_0");
 
-        assertThatThrownBy(() -> createSyntheticJoinProjectionColumn(column, -2147483648)).isInstanceOf(VerifyException.class);
+        assertThatThrownBy(() -> createSyntheticJoinProjectionColumn(column, -2147483648, OptionalInt.of(30))).isInstanceOf(VerifyException.class);
     }
 
     @Test

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -89,6 +89,7 @@ import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -214,6 +215,8 @@ public class OracleClient
     private final boolean synonymsEnabled;
     private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
+
+    private Integer maxColumnNameLength;
 
     @Inject
     public OracleClient(
@@ -346,6 +349,27 @@ public class OracleClient
     public void renameSchema(ConnectorSession session, String schemaName, String newSchemaName)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support renaming schemas");
+    }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        if (maxColumnNameLength != null) {
+            // According to JavaDoc of DatabaseMetaData#getMaxColumnNameLength a value of 0 signifies that the limit is unknown
+            if (maxColumnNameLength == 0) {
+                return OptionalInt.empty();
+            }
+
+            return OptionalInt.of(maxColumnNameLength);
+        }
+
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            maxColumnNameLength = connection.getMetaData().getMaxColumnNameLength();
+            return OptionalInt.of(maxColumnNameLength);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
     }
 
     @Override

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -216,8 +216,6 @@ public class OracleClient
     private final ConnectorExpressionRewriter<ParameterizedExpression> connectorExpressionRewriter;
     private final AggregateFunctionRewriter<JdbcExpression, ?> aggregateFunctionRewriter;
 
-    private Integer maxColumnNameLength;
-
     @Inject
     public OracleClient(
             BaseJdbcConfig config,
@@ -354,22 +352,7 @@ public class OracleClient
     @Override
     public OptionalInt getMaxColumnNameLength(ConnectorSession session)
     {
-        if (maxColumnNameLength != null) {
-            // According to JavaDoc of DatabaseMetaData#getMaxColumnNameLength a value of 0 signifies that the limit is unknown
-            if (maxColumnNameLength == 0) {
-                return OptionalInt.empty();
-            }
-
-            return OptionalInt.of(maxColumnNameLength);
-        }
-
-        try (Connection connection = connectionFactory.openConnection(session)) {
-            maxColumnNameLength = connection.getMetaData().getMaxColumnNameLength();
-            return OptionalInt.of(maxColumnNameLength);
-        }
-        catch (SQLException e) {
-            throw new TrinoException(JDBC_ERROR, e);
-        }
+        return getMaxColumnNameLengthFromDatabaseMetaData(session);
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.Closeables;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
-import io.trino.testing.sql.TestTable;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -28,16 +27,12 @@ import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
 public class TestOracleConnectorTest
         extends BaseOracleConnectorTest
 {
-    // older Oracle versions are limited to 30 character identifier names
-    private static final String MAXIMUM_LENGTH_COLUMN_IDENTIFIER = "z".repeat(30);
-
     private TestingOracleServer oracleServer;
 
     @Override
@@ -102,17 +97,5 @@ public class TestOracleConnectorTest
                 oracleServer.execute(sql);
             }
         };
-    }
-
-    @Test
-    public void testPushdownJoinWithLongNameSucceeds()
-    {
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "long_identifier", "(%s bigint)".formatted(MAXIMUM_LENGTH_COLUMN_IDENTIFIER))) {
-            assertThat(query(joinPushdownEnabled(getSession()), """
-                    SELECT r.name, t.%s, n.name
-                    FROM %s t JOIN region r ON r.regionkey = t.%s
-                    JOIN nation n ON r.regionkey = n.regionkey""".formatted(MAXIMUM_LENGTH_COLUMN_IDENTIFIER, table.getName(), MAXIMUM_LENGTH_COLUMN_IDENTIFIER)))
-                    .isFullyPushedDown();
-        }
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleConnectorTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import static io.trino.plugin.jdbc.DefaultJdbcMetadata.DEFAULT_COLUMN_ALIAS_LENGTH;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_SCHEMA;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
@@ -36,7 +35,8 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class TestOracleConnectorTest
         extends BaseOracleConnectorTest
 {
-    private static final String MAXIMUM_LENGTH_COLUMN_IDENTIFIER = "z".repeat(DEFAULT_COLUMN_ALIAS_LENGTH);
+    // older Oracle versions are limited to 30 character identifier names
+    private static final String MAXIMUM_LENGTH_COLUMN_IDENTIFIER = "z".repeat(30);
 
     private TestingOracleServer oracleServer;
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -131,6 +131,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.function.BiFunction;
@@ -916,6 +917,12 @@ public class PostgreSqlClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return getMaxColumnNameLengthFromDatabaseMetaData(session);
     }
 
     @Override

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -102,6 +102,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.function.BiFunction;
 
@@ -505,6 +506,12 @@ public class RedshiftClient
         catch (SQLException e) {
             throw new TrinoException(JDBC_ERROR, e);
         }
+    }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return getMaxColumnNameLengthFromDatabaseMetaData(session);
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -114,6 +114,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -1096,6 +1097,12 @@ public class SqlServerClient
         catch (SQLException exception) {
             throw new TrinoException(JDBC_ERROR, exception);
         }
+    }
+
+    @Override
+    public OptionalInt getMaxColumnNameLength(ConnectorSession session)
+    {
+        return getMaxColumnNameLengthFromDatabaseMetaData(session);
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Follow-up to https://github.com/trinodb/trino/commit/5e520fcea34149c223090b51f781e93f73165a76.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Postgres, Redshift, SQL Server
* Fix possible query failures when join is pushed down.
```
