### PR TITLE
[WIP] Corrected hash table length for distinct map keys

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
@@ -66,7 +66,7 @@ public class DistinctMapKeys
             if (keyBlock.isNull(i)) {
                 continue;
             }
-            int hash = getHashPosition(keyBlock, i, hashTableSize);
+            int hash = getHashPosition(keyBlock, i, hashTable.length);
             while (true) {
                 if (hashTable[hashTableOffset + hash] == -1) {
                     hashTable[hashTableOffset + hash] = i;
@@ -104,7 +104,7 @@ public class DistinctMapKeys
                 }
 
                 hash++;
-                if (hash == hashTableSize) {
+                if (hash == hashTable.length) {
                     hash = 0;
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Corrected hashtable size. Earlier it was using older value.
Fixes the issue [19142](https://github.com/trinodb/trino/issues/19142)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`19142`)
```
