### PR TITLE
Fix join type for correlated subquery

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
@@ -268,7 +268,7 @@ class SubqueryPlanner
                 subPlan,
                 root,
                 scalarSubquery.getQuery(),
-                CorrelatedJoinNode.Type.INNER,
+                CorrelatedJoinNode.Type.LEFT,
                 TRUE_LITERAL,
                 mapAll(cluster, subPlan.getScope(), column));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -42,6 +42,7 @@ import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.LogicalPlanner.failFunction;
 import static io.trino.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.extractCardinality;
+import static io.trino.sql.planner.plan.CorrelatedJoinNode.Type.INNER;
 import static io.trino.sql.planner.plan.CorrelatedJoinNode.Type.LEFT;
 import static io.trino.sql.planner.plan.Patterns.CorrelatedJoin.correlation;
 import static io.trino.sql.planner.plan.Patterns.CorrelatedJoin.filter;
@@ -123,7 +124,7 @@ public class TransformCorrelatedScalarSubquery
                     correlatedJoinNode.getInput(),
                     rewrittenSubquery,
                     correlatedJoinNode.getCorrelation(),
-                    producesSingleRow ? correlatedJoinNode.getType() : LEFT,
+                    producesSingleRow ? INNER : correlatedJoinNode.getType(),
                     correlatedJoinNode.getFilter(),
                     correlatedJoinNode.getOriginSubquery()));
         }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
@@ -482,4 +482,34 @@ public class TestCorrelatedAggregation
                 "ON TRUE"))
                 .matches("VALUES (1, null), (2, x'd0f70cebd131ec61')");
     }
+
+    @Test
+    public void testCorrelatedSubqueryWithGroupedAggregation()
+    {
+        assertThat(assertions.query("WITH" +
+                "    t(k, v) AS (VALUES ('A', 1), ('B', NULL), ('C', 2), ('D', 3)), " +
+                "    u(k, v) AS (VALUES (1, 10), (1, 20), (2, 30)) " +
+                "SELECT" +
+                "    k," +
+                "    (" +
+                "        SELECT max(v) FROM u WHERE t.v = u.k GROUP BY k" +
+                "     ) AS cols " +
+                "FROM t"))
+                .matches("VALUES ('A', 20), ('B', NULL), ('C', 30), ('D', NULL)");
+    }
+
+    @Test
+    public void testCorrelatedSubqueryWithGlobalAggregation()
+    {
+        assertThat(assertions.query("WITH" +
+                "    t(k, v) AS (VALUES ('A', 1), ('B', NULL), ('C', 2), ('D', 3)), " +
+                "    u(k, v) AS (VALUES (1, 10), (1, 20), (2, 30)) " +
+                "SELECT" +
+                "    k," +
+                "    (" +
+                "        SELECT max(v) FROM u WHERE t.v = u.k" +
+                "     ) AS cols " +
+                "FROM t"))
+                .matches("VALUES ('A', 20), ('B', NULL), ('C', 30), ('D', NULL)");
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -46,7 +46,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
-import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -204,7 +204,7 @@ public class TestSubqueries
                 "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a = t2.b ORDER BY a LIMIT 1) FROM (VALUES 1.0, 2.0) t2(b)",
                 "VALUES 1, 2",
                 output(
-                        join(INNER, builder -> builder
+                        join(LEFT, builder -> builder
                                 .equiCriteria("cast_b", "cast_a")
                                 .left(
                                         any(
@@ -229,7 +229,7 @@ public class TestSubqueries
                 "SELECT (SELECT t.a FROM (VALUES 1, 2, 3, 4, 5) t(a) WHERE t.a = t2.b * t2.c - 1 ORDER BY a LIMIT 1) FROM (VALUES (1, 2), (2, 3)) t2(b, c)",
                 "VALUES 1, 5",
                 output(
-                        join(INNER, builder -> builder
+                        join(LEFT, builder -> builder
                                 .equiCriteria("expr", "a")
                                 .left(
                                         any(

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_26"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_24"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_17"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_17"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_17"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        final aggregation over ()
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    partial aggregation over ()
-                                                                        scan store_sales
-                                                        cross join:
-                                                            final aggregation over ()
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (GATHER, SINGLE, [])
-                                                                        partial aggregation over ()
-                                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
-                                                    final aggregation over ()
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                partial aggregation over ()
-                                                                    scan store_sales
-                                                final aggregation over ()
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (GATHER, SINGLE, [])
-                                                            partial aggregation over ()
-                                                                scan store_sales
-                                            final aggregation over ()
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (GATHER, SINGLE, [])
-                                                        partial aggregation over ()
-                                                            scan store_sales
-                                        final aggregation over ()
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (GATHER, SINGLE, [])
-                                                    partial aggregation over ()
-                                                        scan store_sales
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (RIGHT, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    join (RIGHT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [])
+                                            final aggregation over ()
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        partial aggregation over ()
+                                                            scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            join (RIGHT, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [])
+                                                    final aggregation over ()
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (GATHER, SINGLE, [])
+                                                                partial aggregation over ()
+                                                                    scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    join (RIGHT, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [])
+                                                            final aggregation over ()
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                        partial aggregation over ()
+                                                                            scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            join (RIGHT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    final aggregation over ()
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over ()
+                                                                                    scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    join (RIGHT, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                            final aggregation over ()
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                        partial aggregation over ()
+                                                                                            scan store_sales
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            join (RIGHT, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [])
+                                                                                    final aggregation over ()
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (GATHER, SINGLE, [])
+                                                                                                partial aggregation over ()
+                                                                                                    scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    join (RIGHT, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [])
+                                                                                            final aggregation over ()
+                                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                                    remote exchange (GATHER, SINGLE, [])
+                                                                                                        partial aggregation over ()
+                                                                                                            scan store_sales
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [])
+                                                                                                scan reason
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
+                                    final aggregation over ()
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (GATHER, SINGLE, [])
+                                                partial aggregation over ()
+                                                    scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["ss_customer_sk"])
                                     partial aggregation over (ss_customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         dynamic filter (["ss_customer_sk", "ss_sold_date_sk"])
@@ -48,8 +48,7 @@ local exchange (GATHER, SINGLE, [])
                                                                                                             scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_17"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q09.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q09.plan.txt
@@ -1,93 +1,122 @@
-cross join:
-    cross join:
-        cross join:
-            cross join:
-                cross join:
-                    cross join:
-                        cross join:
-                            cross join:
-                                cross join:
-                                    cross join:
-                                        cross join:
-                                            cross join:
-                                                cross join:
-                                                    cross join:
-                                                        cross join:
+join (LEFT, REPLICATED):
+    join (LEFT, REPLICATED):
+        join (LEFT, REPLICATED):
+            join (LEFT, REPLICATED):
+                join (LEFT, REPLICATED):
+                    join (LEFT, REPLICATED):
+                        join (LEFT, REPLICATED):
+                            join (LEFT, REPLICATED):
+                                join (LEFT, REPLICATED):
+                                    join (LEFT, REPLICATED):
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
+                                                join (LEFT, REPLICATED):
+                                                    join (LEFT, REPLICATED):
+                                                        join (RIGHT, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [])
+                                                                final aggregation over ()
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (GATHER, SINGLE, [])
+                                                                            partial aggregation over ()
+                                                                                scan store_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, [])
+                                                                    scan reason
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                final aggregation over ()
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (GATHER, SINGLE, [])
+                                                                            partial aggregation over ()
+                                                                                scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
                                                             final aggregation over ()
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (GATHER, SINGLE, [])
                                                                         partial aggregation over ()
                                                                             scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (GATHER, SINGLE, [])
-                                                                    scan reason
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
                                                         final aggregation over ()
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (GATHER, SINGLE, [])
                                                                     partial aggregation over ()
                                                                         scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
                                                     final aggregation over ()
                                                         local exchange (GATHER, SINGLE, [])
                                                             remote exchange (GATHER, SINGLE, [])
                                                                 partial aggregation over ()
                                                                     scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
                                                                 scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
                                             final aggregation over ()
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (GATHER, SINGLE, [])
                                                         partial aggregation over ()
                                                             scan store_sales
+                                local exchange (GATHER, SINGLE, [])
+                                    remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (GATHER, SINGLE, [])
                                                     partial aggregation over ()
                                                         scan store_sales
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPLICATE, BROADCAST, [])
                                     final aggregation over ()
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (GATHER, SINGLE, [])
                                                 partial aggregation over ()
                                                     scan store_sales
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPLICATE, BROADCAST, [])
                                 final aggregation over ()
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (GATHER, SINGLE, [])
                                             partial aggregation over ()
                                                 scan store_sales
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPLICATE, BROADCAST, [])
                             final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (GATHER, SINGLE, [])
                                         partial aggregation over ()
                                             scan store_sales
+                local exchange (GATHER, SINGLE, [])
+                    remote exchange (REPLICATE, BROADCAST, [])
                         final aggregation over ()
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (GATHER, SINGLE, [])
                                     partial aggregation over ()
                                         scan store_sales
+            local exchange (GATHER, SINGLE, [])
+                remote exchange (REPLICATE, BROADCAST, [])
                     final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (GATHER, SINGLE, [])
                                 partial aggregation over ()
                                     scan store_sales
+        local exchange (GATHER, SINGLE, [])
+            remote exchange (REPLICATE, BROADCAST, [])
                 final aggregation over ()
                     local exchange (GATHER, SINGLE, [])
                         remote exchange (GATHER, SINGLE, [])
                             partial aggregation over ()
                                 scan store_sales
+    local exchange (GATHER, SINGLE, [])
+        remote exchange (REPLICATE, BROADCAST, [])
             final aggregation over ()
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (GATHER, SINGLE, [])
                         partial aggregation over ()
                             scan store_sales
-        final aggregation over ()
-            local exchange (GATHER, SINGLE, [])
-                remote exchange (GATHER, SINGLE, [])
-                    partial aggregation over ()
-                        scan store_sales
-    final aggregation over ()
-        local exchange (GATHER, SINGLE, [])
-            remote exchange (GATHER, SINGLE, [])
-                partial aggregation over ()
-                    scan store_sales

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q54.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q54.plan.txt
@@ -8,8 +8,8 @@ local exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, ["customer_sk"])
                                     partial aggregation over (customer_sk)
-                                        cross join:
-                                            cross join:
+                                        join (LEFT, REPLICATED):
+                                            join (LEFT, REPLICATED):
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         join (INNER, PARTITIONED):
@@ -50,8 +50,7 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            dynamic filter (["d_month_seq_17"])
-                                                                scan date_dim
+                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                         local exchange (GATHER, SINGLE, [])


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
INNER join is used in subqueryPlanner's planScalarSubquery. But it will result in incorrect results when the subquery returns zero rows.
 Example query:
 ```
 with test_a(id, type, col1) as( values ('123', 'a', 7), ('123', 'a', 8), ('456', 'a', 9)), 
base(claim_id, assess_id) as (values ('AAA', '123'), ('BBB', NULL), ('CCC', '456'), ('DDD', '789'))
select claim_id,
    (select sum(col1) from test_a
    where test_a.type = 'a' and base.assess_id = test_a.id
   group by id 
    ) as cols
from base
```
Actual results:
```
 claim_id | cols
----------+------
 AAA      |   15
 CCC      |    9
(2 rows)
```
Expected results:
```
 claim_id | cols
----------+------
 AAA      |   15
 BBB      | NULL
 CCC      |    9
 DDD      | NULL
(4 rows)
```
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix join type for correlated subquery. ({issue}`18236`)
```
