### PR TITLE
SetDigest jaccard_index implementation Issue

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigest.java
@@ -165,6 +165,20 @@ public class SetDigest
 
     public static double jaccardIndex(SetDigest a, SetDigest b)
     {
+        LongSortedSet minUnion = new LongRBTreeSet(a.minhash.keySet());
+        minUnion.addAll(b.minhash.keySet());
+
+        int intersection = 0;
+        for (long key : minUnion) {
+            if (a.minhash.containsKey(key) && b.minhash.containsKey(key)) {
+                intersection++;
+            }
+        }
+        return intersection / (double) minUnion.size();
+    }
+
+    public static double jaccard(SetDigest a, SetDigest b)
+    {
         int sizeOfSmallerSet = Math.min(a.minhash.size(), b.minhash.size());
         LongSortedSet minUnion = new LongRBTreeSet(a.minhash.keySet());
         minUnion.addAll(b.minhash.keySet());

--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestFunctions.java
@@ -54,7 +54,7 @@ public final class SetDigestFunctions
 
         long cardinality1 = digest1.cardinality();
         long cardinality2 = digest2.cardinality();
-        double jaccard = SetDigest.jaccardIndex(digest1, digest2);
+        double jaccard = SetDigest.jaccard(digest1, digest2);
         digest1.mergeWith(digest2);
         long result = Math.round(jaccard * digest1.cardinality());
 

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
@@ -82,6 +82,15 @@ public class TestSetDigestFunctions
                 "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
                         "FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2)"))
                 .matches("VALUES CAST(0.5 AS DOUBLE)");
+
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES ('ca', 'da'),('ea', 'fa')) T(value,value1)")).matches("VALUES CAST(0.0 AS DOUBLE)");
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES ('a', 'c'),('b', 'd')) T(value,value1)")).matches("VALUES CAST(0.0 AS DOUBLE)");
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES (1,2),(2,1)) T(value,value1)")).matches("VALUES CAST(1.0 AS DOUBLE)");
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES (1.2, 2.3),(2.3, 1.2)) T(value,value1)")).matches("VALUES CAST(1.0 AS DOUBLE)");
     }
 
     @Test


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Jaccard_index

For below query the jaccard_index should be equal to 0.3333333333333333 but the output is coming as 0.5 which is incorrect

SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES ('abc', 'def'),('ee', 'abc')) T(value,value1);


SELECT jaccard_index(make_set_digest(value), make_set_digest(value1)) FROM (VALUES (1,4),(2,5),(3,6),(4,7),(5,8)) T(value,value1);
_col0
0.4
(1 row)

Input: s1 = {1, 2, 3, 4, 5}, s2 = {4, 5, 6, 7, 8} Output: Jaccard index = 0.25 Jaccard distance = 0.75

Fixes #18995