### PR TITLE
Fix dictionary encoded page offsets in parquet writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ColumnWriter.java
@@ -17,6 +17,7 @@ import org.apache.parquet.format.ColumnMetaData;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.OptionalInt;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,10 +39,12 @@ public interface ColumnWriter
     {
         private final ColumnMetaData metaData;
         private final List<ParquetDataOutput> data;
+        private final OptionalInt dictionaryPageSize;
 
-        public BufferData(List<ParquetDataOutput> data, ColumnMetaData metaData)
+        public BufferData(List<ParquetDataOutput> data, OptionalInt dictionaryPageSize, ColumnMetaData metaData)
         {
             this.data = requireNonNull(data, "data is null");
+            this.dictionaryPageSize = requireNonNull(dictionaryPageSize, "dictionaryPageSize is null");
             this.metaData = requireNonNull(metaData, "metaData is null");
         }
 
@@ -53,6 +56,11 @@ public interface ColumnWriter
         public List<ParquetDataOutput> getData()
         {
             return data;
+        }
+
+        public OptionalInt getDictionaryPageSize()
+        {
+            return dictionaryPageSize;
         }
     }
 }


### PR DESCRIPTION
## Description
When dictionary is present, dictionary_page_offset should be populated and data_page_offset should be 
offset of first data page. 
Setting these values correctly allows the parquet reader to avoid reading excess data in 
PredicateUtils#readDictionaryPage for checking if a predicate can prune a row group based on dictionary values.

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Iceberg, Delta
* Reduce data read from parquet files for queries with filters. ({issue}`19032`)
```
