### PR TITLE
Write min/max statistics with truncation for strings in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetMetadataUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetMetadataUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.format.Statistics;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.io.api.Binary;
+
+import static com.google.common.base.Verify.verify;
+import static org.apache.parquet.format.converter.ParquetMetadataConverter.MAX_STATS_SIZE;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+
+public final class ParquetMetadataUtils
+{
+    private ParquetMetadataUtils() {}
+
+    public static <T extends Comparable<T>> Statistics toParquetStatistics(org.apache.parquet.column.statistics.Statistics<T> stats, int truncateLength)
+    {
+        // TODO Utilize https://github.com/apache/parquet-format/pull/216 when available to populate is_max_value_exact/is_min_value_exact
+        if (isTruncationPossible(stats, truncateLength)) {
+            // parquet-mr drops statistics larger than MAX_STATS_SIZE rather than truncating them.
+            // In order to ensure truncation rather than no stats, we need to use a truncateLength which would never exceed ParquetMetadataConverter.MAX_STATS_SIZE
+            verify(
+                    2L * truncateLength < MAX_STATS_SIZE,
+                    "Twice of truncateLength %s must be less than MAX_STATS_SIZE %s",
+                    truncateLength,
+                    MAX_STATS_SIZE);
+            // We need to take a lock here because CharsetValidator inside BinaryTruncator modifies a reusable dummyBuffer in-place
+            // and DEFAULT_UTF8_TRUNCATOR is a static instance, which makes this method thread unsafe.
+            // isTruncationPossible should ensure that locking is used only when we expect truncation, which is an uncommon scenario.
+            // TODO remove synchronization when we use a release with the fix https://github.com/apache/parquet-mr/pull/1154
+            synchronized (ParquetMetadataUtils.class) {
+                return ParquetMetadataConverter.toParquetStatistics(stats, truncateLength);
+            }
+        }
+        return ParquetMetadataConverter.toParquetStatistics(stats);
+    }
+
+    private static <T extends Comparable<T>> boolean isTruncationPossible(org.apache.parquet.column.statistics.Statistics<T> stats, int truncateLength)
+    {
+        PrimitiveTypeName primitiveType = stats.type().getPrimitiveTypeName();
+        if (!primitiveType.equals(BINARY) && !primitiveType.equals(FIXED_LEN_BYTE_ARRAY)) {
+            return false;
+        }
+        if (stats.isEmpty() || !stats.hasNonNullValue() || !(stats instanceof BinaryStatistics binaryStatistics)) {
+            return false;
+        }
+        // non-null value exists, so min and max can't be null
+        Binary min = binaryStatistics.genericGetMin();
+        Binary max = binaryStatistics.genericGetMax();
+        return min.length() > truncateLength || max.length() > truncateLength;
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -60,6 +60,9 @@ public class PrimitiveColumnWriter
     private static final int INSTANCE_SIZE = instanceSize(PrimitiveColumnWriter.class);
     private static final int MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 8 * 1024;
     private static final int MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE = 2 * 1024 * 1024;
+    // ParquetMetadataConverter.MAX_STATS_SIZE is 4096, we need a value which would guarantee that min and max
+    // don't add up to 4096 (so less than 2048). Using 1K as that is big enough for most use cases.
+    private static final int MAX_STATISTICS_LENGTH_IN_BYTES = 1024;
 
     private final ColumnDescriptor columnDescriptor;
     private final CompressionCodec compressionCodec;
@@ -180,7 +183,7 @@ public class PrimitiveColumnWriter
                 totalUnCompressedSize,
                 totalCompressedSize,
                 -1);
-        columnMetaData.setStatistics(ParquetMetadataConverter.toParquetStatistics(columnStatistics));
+        columnMetaData.setStatistics(ParquetMetadataUtils.toParquetStatistics(columnStatistics, MAX_STATISTICS_LENGTH_IN_BYTES));
         ImmutableList.Builder<PageEncodingStats> pageEncodingStats = ImmutableList.builder();
         dataPagesWithEncoding.entrySet().stream()
                 .map(encodingAndCount -> new PageEncodingStats(PageType.DATA_PAGE, encodingAndCount.getKey(), encodingAndCount.getValue()))


### PR DESCRIPTION
## Description
Currently the logic in `org.apache.parquet.format.converter.ParquetMetadataConverter#toParquetStatistics` skips writing min/max row-group statistics if they are longer than 4Kb. This is changed to write stats with truncation to allow readers to perform row-group pruning based on query predicates.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Related issue https://github.com/trinodb/trino/issues/19052
Parquet spec updated at https://github.com/apache/parquet-format/pull/216 to clarify that truncation of min/max row-group stats is allowed

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta, Iceberg
* Improve performance of filtering on columns with long strings stored in parquet files. ({issue}`19038`)
```