### PR TITLE
Avoid re-reading parquet footer for iceberg stats in writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -29,6 +29,7 @@ import io.trino.parquet.reader.ParquetReader;
 import io.trino.parquet.writer.ColumnWriter.BufferData;
 import io.trino.spi.Page;
 import io.trino.spi.type.Type;
+import jakarta.annotation.Nullable;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.CompressionCodec;
@@ -80,13 +81,11 @@ public class ParquetWriter
     private final OutputStreamSliceOutput outputStream;
     private final ParquetWriterOptions writerOption;
     private final MessageType messageType;
-    private final String createdBy;
     private final int chunkMaxLogicalBytes;
     private final Map<List<String>, Type> primitiveTypes;
     private final CompressionCodec compressionCodec;
     private final Optional<DateTimeZone> parquetTimeZone;
-
-    private final ImmutableList.Builder<RowGroup> rowGroupBuilder = ImmutableList.builder();
+    private final FileFooter fileFooter;
     private final Optional<ParquetWriteValidationBuilder> validationBuilder;
 
     private List<ColumnWriter> columnWriters;
@@ -94,6 +93,8 @@ public class ParquetWriter
     private long bufferedBytes;
     private boolean closed;
     private boolean writeHeader;
+    @Nullable
+    private FileMetaData fileMetaData;
 
     public static final Slice MAGIC = wrappedBuffer("PAR1".getBytes(US_ASCII));
 
@@ -114,7 +115,8 @@ public class ParquetWriter
         this.writerOption = requireNonNull(writerOption, "writerOption is null");
         this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
         this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
-        this.createdBy = formatCreatedBy(requireNonNull(trinoVersion, "trinoVersion is null"));
+        String createdBy = formatCreatedBy(requireNonNull(trinoVersion, "trinoVersion is null"));
+        this.fileFooter = new FileFooter(messageType, createdBy, parquetTimeZone);
 
         recordValidation(validation -> validation.setTimeZone(parquetTimeZone.map(DateTimeZone::getID)));
         recordValidation(validation -> validation.setColumns(messageType.getColumns()));
@@ -229,6 +231,12 @@ public class ParquetWriter
         }
     }
 
+    public FileMetaData getFileMetaData()
+    {
+        checkState(closed, "fileMetaData is available only after writer is closed");
+        return requireNonNull(fileMetaData, "fileMetaData is null");
+    }
+
     private ParquetReader createParquetReader(ParquetDataSource input, ParquetMetadata parquetMetadata, ParquetWriteValidation writeValidation)
             throws IOException
     {
@@ -330,9 +338,9 @@ public class ParquetWriter
             throws IOException
     {
         checkState(closed);
-        List<RowGroup> rowGroups = rowGroupBuilder.build();
-        Slice footer = getFooter(rowGroups, messageType);
-        recordValidation(validation -> validation.setRowGroups(rowGroups));
+        fileMetaData = fileFooter.createFileMetadata();
+        Slice footer = serializeFooter(fileMetaData);
+        recordValidation(validation -> validation.setRowGroups(fileMetaData.getRow_groups()));
         createDataOutput(footer).writeData(outputStream);
 
         Slice footerSize = Slices.allocate(SIZE_OF_INT);
@@ -342,31 +350,20 @@ public class ParquetWriter
         createDataOutput(MAGIC).writeData(outputStream);
     }
 
-    Slice getFooter(List<RowGroup> rowGroups, MessageType messageType)
-            throws IOException
-    {
-        FileMetaData fileMetaData = new FileMetaData();
-        fileMetaData.setVersion(1);
-        fileMetaData.setCreated_by(createdBy);
-        fileMetaData.setSchema(MessageTypeConverter.toParquetSchema(messageType));
-        // Added based on org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
-        parquetTimeZone.ifPresent(dateTimeZone -> fileMetaData.setKey_value_metadata(
-                ImmutableList.of(new KeyValue("writer.time.zone").setValue(dateTimeZone.getID()))));
-        long totalRows = rowGroups.stream().mapToLong(RowGroup::getNum_rows).sum();
-        fileMetaData.setNum_rows(totalRows);
-        fileMetaData.setRow_groups(ImmutableList.copyOf(rowGroups));
-
-        DynamicSliceOutput dynamicSliceOutput = new DynamicSliceOutput(40);
-        Util.writeFileMetaData(fileMetaData, dynamicSliceOutput);
-        return dynamicSliceOutput.slice();
-    }
-
     private void updateRowGroups(List<ColumnMetaData> columnMetaData)
     {
         long totalCompressedBytes = columnMetaData.stream().mapToLong(ColumnMetaData::getTotal_compressed_size).sum();
         long totalBytes = columnMetaData.stream().mapToLong(ColumnMetaData::getTotal_uncompressed_size).sum();
         ImmutableList<org.apache.parquet.format.ColumnChunk> columnChunks = columnMetaData.stream().map(ParquetWriter::toColumnChunk).collect(toImmutableList());
-        rowGroupBuilder.add(new RowGroup(columnChunks, totalBytes, rows).setTotal_compressed_size(totalCompressedBytes));
+        fileFooter.addRowGroup(new RowGroup(columnChunks, totalBytes, rows).setTotal_compressed_size(totalCompressedBytes));
+    }
+
+    private static Slice serializeFooter(FileMetaData fileMetaData)
+            throws IOException
+    {
+        DynamicSliceOutput dynamicSliceOutput = new DynamicSliceOutput(40);
+        Util.writeFileMetaData(fileMetaData, dynamicSliceOutput);
+        return dynamicSliceOutput.slice();
     }
 
     private static org.apache.parquet.format.ColumnChunk toColumnChunk(ColumnMetaData metaData)
@@ -394,5 +391,46 @@ public class ParquetWriter
                 .build();
 
         this.columnWriters = ParquetWriters.getColumnWriters(messageType, primitiveTypes, parquetProperties, compressionCodec, parquetTimeZone);
+    }
+
+    private static class FileFooter
+    {
+        private final MessageType messageType;
+        private final String createdBy;
+        private final Optional<DateTimeZone> parquetTimeZone;
+
+        @Nullable
+        private ImmutableList.Builder<RowGroup> rowGroupBuilder = ImmutableList.builder();
+
+        private FileFooter(MessageType messageType, String createdBy, Optional<DateTimeZone> parquetTimeZone)
+        {
+            this.messageType = messageType;
+            this.createdBy = createdBy;
+            this.parquetTimeZone = parquetTimeZone;
+        }
+
+        public void addRowGroup(RowGroup rowGroup)
+        {
+            checkState(rowGroupBuilder != null, "rowGroupBuilder is null");
+            rowGroupBuilder.add(rowGroup);
+        }
+
+        public FileMetaData createFileMetadata()
+        {
+            checkState(rowGroupBuilder != null, "rowGroupBuilder is null");
+            List<RowGroup> rowGroups = rowGroupBuilder.build();
+            rowGroupBuilder = null;
+            long totalRows = rowGroups.stream().mapToLong(RowGroup::getNum_rows).sum();
+            FileMetaData fileMetaData = new FileMetaData(
+                    1,
+                    MessageTypeConverter.toParquetSchema(messageType),
+                    totalRows,
+                    ImmutableList.copyOf(rowGroups));
+            fileMetaData.setCreated_by(createdBy);
+            // Added based on org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport
+            parquetTimeZone.ifPresent(dateTimeZone -> fileMetaData.setKey_value_metadata(
+                    ImmutableList.of(new KeyValue("writer.time.zone").setValue(dateTimeZone.getID()))));
+            return fileMetaData;
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/FileWriter.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive;
 import io.trino.spi.Page;
 
 import java.io.Closeable;
-import java.util.Optional;
 
 public interface FileWriter
 {
@@ -34,9 +33,4 @@ public interface FileWriter
     void rollback();
 
     long getValidationCpuNanos();
-
-    default Optional<Runnable> getVerificationTask()
-    {
-        return Optional.empty();
-    }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSink.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -337,9 +336,6 @@ public class HivePageSink
 
         PartitionUpdate partitionUpdate = writer.getPartitionUpdate();
         partitionUpdates.add(wrappedBuffer(partitionUpdateCodec.toJsonBytes(partitionUpdate)));
-        writer.getVerificationTask()
-                .map(Executors::callable)
-                .ifPresent(verificationTasks::add);
     }
 
     private int[] getWriterIndexes(Page page)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriter.java
@@ -99,11 +99,6 @@ public class HiveWriter
         return fileWriter.getValidationCpuNanos();
     }
 
-    public Optional<Runnable> getVerificationTask()
-    {
-        return fileWriter.getVerificationTask();
-    }
-
     public void rollback()
     {
         fileWriter.rollback();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -43,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.concurrent.atomic.AtomicLong;
@@ -200,12 +199,6 @@ public class SortingFileWriter
                 .add("tempFilePrefix", tempFilePrefix)
                 .add("outputWriter", outputWriter)
                 .toString();
-    }
-
-    @Override
-    public Optional<Runnable> getVerificationTask()
-    {
-        return outputWriter.getVerificationTask();
     }
 
     private void flushToTempFile()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -27,6 +27,7 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.Type;
 import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.format.FileMetaData;
 import org.apache.parquet.schema.MessageType;
 import org.joda.time.DateTimeZone;
 
@@ -197,5 +198,10 @@ public final class ParquetFileWriter
         return toStringHelper(this)
                 .add("writer", parquetWriter)
                 .toString();
+    }
+
+    public FileMetaData getFileMetadata()
+    {
+        return parquetWriter.getFileMetaData();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -50,7 +50,7 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
 import static java.util.Objects.requireNonNull;
 
-public class ParquetFileWriter
+public final class ParquetFileWriter
         implements FileWriter
 {
     private static final int INSTANCE_SIZE = instanceSize(ParquetFileWriter.class);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -191,8 +191,7 @@ public class IcebergFileWriterFactory
                     parquetWriterOptions,
                     IntStream.range(0, fileColumnNames.size()).toArray(),
                     getCompressionCodec(session).getParquetCompressionCodec(),
-                    nodeVersion.toString(),
-                    fileSystem);
+                    nodeVersion.toString());
         }
         catch (IOException e) {
             throw new TrinoException(ICEBERG_WRITER_OPEN_ERROR, "Error creating Parquet file", e);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -13,17 +13,18 @@
  */
 package io.trino.plugin.iceberg;
 
-import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
-import io.trino.plugin.iceberg.fileio.ForwardingInputFile;
 import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.io.InputFile;
 import org.apache.parquet.format.CompressionCodec;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 
 import java.io.Closeable;
@@ -31,16 +32,19 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.iceberg.parquet.ParquetUtil.fileMetrics;
+import static org.apache.iceberg.parquet.ParquetUtil.footerMetrics;
 
 public final class IcebergParquetFileWriter
         implements IcebergFileWriter
 {
     private final MetricsConfig metricsConfig;
-    private final InputFile inputFile;
     private final ParquetFileWriter parquetFileWriter;
+    private final Location location;
 
     public IcebergParquetFileWriter(
             MetricsConfig metricsConfig,
@@ -53,8 +57,7 @@ public final class IcebergParquetFileWriter
             ParquetWriterOptions parquetWriterOptions,
             int[] fileInputColumnIndexes,
             CompressionCodec compressionCodec,
-            String trinoVersion,
-            TrinoFileSystem fileSystem)
+            String trinoVersion)
             throws IOException
     {
         this.parquetFileWriter = new ParquetFileWriter(
@@ -70,14 +73,21 @@ public final class IcebergParquetFileWriter
                 trinoVersion,
                 Optional.empty(),
                 Optional.empty());
+        this.location = outputFile.location();
         this.metricsConfig = requireNonNull(metricsConfig, "metricsConfig is null");
-        this.inputFile = new ForwardingInputFile(fileSystem.newInputFile(outputFile.location()));
     }
 
     @Override
     public Metrics getMetrics()
     {
-        return fileMetrics(inputFile, metricsConfig);
+        ParquetMetadata parquetMetadata;
+        try {
+            parquetMetadata = new ParquetMetadataConverter().fromParquetMetadata(parquetFileWriter.getFileMetadata());
+        }
+        catch (IOException e) {
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, format("Error creating metadata for Parquet file %s", location), e);
+        }
+        return footerMetrics(parquetMetadata, Stream.empty(), metricsConfig);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSortingFileWriter.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.Metrics;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -104,11 +103,5 @@ public class IcebergSortingFileWriter
     public long getValidationCpuNanos()
     {
         return sortingFileWriter.getValidationCpuNanos();
-    }
-
-    @Override
-    public Optional<Runnable> getVerificationTask()
-    {
-        return sortingFileWriter.getVerificationTask();
     }
 }


### PR DESCRIPTION
## Description
Currently we're reading parquet file footer back just after
writing it to file system for computing iceberg stats.
Since Trino parquet writer already has the file footer, there
is no need to perform an extra IO to get the footer again.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of writing parquet files. ({issue}`19090`)
```
