### PR TITLE
Avoid multiple read requests on small parquet files

### DIFF
--- a/docs/src/main/sphinx/connector/object-storage-file-formats.md
+++ b/docs/src/main/sphinx/connector/object-storage-file-formats.md
@@ -98,3 +98,7 @@ with Parquet files performed by supported object storage connectors:
         session property is named ``parquet_max_read_block_row_count`` and
         supported by the Delta Lake, Hive, and Iceberg connectors.
       - ``8192``
+    * - ``parquet.small-file-threshold``
+      - Size below which a parquet file will be read entirely. The equivalent
+        catalog session property is named ``parquet_small_file_threshold``.
+      - ``3MB``

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -25,6 +25,7 @@ public class ParquetReaderOptions
     private static final int DEFAULT_MAX_READ_BLOCK_ROW_COUNT = 8 * 1024;
     private static final DataSize DEFAULT_MAX_MERGE_DISTANCE = DataSize.of(1, MEGABYTE);
     private static final DataSize DEFAULT_MAX_BUFFER_SIZE = DataSize.of(8, MEGABYTE);
+    private static final DataSize DEFAULT_SMALL_FILE_THRESHOLD = DataSize.of(3, MEGABYTE);
 
     private final boolean ignoreStatistics;
     private final DataSize maxReadBlockSize;
@@ -35,6 +36,7 @@ public class ParquetReaderOptions
     private final boolean useBatchColumnReaders;
     private final boolean useBatchNestedColumnReaders;
     private final boolean useBloomFilter;
+    private final DataSize smallFileThreshold;
 
     public ParquetReaderOptions()
     {
@@ -47,6 +49,7 @@ public class ParquetReaderOptions
         useBatchColumnReaders = true;
         useBatchNestedColumnReaders = true;
         useBloomFilter = true;
+        smallFileThreshold = DEFAULT_SMALL_FILE_THRESHOLD;
     }
 
     private ParquetReaderOptions(
@@ -58,7 +61,8 @@ public class ParquetReaderOptions
             boolean useColumnIndex,
             boolean useBatchColumnReaders,
             boolean useBatchNestedColumnReaders,
-            boolean useBloomFilter)
+            boolean useBloomFilter,
+            DataSize smallFileThreshold)
     {
         this.ignoreStatistics = ignoreStatistics;
         this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
@@ -70,6 +74,7 @@ public class ParquetReaderOptions
         this.useBatchColumnReaders = useBatchColumnReaders;
         this.useBatchNestedColumnReaders = useBatchNestedColumnReaders;
         this.useBloomFilter = useBloomFilter;
+        this.smallFileThreshold = requireNonNull(smallFileThreshold, "smallFileThreshold is null");
     }
 
     public boolean isIgnoreStatistics()
@@ -117,6 +122,11 @@ public class ParquetReaderOptions
         return maxReadBlockRowCount;
     }
 
+    public DataSize getSmallFileThreshold()
+    {
+        return smallFileThreshold;
+    }
+
     public ParquetReaderOptions withIgnoreStatistics(boolean ignoreStatistics)
     {
         return new ParquetReaderOptions(
@@ -128,7 +138,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withMaxReadBlockSize(DataSize maxReadBlockSize)
@@ -142,7 +153,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withMaxReadBlockRowCount(int maxReadBlockRowCount)
@@ -156,7 +168,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withMaxMergeDistance(DataSize maxMergeDistance)
@@ -170,7 +183,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withMaxBufferSize(DataSize maxBufferSize)
@@ -184,7 +198,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withUseColumnIndex(boolean useColumnIndex)
@@ -198,7 +213,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withBatchColumnReaders(boolean useBatchColumnReaders)
@@ -212,7 +228,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withBatchNestedColumnReaders(boolean useBatchNestedColumnReaders)
@@ -226,7 +243,8 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
     }
 
     public ParquetReaderOptions withBloomFilter(boolean useBloomFilter)
@@ -240,6 +258,22 @@ public class ParquetReaderOptions
                 useColumnIndex,
                 useBatchColumnReaders,
                 useBatchNestedColumnReaders,
-                useBloomFilter);
+                useBloomFilter,
+                smallFileThreshold);
+    }
+
+    public ParquetReaderOptions withSmallFileThreshold(DataSize smallFileThreshold)
+    {
+        return new ParquetReaderOptions(
+                ignoreStatistics,
+                maxReadBlockSize,
+                maxReadBlockRowCount,
+                maxMergeDistance,
+                maxBufferSize,
+                useColumnIndex,
+                useBatchColumnReaders,
+                useBatchNestedColumnReaders,
+                useBloomFilter,
+                smallFileThreshold);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -54,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
@@ -495,11 +496,11 @@ public class DeltaLakeMergeSink
             throws IOException
     {
         TrinoInputFile inputFile = fileSystem.newInputFile(path);
-
+        long fileSize = inputFile.length();
         return ParquetPageSourceFactory.createPageSource(
                 inputFile,
                 0,
-                inputFile.length(),
+                fileSize,
                 dataColumns.stream()
                         .map(DeltaLakeColumnHandle::toHiveColumnHandle)
                         .collect(toImmutableList()),
@@ -509,7 +510,8 @@ public class DeltaLakeMergeSink
                 new FileFormatDataSourceStats(),
                 new ParquetReaderOptions().withBloomFilter(false),
                 Optional.empty(),
-                domainCompactionThreshold);
+                domainCompactionThreshold,
+                OptionalLong.of(fileSize));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -34,6 +34,7 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
 import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
+import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
@@ -53,6 +54,7 @@ public final class DeltaLakeSessionProperties
     private static final String HIVE_CATALOG_NAME = "hive_catalog_name";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
+    private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_USE_COLUMN_INDEX = "parquet_use_column_index";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
@@ -116,6 +118,12 @@ public final class DeltaLakeSessionProperties
                                         format("%s must be between 128 and 65536: %s", PARQUET_MAX_READ_BLOCK_ROW_COUNT, value));
                             }
                         },
+                        false),
+                dataSizeProperty(
+                        PARQUET_SMALL_FILE_THRESHOLD,
+                        "Parquet: Size below which a parquet file will be read entirely",
+                        parquetReaderConfig.getSmallFileThreshold(),
+                        value -> validateMaxDataSize(PARQUET_SMALL_FILE_THRESHOLD, value, DataSize.valueOf(PARQUET_READER_MAX_SMALL_FILE_THRESHOLD)),
                         false),
                 booleanProperty(
                         PARQUET_USE_COLUMN_INDEX,
@@ -231,6 +239,11 @@ public final class DeltaLakeSessionProperties
     public static int getParquetMaxReadBlockRowCount(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_ROW_COUNT, Integer.class);
+    }
+
+    public static DataSize getParquetSmallFileThreshold(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_SMALL_FILE_THRESHOLD, DataSize.class);
     }
 
     public static boolean isParquetUseColumnIndex(ConnectorSession session)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -201,7 +202,8 @@ public class TableChangesFunctionProcessor
                 fileFormatDataSourceStats,
                 parquetReaderOptions,
                 Optional.empty(),
-                domainCompactionThreshold);
+                domainCompactionThreshold,
+                OptionalLong.empty());
 
         verify(pageSource.getReaderColumns().isEmpty(), "Unexpected reader columns: %s", pageSource.getReaderColumns().orElse(null));
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -197,7 +197,8 @@ public class CheckpointEntryIterator
                 stats,
                 parquetReaderOptions,
                 Optional.empty(),
-                domainCompactionThreshold);
+                domainCompactionThreshold,
+                OptionalLong.empty());
 
         verify(pageSource.getReaderColumns().isEmpty(), "All columns expected to be base columns");
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -3027,6 +3027,14 @@ public class TestDeltaLakeConnectorTest
         }
     }
 
+    @Override
+    protected Session withoutSmallFileThreshold(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "parquet_small_file_threshold", "0B")
+                .build();
+    }
+
     private Session sessionWithPartitionFilterRequirement()
     {
         return Session.builder(getSession())

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -41,6 +41,7 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
+import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
@@ -92,6 +93,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
+    private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -342,6 +344,12 @@ public final class HiveSessionProperties
                                         format("%s must be between 128 and 65536: %s", PARQUET_MAX_READ_BLOCK_ROW_COUNT, value));
                             }
                         },
+                        false),
+                dataSizeProperty(
+                        PARQUET_SMALL_FILE_THRESHOLD,
+                        "Parquet: Size below which a parquet file will be read entirely",
+                        parquetReaderConfig.getSmallFileThreshold(),
+                        value -> validateMaxDataSize(PARQUET_SMALL_FILE_THRESHOLD, value, DataSize.valueOf(PARQUET_READER_MAX_SMALL_FILE_THRESHOLD)),
                         false),
                 dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -702,6 +710,11 @@ public final class HiveSessionProperties
     public static int getParquetMaxReadBlockRowCount(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_ROW_COUNT, Integer.class);
+    }
+
+    public static DataSize getParquetSmallFileThreshold(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_SMALL_FILE_THRESHOLD, DataSize.class);
     }
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/MemoryParquetDataSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/MemoryParquetDataSource.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.parquet;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+import io.airlift.slice.Slice;
+import io.trino.filesystem.TrinoInput;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.parquet.ChunkReader;
+import io.trino.parquet.DiskRange;
+import io.trino.parquet.ParquetDataSource;
+import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.reader.ChunkedInputStream;
+import io.trino.plugin.hive.FileFormatDataSourceStats;
+import jakarta.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class MemoryParquetDataSource
+        implements ParquetDataSource
+{
+    private final ParquetDataSourceId id;
+    private final long readTimeNanos;
+    private final long readBytes;
+    private final LocalMemoryContext memoryUsage;
+    @Nullable
+    private Slice data;
+
+    public MemoryParquetDataSource(TrinoInputFile inputFile, AggregatedMemoryContext memoryContext, FileFormatDataSourceStats stats)
+            throws IOException
+    {
+        try (TrinoInput input = inputFile.newInput()) {
+            long readStart = System.nanoTime();
+            this.data = input.readTail(toIntExact(inputFile.length()));
+            this.readTimeNanos = System.nanoTime() - readStart;
+            stats.readDataBytesPerSecond(data.length(), readTimeNanos);
+        }
+        this.memoryUsage = memoryContext.newLocalMemoryContext(MemoryParquetDataSource.class.getSimpleName());
+        this.memoryUsage.setBytes(data.length());
+        this.readBytes = data.length();
+        this.id = new ParquetDataSourceId(inputFile.location().toString());
+    }
+
+    @Override
+    public ParquetDataSourceId getId()
+    {
+        return id;
+    }
+
+    @Override
+    public long getReadBytes()
+    {
+        return readBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        return readBytes;
+    }
+
+    @Override
+    public Slice readTail(int length)
+    {
+        int readSize = min(data.length(), length);
+        return readFully(data.length() - readSize, readSize);
+    }
+
+    @Override
+    public final Slice readFully(long position, int length)
+    {
+        return data.slice(toIntExact(position), length);
+    }
+
+    @Override
+    public <K> Map<K, ChunkedInputStream> planRead(ListMultimap<K, DiskRange> diskRanges, AggregatedMemoryContext memoryContext)
+    {
+        requireNonNull(diskRanges, "diskRanges is null");
+
+        if (diskRanges.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        ImmutableMap.Builder<K, ChunkedInputStream> builder = ImmutableMap.builder();
+        for (Map.Entry<K, Collection<DiskRange>> entry : diskRanges.asMap().entrySet()) {
+            List<ChunkReader> chunkReaders = entry.getValue().stream()
+                    .map(diskRange -> new ChunkReader()
+                    {
+                        @Override
+                        public long getDiskOffset()
+                        {
+                            return diskRange.getOffset();
+                        }
+
+                        @Override
+                        public Slice read()
+                        {
+                            return data.slice(toIntExact(diskRange.getOffset()), toIntExact(diskRange.getLength()));
+                        }
+
+                        @Override
+                        public void free() {}
+                    })
+                    .collect(toImmutableList());
+            builder.put(entry.getKey(), new ChunkedInputStream(chunkReaders));
+        }
+        return builder.buildOrThrow();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        data = null;
+        memoryUsage.close();
+    }
+
+    @Override
+    public final String toString()
+    {
+        return id.toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -21,6 +21,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoInputFile;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.parquet.BloomFilterStore;
 import io.trino.parquet.Field;
 import io.trino.parquet.ParquetCorruptionException;
@@ -67,6 +68,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 
@@ -89,6 +91,7 @@ import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.trino.plugin.hive.HivePageSourceProvider.projectSufficientColumns;
 import static io.trino.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockRowCount;
 import static io.trino.plugin.hive.HiveSessionProperties.getParquetMaxReadBlockSize;
+import static io.trino.plugin.hive.HiveSessionProperties.getParquetSmallFileThreshold;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetIgnoreStatistics;
 import static io.trino.plugin.hive.HiveSessionProperties.isParquetUseColumnIndex;
 import static io.trino.plugin.hive.HiveSessionProperties.isUseParquetColumnNames;
@@ -191,10 +194,12 @@ public class ParquetPageSourceFactory
                 options.withIgnoreStatistics(isParquetIgnoreStatistics(session))
                         .withMaxReadBlockSize(getParquetMaxReadBlockSize(session))
                         .withMaxReadBlockRowCount(getParquetMaxReadBlockRowCount(session))
+                        .withSmallFileThreshold(getParquetSmallFileThreshold(session))
                         .withUseColumnIndex(isParquetUseColumnIndex(session))
                         .withBloomFilter(useParquetBloomFilter(session)),
                 Optional.empty(),
-                domainCompactionThreshold));
+                domainCompactionThreshold,
+                OptionalLong.of(estimatedFileSize)));
     }
 
     /**
@@ -211,14 +216,16 @@ public class ParquetPageSourceFactory
             FileFormatDataSourceStats stats,
             ParquetReaderOptions options,
             Optional<ParquetWriteValidation> parquetWriteValidation,
-            int domainCompactionThreshold)
+            int domainCompactionThreshold,
+            OptionalLong estimatedFileSize)
     {
         MessageType fileSchema;
         MessageType requestedSchema;
         MessageColumnIO messageColumn;
         ParquetDataSource dataSource = null;
         try {
-            dataSource = new TrinoParquetDataSource(inputFile, options, stats);
+            AggregatedMemoryContext memoryContext = newSimpleAggregatedMemoryContext();
+            dataSource = createDataSource(inputFile, estimatedFileSize, options, memoryContext, stats);
 
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, parquetWriteValidation);
             FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
@@ -279,7 +286,7 @@ public class ParquetPageSourceFactory
                     blockStarts.build(),
                     finalDataSource,
                     timeZone,
-                    newSimpleAggregatedMemoryContext(),
+                    memoryContext,
                     options,
                     exception -> handleException(dataSourceId, exception),
                     Optional.of(parquetPredicate),
@@ -305,6 +312,20 @@ public class ParquetPageSourceFactory
             String message = format("Error opening Hive split %s (offset=%s, length=%s): %s", inputFile.location(), start, length, e.getMessage());
             throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, message, e);
         }
+    }
+
+    public static ParquetDataSource createDataSource(
+            TrinoInputFile inputFile,
+            OptionalLong estimatedFileSize,
+            ParquetReaderOptions options,
+            AggregatedMemoryContext memoryContext,
+            FileFormatDataSourceStats stats)
+            throws IOException
+    {
+        if (estimatedFileSize.isEmpty() || estimatedFileSize.getAsLong() > options.getSmallFileThreshold().toBytes()) {
+            return new TrinoParquetDataSource(inputFile, options, stats);
+        }
+        return new MemoryParquetDataSource(inputFile, memoryContext, stats);
     }
 
     public static Optional<MessageType> getParquetMessageType(List<HiveColumnHandle> columns, boolean useColumnNames, MessageType fileSchema)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetReaderConfig.java
@@ -18,6 +18,7 @@ import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 import io.airlift.units.DataSize;
+import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import io.trino.parquet.ParquetReaderOptions;
 import jakarta.validation.constraints.Max;
@@ -32,6 +33,8 @@ import jakarta.validation.constraints.NotNull;
 })
 public class ParquetReaderConfig
 {
+    public static final String PARQUET_READER_MAX_SMALL_FILE_THRESHOLD = "15MB";
+
     private ParquetReaderOptions options = new ParquetReaderOptions();
 
     @Deprecated
@@ -129,6 +132,21 @@ public class ParquetReaderConfig
     public boolean isUseBloomFilter()
     {
         return options.useBloomFilter();
+    }
+
+    @Config("parquet.small-file-threshold")
+    @ConfigDescription("Size below which a parquet file will be read entirely")
+    public ParquetReaderConfig setSmallFileThreshold(DataSize smallFileThreshold)
+    {
+        options = options.withSmallFileThreshold(smallFileThreshold);
+        return this;
+    }
+
+    @NotNull
+    @MaxDataSize(PARQUET_READER_MAX_SMALL_FILE_THRESHOLD)
+    public DataSize getSmallFileThreshold()
+    {
+        return options.getSmallFileThreshold();
     }
 
     public ParquetReaderOptions toParquetReaderOptions()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -8988,6 +8988,15 @@ public abstract class BaseHiveConnectorTest
         return false;
     }
 
+    @Override
+    protected Session withoutSmallFileThreshold(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "parquet_small_file_threshold", "0B")
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "orc_tiny_stripe_threshold", "0B")
+                .build();
+    }
+
     private static final class BucketedFilterTestSetup
     {
         private final String typeName;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetReaderConfig.java
@@ -37,7 +37,8 @@ public class TestParquetReaderConfig
                 .setMaxMergeDistance(DataSize.of(1, MEGABYTE))
                 .setMaxBufferSize(DataSize.of(8, MEGABYTE))
                 .setUseColumnIndex(true)
-                .setUseBloomFilter(true));
+                .setUseBloomFilter(true)
+                .setSmallFileThreshold(DataSize.of(3, MEGABYTE)));
     }
 
     @Test
@@ -51,6 +52,7 @@ public class TestParquetReaderConfig
                 .put("parquet.max-merge-distance", "342kB")
                 .put("parquet.use-column-index", "false")
                 .put("parquet.use-bloom-filter", "false")
+                .put("parquet.small-file-threshold", "1kB")
                 .buildOrThrow();
 
         ParquetReaderConfig expected = new ParquetReaderConfig()
@@ -60,7 +62,8 @@ public class TestParquetReaderConfig
                 .setMaxBufferSize(DataSize.of(1431, KILOBYTE))
                 .setMaxMergeDistance(DataSize.of(342, KILOBYTE))
                 .setUseColumnIndex(false)
-                .setUseBloomFilter(false);
+                .setUseBloomFilter(false)
+                .setSmallFileThreshold(DataSize.of(1, KILOBYTE));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.units.DataSize;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
@@ -27,6 +28,8 @@ import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
+import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
@@ -40,6 +43,7 @@ public class HudiSessionProperties
 {
     private static final String COLUMNS_TO_HIDE = "columns_to_hide";
     private static final String USE_PARQUET_COLUMN_NAMES = "use_parquet_column_names";
+    private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     private static final String STANDARD_SPLIT_WEIGHT_SIZE = "standard_split_weight_size";
     private static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
@@ -50,7 +54,7 @@ public class HudiSessionProperties
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
-    public HudiSessionProperties(HudiConfig hudiConfig)
+    public HudiSessionProperties(HudiConfig hudiConfig, ParquetReaderConfig parquetReaderConfig)
     {
         sessionProperties = ImmutableList.of(
                 new PropertyMetadata<>(
@@ -68,6 +72,12 @@ public class HudiSessionProperties
                         USE_PARQUET_COLUMN_NAMES,
                         "Access parquet columns using names from the file. If disabled, then columns are accessed using index.",
                         hudiConfig.getUseParquetColumnNames(),
+                        false),
+                dataSizeProperty(
+                        PARQUET_SMALL_FILE_THRESHOLD,
+                        "Parquet: Size below which a parquet file will be read entirely",
+                        parquetReaderConfig.getSmallFileThreshold(),
+                        value -> validateMaxDataSize(PARQUET_SMALL_FILE_THRESHOLD, value, DataSize.valueOf(PARQUET_READER_MAX_SMALL_FILE_THRESHOLD)),
                         false),
                 booleanProperty(
                         SIZE_BASED_SPLIT_WEIGHTS_ENABLED,
@@ -121,6 +131,11 @@ public class HudiSessionProperties
     public static boolean shouldUseParquetColumnNames(ConnectorSession session)
     {
         return session.getProperty(USE_PARQUET_COLUMN_NAMES, Boolean.class);
+    }
+
+    public static DataSize getParquetSmallFileThreshold(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_SMALL_FILE_THRESHOLD, DataSize.class);
     }
 
     public static boolean isSizeBasedSplitWeightsEnabled(ConnectorSession session)

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSessionProperties.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hudi;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.testing.TestingConnectorSession;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ public class TestHudiSessionProperties
     {
         HudiConfig config = new HudiConfig()
                 .setColumnsToHide("col1, col2");
-        HudiSessionProperties sessionProperties = new HudiSessionProperties(config);
+        HudiSessionProperties sessionProperties = new HudiSessionProperties(config, new ParquetReaderConfig());
         ConnectorSession session = TestingConnectorSession.builder()
                 .setPropertyMetadata(sessionProperties.getSessionProperties())
                 .build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -37,6 +37,7 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty
 import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMaxDataSize;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataSize;
+import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
@@ -73,6 +74,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_USE_BLOOM_FILTER = "parquet_use_bloom_filter";
     private static final String PARQUET_MAX_READ_BLOCK_ROW_COUNT = "parquet_max_read_block_row_count";
+    private static final String PARQUET_SMALL_FILE_THRESHOLD = "parquet_small_file_threshold";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
@@ -216,6 +218,12 @@ public final class IcebergSessionProperties
                                         format("%s must be between 128 and 65536: %s", PARQUET_MAX_READ_BLOCK_ROW_COUNT, value));
                             }
                         },
+                        false))
+                .add(dataSizeProperty(
+                        PARQUET_SMALL_FILE_THRESHOLD,
+                        "Parquet: Size below which a parquet file will be read entirely",
+                        parquetReaderConfig.getSmallFileThreshold(),
+                        value -> validateMaxDataSize(PARQUET_SMALL_FILE_THRESHOLD, value, DataSize.valueOf(PARQUET_READER_MAX_SMALL_FILE_THRESHOLD)),
                         false))
                 .add(dataSizeProperty(
                         PARQUET_WRITER_BLOCK_SIZE,
@@ -408,6 +416,11 @@ public final class IcebergSessionProperties
     public static int getParquetMaxReadBlockRowCount(ConnectorSession session)
     {
         return session.getProperty(PARQUET_MAX_READ_BLOCK_ROW_COUNT, Integer.class);
+    }
+
+    public static DataSize getParquetSmallFileThreshold(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_SMALL_FILE_THRESHOLD, DataSize.class);
     }
 
     public static DataSize getParquetWriterPageSize(ConnectorSession session)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -7072,6 +7072,15 @@ public abstract class BaseIcebergConnectorTest
         return false;
     }
 
+    @Override
+    protected Session withoutSmallFileThreshold(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "parquet_small_file_threshold", "0B")
+                .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "orc_tiny_stripe_threshold", "0B")
+                .build();
+    }
+
     private Session withSingleWriterPerTask(Session session)
     {
         return Session.builder(session)

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
@@ -16,3 +16,5 @@ hive.max-partitions-for-eager-load=100
 hive.hive-views.enabled=true
 hive.parquet.time-zone=UTC
 hive.rcfile.time-zone=UTC
+# Using smaller than default parquet.small-file-threshold to get better code coverage in tests
+parquet.small-file-threshold=100kB

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksMinioReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksMinioReads.java
@@ -33,6 +33,6 @@ public class TestDeltaLakeDatabricksMinioReads
     public void testReadRegionTable()
     {
         super.testReadRegionTable();
-        assertNotificationsCount(NOTIFICATIONS_TABLE, OBJECT_ACCESSED_GET, tableName + "/part-00000-98195ace-e492-4cd7-97d1-9b955202874b-c000.snappy.parquet", 2);
+        assertNotificationsCount(NOTIFICATIONS_TABLE, OBJECT_ACCESSED_GET, tableName + "/part-00000-98195ace-e492-4cd7-97d1-9b955202874b-c000.snappy.parquet", 1);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeOssDeltaLakeMinioReads.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeOssDeltaLakeMinioReads.java
@@ -33,6 +33,6 @@ public class TestDeltaLakeOssDeltaLakeMinioReads
     public void testReadRegionTable()
     {
         super.testReadRegionTable();
-        assertNotificationsCount(NOTIFICATIONS_TABLE, OBJECT_ACCESSED_GET, tableName + "/part-00000-274dcbf4-d64c-43ea-8eb7-e153feac98ce-c000.snappy.parquet", 2);
+        assertNotificationsCount(NOTIFICATIONS_TABLE, OBJECT_ACCESSED_GET, tableName + "/part-00000-274dcbf4-d64c-43ea-8eb7-e153feac98ce-c000.snappy.parquet", 1);
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -6297,7 +6297,7 @@ public abstract class BaseConnectorTest
                         .isFullyPushedDown();
 
                 // With Projection Pushdown disabled
-                Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled();
+                Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled(getSession());
                 assertThat(query(sessionWithoutPushdown, selectQuery))
                         .matches(expectedResult)
                         .isNotFullyPushedDown(ProjectNode.class);
@@ -6421,10 +6421,11 @@ public abstract class BaseConnectorTest
                 "AS SELECT val AS id, CAST(ROW(val + 1, val + 2) AS ROW(leaf1 BIGINT, leaf2 BIGINT)) AS root FROM UNNEST(SEQUENCE(1, 10)) AS t(val)")) {
             MaterializedResult expectedResult = computeActual("SELECT val + 2 FROM UNNEST(SEQUENCE(1, 10)) AS t(val)");
             String selectQuery = "SELECT root.leaf2 FROM " + testTable.getName();
-            Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled();
+            Session sessionWithoutSmallFileThreshold = withoutSmallFileThreshold(getSession());
+            Session sessionWithoutPushdown = sessionWithProjectionPushdownDisabled(sessionWithoutSmallFileThreshold);
 
             assertQueryStats(
-                    getSession(),
+                    sessionWithoutSmallFileThreshold,
                     selectQuery,
                     statsWithPushdown -> {
                         DataSize physicalInputDataSizeWithPushdown = statsWithPushdown.getPhysicalInputDataSize();
@@ -6458,12 +6459,13 @@ public abstract class BaseConnectorTest
                 "test_projection_pushdown_physical_input_size_",
                 "AS SELECT val AS id, CAST(ROW(val + 1, val + 2) AS ROW(leaf1 BIGINT, leaf2 BIGINT)) AS root FROM UNNEST(SEQUENCE(1, 10)) AS t(val)")) {
             // Verify that the physical input size is smaller when reading the root.leaf1 field compared to reading the root field
+            Session sessionWithoutSmallFileThreshold = withoutSmallFileThreshold(getSession());
             assertQueryStats(
-                    getSession(),
+                    sessionWithoutSmallFileThreshold,
                     "SELECT root FROM " + testTable.getName(),
                     statsWithSelectRootField -> {
                         assertQueryStats(
-                                getSession(),
+                                sessionWithoutSmallFileThreshold,
                                 "SELECT root.leaf1 FROM " + testTable.getName(),
                                 statsWithSelectLeafField -> {
                                     if (supportsPhysicalPushdown()) {
@@ -6480,11 +6482,11 @@ public abstract class BaseConnectorTest
 
             // Verify that the physical input size is the same when reading the root field compared to reading both the root and root.leaf1 fields
             assertQueryStats(
-                    getSession(),
+                    sessionWithoutSmallFileThreshold,
                     "SELECT root FROM " + testTable.getName(),
                     statsWithSelectRootField -> {
                         assertQueryStats(
-                                getSession(),
+                                sessionWithoutSmallFileThreshold,
                                 "SELECT root, root.leaf1 FROM " + testTable.getName(),
                                 statsWithSelectRootAndLeafField -> {
                                     assertThat(statsWithSelectRootAndLeafField.getPhysicalInputDataSize()).isEqualTo(statsWithSelectRootField.getPhysicalInputDataSize());
@@ -6539,11 +6541,16 @@ public abstract class BaseConnectorTest
         return true;
     }
 
-    protected Session sessionWithProjectionPushdownDisabled()
+    protected Session sessionWithProjectionPushdownDisabled(Session session)
     {
-        return Session.builder(getSession())
+        return Session.builder(session)
                 .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "projection_pushdown_enabled", "false")
                 .build();
+    }
+
+    protected Session withoutSmallFileThreshold(Session session)
+    {
+        return session;
     }
 
     protected static final class DataMappingTestSetup


### PR DESCRIPTION
## Description
Read files below parquet.small-file-threshold size in a single file system request to avoid multiple small read requests

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This is similar to `hive.orc.tiny-stripe-threshold` in ORC reader


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Reduce read requests for scanning small parquet files. 
  The catalog configuration property `parquet.small-file-threshold` or the corresponding
  catalog session property can be used to change the default size of `3MB` below which files 
  will be read entirely. Setting this configuration to `0B` disables the feature. ({issue}`19127`)
```
