### PR TITLE
Support Pinot Hexed BYTES of PinotDataTableImplv4

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSegmentPageSource.java
@@ -29,6 +29,8 @@ import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTableImplV4;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
@@ -347,6 +349,10 @@ public class PinotSegmentPageSource
             return getUtf8Slice(field);
         }
         if (trinoType instanceof VarbinaryType) {
+            DataTable baseDataTable = currentDataTable.getDataTable();
+            if (baseDataTable instanceof DataTableImplV4) {
+                return Slices.wrappedBuffer(toBytes(currentDataTable.getDataTable().getBytes(rowIndex, columnIndex).toHexString()));
+            }
             return Slices.wrappedBuffer(toBytes(currentDataTable.getDataTable().getString(rowIndex, columnIndex)));
         }
         if (trinoType.getTypeSignature().getBase() == StandardTypes.JSON) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Cisco Wap Storage Team provide support to query the bytes column of pinot cluster that enabled datatablev4.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
The root cause is that before DataTablev4，DataTable V2/V3 uses String to store BYTES value. So you will get String via fetching bytes columns. But when you enable DataTableV4, you can't use getString to visist bytes column that is store bytes other than string.
And This modification is also compatible with DataTable V2/V3., because class DataTableV2/DataTableV3 don't implement getString or getBytes function, both of those all use BaseDataTable that is trino class. So this modification won't affect legacy DataTable.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
# Section
```
