### PR TITLE
Increase GCLocker retry allocation count to avoid OOM too early

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -17,3 +17,5 @@
 -XX:+UseAESCTRIntrinsics
 # Disable Preventive GC for performance reasons (JDK-8293861)
 -XX:-G1UsePreventiveGC
+# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+-XX:GCLockerRetryAllocationCount=32

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -16,3 +16,5 @@
 -XX:+UseAESCTRIntrinsics
 # Disable Preventive GC for performance reasons (JDK-8293861)
 -XX:-G1UsePreventiveGC
+# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+-XX:GCLockerRetryAllocationCount=32

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -142,7 +142,9 @@ The following provides a good starting point for creating `etc/jvm.config`:
 -XX:+UseAESCTRIntrinsics
 -Dfile.encoding=UTF-8
 # Disable Preventive GC for performance reasons (JDK-8293861)
--XX:-G1UsePreventiveGC
+-XX:-G1UsePreventiveGC  
+# Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
+-XX:GCLockerRetryAllocationCount=32
 ```
 
 You must adjust the value for the memory used by Trino, specified with `-Xmx`
@@ -173,8 +175,9 @@ prevents Trino from starting. You can workaround this by overriding the
 temporary directory by adding `-Djava.io.tmpdir=/path/to/other/tmpdir` to the
 list of JVM options.
 
-We enable `-XX:+UnlockDiagnosticVMOptions` and `-XX:+UseAESCTRIntrinsics` to improve AES performance for S3, etc. on ARM64 ([JDK-8271567](https://bugs.openjdk.java.net/browse/JDK-8271567))
-We disable Preventive GC (`-XX:-G1UsePreventiveGC`) for performance reasons (see [JDK-8293861](https://bugs.openjdk.org/browse/JDK-8293861))
+We enable `-XX:+UnlockDiagnosticVMOptions` and `-XX:+UseAESCTRIntrinsics` to improve AES performance for S3, etc. on ARM64 ([JDK-8271567](https://bugs.openjdk.java.net/browse/JDK-8271567))  
+We disable Preventive GC (`-XX:-G1UsePreventiveGC`) for performance reasons (see [JDK-8293861](https://bugs.openjdk.org/browse/JDK-8293861))  
+We set GCLocker retry allocation count (`-XX:GCLockerRetryAllocationCount=32`) to avoid OOM too early (see [JDK-8192647](https://bugs.openjdk.org/browse/JDK-8192647))
 
 (config-properties)=
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
JDK 9 to 21 has a GCLocker bug which causes JVM to throw OOME too early, because the default value of `-XX:GCLockerRetryAllocationCount` is 2, most of Trino clusters in production environments has 8 to 16+ CPU physical cores(which mostly means 32 vcores), so threads may be starved from receiving memory by the GClocker. The relevant issue: https://bugs.openjdk.org/browse/JDK-8192647  

The principle flow chart of obtaining GCLocker in JVM is as follows:  
![img_v2_51b8f20a-d7d3-47c5-8166-744da482895g](https://github.com/trinodb/trino/assets/26461591/4b8d1bbb-58b1-48e9-ad86-6fdd3cb5d4cb)  
And this OOM phenomenon was also seen in our production environment:  
![BbdhuON6yf](https://github.com/trinodb/trino/assets/26461591/89cd12f5-06b4-4642-a7a5-883ee5565e4b)  
After investigating the JVM tuning articles shared by some companies, I found that `Tencent`(i.e. the parent company of `League of Legends`) also set this parameter to 100:  
![image](https://github.com/trinodb/trino/assets/26461591/1313b93c-a831-4adc-884d-a4f7da42bcf8)  
I know our community will migrate to JDK 21 partially for auto vectorization in `Project Hummingbird`, so maybe we will need this parameter in a little long time.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Increase GCLocker retry allocation count to avoid OOM too early. ({issue}`19026`)
```
