### PR TITLE
Add requirement for Blob Storage instead of ALDS for FTE

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -553,7 +553,9 @@ exchange.base-directories=s3://exchange-spooling-bucket-1,s3://exchange-spooling
 #### Azure Blob Storage
 
 The following example `exchange-manager.properties` configuration specifies an
-Azure Blob Storage container as the spooling storage destination.
+Azure Blob Storage container as the spooling storage destination. You must use
+Azure Blob Storage, not Azure Data Lake Storage or any other hierarchical
+storage option in Azure.
 
 ```properties
 exchange-manager.name=filesystem


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Azure Data Lake Storage Gen2 is hierarchical. When using FTE with ADLS Gen2, batch operation errors can occur when deleting folders during blob cleanup. While the data is deleted, the file path remains. Because ADLS is hierarchical, folders need explicit deletion. This PR adds a line to FTE configuration documentation to make it clear that Azure Blob Storage should be used instead of ADLS.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
