### PR TITLE
Fix inferring type of decimals with leading zeros in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -922,7 +922,10 @@ public class MongoSession
             catch (ArithmeticException e) {
                 return Optional.empty();
             }
-            typeSignature = createDecimalType(decimal.precision(), decimal.scale()).getTypeSignature();
+            // Java's BigDecimal.precision() returns precision for the unscaled value, so it skips leading zeros for values lower than 1.
+            // Trino's (SQL) decimal precision must include leading zeros in values less than 1, and can never be lower than scale.
+            int precision = Math.max(decimal.precision(), decimal.scale());
+            typeSignature = createDecimalType(precision, decimal.scale()).getTypeSignature();
         }
         else if (value instanceof Date) {
             typeSignature = TIMESTAMP_MILLIS.getTypeSignature();

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoTypeMapping.java
@@ -190,6 +190,8 @@ public class TestMongoTypeMapping
                 .addRoundTrip("NumberDecimal(\"2\")", "CAST('2' AS decimal(1, 0))")
                 .addRoundTrip("NumberDecimal(\"2.3\")", "CAST('2.3' AS decimal(2, 1))")
                 .addRoundTrip("NumberDecimal(\"-2.3\")", "CAST('-2.3' AS decimal(2, 1))")
+                .addRoundTrip("NumberDecimal(\"0.03\")", "CAST('0.03' AS decimal(2, 2))")
+                .addRoundTrip("NumberDecimal(\"-0.03\")", "CAST('-0.03' AS decimal(2, 2))")
                 .addRoundTrip("NumberDecimal(\"1234567890123456789012345678901234\")", "CAST('1234567890123456789012345678901234' AS decimal(34, 0))") // 34 is the max precision in Decimal128
                 .addRoundTrip("NumberDecimal(\"1234567890123456.789012345678901234\")", "CAST('1234567890123456.789012345678901234' AS decimal(34, 18))")
                 .execute(getQueryRunner(), mongoCreateAndInsert(getSession(), "tpch", "test_decimal"));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Trying to read collections with fractional decimal values like `0.03` was throwing an exception.

Java's `BigDecimal.precision()` returns precision for the unscaled value, so it skips leading zeros. SQL decimal's precision must include leading zeros in values less than 1.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
