### PR TITLE
Ensure ConnectorSplitSource#close() is called

### DIFF
--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -80,7 +80,7 @@ public class ConnectorAwareSplitSource
             if (noMoreSplits) {
                 finished = true;
                 tableExecuteSplitsInfo = Optional.of(source.getTableExecuteSplitsInfo());
-                source = null;
+                closeSource();
             }
             return new SplitBatch(result.build(), noMoreSplits);
         }, directExecutor());
@@ -88,6 +88,11 @@ public class ConnectorAwareSplitSource
 
     @Override
     public void close()
+    {
+        closeSource();
+    }
+
+    private void closeSource()
     {
         if (source != null) {
             try {
@@ -107,7 +112,7 @@ public class ConnectorAwareSplitSource
             if (source.isFinished()) {
                 finished = true;
                 tableExecuteSplitsInfo = Optional.of(source.getTableExecuteSplitsInfo());
-                source = null;
+                closeSource();
             }
         }
         return finished;

--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -72,8 +72,9 @@ public class ConnectorAwareSplitSource
         checkState(source != null, "Already finished or closed");
         ListenableFuture<ConnectorSplitBatch> nextBatch = toListenableFuture(source.getNextBatch(maxSize));
         return Futures.transform(nextBatch, splitBatch -> {
-            ImmutableList.Builder<Split> result = ImmutableList.builder();
-            for (ConnectorSplit connectorSplit : splitBatch.getSplits()) {
+            List<ConnectorSplit> connectorSplits = splitBatch.getSplits();
+            ImmutableList.Builder<Split> result = ImmutableList.builderWithExpectedSize(connectorSplits.size());
+            for (ConnectorSplit connectorSplit : connectorSplits) {
                 result.add(new Split(catalogHandle, connectorSplit));
             }
             boolean noMoreSplits = splitBatch.isNoMoreSplits();


### PR DESCRIPTION
## Description
Ensures that `ConnectorSplitSource#close()` is called from `ConnectorAwareSplitSource` before clearing the reference to it so that any cleanup that may need to happen in the underlying implementation can occur as would happen before https://github.com/trinodb/trino/pull/19009


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

