### PR TITLE
Correct header level of inequality pushdown fragment

### DIFF
--- a/docs/src/main/sphinx/connector/no-inequality-pushdown-text-type.fragment
+++ b/docs/src/main/sphinx/connector/no-inequality-pushdown-text-type.fragment
@@ -1,4 +1,4 @@
-# Predicate pushdown support
+#### Predicate pushdown support
 
 The connector does not support pushdown of inequality predicates, such as
 `!=`, and range predicates such as `>`, or `BETWEEN`, on columns with


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Corrects the header level of this docs fragment to H4, reflecting what it was before markdown conversion

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

See the unintended header level change in https://github.com/trinodb/trino/commit/fa23a09355f81ccd6f128b8c251e55d667cb796e#diff-c577586c459f509ce9b8317ab68628a55f2f394e65188480de34a5346010362f

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
