### PR TITLE
Do not list all tables in testHideDeltaLakeTables

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -3211,10 +3211,6 @@ public abstract class AbstractTestHive
                 assertThat(metadata.listTables(session, Optional.of(tableName.getSchemaName())))
                         .doesNotContain(tableName);
 
-                // list all columns
-                assertThat(listTableColumns(metadata, session, new SchemaTablePrefix()).keySet())
-                        .doesNotContain(tableName);
-
                 // list all columns in a schema
                 assertThat(listTableColumns(metadata, session, new SchemaTablePrefix(tableName.getSchemaName())).keySet())
                         .doesNotContain(tableName);


### PR DESCRIPTION
Listing all tables in metastore in testHideDeltaLakeTables leads to clashes with other tests and/or users of metastore.

