### PR TITLE
Avoid quadratic traversal when many columns accessible

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -4356,7 +4356,7 @@ class StatementAnalyzer
                 return fields;
             }
 
-            List<Field> accessibleFields = new ArrayList<>();
+            ImmutableSet.Builder<Field> accessibleFields = ImmutableSet.builder();
 
             //collect fields by table
             ListMultimap<QualifiedObjectName, Field> tableFieldsMap = ArrayListMultimap.create();
@@ -4384,7 +4384,7 @@ class StatementAnalyzer
             });
 
             return fields.stream()
-                    .filter(field -> accessibleFields.contains(field))
+                    .filter(accessibleFields.build()::contains)
                     .collect(toImmutableList());
         }
 


### PR DESCRIPTION
When `hide-inaccessible-columns` is enabled and table has N accessible columns, `filterInaccessibleFields` would have `O(N²)` running time.
