### PR TITLE
Fix broken Azure FileSystem Cloud Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
         if: >-
           false &&
           contains(matrix.modules, 'trino-filesystem-azure') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_BLOB_ACCOUNT != '' || env.ABFS_BLOB_ACCESS_KEY != '' || env.ABFS_FLAT_ACCOUNT != '' || ABFS_FLAT_ACCESS_KEY != '' || ABFS_ACCOUNT != '' || ABFS_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_BLOB_ACCOUNT != '' || env.ABFS_BLOB_ACCESS_KEY != '' || env.ABFS_FLAT_ACCOUNT != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_ACCOUNT != '' || env.ABFS_ACCESS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl ${{ matrix.modules }} ${{ format('-P {0}', matrix.profile) }}
       - name: Cloud Delta Lake Tests


### PR DESCRIPTION
## Description

CI is broken on master. https://github.com/trinodb/trino/actions/runs/6153633190
```
The workflow is not valid. .github/workflows/ci.yml (Line: 683, Col: 13): Unrecognized named-value: 'ABFS_FLAT_ACCESS_KEY'. Located at position 249 within expression: false && contains(matrix.modules, 'trino-filesystem-azure') && contains(matrix.profile, 'cloud-tests') && (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_BLOB_ACCOUNT != '' || env.ABFS_BLOB_ACCESS_KEY != '' || env.ABFS_FLAT_ACCOUNT != '' || ABFS_FLAT_ACCESS_KEY != '' || ABFS_ACCOUNT != '' || ABFS_ACCESS_KEY != '')
```

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
