### PR TITLE
Do not allocate task memory for VALUES/metadata-only queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/BinPackingNodeAllocatorService.java
@@ -512,7 +512,7 @@ public class BinPackingNodeAllocatorService
                     continue;
                 }
                 long nodeReservedMemory = preReservedMemory.getOrDefault(node.getNodeIdentifier(), 0L);
-                nodesRemainingMemory.put(node.getNodeIdentifier(), memoryPoolInfo.getMaxBytes() - nodeReservedMemory);
+                nodesRemainingMemory.put(node.getNodeIdentifier(), max(memoryPoolInfo.getMaxBytes() - nodeReservedMemory, 0L));
             }
 
             nodesRemainingMemoryRuntimeAdjusted = new HashMap<>();
@@ -540,7 +540,7 @@ public class BinPackingNodeAllocatorService
                 // if globally reported memory usage of node is greater than computed one lets use that.
                 // it can be greater if there are tasks executed on cluster which do not have task retries enabled.
                 nodeUsedMemoryRuntimeAdjusted = max(nodeUsedMemoryRuntimeAdjusted, memoryPoolInfo.getReservedBytes());
-                nodesRemainingMemoryRuntimeAdjusted.put(node.getNodeIdentifier(), memoryPoolInfo.getMaxBytes() - nodeUsedMemoryRuntimeAdjusted);
+                nodesRemainingMemoryRuntimeAdjusted.put(node.getNodeIdentifier(), max(memoryPoolInfo.getMaxBytes() - nodeUsedMemoryRuntimeAdjusted, 0L));
             }
         }
 
@@ -610,10 +610,10 @@ public class BinPackingNodeAllocatorService
         {
             nodesRemainingMemoryRuntimeAdjusted.compute(
                     nodeIdentifier,
-                    (key, free) -> free - memoryLease);
+                    (key, free) -> max(free - memoryLease, 0));
             nodesRemainingMemory.compute(
                     nodeIdentifier,
-                    (key, free) -> free - memoryLease);
+                    (key, free) -> max(free - memoryLease, 0));
         }
 
         private boolean isNodeEmpty(String nodeIdentifier)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/EventDrivenFaultTolerantQueryScheduler.java
@@ -37,6 +37,9 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.Session;
+import io.trino.connector.informationschema.InformationSchemaTableHandle;
+import io.trino.connector.system.GlobalSystemConnector;
+import io.trino.connector.system.SystemTableHandle;
 import io.trino.exchange.SpoolingExchangeInput;
 import io.trino.execution.BasicStageStats;
 import io.trino.execution.ExecutionFailureInfo;
@@ -85,12 +88,14 @@ import io.trino.sql.planner.PlanFragment;
 import io.trino.sql.planner.PlanFragmentIdAllocator;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SubPlan;
+import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.PlanFragmentId;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.RefreshMaterializedViewNode;
 import io.trino.sql.planner.plan.RemoteSourceNode;
+import io.trino.sql.planner.plan.TableScanNode;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -1150,6 +1155,7 @@ public class EventDrivenFaultTolerantQueryScheduler
 
                 boolean coordinatorStage = stage.getFragment().getPartitioning().equals(COORDINATOR_DISTRIBUTION);
 
+                boolean noMemoryFragment = isNoMemoryFragment(fragment);
                 StageExecution execution = new StageExecution(
                         queryStateMachine,
                         taskDescriptorStorage,
@@ -1157,7 +1163,8 @@ public class EventDrivenFaultTolerantQueryScheduler
                         taskSource,
                         sinkPartitioningScheme,
                         exchange,
-                        memoryEstimatorFactory.createPartitionMemoryEstimator(),
+                        noMemoryFragment,
+                        noMemoryFragment ? new NoMemoryPartitionMemoryEstimator() : memoryEstimatorFactory.createPartitionMemoryEstimator(),
                         // do not retry coordinator only tasks
                         coordinatorStage ? 1 : maxTaskExecutionAttempts,
                         schedulingPriority,
@@ -1188,6 +1195,29 @@ public class EventDrivenFaultTolerantQueryScheduler
                 }
                 throw t;
             }
+        }
+
+        private boolean isNoMemoryFragment(PlanFragment fragment)
+        {
+            // If source fragments are not tagged as "no-memory" assume that they may produce significant amount of data.
+            // We stay on the safe side an assume that we should use standard memory estimation for this fragment
+            if (!fragment.getRemoteSourceNodes().stream().flatMap(node -> node.getSourceFragmentIds().stream())
+                    .allMatch(sourceFragmentId -> stageExecutions.get(getStageId(sourceFragmentId)).isNoMemoryFragment())) {
+                return false;
+            }
+
+            // If fragment source is not reading any external tables or only accesses information_schema assume it does not need significant amount of memory.
+            // Allow scheduling even if whole server memory is pre allocated.
+            List<PlanNode> tableScanNodes = PlanNodeSearcher.searchFrom(fragment.getRoot()).whereIsInstanceOfAny(TableScanNode.class).findAll();
+            return tableScanNodes.stream().allMatch(node -> isMetadataTableScan((TableScanNode) node));
+        }
+
+        private static boolean isMetadataTableScan(TableScanNode tableScanNode)
+        {
+            return (tableScanNode.getTable().getConnectorHandle() instanceof InformationSchemaTableHandle) ||
+                    (tableScanNode.getTable().getCatalogHandle().getCatalogName().equals(GlobalSystemConnector.NAME) &&
+                            (tableScanNode.getTable().getConnectorHandle() instanceof SystemTableHandle systemHandle) &&
+                            systemHandle.getSchemaName().equals("jdbc"));
         }
 
         private StageId getStageId(PlanFragmentId fragmentId)
@@ -1523,6 +1553,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private final EventDrivenTaskSource taskSource;
         private final FaultTolerantPartitioningScheme sinkPartitioningScheme;
         private final Exchange exchange;
+        private final boolean noMemoryFragment;
         private final PartitionMemoryEstimator partitionMemoryEstimator;
         private final int maxTaskExecutionAttempts;
         private final int schedulingPriority;
@@ -1559,6 +1590,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 EventDrivenTaskSource taskSource,
                 FaultTolerantPartitioningScheme sinkPartitioningScheme,
                 Exchange exchange,
+                boolean noMemoryFragment,
                 PartitionMemoryEstimator partitionMemoryEstimator,
                 int maxTaskExecutionAttempts,
                 int schedulingPriority,
@@ -1576,6 +1608,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.taskSource = requireNonNull(taskSource, "taskSource is null");
             this.sinkPartitioningScheme = requireNonNull(sinkPartitioningScheme, "sinkPartitioningScheme is null");
             this.exchange = requireNonNull(exchange, "exchange is null");
+            this.noMemoryFragment = noMemoryFragment;
             this.partitionMemoryEstimator = requireNonNull(partitionMemoryEstimator, "partitionMemoryEstimator is null");
             this.maxTaskExecutionAttempts = maxTaskExecutionAttempts;
             this.schedulingPriority = schedulingPriority;
@@ -1626,6 +1659,11 @@ public class EventDrivenFaultTolerantQueryScheduler
         public boolean isExchangeClosed()
         {
             return exchangeClosed;
+        }
+
+        public boolean isNoMemoryFragment()
+        {
+            return noMemoryFragment;
         }
 
         public void addPartition(int partitionId, NodeRequirements nodeRequirements)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NoMemoryPartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NoMemoryPartitionMemoryEstimator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler;
+
+import io.airlift.units.DataSize;
+import io.trino.Session;
+import io.trino.spi.ErrorCode;
+
+import java.util.Optional;
+
+public class NoMemoryPartitionMemoryEstimator
+        implements PartitionMemoryEstimator
+{
+    @Override
+    public MemoryRequirements getInitialMemoryRequirements(Session session, DataSize defaultMemoryLimit)
+    {
+        return new MemoryRequirements(DataSize.ofBytes(0));
+    }
+
+    @Override
+    public MemoryRequirements getNextRetryMemoryRequirements(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, ErrorCode errorCode)
+    {
+        return new MemoryRequirements(DataSize.ofBytes(0));
+    }
+
+    @Override
+    public void registerPartitionFinished(Session session, MemoryRequirements previousMemoryRequirements, DataSize peakMemoryUsage, boolean success, Optional<ErrorCode> errorCode) {}
+}


### PR DESCRIPTION
If query does not scan any tables or only accesses information_schema do assume its tasks do not requrie any memory when allocating node for task execution.

That way metadata only queries can execute even if cluster is fully pre allocated.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
