### PR TITLE
Disallow null offset in lead/lag window functions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/window/LagFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/LagFunction.java
@@ -45,41 +45,38 @@ public class LagFunction
     @Override
     public void processRow(BlockBuilder output, int frameStart, int frameEnd, int currentPosition)
     {
-        if ((offsetChannel >= 0) && windowIndex.isNull(offsetChannel, currentPosition)) {
-            output.appendNull();
+        checkCondition(offsetChannel < 0 || !windowIndex.isNull(offsetChannel, currentPosition), INVALID_FUNCTION_ARGUMENT, "Offset must not be null");
+
+        long offset = (offsetChannel < 0) ? 1 : windowIndex.getLong(offsetChannel, currentPosition);
+        checkCondition(offset >= 0, INVALID_FUNCTION_ARGUMENT, "Offset must be at least 0");
+
+        long valuePosition;
+
+        if (ignoreNulls && (offset > 0)) {
+            long count = 0;
+            valuePosition = currentPosition - 1;
+            while (withinPartition(valuePosition, currentPosition)) {
+                if (!windowIndex.isNull(valueChannel, toIntExact(valuePosition))) {
+                    count++;
+                    if (count == offset) {
+                        break;
+                    }
+                }
+                valuePosition--;
+            }
         }
         else {
-            long offset = (offsetChannel < 0) ? 1 : windowIndex.getLong(offsetChannel, currentPosition);
-            checkCondition(offset >= 0, INVALID_FUNCTION_ARGUMENT, "Offset must be at least 0");
+            valuePosition = currentPosition - offset;
+        }
 
-            long valuePosition;
-
-            if (ignoreNulls && (offset > 0)) {
-                long count = 0;
-                valuePosition = currentPosition - 1;
-                while (withinPartition(valuePosition, currentPosition)) {
-                    if (!windowIndex.isNull(valueChannel, toIntExact(valuePosition))) {
-                        count++;
-                        if (count == offset) {
-                            break;
-                        }
-                    }
-                    valuePosition--;
-                }
-            }
-            else {
-                valuePosition = currentPosition - offset;
-            }
-
-            if (withinPartition(valuePosition, currentPosition)) {
-                windowIndex.appendTo(valueChannel, toIntExact(valuePosition), output);
-            }
-            else if (defaultChannel >= 0) {
-                windowIndex.appendTo(defaultChannel, currentPosition, output);
-            }
-            else {
-                output.appendNull();
-            }
+        if (withinPartition(valuePosition, currentPosition)) {
+            windowIndex.appendTo(valueChannel, toIntExact(valuePosition), output);
+        }
+        else if (defaultChannel >= 0) {
+            windowIndex.appendTo(defaultChannel, currentPosition, output);
+        }
+        else {
+            output.appendNull();
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/window/TestLagFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/TestLagFunction.java
@@ -149,20 +149,6 @@ public class TestLagFunction
                         .row(34, "O", null)
                         .build());
 
-        assertWindowQuery("lag(orderkey, null, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
-                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, BIGINT)
-                        .row(3, "F", null)
-                        .row(5, "F", null)
-                        .row(6, "F", null)
-                        .row(33, "F", null)
-                        .row(1, "O", null)
-                        .row(2, "O", null)
-                        .row(4, "O", null)
-                        .row(7, "O", null)
-                        .row(32, "O", null)
-                        .row(34, "O", null)
-                        .build());
-
         assertWindowQuery("lag(orderkey, 0) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
                         .row(3, "F", 3)

--- a/core/trino-main/src/test/java/io/trino/operator/window/TestLeadFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/TestLeadFunction.java
@@ -163,20 +163,6 @@ public class TestLeadFunction
                         .row(34, "O", null)
                         .build());
 
-        assertWindowQuery("lead(orderkey, null, -1) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
-                resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
-                        .row(3, "F", null)
-                        .row(5, "F", null)
-                        .row(6, "F", null)
-                        .row(33, "F", null)
-                        .row(1, "O", null)
-                        .row(2, "O", null)
-                        .row(4, "O", null)
-                        .row(7, "O", null)
-                        .row(32, "O", null)
-                        .row(34, "O", null)
-                        .build());
-
         assertWindowQuery("lead(orderkey, 0) OVER (PARTITION BY orderstatus ORDER BY orderkey)",
                 resultBuilder(TEST_SESSION, INTEGER, VARCHAR, INTEGER)
                         .row(3, "F", 3)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestLag.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestLag.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestLag
+{
+    @Test
+    public void testNullOffset()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThatThrownBy(() -> assertions.query("""
+                    SELECT lag(v, null) OVER (ORDER BY k)
+                    FROM (VALUES (1, 10), (2, 20)) t(k, v)
+                    """))
+                    .hasMessageMatching("Offset must not be null");
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestLead.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestLead.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestLead
+{
+    @Test
+    public void testNullOffset()
+    {
+        try (QueryAssertions assertions = new QueryAssertions()) {
+            assertThatThrownBy(() -> assertions.query("""
+                    SELECT lead(v, null) OVER (ORDER BY k)
+                    FROM (VALUES (1, 10), (2, 20)) t(k, v)
+                    """))
+                .hasMessageMatching("Offset must not be null");
+        }
+    }
+}

--- a/docs/src/main/sphinx/functions/window.md
+++ b/docs/src/main/sphinx/functions/window.md
@@ -108,7 +108,7 @@ negative.
 Returns the value at `offset` rows after the current row in the window partition.
 Offsets start at `0`, which is the current row. The
 offset can be any scalar expression.  The default `offset` is `1`. If the
-offset is null, `null` is returned. If the offset refers to a row that is not
+offset is null, an error is raised. If the offset refers to a row that is not
 within the partition, the `default_value` is returned, or if it is not specified
 `null` is returned.
 The {func}`lead` function requires that the window ordering be specified.
@@ -119,7 +119,7 @@ Window frame must not be specified.
 Returns the value at `offset` rows before the current row in the window partition.
 Offsets start at `0`, which is the current row. The
 offset can be any scalar expression.  The default `offset` is `1`. If the
-offset is null, `null` is returned. If the offset refers to a row that is not
+offset is null, an error is raised. If the offset refers to a row that is not
 within the partition, the `default_value` is returned, or if it is not specified
 `null` is returned.
 The {func}`lag` function requires that the window ordering be specified.


### PR DESCRIPTION
Per the SQL spec, the offset cannot be null.

    <lead or lag function> ::=
      <lead or lag> <left paren> <lead or lag extent>
          [ <comma> <offset> [ <comma> <default expression> ] ] <right paren>
          [ <window function null treatment> ]

    <offset> ::=
      <unsigned integer>

Moreover, it should be a constant value, but this is not being addressed in this change.

Fixes #19003

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Disallow a null offset in {func}`lead` and {func}`lag`. ({issue}`19003`)
```
