### PR TITLE
Temporarily disable telemetry for JDBC connections

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java
@@ -75,7 +75,9 @@ public class DriverConnectionFactory
             throws SQLException
     {
         Properties properties = getCredentialProperties(session.getIdentity());
-        Connection connection = dataSource.getConnection(properties);
+        // TODO: Telemetry is disabled due to NPE being thrown on null connection
+        // Connection connection = dataSource.getConnection(properties);
+        Connection connection = driver.connect(connectionUrl, properties);
         checkState(connection != null, "Driver returned null connection, make sure the connection URL '%s' is valid for the driver %s", connectionUrl, driver);
         return connection;
     }


### PR DESCRIPTION
We've observed NPE being thrown in the codepaths where connection was not expected to be null.

Alternative to https://github.com/trinodb/trino/pull/19010

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
