### PR TITLE
Upgrade to Pinot 1.0.0

### DIFF
--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.pinot.version>0.12.1</dep.pinot.version>
+        <dep.pinot.version>1.0.0</dep.pinot.version>
         <!--
            Project's default for air.test.parallel is 'methods'. By design, 'instances' makes TestNG run tests from one class in a single thread.
            As a side effect, it prevents TestNG from initializing multiple test instances upfront, which happens with 'methods'.


### PR DESCRIPTION
## Description

Apache Pinot reached 1.0.0 - connector should update. This PR is just test for now.. 

fyi @elonazoulay 

## Additional context and related issues



## Release notes

To be determined .. 

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Pinot connector
* tbd
```
