### PR TITLE
Simplify writer count properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -66,8 +66,8 @@ public final class SystemSessionProperties
     public static final String MIN_HASH_PARTITION_COUNT = "min_hash_partition_count";
     public static final String MIN_HASH_PARTITION_COUNT_FOR_WRITE = "min_hash_partition_count_for_write";
     public static final String PREFER_STREAMING_OPERATORS = "prefer_streaming_operators";
-    public static final String TASK_WRITER_COUNT = "task_writer_count";
-    public static final String TASK_PARTITIONED_WRITER_COUNT = "task_partitioned_writer_count";
+    public static final String TASK_MIN_WRITER_COUNT = "task_min_writer_count";
+    public static final String TASK_MAX_WRITER_COUNT = "task_max_writer_count";
     public static final String TASK_CONCURRENCY = "task_concurrency";
     public static final String TASK_SHARE_INDEX_LOADING = "task_share_index_loading";
     public static final String QUERY_MAX_MEMORY = "query_max_memory";
@@ -84,7 +84,6 @@ public final class SystemSessionProperties
     public static final String SCALE_WRITERS = "scale_writers";
     public static final String TASK_SCALE_WRITERS_ENABLED = "task_scale_writers_enabled";
     public static final String MAX_WRITER_TASKS_COUNT = "max_writer_tasks_count";
-    public static final String TASK_SCALE_WRITERS_MAX_WRITER_COUNT = "task_scale_writers_max_writer_count";
     public static final String WRITER_SCALING_MIN_DATA_PROCESSED = "writer_scaling_min_data_processed";
     public static final String SKEWED_PARTITION_MIN_DATA_PROCESSED_REBALANCE_THRESHOLD = "skewed_partition_min_data_processed_rebalance_threshold";
     public static final String MAX_MEMORY_PER_PARTITION_WRITER = "max_memory_per_partition_writer";
@@ -297,15 +296,15 @@ public final class SystemSessionProperties
                         false,
                         false),
                 integerProperty(
-                        TASK_WRITER_COUNT,
-                        "Number of local parallel table writers per task when prefer partitioning and task writer scaling are not used",
-                        taskManagerConfig.getWriterCount(),
+                        TASK_MIN_WRITER_COUNT,
+                        "Minimum number of local parallel table writers per task when preferred partitioning and task writer scaling are not used",
+                        taskManagerConfig.getMinWriterCount(),
                         false),
                 integerProperty(
-                        TASK_PARTITIONED_WRITER_COUNT,
-                        "Number of local parallel table writers per task when prefer partitioning is used",
-                        taskManagerConfig.getPartitionedWriterCount(),
-                        value -> validateValueIsPowerOfTwo(value, TASK_PARTITIONED_WRITER_COUNT),
+                        TASK_MAX_WRITER_COUNT,
+                        "Maximum number of local parallel table writers per task when either task writer scaling or preferred partitioning is used",
+                        taskManagerConfig.getMaxWriterCount(),
+                        value -> validateValueIsPowerOfTwo(value, TASK_MAX_WRITER_COUNT),
                         false),
                 booleanProperty(
                         REDISTRIBUTE_WRITES,
@@ -333,11 +332,6 @@ public final class SystemSessionProperties
                         "Scale the number of concurrent table writers per task based on throughput",
                         taskManagerConfig.isScaleWritersEnabled(),
                         false),
-                integerProperty(
-                        TASK_SCALE_WRITERS_MAX_WRITER_COUNT,
-                        "Maximum number of writers per task up to which scaling will happen if task.scale-writers.enabled is set",
-                        taskManagerConfig.getScaleWritersMaxWriterCount(),
-                        true),
                 dataSizeProperty(
                         WRITER_SCALING_MIN_DATA_PROCESSED,
                         "Minimum amount of uncompressed output data processed by writers before writer scaling can happen",
@@ -1135,14 +1129,14 @@ public final class SystemSessionProperties
         return session.getSystemProperty(PREFER_STREAMING_OPERATORS, Boolean.class);
     }
 
-    public static int getTaskWriterCount(Session session)
+    public static int getTaskMinWriterCount(Session session)
     {
-        return session.getSystemProperty(TASK_WRITER_COUNT, Integer.class);
+        return session.getSystemProperty(TASK_MIN_WRITER_COUNT, Integer.class);
     }
 
-    public static int getTaskPartitionedWriterCount(Session session)
+    public static int getTaskMaxWriterCount(Session session)
     {
-        return session.getSystemProperty(TASK_PARTITIONED_WRITER_COUNT, Integer.class);
+        return session.getSystemProperty(TASK_MAX_WRITER_COUNT, Integer.class);
     }
 
     public static boolean isRedistributeWrites(Session session)
@@ -1163,11 +1157,6 @@ public final class SystemSessionProperties
     public static boolean isTaskScaleWritersEnabled(Session session)
     {
         return session.getSystemProperty(TASK_SCALE_WRITERS_ENABLED, Boolean.class);
-    }
-
-    public static int getTaskScaleWritersMaxWriterCount(Session session)
-    {
-        return session.getSystemProperty(TASK_SCALE_WRITERS_MAX_WRITER_COUNT, Integer.class);
     }
 
     public static int getMaxWriterTaskCount(Session session)

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -243,8 +243,8 @@ public class TestingTrinoServer
                 .put("catalog.management", "dynamic")
                 .put("task.concurrency", "4")
                 .put("task.max-worker-threads", "4")
-                // Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
-                .put("task.writer-count", "2")
+                // Use task.min-writer-count > 1, as this allows to expose writer-concurrency related bugs.
+                .put("task.min-writer-count", "2")
                 .put("exchange.client-threads", "4")
                 // Reduce memory footprint in tests
                 .put("exchange.max-buffer-size", "4MB")

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -303,9 +303,8 @@ import static io.trino.SystemSessionProperties.getFilterAndProjectMinOutputPageS
 import static io.trino.SystemSessionProperties.getPagePartitioningBufferPoolSize;
 import static io.trino.SystemSessionProperties.getSkewedPartitionMinDataProcessedRebalanceThreshold;
 import static io.trino.SystemSessionProperties.getTaskConcurrency;
-import static io.trino.SystemSessionProperties.getTaskPartitionedWriterCount;
-import static io.trino.SystemSessionProperties.getTaskScaleWritersMaxWriterCount;
-import static io.trino.SystemSessionProperties.getTaskWriterCount;
+import static io.trino.SystemSessionProperties.getTaskMaxWriterCount;
+import static io.trino.SystemSessionProperties.getTaskMinWriterCount;
 import static io.trino.SystemSessionProperties.getWriterScalingMinDataProcessed;
 import static io.trino.SystemSessionProperties.isAdaptivePartialAggregationEnabled;
 import static io.trino.SystemSessionProperties.isEnableCoordinatorDynamicFiltersDistribution;
@@ -3496,7 +3495,7 @@ public class LocalExecutionPlanner
         {
             // This check is required because we don't know which writer count to use when exchange is
             // single distribution. It could be possible that when scaling is enabled, a single distribution is
-            // selected for partitioned write using "task_partitioned_writer_count". However, we can't say for sure
+            // selected for partitioned write using "task_max_writer_count". However, we can't say for sure
             // whether this single distribution comes from unpartitioned or partitioned writer count.
             if (isSingleGatheringExchange(source)) {
                 return 1;
@@ -3507,20 +3506,20 @@ public class LocalExecutionPlanner
                 // enough to use it for cases with or without scaling enabled. Additionally, it doesn't lead
                 // to too many small files when scaling is disabled because single partition will be written by
                 // a single writer only.
-                int partitionedWriterCount = getTaskPartitionedWriterCount(session);
+                int partitionedWriterCount = getTaskMaxWriterCount(session);
                 if (isLocalScaledWriterExchange(source)) {
                     partitionedWriterCount = connectorScalingOptions.perTaskMaxScaledWriterCount()
-                            .map(writerCount -> min(writerCount, getTaskPartitionedWriterCount(session)))
-                            .orElse(getTaskPartitionedWriterCount(session));
+                            .map(writerCount -> min(writerCount, getTaskMaxWriterCount(session)))
+                            .orElse(getTaskMaxWriterCount(session));
                 }
                 return getPartitionedWriterCountBasedOnMemory(partitionedWriterCount, session);
             }
 
-            int unpartitionedWriterCount = getTaskWriterCount(session);
+            int unpartitionedWriterCount = getTaskMinWriterCount(session);
             if (isLocalScaledWriterExchange(source)) {
                 unpartitionedWriterCount = connectorScalingOptions.perTaskMaxScaledWriterCount()
-                        .map(writerCount -> min(writerCount, getTaskScaleWritersMaxWriterCount(session)))
-                        .orElse(getTaskScaleWritersMaxWriterCount(session));
+                        .map(writerCount -> min(writerCount, getTaskMaxWriterCount(session)))
+                        .orElse(getTaskMaxWriterCount(session));
             }
             // Consider memory while calculating writer count.
             return min(unpartitionedWriterCount, getMaxWritersBasedOnMemory(session));
@@ -3542,8 +3541,8 @@ public class LocalExecutionPlanner
         {
             // Todo: Implement writer scaling for merge. https://github.com/trinodb/trino/issues/14622
             int writerCount = node.getPartitioningScheme()
-                    .map(scheme -> getTaskPartitionedWriterCount(session))
-                    .orElseGet(() -> getTaskWriterCount(session));
+                    .map(scheme -> getTaskMaxWriterCount(session))
+                    .orElseGet(() -> getTaskMinWriterCount(session));
             context.setDriverInstanceCount(writerCount);
 
             PhysicalOperation source = node.getSource().accept(this, context);
@@ -4109,7 +4108,7 @@ public class LocalExecutionPlanner
 
     private int getPartitionedWriterCountBasedOnMemory(Session session)
     {
-        return getPartitionedWriterCountBasedOnMemory(getTaskPartitionedWriterCount(session), session);
+        return getPartitionedWriterCountBasedOnMemory(getTaskMaxWriterCount(session), session);
     }
 
     private int getPartitionedWriterCountBasedOnMemory(int partitionedWriterCount, Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -82,8 +82,8 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.getTaskConcurrency;
-import static io.trino.SystemSessionProperties.getTaskPartitionedWriterCount;
-import static io.trino.SystemSessionProperties.getTaskWriterCount;
+import static io.trino.SystemSessionProperties.getTaskMaxWriterCount;
+import static io.trino.SystemSessionProperties.getTaskMinWriterCount;
 import static io.trino.SystemSessionProperties.isDistributedSortEnabled;
 import static io.trino.SystemSessionProperties.isSpillEnabled;
 import static io.trino.SystemSessionProperties.isTaskScaleWritersEnabled;
@@ -746,7 +746,7 @@ public class AddLocalExchanges
                 return rebaseAndDeriveProperties(node, ImmutableList.of(exchange));
             }
 
-            if (getTaskWriterCount(session) == 1) {
+            if (getTaskMinWriterCount(session) == 1) {
                 return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
             }
 
@@ -755,7 +755,7 @@ public class AddLocalExchanges
 
         private PlanWithProperties visitPartitionedWriter(PlanNode node, PartitioningScheme partitioningScheme, PlanNode source, StreamPreferredProperties parentPreferences)
         {
-            if (getTaskPartitionedWriterCount(session) == 1) {
+            if (getTaskMaxWriterCount(session) == 1) {
                 return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
             }
 
@@ -784,7 +784,7 @@ public class AddLocalExchanges
 
         private PlanWithProperties visitScalePartitionedWriter(PlanNode node, PartitioningScheme partitioningScheme, PlanNode source)
         {
-            if (getTaskPartitionedWriterCount(session) == 1) {
+            if (getTaskMaxWriterCount(session) == 1) {
                 return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
             }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -34,8 +34,7 @@ import static java.lang.Math.min;
 public class TestTaskManagerConfig
 {
     private static final int DEFAULT_PROCESSOR_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount()), 2), 32);
-    private static final int DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT = min(getAvailablePhysicalProcessorCount() * 2, 64);
-    private static final int DEFAULT_PARTITIONED_WRITER_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount() * 2), 2), 64);
+    private static final int DEFAULT_MAX_WRITER_COUNT = min(max(nextPowerOfTwo(getAvailablePhysicalProcessorCount() * 2), 2), 64);
 
     @Test
     public void testDefaults()
@@ -65,9 +64,8 @@ public class TestTaskManagerConfig
                 .setMaxPagePartitioningBufferSize(DataSize.of(32, Unit.MEGABYTE))
                 .setPagePartitioningBufferPoolSize(8)
                 .setScaleWritersEnabled(true)
-                .setScaleWritersMaxWriterCount(DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT)
-                .setWriterCount(1)
-                .setPartitionedWriterCount(DEFAULT_PARTITIONED_WRITER_COUNT)
+                .setMinWriterCount(1)
+                .setMaxWriterCount(DEFAULT_MAX_WRITER_COUNT)
                 .setTaskConcurrency(DEFAULT_PROCESSOR_COUNT)
                 .setHttpResponseThreads(100)
                 .setHttpTimeoutThreads(3)
@@ -85,8 +83,7 @@ public class TestTaskManagerConfig
     public void testExplicitPropertyMappings()
     {
         int processorCount = DEFAULT_PROCESSOR_COUNT == 32 ? 16 : 32;
-        int scaleWritersMaxWriterCount = DEFAULT_SCALE_WRITERS_MAX_WRITER_COUNT == 32 ? 16 : 32;
-        int partitionedWriterCount = DEFAULT_PARTITIONED_WRITER_COUNT == 32 ? 16 : 32;
+        int maxWriterCount = DEFAULT_MAX_WRITER_COUNT == 32 ? 16 : 32;
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("experimental.thread-per-driver-scheduler-enabled", "true")
                 .put("task.initial-splits-per-node", "1")
@@ -112,9 +109,8 @@ public class TestTaskManagerConfig
                 .put("driver.max-page-partitioning-buffer-size", "40MB")
                 .put("driver.page-partitioning-buffer-pool-size", "0")
                 .put("task.scale-writers.enabled", "false")
-                .put("task.scale-writers.max-writer-count", Integer.toString(scaleWritersMaxWriterCount))
-                .put("task.writer-count", "4")
-                .put("task.partitioned-writer-count", Integer.toString(partitionedWriterCount))
+                .put("task.min-writer-count", "4")
+                .put("task.max-writer-count", Integer.toString(maxWriterCount))
                 .put("task.concurrency", Integer.toString(processorCount))
                 .put("task.http-response-threads", "4")
                 .put("task.http-timeout-threads", "10")
@@ -153,9 +149,8 @@ public class TestTaskManagerConfig
                 .setMaxPagePartitioningBufferSize(DataSize.of(40, Unit.MEGABYTE))
                 .setPagePartitioningBufferPoolSize(0)
                 .setScaleWritersEnabled(false)
-                .setScaleWritersMaxWriterCount(scaleWritersMaxWriterCount)
-                .setWriterCount(4)
-                .setPartitionedWriterCount(partitionedWriterCount)
+                .setMinWriterCount(4)
+                .setMaxWriterCount(maxWriterCount)
                 .setTaskConcurrency(processorCount)
                 .setHttpResponseThreads(4)
                 .setHttpTimeoutThreads(10)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestInsert.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestInsert.java
@@ -37,9 +37,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.SCALE_WRITERS;
-import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MIN_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
-import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.USE_PREFERRED_WRITE_PARTITIONING;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
@@ -255,8 +255,8 @@ public class TestInsert
                 .setSystemProperty(USE_PREFERRED_WRITE_PARTITIONING, "true")
                 .setSystemProperty(SCALE_WRITERS, "false")
                 .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "false")
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "16")
-                .setSystemProperty(TASK_WRITER_COUNT, "16")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "16")
+                .setSystemProperty(TASK_MIN_WRITER_COUNT, "16")
                 .build();
     }
 
@@ -265,8 +265,8 @@ public class TestInsert
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setSystemProperty(USE_PREFERRED_WRITE_PARTITIONING, "false")
                 .setSystemProperty(TASK_SCALE_WRITERS_ENABLED, "false")
-                .setSystemProperty(TASK_WRITER_COUNT, "16")
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "2") // force parallel plan even on test nodes with single CPU
+                .setSystemProperty(TASK_MIN_WRITER_COUNT, "16")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "2") // force parallel plan even on test nodes with single CPU
                 .build();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForPartitionedInsertAndMerge.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestAddLocalExchangesForPartitionedInsertAndMerge.java
@@ -35,9 +35,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.SCALE_WRITERS;
-import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MIN_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_ENABLED;
-import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
@@ -121,8 +121,8 @@ public class TestAddLocalExchangesForPartitionedInsertAndMerge
         assertDistributedPlan(
                 query,
                 Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
-                        .setSystemProperty(TASK_WRITER_COUNT, "8")
+                        .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
+                        .setSystemProperty(TASK_MIN_WRITER_COUNT, "8")
                         .build(),
                 anyTree(
                         mergeWriter(
@@ -134,8 +134,8 @@ public class TestAddLocalExchangesForPartitionedInsertAndMerge
         assertDistributedPlan(
                 query,
                 Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "4")
-                        .setSystemProperty(TASK_WRITER_COUNT, "1")
+                        .setSystemProperty(TASK_MAX_WRITER_COUNT, "4")
+                        .setSystemProperty(TASK_MIN_WRITER_COUNT, "1")
                         .build(),
                 anyTree(
                         mergeWriter(
@@ -153,8 +153,8 @@ public class TestAddLocalExchangesForPartitionedInsertAndMerge
         assertDistributedPlan(
                 query,
                 Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
-                        .setSystemProperty(TASK_WRITER_COUNT, "8")
+                        .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
+                        .setSystemProperty(TASK_MIN_WRITER_COUNT, "8")
                         .build(),
                 anyTree(
                         tableWriter(
@@ -167,8 +167,8 @@ public class TestAddLocalExchangesForPartitionedInsertAndMerge
         assertDistributedPlan(
                 query,
                 Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "4")
-                        .setSystemProperty(TASK_WRITER_COUNT, "1")
+                        .setSystemProperty(TASK_MAX_WRITER_COUNT, "4")
+                        .setSystemProperty(TASK_MIN_WRITER_COUNT, "1")
                         .build(),
                 anyTree(
                         tableWriter(

--- a/docs/src/main/sphinx/admin/properties-task.md
+++ b/docs/src/main/sphinx/admin/properties-task.md
@@ -104,15 +104,24 @@ the task has remaining splits to process.
 
 - **Description:** see details at {ref}`prop-task-scale-writers`
 
+## `task.writer-count`
+
+Deprecated and replaced by {ref}`prop-task-min-writer-count`.
+
+## `task.partitioned-writer-count`
+
+Deprecated and replaced by {ref}`prop-task-max-writer-count`.
+
 ## `task.scale-writers.max-writer-count`
 
-- **Description:** see details at {ref}`prop-task-scale-writers-max-writer-count`
+Deprecated and replaced by {ref}`prop-task-max-writer-count`.
 
-## `task.writer-count`
+(prop-task-min-writer-count)=
+## `task.min-writer-count`
 
 - **Type:** {ref}`prop-type-integer`
 - **Default value:** `1`
-- **Session property:** `task_writer_count`
+- **Session property:** `task_min_writer_count`
 
 The number of concurrent writer threads per worker per query when
 {ref}`preferred partitioning <preferred-write-partitioning>` and
@@ -127,14 +136,16 @@ utilization. Especially when the engine is inserting into a partitioned table wi
 could write to all partitions. This can lead to out of memory error since writing to a partition
 allocates a certain amount of memory for buffering.
 
-## `task.partitioned-writer-count`
+(prop-task-max-writer-count)=
+## `task.max-writer-count`
 
 - **Type:** {ref}`prop-type-integer`
 - **Restrictions:** Must be a power of two
 - **Default value:** The number of physical CPUs of the node, with a minimum value of 2 and a maximum of 64
-- **Session property:** `task_partitioned_writer_count`
+- **Session property:** `task_max_writer_count`
 
-The number of concurrent writer threads per worker per query when
+The number of concurrent writer threads per worker per query when either
+{ref}`task writer scaling <prop-task-scale-writers>` or
 {ref}`preferred partitioning <preferred-write-partitioning>` is used. Increasing this value may
 increase write speed, especially when a query is not I/O bound and can take advantage of additional
 CPU for parallel writes. Some connectors can be bottlenecked on CPU when writing due to compression

--- a/docs/src/main/sphinx/admin/properties-writer-scaling.md
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.md
@@ -34,18 +34,9 @@ writers are added only when the average amount of uncompressed data processed pe
 is above the minimum threshold of `writer-scaling-min-data-processed` and query is bottlenecked on
 writing.
 
-(prop-task-scale-writers-max-writer-count)=
-
 ## `task.scale-writers.max-writer-count`
 
-- **Type:** {ref}`prop-type-integer`
-- **Default value:** The number of physical CPUs of the node with a maximum of 64
-
-Maximum number of concurrent writers per task up to which the task can be scaled
-when `task.scale-writers.enabled` is set. Increasing this value may improve the
-performance of writes when the query is bottlenecked on writing. Setting this
-too high may cause the cluster to become overloaded due to excessive resource
-utilization.
+Deprecated and replaced by {ref}`prop-task-max-writer-count`.
 
 ## `writer-min-size`
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.SystemSessionProperties.TASK_SCALE_WRITERS_MAX_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
 import static java.util.Collections.synchronizedMap;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,7 +65,7 @@ public abstract class BaseJdbcConnectionCreationTest
         else {
             // Disabling writers scaling to make expected number of opened connections constant
             Session querySession = Session.builder(getSession())
-                    .setSystemProperty(TASK_SCALE_WRITERS_MAX_WRITER_COUNT, "4")
+                    .setSystemProperty(TASK_MAX_WRITER_COUNT, "4")
                     .build();
             getQueryRunner().execute(querySession, query);
         }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -270,9 +270,9 @@ public class TestDeltaLakeBasic
         assertUpdate("INSERT INTO " + tableName + " VALUES 10", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES 20", 1);
         assertUpdate("INSERT INTO " + tableName + " VALUES NULL", 1);
-        // For optimize we need to set task_writer_count to 1, otherwise it will create more than one file.
+        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
         assertUpdate(Session.builder(getQueryRunner().getDefaultSession())
-                        .setSystemProperty("task_writer_count", "1")
+                        .setSystemProperty("task_min_writer_count", "1")
                         .build(),
                 "ALTER TABLE " + tableName + " EXECUTE OPTIMIZE");
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -728,7 +728,7 @@ public class TestDeltaLakeConnectorTest
         @Language("SQL") String createTableSql = format("CREATE TABLE %s AS SELECT * FROM tpch.sf1.lineitem LIMIT 100000", tableName);
 
         Session session = Session.builder(getSession())
-                .setSystemProperty("task_writer_count", "1")
+                .setSystemProperty("task_min_writer_count", "1")
                 // task scale writers should be disabled since we want to write with a single task writer
                 .setSystemProperty("task_scale_writers_enabled", "false")
                 .build();
@@ -739,7 +739,7 @@ public class TestDeltaLakeConnectorTest
 
         DataSize maxSize = DataSize.of(40, DataSize.Unit.KILOBYTE);
         session = Session.builder(getSession())
-                .setSystemProperty("task_writer_count", "1")
+                .setSystemProperty("task_min_writer_count", "1")
                 // task scale writers should be disabled since we want to write with a single task writer
                 .setSystemProperty("task_scale_writers_enabled", "false")
                 .setCatalogSessionProperty("delta", "target_max_file_size", maxSize.toString())

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePreferredPartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePreferredPartitioning.java
@@ -22,7 +22,7 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.containers.Minio;
 import org.testng.annotations.Test;
 
-import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
 import static io.trino.SystemSessionProperties.USE_PREFERRED_WRITE_PARTITIONING;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
@@ -163,7 +163,7 @@ public class TestDeltaLakePreferredPartitioning
                 // It is important to explicitly set partitioned writer count to 1 since in above tests we are testing
                 // the open writers limit for partitions. So, with default value of 32 writer count, we will never
                 // hit that limit thus, tests will fail.
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
                 .build();
     }
 
@@ -174,7 +174,7 @@ public class TestDeltaLakePreferredPartitioning
                 // It is important to explicitly set partitioned writer count to 1 since in above tests we are testing
                 // the open writers limit for partitions. So, with default value of 32 writer count, we will never
                 // hit that limit thus, tests will fail.
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
                 .build();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -46,8 +46,8 @@ import java.util.Optional;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.SystemSessionProperties.MAX_DRIVERS_PER_TASK;
 import static io.trino.SystemSessionProperties.TASK_CONCURRENCY;
-import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
-import static io.trino.SystemSessionProperties.TASK_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MIN_WRITER_COUNT;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.plugin.iceberg.DataFileRecord.toDataFileRecord;
@@ -71,8 +71,8 @@ public class TestIcebergOrcMetricsCollection
                 .setCatalog("iceberg")
                 .setSchema("test_schema")
                 .setSystemProperty(TASK_CONCURRENCY, "1")
-                .setSystemProperty(TASK_WRITER_COUNT, "1")
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
+                .setSystemProperty(TASK_MIN_WRITER_COUNT, "1")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
                 .setSystemProperty(MAX_DRIVERS_PER_TASK, "1")
                 .setCatalogSessionProperty("iceberg", "orc_string_statistics_limit", Integer.MAX_VALUE + "B")
                 .build();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
-import static io.trino.SystemSessionProperties.TASK_PARTITIONED_WRITER_COUNT;
+import static io.trino.SystemSessionProperties.TASK_MAX_WRITER_COUNT;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
@@ -57,7 +57,7 @@ public class TestMetadataQueryOptimization
                 .setCatalog(ICEBERG_CATALOG)
                 .setSchema(SCHEMA_NAME)
                 // optimize_metadata_queries doesn't work when files are written by different writers
-                .setSystemProperty(TASK_PARTITIONED_WRITER_COUNT, "1")
+                .setSystemProperty(TASK_MAX_WRITER_COUNT, "1")
                 .build();
 
         try {

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFaultTolerantExecutionTest.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/BaseFaultTolerantExecutionTest.java
@@ -101,8 +101,8 @@ public abstract class BaseFaultTolerantExecutionTest
     {
         return Session.builder(session)
                 // one writer per partition per task
-                .setSystemProperty("task_writer_count", "1")
-                .setSystemProperty("task_partitioned_writer_count", "1")
+                .setSystemProperty("task_min_writer_count", "1")
+                .setSystemProperty("task_max_writer_count", "1")
                 .setSystemProperty("task_scale_writers_enabled", "false")
                 .build();
     }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-master-config.properties
@@ -8,7 +8,7 @@ http-server.http.port=8080
 query.max-memory=1GB
 discovery.uri=http://presto-master:8080
 
-# Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
-task.writer-count=2
+# Use task.min-writer-count > 1, as this allows to expose writer-concurrency related bugs.
+task.min-writer-count=2
 task.concurrency=2
-task.partitioned-writer-count=2
+task.max-writer-count=2

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard-multinode/multinode-worker-config.properties
@@ -8,7 +8,7 @@ query.max-memory=1GB
 query.max-memory-per-node=1GB
 discovery.uri=http://presto-master:8080
 
-# Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
-task.writer-count=2
+# Use task.min-writer-count > 1, as this allows to expose writer-concurrency related bugs.
+task.min-writer-count=2
 task.concurrency=2
-task.partitioned-writer-count=2
+task.max-writer-count=2

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/config.properties
@@ -9,7 +9,7 @@ query.max-memory=2GB
 query.max-memory-per-node=1.25GB
 discovery.uri=http://presto-master:8080
 
-# Use task.writer-count > 1, as this allows to expose writer-concurrency related bugs.
-task.writer-count=2
+# Use task.min-writer-count > 1, as this allows to expose writer-concurrency related bugs.
+task.min-writer-count=2
 task.concurrency=2
-task.partitioned-writer-count=2
+task.max-writer-count=2

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -781,7 +781,7 @@ public class TestHiveStorageFormats
                 ImmutableMap.of(
                         "hive.parquet_writer_page_size", reducedRowGroupSize.toBytesValueString(),
                         "task_scale_writers_enabled", "false",
-                        "task_writer_count", "1")));
+                        "task_min_writer_count", "1")));
     }
 
     @Test(groups = STORAGE_FORMATS_DETAILED)
@@ -1005,7 +1005,7 @@ public class TestHiveStorageFormats
     {
         try {
             // create more than one split
-            setSessionProperty(connection, "task_writer_count", "4");
+            setSessionProperty(connection, "task_min_writer_count", "4");
             setSessionProperty(connection, "task_scale_writers_enabled", "false");
             setSessionProperty(connection, "redistribute_writes", "false");
             for (Map.Entry<String, String> sessionProperty : sessionProperties.entrySet()) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -1904,7 +1904,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery("SET SESSION scale_writers = true");
             onTrino().executeQuery("SET SESSION writer_scaling_min_data_processed = '4kB'");
             onTrino().executeQuery("SET SESSION task_scale_writers_enabled = false");
-            onTrino().executeQuery("SET SESSION task_writer_count = 2");
+            onTrino().executeQuery("SET SESSION task_min_writer_count = 2");
             onTrino().executeQuery(format(
                     "CREATE TABLE %s WITH (transactional = true) AS SELECT * FROM tpch.sf1000.orders LIMIT 100000", tableName));
 
@@ -1925,7 +1925,7 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery("SET SESSION scale_writers = true");
             onTrino().executeQuery("SET SESSION writer_scaling_min_data_processed = '4kB'");
             onTrino().executeQuery("SET SESSION task_scale_writers_enabled = false");
-            onTrino().executeQuery("SET SESSION task_writer_count = 2");
+            onTrino().executeQuery("SET SESSION task_min_writer_count = 2");
             onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true) AS SELECT * FROM tpch.sf1000.orders LIMIT 100000", tableName));
 
             verify(onTrino().executeQuery(format("SELECT DISTINCT \"$path\" FROM %s", tableName)).getRowsCount() >= 2,
@@ -1991,8 +1991,8 @@ public class TestHiveTransactionalTable
             onTrino().executeQuery("SET SESSION scale_writers = true");
             onTrino().executeQuery("SET SESSION writer_scaling_min_data_processed = '4kB'");
             onTrino().executeQuery("SET SESSION task_scale_writers_enabled = false");
-            onTrino().executeQuery("SET SESSION task_writer_count = 4");
-            onTrino().executeQuery("SET SESSION task_partitioned_writer_count = 4");
+            onTrino().executeQuery("SET SESSION task_min_writer_count = 4");
+            onTrino().executeQuery("SET SESSION task_max_writer_count = 4");
             onTrino().executeQuery("SET SESSION hive.target_max_file_size = '1MB'");
 
             onTrino().executeQuery(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergOptimize.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergOptimize.java
@@ -75,8 +75,8 @@ public class TestIcebergOptimize
         // TODO Drop Spark dependency once that the setting 'read.split.target-size' can be set through Trino
         onSpark().executeQuery("ALTER TABLE " + sparkTableName + " SET TBLPROPERTIES ('read.split.target-size'='100')");
 
-        // For optimize we need to set task_writer_count to 1, otherwise it will create more than one file.
-        onTrino().executeQuery("SET SESSION task_writer_count = 1");
+        // For optimize we need to set task_min_writer_count to 1, otherwise it will create more than one file.
+        onTrino().executeQuery("SET SESSION task_min_writer_count = 1");
         onTrino().executeQuery("ALTER TABLE " + trinoTableName + " EXECUTE OPTIMIZE");
 
         List<String> updatedFiles = getActiveFiles(TRINO_CATALOG, TEST_SCHEMA_NAME, baseTableName);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Now, we have only two properties

task.min-writer-count:
Minimum number of local parallel table
writers per task when prefer partitioning and
task writer scaling are not used.

task.max-writer-count:
Maximum number of local parallel table writers
per task when either task writer scaling or prefer
partitioning is used.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
