### PR TITLE
Collapse repeated surefire plugin entries

### DIFF
--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -199,6 +199,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--Disabled to reduce logging in CI https://github.com/trinodb/trino/issues/17452 -->
+                        <ProgressLoggingListener.enabled>false</ProgressLoggingListener.enabled>
+                    </systemPropertyVariables>
+                </configuration>
                 <dependencies>
                     <!-- allow both JUnit and TestNG -->
                     <dependency>
@@ -217,17 +223,6 @@
                         <version>${dep.junit.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <!--Disabled to reduce logging in CI https://github.com/trinodb/trino/issues/17452 -->
-                        <ProgressLoggingListener.enabled>false</ProgressLoggingListener.enabled>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -191,6 +191,18 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <!--Run this after uncommenting properties below-->
+                        <exclude>**/TestMinimalFunctionality.java</exclude>
+                        <exclude>**/TestS3TableConfigClient.java</exclude>
+                    </excludes>
+                    <systemPropertyVariables>
+                        <kinesis.awsAccessKey>ACCESS-KEY</kinesis.awsAccessKey>
+                        <kinesis.awsSecretKey>SECRET-KEY</kinesis.awsSecretKey>
+                        <kinesis.test-table-description-location>s3://S3-LOC</kinesis.test-table-description-location>
+                    </systemPropertyVariables>
+                </configuration>
                 <dependencies>
                     <!-- allow both JUnit and TestNG -->
                     <dependency>
@@ -209,22 +221,6 @@
                         <version>${dep.junit.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!--Run this after uncommenting properties below-->
-                        <exclude>**/TestMinimalFunctionality.java</exclude>
-                        <exclude>**/TestS3TableConfigClient.java</exclude>
-                    </excludes>
-                    <systemPropertyVariables>
-                        <kinesis.awsAccessKey>ACCESS-KEY</kinesis.awsAccessKey>
-                        <kinesis.awsSecretKey>SECRET-KEY</kinesis.awsSecretKey>
-                        <kinesis.test-table-description-location>s3://S3-LOC</kinesis.test-table-description-location>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.basepom.maven</groupId>


### PR DESCRIPTION
This removes warnings generated by maven:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.trino:trino-parquet:jar:427-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-surefire-plugin @ line 222, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for io.trino:trino-kinesis:trino-plugin:427-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-surefire-plugin @ line 213, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```