### PR TITLE
Avoid re-reading parquet footer for delta stats in writer

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -116,8 +116,16 @@ public final class MetadataReader
         InputStream metadataStream = buffer.slice(buffer.length() - completeFooterSize, metadataLength).getInput();
 
         FileMetaData fileMetaData = readFileMetaData(metadataStream);
+        ParquetMetadata parquetMetadata = createParquetMetadata(fileMetaData, dataSource.getId().toString());
+        validateFileMetadata(dataSource.getId(), parquetMetadata.getFileMetaData(), parquetWriteValidation);
+        return parquetMetadata;
+    }
+
+    public static ParquetMetadata createParquetMetadata(FileMetaData fileMetaData, String filename)
+            throws ParquetCorruptionException
+    {
         List<SchemaElement> schema = fileMetaData.getSchema();
-        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", dataSource.getId());
+        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", filename);
 
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetaData> blocks = new ArrayList<>();
@@ -174,7 +182,6 @@ public final class MetadataReader
                 messageType,
                 keyValueMetaData,
                 fileMetaData.getCreated_by());
-        validateFileMetadata(dataSource.getId(), parquetFileMetadata, parquetWriteValidation);
         return new ParquetMetadata(parquetFileMetadata, blocks);
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -27,7 +27,6 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.deltalake.DataFileInfo.DataFileType;
 import io.trino.plugin.deltalake.util.DeltaLakeWriteUtils;
-import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HivePartitionKey;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.plugin.hive.util.HiveUtil;
@@ -360,10 +359,9 @@ public abstract class AbstractDeltaLakePageSink
             String fileName = session.getQueryId() + "_" + randomUUID();
             filePath = filePath.appendPath(fileName);
 
-            FileWriter fileWriter = createParquetFileWriter(filePath);
+            ParquetFileWriter fileWriter = createParquetFileWriter(filePath);
 
             DeltaLakeWriter writer = new DeltaLakeWriter(
-                    fileSystem,
                     fileWriter,
                     tableLocation,
                     getRelativeFilePath(partitionName, fileName),
@@ -437,7 +435,7 @@ public abstract class AbstractDeltaLakePageSink
                 .collect(toList());
     }
 
-    private FileWriter createParquetFileWriter(Location path)
+    private ParquetFileWriter createParquetFileWriter(Location path)
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -25,7 +25,6 @@ import io.trino.filesystem.TrinoInputFile;
 import io.trino.parquet.ParquetReaderOptions;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
-import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.ReaderPageSource;
 import io.trino.plugin.hive.parquet.ParquetFileWriter;
 import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
@@ -332,10 +331,9 @@ public class DeltaLakeMergeSink
 
             Location targetLocation = sourceLocation.sibling(session.getQueryId() + "_" + randomUUID());
             String targetRelativePath = relativePath(tablePath, targetLocation.toString());
-            FileWriter fileWriter = createParquetFileWriter(targetLocation, dataColumns);
+            ParquetFileWriter fileWriter = createParquetFileWriter(targetLocation, dataColumns);
 
             DeltaLakeWriter writer = new DeltaLakeWriter(
-                    fileSystem,
                     fileWriter,
                     rootTableLocation,
                     targetRelativePath,
@@ -354,7 +352,7 @@ public class DeltaLakeMergeSink
         }
     }
 
-    private FileWriter createParquetFileWriter(Location path, List<DeltaLakeColumnHandle> dataColumns)
+    private ParquetFileWriter createParquetFileWriter(Location path, List<DeltaLakeColumnHandle> dataColumns)
     {
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -113,8 +113,6 @@ public class TestDeltaLakeFileOperations
                         .add(new FileOperation(TRINO_EXTENDED_STATS_JSON, "extended_stats.json", OUTPUT_FILE_CREATE_OR_OVERWRITE))
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", OUTPUT_FILE_CREATE))
                         .add(new FileOperation(DATA, "no partition", OUTPUT_FILE_CREATE))
-                        .add(new FileOperation(DATA, "no partition", INPUT_FILE_NEW_STREAM))
-                        .add(new FileOperation(DATA, "no partition", INPUT_FILE_GET_LENGTH))
                         .build());
         assertUpdate("DROP TABLE test_create_as_select");
 
@@ -128,10 +126,6 @@ public class TestDeltaLakeFileOperations
                         .add(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", OUTPUT_FILE_CREATE))
                         .add(new FileOperation(DATA, "key=1/", OUTPUT_FILE_CREATE))
                         .add(new FileOperation(DATA, "key=2/", OUTPUT_FILE_CREATE))
-                        .add(new FileOperation(DATA, "key=1/", INPUT_FILE_NEW_STREAM))
-                        .add(new FileOperation(DATA, "key=1/", INPUT_FILE_GET_LENGTH))
-                        .add(new FileOperation(DATA, "key=2/", INPUT_FILE_NEW_STREAM))
-                        .add(new FileOperation(DATA, "key=2/", INPUT_FILE_GET_LENGTH))
                         .build());
         assertUpdate("DROP TABLE test_create_partitioned_as_select");
     }


### PR DESCRIPTION
## Description
Currently we're reading parquet file footer back just after
writing it to file system for computing delta stats.
Since Trino parquet writer already has the file footer, there
is no need to perform an extra IO to get the footer again.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Similar to https://github.com/trinodb/trino/pull/19090 but for delta


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta
* Improve performance of writing parquet files. ({issue}`19122`)
```
