### PR TITLE
Allow re-using PostgreSQL container in tests

### DIFF
--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -93,7 +93,7 @@ public class TestPostgreSqlConnectorTest
     @BeforeClass
     public void setExtensions()
     {
-        onRemoteDatabase().execute("CREATE EXTENSION file_fdw");
+        onRemoteDatabase().execute("CREATE EXTENSION IF NOT EXISTS file_fdw");
     }
 
     @Override

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ManageTestResources.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ManageTestResources.java
@@ -41,6 +41,7 @@ import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.trino.testng.services.Listeners.reportListenerFailure;
 import static io.trino.testng.services.ManageTestResources.Stage.AFTER_CLASS;
 import static io.trino.testng.services.ManageTestResources.Stage.BEFORE_CLASS;
+import static java.lang.System.getenv;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -88,7 +89,10 @@ public class ManageTestResources
         if (System.getProperty("ManageTestResources.enabled") != null) {
             return Boolean.getBoolean("ManageTestResources.enabled");
         }
-        if (System.getenv("DISABLE_REPORT_RESOURCE_HUNGRY_TESTS_CHECK") != null) {
+        if (getenv("DISABLE_REPORT_RESOURCE_HUNGRY_TESTS_CHECK") != null) {
+            return false;
+        }
+        if (getenv("TESTCONTAINERS_REUSE_ENABLE") != null) {
             return false;
         }
         return true;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Ability to iterate faster on integration test development for PostgreSQL by adding the support for TESTCONTAINERS_REUSE_ENABLE environment variable.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is based on previous commit 
https://github.com/trinodb/trino/commit/fbd1de01bba0c896e6e584f26d128452fdf35bc1
by @kokosing, which adds the feature and enables it for SQL Server and MySQL. Based on further comments from @kokosing, enablement of this feature for specific database tests needs to be tested one-by-one as not all test containers seem to digest that change without problems. This justifies adding it iteratively for selected databases based on a need-to-use basis.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
