### PR TITLE
Fix delta-lake cloud tests

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeAwsConnectorSmokeTest.java
@@ -68,6 +68,14 @@ public abstract class BaseDeltaLakeAwsConnectorSmokeTest
     }
 
     @Override
+    protected void deleteFile(String filePath)
+    {
+        String key = filePath.substring(bucketUrl().length());
+        hiveMinioDataLake.getMinioClient()
+                .removeObject(bucketName, key);
+    }
+
+    @Override
     protected String bucketUrl()
     {
         return format("s3://%s/", bucketName);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -144,6 +144,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
     protected abstract List<String> listCheckpointFiles(String transactionLogDirectory);
 
+    protected abstract void deleteFile(String filePath);
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
@@ -1973,10 +1975,8 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
 
             String tableLocation = getTableLocation(table.getName());
             // Remove first two transaction logs to mimic log retention duration exceeds
-            String key = tableLocation.substring(bucketUrl().length());
-            MinioClient minio = hiveMinioDataLake.getMinioClient();
-            minio.removeObject(bucketName, "%s/_delta_log/%020d.json".formatted(key, 0));
-            minio.removeObject(bucketName, "%s/_delta_log/%020d.json".formatted(key, 1));
+            deleteFile("%s/_delta_log/%020d.json".formatted(tableLocation, 0));
+            deleteFile("%s/_delta_log/%020d.json".formatted(tableLocation, 1));
 
             assertQuery("SELECT version, operation FROM \"" + table.getName() + "$history\"", "VALUES (2, 'WRITE'), (3, 'MERGE'), (4, 'MERGE')");
             assertThat(query("SELECT version, operation FROM \"" + table.getName() + "$history\" WHERE version = 1")).returnsEmptyResult();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -183,6 +183,14 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
     }
 
     @Override
+    protected void deleteFile(String filePath)
+    {
+        String blobName = bucketName + "/" + filePath.substring(bucketUrl().length());
+        azureContainerClient.getBlobClient(blobName)
+                .deleteIfExists();
+    }
+
+    @Override
     protected String bucketUrl()
     {
         return format("abfs://%s@%s.dfs.core.windows.net/%s/", container, account, bucketName);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -220,6 +220,17 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     }
 
     @Override
+    protected void deleteFile(String filePath)
+    {
+        try {
+            fileSystem.deleteFile(Location.of(filePath));
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     protected String bucketUrl()
     {
         return format("gs://%s/%s/", gcpStorageBucket, bucketName);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/19044

In the case of ADLS/GCS, I've observed no files in the MINIO bucket. Consequently, attempts to delete a file using `minio.removeObject` have no effect, although I could not find the underlying cause yet. To address this, I am introducing an abstract method `deleteFile(String filePath)`. This method will be implemented in the respective classes. This approach is intended to rectify issues in the CI build and ensure proper file deletion functionality.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The `testUnregisterBrokenTable` test requires an update since it currently relies on `minio.removeObject`.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
