### PR TITLE
Mark parse-decimal-literals-as-double as defunct

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -64,6 +64,7 @@ import static io.trino.sql.analyzer.RegexLibrary.JONI;
         "spill-window-operator",
         "experimental.spill-window-operator",
         "legacy.allow-set-view-authorization",
+        "parse-decimal-literals-as-double"
 })
 public class FeaturesConfig
 {


### PR DESCRIPTION
Followup to https://github.com/trinodb/trino/pull/19166 -- forgot to push this change to that branch before merging.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
