### PR TITLE
Fix type mapping documentation error.

### DIFF
--- a/docs/src/main/sphinx/develop/connectors.md
+++ b/docs/src/main/sphinx/develop/connectors.md
@@ -670,7 +670,7 @@ The built-in SQL data types use different Java types as carrier types.
 * - `BIGINT`
   - `long`
 * - `REAL`
-  - `double`
+  - `long`
 * - `DOUBLE`
   - `double`
 * - `DECIMAL`
@@ -731,6 +731,10 @@ the carrier type:
 - `getDouble(int field)`
 - `getSlice(int field)`
 - `getObject(int field)`
+
+Values for the `real` type are encoded into `long` using the IEEE 754
+floating-point "single format" bit layout, with NaN preservation. This can be
+accomplished using the `java.lang.Float.floatToRawIntBits` static method.
 
 Values for the `timestamp(p) with time zone` and `time(p) with time zone`
 types of regular precision can be converted into `long` using static methods


### PR DESCRIPTION
The `REAL` type is mapped to Java `long`, not `double`.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The documentation currently states that the `REAL` type uses the Java carrier type `double`, but from what I can tell from the `RealType` implementation, the Java type used is actually `long`.

Found while working on Neo4j connector.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Sources:
[`RealType extends AbstractIntType`](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java#L50)
[`AbstractIntType` passes `long.class` as javaType](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/type/AbstractIntType.java#L54)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: