### PR TITLE
Truncate class names in CompilerUtils

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
@@ -36,15 +36,33 @@ public final class CompilerUtils
 
     private static final AtomicLong CLASS_ID = new AtomicLong();
     private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+    private static final String PACKAGE_PREFIX = "io.trino.$gen.";
+    // Maximum symbol table entry allowed by the JVM class file format
+    private static final int MAX_SYMBOL_TABLE_ENTRY_LENGTH = 65535;
+    // Leave enough of a buffer between the maximum generated class name length and the symbol table limit
+    // so that method handles and other symbols that embed the class name can be encoded without failing
+    private static final int MAX_CLASS_NAME_LENGTH = MAX_SYMBOL_TABLE_ENTRY_LENGTH - 8192;
 
     private CompilerUtils() {}
 
     public static ParameterizedType makeClassName(String baseName, Optional<String> suffix)
     {
-        String className = baseName
-                + "_" + suffix.orElseGet(() -> Instant.now().atZone(UTC).format(TIMESTAMP_FORMAT))
-                + "_" + CLASS_ID.incrementAndGet();
-        return typeFromJavaClassName("io.trino.$gen." + toJavaIdentifierString(className));
+        String classNameSuffix = suffix.orElseGet(() -> Instant.now().atZone(UTC).format(TIMESTAMP_FORMAT));
+        String classUniqueId = String.valueOf(CLASS_ID.incrementAndGet());
+
+        int addedNameLength = PACKAGE_PREFIX.length() +
+                2 + // underscores
+                classNameSuffix.length() +
+                classUniqueId.length();
+
+        // truncate the baseName to ensure that we don't exceed the bytecode limit on class names, while also ensuring
+        // the class suffix and unique ID are fully preserved to avoid conflicts with other generated class names
+        if (baseName.length() + addedNameLength > MAX_CLASS_NAME_LENGTH) {
+            baseName = baseName.substring(0, MAX_CLASS_NAME_LENGTH - addedNameLength);
+        }
+
+        String className = baseName + "_" + classNameSuffix + "_" + classUniqueId;
+        return typeFromJavaClassName(PACKAGE_PREFIX + toJavaIdentifierString(className));
     }
 
     public static ParameterizedType makeClassName(String baseName)

--- a/core/trino-main/src/test/java/io/trino/type/TestSingleAccessMethodCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSingleAccessMethodCompiler.java
@@ -14,6 +14,7 @@
 package io.trino.type;
 
 import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ByteVector;
 
 import java.lang.invoke.MethodType;
 import java.util.function.LongFunction;
@@ -21,7 +22,9 @@ import java.util.function.LongUnaryOperator;
 
 import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.lang.invoke.MethodHandles.lookup;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestSingleAccessMethodCompiler
 {
@@ -39,6 +42,33 @@ public class TestSingleAccessMethodCompiler
     private static long increment(long x)
     {
         return x + 1;
+    }
+
+    @Test
+    public void testBasicWithClassNameTooLong()
+            throws ReflectiveOperationException
+    {
+        int symbolTableSizeLimit = 65535;
+        int overflowingNameLength = 65550;
+        StringBuilder builder = new StringBuilder(overflowingNameLength);
+        for (int i = 0; i < 1150; i++) {
+            builder.append("NameThatIsLongerThanTheAllowedSymbolTableUTF8ConstantSize");
+        }
+        String suggestedName = builder.toString();
+        assertEquals(suggestedName.length(), overflowingNameLength);
+
+        // Ensure that symbol table entries are still limited to 65535 bytes
+        assertThatThrownBy(() -> new ByteVector().putUTF8(suggestedName))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("UTF8 string too large");
+
+        // Class generation should succeed by truncating the class name
+        LongUnaryOperator addOne = compileSingleAccessMethod(
+                suggestedName,
+                LongUnaryOperator.class,
+                lookup().findStatic(TestSingleAccessMethodCompiler.class, "increment", MethodType.methodType(long.class, long.class)));
+        assertEquals(addOne.applyAsLong(1), 2L);
+        assertTrue(addOne.getClass().getName().length() < symbolTableSizeLimit, "class name should be truncated with extra room to spare");
     }
 
     @Test


### PR DESCRIPTION
## Description
Ensures that all class names generated by CompilerUtils are shorter than the `65535` byte length limit imposed on constant pool entries by the JVM language spec and by the asm library. This is done by truncating the provided base name while ensuring the suffixes that guarantee the class name is unique are preserved to avoid name collisions. This prevents code generation from failing when, for example particularly complex `ROW` types are used as part of the generated class name passed in.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
None


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

