### PR TITLE
Fix releasing query scheduler on query completion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -565,6 +565,11 @@ public class SqlQueryExecution
         }
 
         queryScheduler.set(scheduler);
+        stateMachine.addQueryInfoStateChangeListener(queryInfo -> {
+            if (queryInfo.isFinalQueryInfo()) {
+                queryScheduler.set(null);
+            }
+        });
     }
 
     @Override
@@ -686,14 +691,7 @@ public class SqlQueryExecution
         if (scheduler != null) {
             stageInfo = Optional.ofNullable(scheduler.getStageInfo());
         }
-
-        QueryInfo queryInfo = stateMachine.updateQueryInfo(stageInfo);
-        if (queryInfo.isFinalQueryInfo()) {
-            // capture the final query state and drop reference to the scheduler
-            queryScheduler.set(null);
-        }
-
-        return queryInfo;
+        return stateMachine.updateQueryInfo(stageInfo);
     }
 
     @Override


### PR DESCRIPTION
Previously, the `queryScheduler.set(null)` was only sometimes reached, leading to `QueryTracker.queries` containing references to query scheduler and thus to all split sources and lots of other objects.

Relates to https://trinodb.slack.com/archives/CGB0QHWSW/p1694416588864109



Complimentary to https://github.com/trinodb/trino/pull/19009. One does not obsolete the other.