### PR TITLE
Introduce a way to pass SDK request override/additional configuration in S3FileSystem

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -103,6 +103,6 @@ public final class S3FileSystemFactory
     @Override
     public TrinoFileSystem create(ConnectorIdentity identity)
     {
-        return new S3FileSystem(client, context);
+        return new S3FileSystem(client, context, null);
     }
 }

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3InputFile.java
@@ -17,6 +17,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoInput;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoInputStream;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -35,15 +36,17 @@ final class S3InputFile
         implements TrinoInputFile
 {
     private final S3Client client;
+    private final AwsRequestOverrideConfiguration awsRequestOverrideConfiguration;
     private final S3Location location;
     private final RequestPayer requestPayer;
     private Long length;
     private Instant lastModified;
 
-    public S3InputFile(S3Client client, S3Context context, S3Location location, Long length)
+    public S3InputFile(S3Client client, S3Context context, AwsRequestOverrideConfiguration awsRequestOverrideConfiguration, S3Location location, Long length)
     {
         this.client = requireNonNull(client, "client is null");
         this.location = requireNonNull(location, "location is null");
+        this.awsRequestOverrideConfiguration = awsRequestOverrideConfiguration;
         this.requestPayer = context.requestPayer();
         this.length = length;
         location.location().verifyValidFileLocation();
@@ -100,6 +103,7 @@ final class S3InputFile
                 .requestPayer(requestPayer)
                 .bucket(location.bucket())
                 .key(location.key())
+                .overrideConfiguration(awsRequestOverrideConfiguration)
                 .build();
     }
 
@@ -110,6 +114,7 @@ final class S3InputFile
                 .requestPayer(requestPayer)
                 .bucket(location.bucket())
                 .key(location.key())
+                .overrideConfiguration(awsRequestOverrideConfiguration)
                 .build();
 
         try {

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.s3;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoOutputFile;
 import io.trino.memory.context.AggregatedMemoryContext;
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.OutputStream;
@@ -27,13 +28,15 @@ final class S3OutputFile
 {
     private final S3Client client;
     private final S3Context context;
+    private final AwsRequestOverrideConfiguration awsRequestOverrideConfiguration;
     private final S3Location location;
 
-    public S3OutputFile(S3Client client, S3Context context, S3Location location)
+    public S3OutputFile(S3Client client, S3Context context, AwsRequestOverrideConfiguration awsRequestOverrideConfiguration, S3Location location)
     {
         this.client = requireNonNull(client, "client is null");
         this.context = requireNonNull(context, "context is null");
         this.location = requireNonNull(location, "location is null");
+        this.awsRequestOverrideConfiguration = awsRequestOverrideConfiguration;
         location.location().verifyValidFileLocation();
     }
 
@@ -47,7 +50,7 @@ final class S3OutputFile
     @Override
     public OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
     {
-        return new S3OutputStream(memoryContext, client, context, location);
+        return new S3OutputStream(memoryContext, client, context, awsRequestOverrideConfiguration, location);
     }
 
     @Override


### PR DESCRIPTION
## Description
S3FileSystemFactory creates S3FileSystem with the S3 Client that gets created using default configurations when the factory is inited. At the time of filesystem creation, some ConnectorSession/ConnectorIdentity level information e.g. extra headers, credentials etc might be needed to be passed to SDK.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
