### PR TITLE
Do not verify timeOfDayNanos

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTimestampUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTimestampUtils.java
@@ -20,11 +20,9 @@ import io.trino.spi.TrinoException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 
-import static com.google.common.base.Verify.verify;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
-import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_DAY;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_SECOND;
@@ -64,7 +62,6 @@ public final class ParquetTimestampUtils
 
     public static DecodedTimestamp decodeInt96Timestamp(long timeOfDayNanos, int julianDay)
     {
-        verify(timeOfDayNanos >= 0 && timeOfDayNanos < NANOSECONDS_PER_DAY, "Invalid timeOfDayNanos: %s", timeOfDayNanos);
         long epochSeconds = (julianDay - JULIAN_EPOCH_OFFSET_DAYS) * SECONDS_PER_DAY + timeOfDayNanos / NANOSECONDS_PER_SECOND;
         return new DecodedTimestamp(epochSeconds, (int) (timeOfDayNanos % NANOSECONDS_PER_SECOND));
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/DecodedTimestamp.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/type/DecodedTimestamp.java
@@ -13,15 +13,6 @@
  */
 package io.trino.plugin.base.type;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 public record DecodedTimestamp(long epochSeconds, int nanosOfSecond)
 {
-    private static final long NANOS_PER_SECOND = SECONDS.toNanos(1);
-
-    public DecodedTimestamp
-    {
-        checkArgument(nanosOfSecond >= 0 && nanosOfSecond < NANOS_PER_SECOND, "Invalid value for nanosOfSecond: %s", nanosOfSecond);
-    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

It appears that this validation check only exists in Trino, and other tools/engines (Spark, parquet-tools, etc.) simply add the `timeOfDayNanos` to the Julian day value regardless of whether it's in the range of nanoseconds within a day.

While there's an argument this is enforcing correct data, it seems that some parquet writing tools do make use of negative values for the time of day value. This check thus appears to be doing more harm than good in a lot of use cases.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
