### PR TITLE
[pinot] Adding query option support for DynamicTable

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -151,7 +151,7 @@ public class PinotMetadata
     @Override
     public PinotTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        if (tableName.getTableName().trim().startsWith("select ")) {
+        if (tableName.getTableName().trim().contains("select ")) {
             DynamicTable dynamicTable = DynamicTableBuilder.buildFromPql(this, tableName, pinotClient, typeConverter);
             return new PinotTableHandle(tableName.getSchemaName(), dynamicTable.getTableName(), TupleDomain.all(), OptionalLong.empty(), Optional.of(dynamicTable));
         }
@@ -256,6 +256,7 @@ public class PinotMetadata
                     dynamicTable.get().getOrderBy(),
                     OptionalLong.of(limit),
                     dynamicTable.get().getOffset(),
+                    dynamicTable.get().getQueryOptions(),
                     dynamicTable.get().getQuery()));
         }
 
@@ -433,6 +434,7 @@ public class PinotMetadata
                 ImmutableList.of(),
                 limitForDynamicTable,
                 OptionalLong.empty(),
+                ImmutableMap.of(),
                 newQuery);
         tableHandle = new PinotTableHandle(tableHandle.getSchemaName(), tableHandle.getTableName(), tableHandle.getConstraint(), tableHandle.getLimit(), Optional.of(dynamicTable));
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
@@ -16,9 +16,11 @@ package io.trino.plugin.pinot.query;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.pinot.PinotColumnHandle;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -48,6 +50,8 @@ public final class DynamicTable
     private final OptionalLong limit;
     private final OptionalLong offset;
 
+    private final Map<String, String> queryOptions;
+
     private final String query;
 
     private final boolean isAggregateInProjections;
@@ -64,6 +68,7 @@ public final class DynamicTable
             @JsonProperty("orderBy") List<OrderByExpression> orderBy,
             @JsonProperty("limit") OptionalLong limit,
             @JsonProperty("offset") OptionalLong offset,
+            @JsonProperty("queryOptions") Map<String, String> queryOptions,
             @JsonProperty("query") String query)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -76,6 +81,7 @@ public final class DynamicTable
         this.orderBy = ImmutableList.copyOf(requireNonNull(orderBy, "orderBy is null"));
         this.limit = requireNonNull(limit, "limit is null");
         this.offset = requireNonNull(offset, "offset is null");
+        this.queryOptions = ImmutableMap.copyOf(requireNonNull(queryOptions, "queryOptions is null"));
         this.query = requireNonNull(query, "query is null");
         this.isAggregateInProjections = projections.stream()
                 .anyMatch(PinotColumnHandle::isAggregate);
@@ -142,6 +148,12 @@ public final class DynamicTable
     }
 
     @JsonProperty
+    public Map<String, String> getQueryOptions()
+    {
+        return queryOptions;
+    }
+
+    @JsonProperty
     public String getQuery()
     {
         return query;
@@ -173,13 +185,14 @@ public final class DynamicTable
                 orderBy.equals(that.orderBy) &&
                 limit.equals(that.limit) &&
                 offset.equals(that.offset) &&
+                queryOptions.equals(that.queryOptions) &&
                 query.equals(that.query);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableName, projections, filter, groupingColumns, aggregateColumns, havingExpression, orderBy, limit, offset, query);
+        return Objects.hash(tableName, projections, filter, groupingColumns, aggregateColumns, havingExpression, orderBy, limit, offset, queryOptions, query);
     }
 
     @Override
@@ -195,6 +208,7 @@ public final class DynamicTable
                 .add("orderBy", orderBy)
                 .add("limit", limit)
                 .add("offset", offset)
+                .add("queryOptions", queryOptions)
                 .add("query", query)
                 .toString();
     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTableBuilder.java
@@ -127,7 +127,7 @@ public final class DynamicTableBuilder
             filter = Optional.of(formatted);
         }
 
-        return new DynamicTable(pinotTableName, suffix, selectColumns, filter, groupByColumns, ImmutableList.of(), havingExpression, orderBy, OptionalLong.of(queryContext.getLimit()), getOffset(queryContext), query);
+        return new DynamicTable(pinotTableName, suffix, selectColumns, filter, groupByColumns, ImmutableList.of(), havingExpression, orderBy, OptionalLong.of(queryContext.getLimit()), getOffset(queryContext), queryContext.getQueryOptions(), query);
     }
 
     private static List<PinotColumnHandle> getPinotColumns(SchemaTableName schemaTableName, List<ExpressionContext> expressions, List<String> aliases, Map<String, ColumnHandle> columnHandles, PinotTypeResolver pinotTypeResolver, Map<String, PinotColumnNameAndTrinoType> aggregateTypes)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTablePqlExtractor.java
@@ -17,6 +17,7 @@ import io.trino.plugin.pinot.PinotColumnHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.plugin.pinot.query.PinotQueryBuilder.getFilterClause;
@@ -33,6 +34,14 @@ public final class DynamicTablePqlExtractor
     public static String extractPql(DynamicTable table, TupleDomain<ColumnHandle> tupleDomain)
     {
         StringBuilder builder = new StringBuilder();
+        Map<String, String> queryOptions = table.getQueryOptions();
+        queryOptions.keySet().stream().sorted().forEach(
+                key -> builder
+                        .append("SET ")
+                        .append(key)
+                        .append(" = ")
+                        .append(format("'%s'", queryOptions.get(key)))
+                        .append(";\n"));
         builder.append("SELECT ");
         if (!table.getProjections().isEmpty()) {
             builder.append(table.getProjections().stream()

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/BasePinotConnectorSmokeTest.java
@@ -2833,4 +2833,18 @@ public abstract class BasePinotConnectorSmokeTest
                 .matches("VALUES (VARCHAR 'Los Angeles', BIGINT '50000')")
                 .isFullyPushedDown();
     }
+
+    @Test
+    public void testQueryOptions()
+    {
+        assertThat(query("SELECT city, \"sum(long_number)\" FROM" +
+                         " \"SET skipUpsert = 'true';" +
+                         " SET numReplicaGroupsToQuery = '1';" +
+                         " SELECT city, SUM(long_number)" +
+                         "  FROM my_table" +
+                         "  GROUP BY city" +
+                         "  HAVING SUM(long_number) > 10000\""))
+                .matches("VALUES (VARCHAR 'Los Angeles', DOUBLE '50000.0'), (VARCHAR 'New York', DOUBLE '20000.0')")
+                .isFullyPushedDown();
+    }
 }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestDynamicTable.java
@@ -448,4 +448,27 @@ public class TestDynamicTable
         assertEquals(extractPql(dynamicTable, TupleDomain.all()), expectedPql);
         assertEquals(dynamicTable.getTableName(), tableName);
     }
+
+    @Test
+    public void testQueryOptions()
+    {
+        String tableName = realtimeOnlyTable.getTableName();
+        String tableNameWithSuffix = tableName + REALTIME_SUFFIX;
+        String query = """
+                SET skipUpsert='true';
+                SET useMultistageEngine='true';
+                SELECT FlightNum
+                FROM %s
+                LIMIT 50;
+                """.formatted(tableNameWithSuffix);
+        DynamicTable dynamicTable = buildFromPql(pinotMetadata, new SchemaTableName("default", query), mockClusterInfoFetcher, TESTING_TYPE_CONVERTER);
+        String expectedPql = """
+                SET skipUpsert = 'true';
+                SET useMultistageEngine = 'true';
+                SELECT "FlightNum" \
+                FROM %s \
+                LIMIT 50""".formatted(tableNameWithSuffix);
+        assertEquals(extractPql(dynamicTable, TupleDomain.all()), expectedPql);
+        assertEquals(dynamicTable.getTableName(), tableName);
+    }
 }


### PR DESCRIPTION
## Description
Adopted the idea introduced by (https://github.com/trinodb/trino/pull/17001#issuecomment-1594391322),
Support QueryOptions in Pinot DynamicTable.

label: pinot

## Additional context and related issues
Before:
<img width="1048" alt="image" src="https://github.com/trinodb/trino/assets/1202120/b7306fe6-5e2e-4b7c-950e-8acfcf1dc74a">
After:
<img width="1006" alt="image" src="https://github.com/trinodb/trino/assets/1202120/3b413272-69b7-4577-ae0b-9a9649bcedf9">

Server logs: 
```
2023-09-24T16:01:57.264-0700	INFO	20230924_230157_00003_92mfq.0.0.0-0-112	io.trino.plugin.pinot.client.PinotClient	Query 'SET skipUpsert = 'true';
SELECT "event_id", count(*) FROM upsertMeetupRsvp GROUP BY "event_id" LIMIT 10' on broker host 'http://192.168.1.248:8000/query/sql'
```

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Pinot
* Add support for [query options](https://docs.pinot.apache.org/users/user-guide-query/query-options) in Dynamic tables
```
