### PR TITLE
Update airbase to 146

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>144</version>
+        <version>146</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -151,8 +151,6 @@
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
 
-        <dep.slice.version>2.2</dep.slice.version>
-
         <dep.accumulo.version>1.10.2</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.13.0</dep.antlr.version>
@@ -179,16 +177,13 @@
         <dep.iceberg.version>1.3.1</dep.iceberg.version>
         <dep.protobuf.version>3.23.2</dep.protobuf.version>
         <dep.wire.version>4.5.0</dep.wire.version>
-        <dep.opentelemetry.version>1.30.1</dep.opentelemetry.version>
-        <dep.opentelemetry-instrumentation.version>1.30.0</dep.opentelemetry-instrumentation.version>
         <dep.netty.version>4.1.97.Final</dep.netty.version>
         <dep.jna.version>5.13.0</dep.jna.version>
         <dep.okio.version>3.3.0</dep.okio.version>
         <dep.flyway.version>9.22.2</dep.flyway.version>
         <dep.parquet.version>1.13.1</dep.parquet.version>
-        <dep.jmh.version>1.37</dep.jmh.version>
-        <dep.junit.version>5.10.0</dep.junit.version>
         <dep.antlr.version>4.13.1</dep.antlr.version>
+        <dep.logback.version>1.4.8</dep.logback.version>
 
         <dep.docker.images.version>86</dep.docker.images.version>
 


### PR DESCRIPTION
Some version of logback after 1.4.8 has a regression that's causing our tests to fail. I'm investigating which version exactly it is and I'll try to triage the offending commit. Until then, we should stick to the 1.4.8 which is known to work.