### PR TITLE
Corrected hash table length for distinct map keys

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
@@ -60,7 +60,6 @@ public class DistinctMapKeys
         int[] hashTable = hashTableBuffer;
         Arrays.fill(hashTable, -1);
 
-        int hashTableOffset = 0;
         for (int i = 0; i < keyCount; i++) {
             // Nulls are not marked as distinct and thus are ignored
             if (keyBlock.isNull(i)) {
@@ -68,8 +67,8 @@ public class DistinctMapKeys
             }
             int hash = getHashPosition(keyBlock, i, hashTableSize);
             while (true) {
-                if (hashTable[hashTableOffset + hash] == -1) {
-                    hashTable[hashTableOffset + hash] = i;
+                if (hashTable[hash] == -1) {
+                    hashTable[hash] = i;
                     distinct[i] = true;
                     break;
                 }
@@ -77,7 +76,7 @@ public class DistinctMapKeys
                 Boolean isDuplicateKey;
                 try {
                     // assuming maps with indeterminate keys are not supported
-                    isDuplicateKey = (Boolean) mapType.getKeyBlockEqual().invokeExact(keyBlock, i, keyBlock, hashTable[hashTableOffset + hash]);
+                    isDuplicateKey = (Boolean) mapType.getKeyBlockEqual().invokeExact(keyBlock, i, keyBlock, hashTable[hash]);
                 }
                 catch (RuntimeException e) {
                     throw e;
@@ -94,10 +93,10 @@ public class DistinctMapKeys
                 // duplicate keys are ignored
                 if (isDuplicateKey) {
                     if (userLastEntry) {
-                        int duplicateIndex = hashTable[hashTableOffset + hash];
+                        int duplicateIndex = hashTable[hash];
                         distinct[duplicateIndex] = false;
 
-                        hashTable[hashTableOffset + hash] = i;
+                        hashTable[hash] = i;
                         distinct[i] = true;
                     }
                     break;

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/DistinctMapKeys.java
@@ -51,9 +51,11 @@ public class DistinctMapKeys
         int hashTableSize = keyCount * HASH_MULTIPLIER;
 
         if (distinctBuffer.length < keyCount) {
-            int bufferSize = calculateBufferSize(keyCount);
-            distinctBuffer = new boolean[bufferSize];
-            hashTableBuffer = new int[bufferSize];
+            distinctBuffer = new boolean[calculateBufferSize(keyCount)];
+        }
+
+        if (hashTableBuffer.length < hashTableSize) {
+            hashTableBuffer = new int[calculateBufferSize(hashTableSize)];
         }
         boolean[] distinct = distinctBuffer;
         Arrays.fill(distinct, false);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Corrected hashtable size. Earlier it was using older value.
Fixes the issue [19142](https://github.com/trinodb/trino/issues/19142)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`19142`)
```
