### PR TITLE
Add support for timezone parameter to JDBC driver

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -325,7 +325,7 @@ public class ClientOptions
                 .clientInfo(clientInfo.orElse(null))
                 .catalog(uri.getCatalog().orElse(catalog.orElse(null)))
                 .schema(uri.getSchema().orElse(schema.orElse(null)))
-                .timeZone(timeZone)
+                .timeZone(uri.getTimeZone())
                 .locale(Locale.getDefault())
                 .resourceEstimates(toResourceEstimates(resourceEstimates))
                 .properties(toProperties(sessionProperties))
@@ -409,6 +409,7 @@ public class ClientOptions
         traceToken.ifPresent(builder::setTraceToken);
         socksProxy.ifPresent(builder::setSocksProxy);
         httpProxy.ifPresent(builder::setHttpProxy);
+        builder.setTimeZone(timeZone);
         builder.setDisableCompression(disableCompression);
         TrinoUri trinoUri;
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -24,6 +24,7 @@ import io.trino.client.auth.external.ExternalRedirectStrategy;
 import org.ietf.jgss.GSSCredential;
 
 import java.io.File;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -97,6 +98,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, Class<? extends DnsResolver>> DNS_RESOLVER = new Resolver();
     public static final ConnectionProperty<String, String> DNS_RESOLVER_CONTEXT = new ResolverContext();
     public static final ConnectionProperty<String, String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
+    public static final ConnectionProperty<String, ZoneId> TIMEZONE = new TimeZone();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             .add(USER)
@@ -141,6 +143,7 @@ final class ConnectionProperties
             .add(DNS_RESOLVER)
             .add(DNS_RESOLVER_CONTEXT)
             .add(HOSTNAME_IN_CERTIFICATE)
+            .add(TIMEZONE)
             .build();
 
     private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -701,6 +704,15 @@ final class ConnectionProperties
         public HostnameInCertificate()
         {
             super(PropertyName.HOSTNAME_IN_CERTIFICATE, NOT_REQUIRED, SslVerification.validateFull(PropertyName.HOSTNAME_IN_CERTIFICATE), STRING_CONVERTER);
+        }
+    }
+
+    private static class TimeZone
+            extends AbstractConnectionProperty<String, ZoneId>
+    {
+        public TimeZone()
+        {
+            super(PropertyName.TIMEZONE, NOT_REQUIRED, ALLOWED, ZoneId::of);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -64,6 +64,7 @@ public enum PropertyName
     DNS_RESOLVER("dnsResolver"),
     DNS_RESOLVER_CONTEXT("dnsResolverContext"),
     HOSTNAME_IN_CERTIFICATE("hostnameInCertificate"),
+    TIMEZONE("timezone"),
     // these two are not actual properties but parts of the path
     CATALOG("catalog"),
     SCHEMA("schema");

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -141,7 +141,7 @@ public class TrinoConnection
         uri.getTraceToken().ifPresent(tags -> clientInfo.put(TRACE_TOKEN, tags));
 
         roles.putAll(uri.getRoles());
-        timeZoneId.set(ZoneId.systemDefault());
+        timeZoneId.set(uri.getTimeZone());
         locale.set(Locale.getDefault());
         sessionProperties.putAll(uri.getSessionProperties());
     }

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -248,4 +248,8 @@ may not be specified using both methods.
         treated as underscores. You can use this as a workaround for
         applications that do not escape schema or table names when passing them
         to ``DatabaseMetaData`` methods as schema or table name patterns.
+   * - ``timezone``
+     - Sets the time zone for the session using the `time zone passed
+       <https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/ZoneId.html#of(java.lang.String)>`_. Defaults
+       to the timezone of the JVM running the JDBC driver.
 ```


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add support for timezone parameter to JDBC driver

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# JDBC
* Add `timezone` parameter to set the session timezone. ({issue}``)
```
