### PR TITLE
Avoid exponential DFA in LIKE matcher

### DIFF
--- a/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/LikeMatcher.java
@@ -116,15 +116,24 @@ public class LikeMatcher
         Optional<Matcher> matcher = Optional.empty();
         if (patternStart <= patternEnd) {
             boolean hasAny = false;
+            boolean hasAnyAfterZeroOrMore = false;
+            boolean foundZeroOrMore = false;
             for (int i = patternStart; i <= patternEnd; i++) {
-                if (parsed.get(i) instanceof Any) {
+                Pattern item = parsed.get(i);
+                if (item instanceof Any) {
+                    if (foundZeroOrMore) {
+                        hasAnyAfterZeroOrMore = true;
+                    }
                     hasAny = true;
                     break;
+                }
+                else if (item instanceof Pattern.ZeroOrMore) {
+                    foundZeroOrMore = true;
                 }
             }
 
             if (hasAny) {
-                if (optimize) {
+                if (optimize && !hasAnyAfterZeroOrMore) {
                     matcher = Optional.of(new DenseDfaMatcher(parsed, patternStart, patternEnd, exact));
                 }
                 else {

--- a/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
@@ -16,6 +16,7 @@ package io.trino.likematcher;
 import com.google.common.base.Strings;
 import io.trino.type.LikePattern;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -108,6 +109,13 @@ public class TestLikeMatcher
             assertTrue(multipleOptimized.match(value.getBytes(StandardCharsets.UTF_8)));
             assertTrue(multiple.match(value.getBytes(StandardCharsets.UTF_8)));
         }
+    }
+
+    @Test
+    @Timeout(2)
+    public void testExponentialBehavior()
+    {
+        assertTrue(match("%a________________", "xyza1234567890123456"));
     }
 
     @Test


### PR DESCRIPTION
When a pattern contains a % and a sequence of _ somewhere after it, it may produce a DFA with exponential number of states. In such cases, fall back to the NFA matcher.

Fixes #19146 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* TBD. ({issue}`19146`)
```
