### PR TITLE
Add note about nessie catalog view/materialized view support

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -431,6 +431,9 @@ iceberg.nessie-catalog.uri=https://localhost:19120/api/v1
 iceberg.nessie-catalog.default-warehouse-dir=/tmp
 ```
 
+The Nessie catalog does not support {doc}`views</sql/create-view>` or
+{doc}`materialized views</sql/create-materialized-view>`.
+
 (partition-projection)=
 
 ## Access tables with Athena partition projection metadata


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add same note about nessie catalog support based on this issue #17768.

Currently the JDBC and REST catalogs have this note. 
When this note is not on Nessie, this can make the user think that th catalog has full support.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

