### PR TITLE
Expose property to set the degree of acceleration of the geometry

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -23,6 +23,7 @@ import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.NodeMemoryConfig;
+import io.trino.operator.GeometryAccelerationDegree;
 import io.trino.operator.RetryPolicy;
 import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
@@ -208,6 +209,7 @@ public final class SystemSessionProperties
     public static final String USE_COST_BASED_PARTITIONING = "use_cost_based_partitioning";
     public static final String FORCE_SPILLING_JOIN = "force_spilling_join";
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
+    public static final String SPATIAL_GEOMETRY_ACCELERATION_DEGREE = "spatial_geometry_acceleration_degree";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1064,7 +1066,12 @@ public final class SystemSessionProperties
                 integerProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE,
                         "Maximum number of free buffers in the per task partitioned page buffer pool. Setting this to zero effectively disables the pool",
                         taskManagerConfig.getPagePartitioningBufferPoolSize(),
-                        true));
+                        true),
+                enumProperty(SPATIAL_GEOMETRY_ACCELERATION_DEGREE,
+                        "Set the degree of acceleration of the geometry. Acceleration usually builds a raster and a quadtree",
+                        GeometryAccelerationDegree.class,
+                        optimizerConfig.getGeometryAccelerationDegree(),
+                        false));
     }
 
     @Override
@@ -1906,5 +1913,10 @@ public final class SystemSessionProperties
     public static int getPagePartitioningBufferPoolSize(Session session)
     {
         return session.getSystemProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE, Integer.class);
+    }
+
+    public static GeometryAccelerationDegree getSpatialGeometryAccelerationDegree(Session session)
+    {
+        return session.getSystemProperty(SPATIAL_GEOMETRY_ACCELERATION_DEGREE, GeometryAccelerationDegree.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/GeometryAccelerationDegree.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GeometryAccelerationDegree.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.esri.core.geometry.Geometry;
+
+public enum GeometryAccelerationDegree
+{
+    MILD(Geometry.GeometryAccelerationDegree.enumMild),
+    MEDIUM(Geometry.GeometryAccelerationDegree.enumMedium),
+    HOT(Geometry.GeometryAccelerationDegree.enumHot),
+    /**/;
+
+    private final Geometry.GeometryAccelerationDegree accelerationDegree;
+
+    GeometryAccelerationDegree(Geometry.GeometryAccelerationDegree accelerationDegree)
+    {
+        this.accelerationDegree = accelerationDegree;
+    }
+
+    public Geometry.GeometryAccelerationDegree getAccelerationDegree()
+    {
+        return accelerationDegree;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -20,6 +20,7 @@ import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.operator.GeometryAccelerationDegree;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -93,6 +94,7 @@ public class OptimizerConfig
     private long joinPartitionedBuildMinRowCount = 1_000_000L;
     private DataSize minInputSizePerTask = DataSize.of(5, GIGABYTE);
     private long minInputRowsPerTask = 10_000_000L;
+    private GeometryAccelerationDegree geometryAccelerationDegree = GeometryAccelerationDegree.MILD;
 
     public enum JoinReorderingStrategy
     {
@@ -785,6 +787,19 @@ public class OptimizerConfig
     public OptimizerConfig setUseCostBasedPartitioning(boolean useCostBasedPartitioning)
     {
         this.useCostBasedPartitioning = useCostBasedPartitioning;
+        return this;
+    }
+
+    public GeometryAccelerationDegree getGeometryAccelerationDegree()
+    {
+        return geometryAccelerationDegree;
+    }
+
+    @Config("spatial-geometry-acceleration-degree")
+    @ConfigDescription("Set the degree of acceleration of the geometry. Acceleration usually builds a raster and a quadtree")
+    public OptimizerConfig setGeometryAccelerationDegree(GeometryAccelerationDegree geometryAccelerationDegree)
+    {
+        this.geometryAccelerationDegree = geometryAccelerationDegree;
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -16,6 +16,7 @@ package io.trino.cost;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.operator.GeometryAccelerationDegree;
 import io.trino.sql.planner.OptimizerConfig;
 import io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import io.trino.sql.planner.OptimizerConfig.JoinReorderingStrategy;
@@ -91,7 +92,8 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(5, GIGABYTE))
                 .setMinInputRowsPerTask(10_000_000L)
                 .setUseExactPartitioning(false)
-                .setUseCostBasedPartitioning(true));
+                .setUseCostBasedPartitioning(true)
+                .setGeometryAccelerationDegree(GeometryAccelerationDegree.MILD));
     }
 
     @Test
@@ -150,6 +152,7 @@ public class TestOptimizerConfig
                 .put("optimizer.min-input-rows-per-task", "1000000")
                 .put("optimizer.use-exact-partitioning", "true")
                 .put("optimizer.use-cost-based-partitioning", "false")
+                .put("spatial-geometry-acceleration-degree", "hot")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -204,7 +207,8 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(1, MEGABYTE))
                 .setMinInputRowsPerTask(1_000_000L)
                 .setUseExactPartitioning(true)
-                .setUseCostBasedPartitioning(false);
+                .setUseCostBasedPartitioning(false)
+                .setGeometryAccelerationDegree(GeometryAccelerationDegree.HOT);
         assertFullMapping(properties, expected);
     }
 }

--- a/docs/src/main/sphinx/admin/properties-general.md
+++ b/docs/src/main/sphinx/admin/properties-general.md
@@ -67,3 +67,16 @@ size limits.
 Prepared statement compression is not applied if the size gain is less than the
 configured value. Smaller statements do not benefit from compression, and are
 left uncompressed.
+
+## `spatial-geometry-acceleration-degree`
+
+- **Type:** {ref}`prop-type-string`
+- **Allowed values:** `MILD`, `MEDIUM`, `HOT`
+- **Default value:** `MILD`
+- **Session property:**  `spatial_geometry_acceleration_degree`
+
+Set the degree of acceleration of the geometry. Acceleration usually builds a
+raster and a quadtree. `MILD` acceleration, takes least amount of memory.
+`MEDIUM` acceleration, takes more memory and takes more time to accelerate,
+but may work faster. `HOT` acceleration, takes even more memory and may take
+longest time to accelerate, but may work faster than the other two.

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSpatialJoin.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/BenchmarkSpatialJoin.java
@@ -41,6 +41,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.io.Resources.getResource;
+import static io.trino.SystemSessionProperties.SPATIAL_GEOMETRY_ACCELERATION_DEGREE;
 import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -65,6 +66,8 @@ public class BenchmarkSpatialJoin
 
         @Param({"10", "100", "1000", "10000"})
         private int pointCount;
+        @Param({"MILD", "MEDIUM", "HOT"})
+        private String accelerationDegree = "MILD";
 
         public LocalQueryRunner getQueryRunner()
         {
@@ -78,6 +81,7 @@ public class BenchmarkSpatialJoin
             queryRunner = LocalQueryRunner.create(testSessionBuilder()
                     .setCatalog("memory")
                     .setSchema("default")
+                    .setSystemProperty(SPATIAL_GEOMETRY_ACCELERATION_DEGREE, accelerationDegree)
                     .build());
             queryRunner.installPlugin(new GeoPlugin());
             queryRunner.createCatalog("memory", new MemoryConnectorFactory(), ImmutableMap.of());

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithHotAcceleration.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithHotAcceleration.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import io.trino.operator.GeometryAccelerationDegree;
+
+public class TestSpatialJoinOperatorWithHotAcceleration
+        extends BaseSpatialJoinOperator
+{
+    TestSpatialJoinOperatorWithHotAcceleration()
+    {
+        super(GeometryAccelerationDegree.HOT);
+    }
+}

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithMediumAcceleration.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithMediumAcceleration.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import io.trino.operator.GeometryAccelerationDegree;
+
+public class TestSpatialJoinOperatorWithMediumAcceleration
+        extends BaseSpatialJoinOperator
+{
+    TestSpatialJoinOperatorWithMediumAcceleration()
+    {
+        super(GeometryAccelerationDegree.MEDIUM);
+    }
+}

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithMildAcceleration.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperatorWithMildAcceleration.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.geospatial;
+
+import io.trino.operator.GeometryAccelerationDegree;
+
+public class TestSpatialJoinOperatorWithMildAcceleration
+        extends BaseSpatialJoinOperator
+{
+    TestSpatialJoinOperatorWithMildAcceleration()
+    {
+        super(GeometryAccelerationDegree.MILD);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR introduces config property `spatial-geometry-acceleration-degree` and session property `spatial_geometry_acceleration_degree` to set the degree of acceleration of the geometry. Acceleration usually builds a
raster and a quadtree. `MILD` acceleration, takes least amount of memory. `MEDIUM` acceleration, takes more memory and takes more time to accelerate, but may work faster. `HOT` acceleration, takes even more memory and may take longest time to accelerate, but may work faster than the other two.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
