### PR TITLE
Document tpch.column-naming

### DIFF
--- a/docs/src/main/sphinx/connector/tpch.md
+++ b/docs/src/main/sphinx/connector/tpch.md
@@ -18,6 +18,16 @@ To configure the TPCH connector, create a catalog properties file
 connector.name=tpch
 ```
 
+In the TPC-H specification, each column is assigned a prefix based on its
+corresponding table name, such as `l_` for the `lineitem` table. By default, the
+TPCH connector simplifies column names by excluding these prefixes with the
+default of `tpch.column-naming` to `SIMPLIFIED`. To use the long, standard
+column names, use the configuration in the catalog properties file:
+
+```text
+tpch.column-naming=STANDARD
+```
+
 ## TPCH schemas
 
 The TPCH connector supplies several schemas:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add a paragraph on `tpch.column-naming=STANDARD` to the documentation of the TPCH connector. Useful when trying to run TPC-H queries without modifications.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.