### PR TITLE
Release split source memory when finished

### DIFF
--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -16,29 +16,48 @@ package io.trino.split;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.annotation.NotThreadSafe;
 import io.trino.metadata.Split;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorSplitSource.ConnectorSplitBatch;
+import jakarta.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
 
+/**
+ * Adapts {@link ConnectorSplitSource} to {@link SplitSource} interface.
+ * <p>
+ * Thread-safety: the implementations is not thread-safe
+ *
+ * @implNote The implementation is internally not thread-safe but also {@link ConnectorSplitSource} is
+ * not required to be thread-safe.
+ */
+@NotThreadSafe
 public class ConnectorAwareSplitSource
         implements SplitSource
 {
     private final CatalogHandle catalogHandle;
-    private final ConnectorSplitSource source;
+    private final String sourceToString;
+
+    @Nullable
+    private ConnectorSplitSource source;
+    private boolean finished;
+    private Optional<Optional<List<Object>>> tableExecuteSplitsInfo = Optional.empty();
 
     public ConnectorAwareSplitSource(CatalogHandle catalogHandle, ConnectorSplitSource source)
     {
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
         this.source = requireNonNull(source, "source is null");
+        this.sourceToString = source.toString();
     }
 
     @Override
@@ -50,37 +69,59 @@ public class ConnectorAwareSplitSource
     @Override
     public ListenableFuture<SplitBatch> getNextBatch(int maxSize)
     {
+        checkState(source != null, "Already finished or closed");
         ListenableFuture<ConnectorSplitBatch> nextBatch = toListenableFuture(source.getNextBatch(maxSize));
         return Futures.transform(nextBatch, splitBatch -> {
             ImmutableList.Builder<Split> result = ImmutableList.builder();
             for (ConnectorSplit connectorSplit : splitBatch.getSplits()) {
                 result.add(new Split(catalogHandle, connectorSplit));
             }
-            return new SplitBatch(result.build(), splitBatch.isNoMoreSplits());
+            boolean noMoreSplits = splitBatch.isNoMoreSplits();
+            if (noMoreSplits) {
+                finished = true;
+                tableExecuteSplitsInfo = Optional.of(source.getTableExecuteSplitsInfo());
+                source = null;
+            }
+            return new SplitBatch(result.build(), noMoreSplits);
         }, directExecutor());
     }
 
     @Override
     public void close()
     {
-        source.close();
+        if (source != null) {
+            try {
+                source.close();
+            }
+            finally {
+                source = null;
+            }
+        }
     }
 
     @Override
     public boolean isFinished()
     {
-        return source.isFinished();
+        if (!finished) {
+            checkState(source != null, "Already closed");
+            if (source.isFinished()) {
+                finished = true;
+                tableExecuteSplitsInfo = Optional.of(source.getTableExecuteSplitsInfo());
+                source = null;
+            }
+        }
+        return finished;
     }
 
     @Override
     public Optional<List<Object>> getTableExecuteSplitsInfo()
     {
-        return source.getTableExecuteSplitsInfo();
+        return tableExecuteSplitsInfo.orElseThrow(() -> new IllegalStateException("Not finished yet"));
     }
 
     @Override
     public String toString()
     {
-        return catalogHandle + ":" + source;
+        return catalogHandle + ":" + firstNonNull(source, sourceToString);
     }
 }


### PR DESCRIPTION
`ConnectorSplitSource` implementation may hold on to considerable amounts of memory. For example, Iceberg split source keeps table metadata which can be arbitrarily large if table is not maintained.

Each `ConnectorSplitSource` is wrapped by `ConnectorAwareSplitSource`. To free connectors from hassle of freeing memory, the `ConnectorAwareSplitSource` releases the whole `ConnectorSplitSource` once it is finished or closed.


Relates to https://trinodb.slack.com/archives/CGB0QHWSW/p1694416588864109 

Complimentary to https://github.com/trinodb/trino/pull/19011. One does not obsolete the other.