### PR TITLE
Disable Jackson's read constraints 

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
@@ -13,12 +13,15 @@
  */
 package io.trino.client;
 
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
 import java.io.IOException;
@@ -33,18 +36,29 @@ import static java.util.Objects.requireNonNull;
 public class JsonCodec<T>
 {
     // copy of https://github.com/airlift/airlift/blob/master/json/src/main/java/io/airlift/json/ObjectMapperProvider.java
-    static final Supplier<ObjectMapper> OBJECT_MAPPER_SUPPLIER = () -> new ObjectMapper()
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .disable(MapperFeature.AUTO_DETECT_CREATORS)
-            .disable(MapperFeature.AUTO_DETECT_FIELDS)
-            .disable(MapperFeature.AUTO_DETECT_SETTERS)
-            .disable(MapperFeature.AUTO_DETECT_GETTERS)
-            .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
-            .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
-            .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
-            .disable(MapperFeature.INFER_PROPERTY_MUTATORS)
-            .disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS)
-            .registerModule(new Jdk8Module());
+    static final Supplier<ObjectMapper> OBJECT_MAPPER_SUPPLIER = () -> {
+        JsonFactory jsonFactory = JsonFactory.builder()
+                .streamReadConstraints(StreamReadConstraints.builder()
+                    .maxStringLength(Integer.MAX_VALUE)
+                    .maxNestingDepth(Integer.MAX_VALUE)
+                    .maxNumberLength(Integer.MAX_VALUE)
+                    .build())
+                .build();
+
+        return JsonMapper.builder(jsonFactory)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(MapperFeature.AUTO_DETECT_CREATORS)
+                .disable(MapperFeature.AUTO_DETECT_FIELDS)
+                .disable(MapperFeature.AUTO_DETECT_SETTERS)
+                .disable(MapperFeature.AUTO_DETECT_GETTERS)
+                .disable(MapperFeature.AUTO_DETECT_IS_GETTERS)
+                .disable(MapperFeature.USE_GETTERS_AS_SETTERS)
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .disable(MapperFeature.INFER_PROPERTY_MUTATORS)
+                .disable(MapperFeature.ALLOW_FINAL_FIELDS_AS_MUTATORS)
+                .addModule(new Jdk8Module())
+                .build();
+    };
 
     public static <T> JsonCodec<T> jsonCodec(Class<T> type)
     {

--- a/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
+++ b/client/trino-client/src/main/java/io/trino/client/JsonCodec.java
@@ -84,7 +84,7 @@ public class JsonCodec<T>
     }
 
     public T fromJson(InputStream inputStream)
-            throws IOException, JsonProcessingException
+            throws IOException
     {
         try (JsonParser parser = mapper.createParser(inputStream)) {
             T value = mapper.readerFor(javaType).readValue(parser);

--- a/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestQueryResults.java
@@ -13,53 +13,66 @@
  */
 package io.trino.client;
 
-import io.airlift.json.JsonCodec;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.google.common.base.Strings;
 import org.testng.annotations.Test;
 
-import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.client.JsonCodec.jsonCodec;
+import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 
 public class TestQueryResults
 {
     private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
 
+    private static final String GOLDEN_VALUE = "{\n" +
+            "  \"id\" : \"20160128_214710_00012_rk68b\",\n" +
+            "  \"infoUri\" : \"http://localhost:54855/query.html?20160128_214710_00012_rk68b\",\n" +
+            "  \"columns\" : [ {\n" +
+            "    \"name\" : \"_col0\",\n" +
+            "    \"type\" : \"bigint\",\n" +
+            "    \"typeSignature\" : {\n" +
+            "      \"rawType\" : \"varchar\",\n" +
+            "      \"typeArguments\" : [ ],\n" +
+            "      \"literalArguments\" : [ ],\n" +
+            "      \"arguments\" : [ ]\n" +
+            "    }\n" +
+            "  } ],\n" +
+            "  \"data\" : [ [ %s ] ],\n" +
+            "  \"stats\" : {\n" +
+            "    \"state\" : \"FINISHED\",\n" +
+            "    \"queued\" : false,\n" +
+            "    \"scheduled\" : false,\n" +
+            "    \"nodes\" : 0,\n" +
+            "    \"totalSplits\" : 0,\n" +
+            "    \"queuedSplits\" : 0,\n" +
+            "    \"runningSplits\" : 0,\n" +
+            "    \"completedSplits\" : 0,\n" +
+            "    \"cpuTimeMillis\" : 0,\n" +
+            "    \"wallTimeMillis\" : 0,\n" +
+            "    \"queuedTimeMillis\" : 0,\n" +
+            "    \"elapsedTimeMillis\" : 0,\n" +
+            "    \"processedRows\" : 0,\n" +
+            "    \"processedBytes\" : 0,\n" +
+            "    \"peakMemoryBytes\" : 0\n" +
+            "  }\n" +
+            "}";
+
     @Test
     public void testCompatibility()
+            throws JsonProcessingException
     {
-        String goldenValue = "{\n" +
-                "  \"id\" : \"20160128_214710_00012_rk68b\",\n" +
-                "  \"infoUri\" : \"http://localhost:54855/query.html?20160128_214710_00012_rk68b\",\n" +
-                "  \"columns\" : [ {\n" +
-                "    \"name\" : \"_col0\",\n" +
-                "    \"type\" : \"bigint\",\n" +
-                "    \"typeSignature\" : {\n" +
-                "      \"rawType\" : \"bigint\",\n" +
-                "      \"typeArguments\" : [ ],\n" +
-                "      \"literalArguments\" : [ ],\n" +
-                "      \"arguments\" : [ ]\n" +
-                "    }\n" +
-                "  } ],\n" +
-                "  \"data\" : [ [ 123 ] ],\n" +
-                "  \"stats\" : {\n" +
-                "    \"state\" : \"FINISHED\",\n" +
-                "    \"queued\" : false,\n" +
-                "    \"scheduled\" : false,\n" +
-                "    \"nodes\" : 0,\n" +
-                "    \"totalSplits\" : 0,\n" +
-                "    \"queuedSplits\" : 0,\n" +
-                "    \"runningSplits\" : 0,\n" +
-                "    \"completedSplits\" : 0,\n" +
-                "    \"cpuTimeMillis\" : 0,\n" +
-                "    \"wallTimeMillis\" : 0,\n" +
-                "    \"queuedTimeMillis\" : 0,\n" +
-                "    \"elapsedTimeMillis\" : 0,\n" +
-                "    \"processedRows\" : 0,\n" +
-                "    \"processedBytes\" : 0,\n" +
-                "    \"peakMemoryBytes\" : 0\n" +
-                "  }\n" +
-                "}";
+        QueryResults results = QUERY_RESULTS_CODEC.fromJson(format(GOLDEN_VALUE, "\"123\""));
+        assertEquals(results.getId(), "20160128_214710_00012_rk68b");
+    }
 
-        QueryResults results = QUERY_RESULTS_CODEC.fromJson(goldenValue);
+    @Test
+    public void testReadLongColumn()
+            throws JsonProcessingException
+    {
+        String longString = Strings.repeat("a", StreamReadConstraints.DEFAULT_MAX_STRING_LEN + 1);
+        QueryResults results = QUERY_RESULTS_CODEC.fromJson(format(GOLDEN_VALUE, '"' + longString + '"'));
         assertEquals(results.getId(), "20160128_214710_00012_rk68b");
     }
 }


### PR DESCRIPTION
Right now both JDBC and the CLI won't be able do deserialize columns longer than 20_000_000 bytes (20 MB) due to the read constraints introduced in Jackson that we use. We've disabled these read constraints on the server side, but not in the client.