### PR TITLE
Fix broken resource reference in test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -858,7 +858,7 @@ public class TestFileBasedSystemAccessControl
     @Test
     public void parseUnknownRules()
     {
-        assertThatThrownBy(() -> parse("src/test/resources/security-config-file-with-unknown-rules.json"))
+        assertThatThrownBy(() -> parse(getResourcePath("security-config-file-with-unknown-rules.json")))
                 .hasMessageContaining("Failed to convert JSON tree node");
     }
 


### PR DESCRIPTION
The resource can't be loaded with a path reference, as the current working dir when running tests may vary across environments.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
