### PR TITLE
Fix the wrong time unit used for reporting elapsed time in query planing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/IterativeOptimizer.java
@@ -373,7 +373,7 @@ public class IterativeOptimizer
                             .map(ruleStats -> format(
                                     "%s: %s ms, %s invocations, %s applications",
                                     ruleStats.rule(),
-                                    ruleStats.totalTime(),
+                                    NANOSECONDS.toMillis(ruleStats.totalTime()),
                                     ruleStats.invocations(),
                                     ruleStats.applied()))
                             .collect(joining(",\n\t\t", "{\n\t\t", " }"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The number for elapsed time should be changed back to milli-seconds from nanoseconds. This was an oversight caused by #16365.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
