### PR TITLE
Add additional coercions for Hive

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -33,13 +33,17 @@ import io.trino.spi.block.ColumnarRow;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.RowType.Field;
+import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.VarcharType;
@@ -55,6 +59,7 @@ import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_SHORT;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDecimalCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToDoubleCoercer;
+import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToInteger;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToRealCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDecimalToVarcharCoercer;
 import static io.trino.plugin.hive.coercions.DecimalCoercers.createDoubleToDecimalCoercer;
@@ -142,6 +147,13 @@ public final class CoercionUtils
         }
         if (fromType instanceof DecimalType fromDecimalType && toType instanceof VarcharType toVarcharType) {
             return Optional.of(createDecimalToVarcharCoercer(fromDecimalType, toVarcharType));
+        }
+        if (fromType instanceof DecimalType fromDecimalType &&
+                (toType instanceof TinyintType ||
+                        toType instanceof SmallintType ||
+                        toType instanceof IntegerType ||
+                        toType instanceof BigintType)) {
+            return Optional.of(createDecimalToInteger(fromDecimalType, toType));
         }
         if (fromType == DOUBLE && toType instanceof DecimalType toDecimalType) {
             return Optional.of(createDoubleToDecimalCoercer(toDecimalType));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.coercions;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
 import io.trino.plugin.hive.type.Category;
@@ -33,6 +34,7 @@ import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RowBlock;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
+import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.MapType;
 import io.trino.spi.type.RowType;
@@ -104,6 +106,9 @@ public final class CoercionUtils
                 return Optional.of(new VarcharCoercer(fromVarcharType, toVarcharType));
             }
             return Optional.empty();
+        }
+        if (fromType instanceof VarcharType fromVarcharType && toType instanceof DateType toDateType) {
+            return Optional.of(new VarcharToDateCoercer(fromVarcharType, toDateType));
         }
         if (fromType instanceof CharType fromCharType && toType instanceof CharType toCharType) {
             if (narrowerThan(toCharType, fromCharType)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DateCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DateCoercer.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.VarcharType;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_TIMESTAMP_COERCION;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+
+public final class DateCoercer
+{
+    private static final long START_OF_MODERN_ERA_DAYS = java.time.LocalDate.of(1900, 1, 1).toEpochDay();
+
+    private DateCoercer() {}
+
+    public static class VarcharToDateCoercer
+            extends TypeCoercer<VarcharType, DateType>
+    {
+        public VarcharToDateCoercer(VarcharType fromType, DateType toType)
+        {
+            super(fromType, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            String value = fromType.getSlice(block, position).toStringUtf8();
+            try {
+                LocalDate localDate = ISO_LOCAL_DATE.parse(value, LocalDate::from);
+                if (localDate.toEpochDay() < START_OF_MODERN_ERA_DAYS) {
+                    throw new TrinoException(HIVE_INVALID_TIMESTAMP_COERCION, "Coercion on historical dates is not supported");
+                }
+                toType.writeLong(blockBuilder, localDate.toEpochDay());
+            }
+            catch (DateTimeParseException ignored) {
+                throw new IllegalArgumentException("Invalid date value: " + value + " is not a valid date");
+            }
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.hive.HiveType.HIVE_BYTE;
+import static io.trino.plugin.hive.HiveType.HIVE_DATE;
 import static io.trino.plugin.hive.HiveType.HIVE_DOUBLE;
 import static io.trino.plugin.hive.HiveType.HIVE_FLOAT;
 import static io.trino.plugin.hive.HiveType.HIVE_INT;
@@ -64,6 +65,7 @@ public final class HiveCoercionPolicy
                     toHiveType.equals(HIVE_SHORT) ||
                     toHiveType.equals(HIVE_INT) ||
                     toHiveType.equals(HIVE_LONG) ||
+                    toHiveType.equals(HIVE_DATE) ||
                     toHiveType.equals(HIVE_TIMESTAMP);
         }
         if (fromType instanceof CharType) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -96,7 +96,13 @@ public final class HiveCoercionPolicy
             return toHiveType.equals(HIVE_FLOAT) || toType instanceof DecimalType;
         }
         if (fromType instanceof DecimalType) {
-            return toType instanceof DecimalType || toHiveType.equals(HIVE_FLOAT) || toHiveType.equals(HIVE_DOUBLE);
+            return toType instanceof DecimalType ||
+                    toHiveType.equals(HIVE_FLOAT) ||
+                    toHiveType.equals(HIVE_DOUBLE) ||
+                    toHiveType.equals(HIVE_BYTE) ||
+                    toHiveType.equals(HIVE_SHORT) ||
+                    toHiveType.equals(HIVE_INT) ||
+                    toHiveType.equals(HIVE_LONG);
         }
 
         return canCoerceForList(fromHiveType, toHiveType, hiveTimestampPrecision)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDateCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDateCoercer.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.trino.plugin.hive.coercions.CoercionUtils.CoercionContext;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.Type;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
+import static io.trino.spi.predicate.Utils.blockToNativeValue;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestDateCoercer
+{
+    @Test(dataProvider = "validDateProvider")
+    public void testValidVarcharToDate(String date)
+    {
+        assertVarcharToDateCoercion(createUnboundedVarcharType(), date);
+    }
+
+    @DataProvider
+    public static Object[][] validDateProvider()
+    {
+        return new Object[][] {
+                {"+10000-04-13"},
+                {"1900-01-01"},
+                {"2000-01-01"},
+                {"2023-03-12"}};
+    }
+
+    @Test(dataProvider = "invalidDateProvider")
+    public void testThrowsExceptionWhenStringIsNotAValidDate(String date)
+    {
+        assertThatThrownBy(() -> assertVarcharToDateCoercion(createUnboundedVarcharType(), date, null))
+                .hasMessageMatching(".*Invalid date value.*is not a valid date.*");
+    }
+
+    @DataProvider
+    public static Object[][] invalidDateProvider()
+    {
+        return new Object[][] {
+                {"2023-01-40"}, // hive would return 2023-02-09
+                {"2023-15-13"}, // hive would return 2024-03-13
+                {"invalidDate"}}; // hive would return null
+    }
+
+    @Test
+    public void testThrowsExceptionWhenDateIsTooOld()
+    {
+        assertThatThrownBy(() -> assertVarcharToDateCoercion(createUnboundedVarcharType(), "1899-12-31", null))
+                .hasMessageMatching(".*Coercion on historical dates is not supported.*");
+    }
+
+    private void assertVarcharToDateCoercion(Type fromType, String date)
+    {
+        assertVarcharToDateCoercion(fromType, date, fromDateToEpochDate(date));
+    }
+
+    private void assertVarcharToDateCoercion(Type fromType, String date, Long expected)
+    {
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(DateType.DATE), new CoercionContext(NANOSECONDS, false)).orElseThrow()
+                .apply(nativeValueToBlock(fromType, utf8Slice(date)));
+        assertThat(blockToNativeValue(DateType.DATE, coercedValue))
+                .isEqualTo(expected);
+    }
+
+    private long fromDateToEpochDate(String dateString)
+    {
+        LocalDate date = LocalDate.parse(dateString);
+        return date.toEpochDay();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDecimalCoercers.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestDecimalCoercers.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.coercions;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.type.DecimalParseResult;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Type;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
+import static io.trino.spi.predicate.Utils.blockToNativeValue;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDecimalCoercers
+{
+    @Test(dataProvider = "dataProvider")
+    public void testDecimalToIntCoercion(String decimalString, Type coercedType, Object expectedValue)
+    {
+        DecimalParseResult parseResult = Decimals.parse(decimalString);
+
+        if (decimalString.length() > 19) {
+            assertThat(parseResult.getType().isShort()).isFalse();
+        }
+        else {
+            assertThat(parseResult.getType().isShort()).isTrue();
+        }
+        assertDecimalToIntCoercion(parseResult.getType(), parseResult.getObject(), coercedType, expectedValue);
+    }
+
+    @DataProvider
+    public static Object[][] dataProvider()
+    {
+        return new Object[][] {
+                {"12.120000000000000000", TINYINT, 12L},
+                {"-12.120000000000000000", TINYINT, -12L},
+                {"12.120", TINYINT, 12L},
+                {"-12.120", TINYINT, -12L},
+                {"141.120000000000000000", TINYINT, null},
+                {"-141.120", TINYINT, null},
+                {"130.120000000000000000", SMALLINT, 130L},
+                {"-130.120000000000000000", SMALLINT, -130L},
+                {"130.120", SMALLINT, 130L},
+                {"-130.120", SMALLINT, -130L},
+                {"66000.30120000000000000", SMALLINT, null},
+                {"-66000.120", SMALLINT, null},
+                {"33000.12000000000000000", INTEGER, 33000L},
+                {"-33000.12000000000000000", INTEGER, -33000L},
+                {"33000.120", INTEGER, 33000L},
+                {"-33000.120", INTEGER, -33000L},
+                {"3300000000.1200000000000", INTEGER, null},
+                {"3300000000.120", INTEGER, null},
+                {"3300000000.1200000000000", BIGINT, 3300000000L},
+                {"-3300000000.120000000000", BIGINT, -3300000000L},
+                {"3300000000.12", BIGINT, 3300000000L},
+                {"-3300000000.12", BIGINT, -3300000000L},
+                {"330000000000000000000.12000000000", BIGINT, null},
+                {"-330000000000000000000.12000000000", BIGINT, null},
+                {"3300000", INTEGER, 3300000L},
+        };
+    }
+
+    private void assertDecimalToIntCoercion(Type fromType, Object valueToBeCoerced, Type toType, Object expectedValue)
+    {
+        Block coercedValue = createCoercer(TESTING_TYPE_MANAGER, toHiveType(fromType), toHiveType(toType), new CoercionUtils.CoercionContext(NANOSECONDS, false)).orElseThrow()
+                .apply(nativeValueToBlock(fromType, valueToBeCoerced));
+        assertThat(blockToNativeValue(toType, coercedValue))
+                .isEqualTo(expectedValue);
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -69,6 +69,7 @@ import static java.sql.JDBCType.REAL;
 import static java.sql.JDBCType.SMALLINT;
 import static java.sql.JDBCType.STRUCT;
 import static java.sql.JDBCType.TIMESTAMP;
+import static java.sql.JDBCType.TINYINT;
 import static java.sql.JDBCType.VARCHAR;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
@@ -118,6 +119,16 @@ public abstract class BaseTestHiveCoercion
                 "double_to_decimal",
                 "decimal_to_float",
                 "decimal_to_double",
+                "longdecimal_to_tinyint",
+                "shortdecimal_to_tinyint",
+                "longdecimal_to_smallint",
+                "shortdecimal_to_smallint",
+                "too_big_shortdecimal_to_smallint",
+                "longdecimal_to_int",
+                "shortdecimal_to_int",
+                "shortdecimal_with_0_scale_to_int",
+                "longdecimal_to_bigint",
+                "shortdecimal_to_bigint",
                 "short_decimal_to_varchar",
                 "long_decimal_to_varchar",
                 "short_decimal_to_bounded_varchar",
@@ -180,6 +191,16 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '12345678.12', " +
                         "  DECIMAL '12345678.123456123456', " +
                         "  DECIMAL '12345678.123456123456', " +
+                        "  DECIMAL '13.1313', " +
+                        "  DECIMAL '11.99', " +
+                        "  DECIMAL '140.1323', " +
+                        "  DECIMAL '142.99', " +
+                        "  DECIMAL '312343.99', " +
+                        "  DECIMAL '312345.99', " +
+                        "  DECIMAL '312347.13433', " +
+                        "  DECIMAL '123', " +
+                        "  DECIMAL '123471234567.9989', " +
+                        "  DECIMAL '12345678.12', " +
                         "  %2$s '12345.12345', " +
                         "  DOUBLE '12345.12345', " +
                         "  DECIMAL '12345.12345', " +
@@ -220,6 +241,16 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '-12345678.12', " +
                         "  DECIMAL '-12345678.123456123456', " +
                         "  DECIMAL '-12345678.123456123456', " +
+                        "  DECIMAL '-12.1313', " +
+                        "  DECIMAL '-10.99', " +
+                        "  DECIMAL '-141.1323', " +
+                        "  DECIMAL '-143.99', " +
+                        "  DECIMAL '-312342.99', " +
+                        "  DECIMAL '-312346.99', " +
+                        "  DECIMAL '-312348.13433', " +
+                        "  DECIMAL '-124', " +
+                        "  DECIMAL '-123471234577.9989', " +
+                        "  DECIMAL '-12345678.12', " +
                         "  %2$s '-12345.12345', " +
                         "  DOUBLE '-12345.12345', " +
                         "  DECIMAL '-12345.12345', " +
@@ -367,6 +398,36 @@ public abstract class BaseTestHiveCoercion
                 .put("decimal_to_double", ImmutableList.of(
                         12345.12345,
                         -12345.12345))
+                .put("longdecimal_to_tinyint", ImmutableList.of(
+                        13,
+                        -12))
+                .put("shortdecimal_to_tinyint", ImmutableList.of(
+                        11,
+                        -10))
+                .put("longdecimal_to_smallint", ImmutableList.of(
+                        140,
+                        -141))
+                .put("shortdecimal_to_smallint", ImmutableList.of(
+                        142,
+                        -143))
+                .put("too_big_shortdecimal_to_smallint", Arrays.asList(
+                        null,
+                        null))
+                .put("longdecimal_to_int", ImmutableList.of(
+                        312345,
+                        -312346))
+                .put("shortdecimal_to_int", ImmutableList.of(
+                        312347,
+                        -312348))
+                .put("shortdecimal_with_0_scale_to_int", ImmutableList.of(
+                        123,
+                        -124))
+                .put("longdecimal_to_bigint", ImmutableList.of(
+                        123471234567L,
+                        -123471234577L))
+                .put("shortdecimal_to_bigint", ImmutableList.of(
+                        12345678,
+                        -12345678))
                 .put("short_decimal_to_varchar", ImmutableList.of(
                         "12345.12345",
                         "-12345.12345"))
@@ -789,6 +850,16 @@ public abstract class BaseTestHiveCoercion
                 row("shortdecimal_to_longdecimal", "decimal(20,4)"),
                 row("longdecimal_to_shortdecimal", "decimal(12,2)"),
                 row("longdecimal_to_longdecimal", "decimal(38,14)"),
+                row("longdecimal_to_tinyint", "tinyint"),
+                row("shortdecimal_to_tinyint", "tinyint"),
+                row("longdecimal_to_smallint", "smallint"),
+                row("shortdecimal_to_smallint", "smallint"),
+                row("too_big_shortdecimal_to_smallint", "smallint"),
+                row("longdecimal_to_int", "integer"),
+                row("shortdecimal_to_int", "integer"),
+                row("shortdecimal_with_0_scale_to_int", "integer"),
+                row("longdecimal_to_bigint", "bigint"),
+                row("shortdecimal_to_bigint", "bigint"),
                 row("float_to_decimal", "decimal(10,5)"),
                 row("double_to_decimal", "decimal(10,5)"),
                 row("decimal_to_float", floatType),
@@ -845,6 +916,16 @@ public abstract class BaseTestHiveCoercion
                 .put("shortdecimal_to_longdecimal", DECIMAL)
                 .put("longdecimal_to_shortdecimal", DECIMAL)
                 .put("longdecimal_to_longdecimal", DECIMAL)
+                .put("longdecimal_to_tinyint", TINYINT)
+                .put("shortdecimal_to_tinyint", TINYINT)
+                .put("longdecimal_to_smallint", SMALLINT)
+                .put("shortdecimal_to_smallint", SMALLINT)
+                .put("too_big_shortdecimal_to_smallint", SMALLINT)
+                .put("longdecimal_to_int", INTEGER)
+                .put("shortdecimal_to_int", INTEGER)
+                .put("shortdecimal_with_0_scale_to_int", INTEGER)
+                .put("longdecimal_to_bigint", BIGINT)
+                .put("shortdecimal_to_bigint", BIGINT)
                 .put("float_to_decimal", DECIMAL)
                 .put("double_to_decimal", DECIMAL)
                 .put("decimal_to_float", floatType)
@@ -900,6 +981,16 @@ public abstract class BaseTestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_to_longdecimal shortdecimal_to_longdecimal DECIMAL(20,4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_shortdecimal longdecimal_to_shortdecimal DECIMAL(12,2)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_longdecimal longdecimal_to_longdecimal DECIMAL(38,14)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_tinyint longdecimal_to_tinyint TINYINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_to_tinyint shortdecimal_to_tinyint TINYINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_smallint longdecimal_to_smallint SMALLINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_to_smallint shortdecimal_to_smallint SMALLINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN too_big_shortdecimal_to_smallint too_big_shortdecimal_to_smallint SMALLINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_int longdecimal_to_int INTEGER", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_to_int shortdecimal_to_int INTEGER", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_with_0_scale_to_int shortdecimal_with_0_scale_to_int INTEGER", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN longdecimal_to_bigint longdecimal_to_bigint BIGINT", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN shortdecimal_to_bigint shortdecimal_to_bigint BIGINT", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN float_to_decimal float_to_decimal DECIMAL(10,5)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN double_to_decimal double_to_decimal DECIMAL(10,5)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN decimal_to_float decimal_to_float %s", tableName, floatType));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -59,6 +59,7 @@ import static java.lang.String.format;
 import static java.sql.JDBCType.ARRAY;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.CHAR;
+import static java.sql.JDBCType.DATE;
 import static java.sql.JDBCType.DECIMAL;
 import static java.sql.JDBCType.DOUBLE;
 import static java.sql.JDBCType.FLOAT;
@@ -123,6 +124,8 @@ public abstract class BaseTestHiveCoercion
                 "long_decimal_to_bounded_varchar",
                 "varchar_to_bigger_varchar",
                 "varchar_to_smaller_varchar",
+                "varchar_to_date",
+                "varchar_to_distant_date",
                 "char_to_bigger_char",
                 "char_to_smaller_char",
                 "timestamp_to_string",
@@ -187,6 +190,8 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '12345678.123456123456', " +
                         "  'abc', " +
                         "  'abc', " +
+                        "  '2023-09-28', " +
+                        "  '8000-04-13', " +
                         "  'abc', " +
                         "  'abc', " +
                         "  TIMESTAMP '2121-07-15 15:30:12.123', " +
@@ -225,6 +230,8 @@ public abstract class BaseTestHiveCoercion
                         "  DECIMAL '-12345678.123456123456', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
+                        "  '2023-09-27', " +
+                        "  '1900-01-01', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  TIMESTAMP '1970-01-01 00:00:00.123', " +
@@ -378,6 +385,12 @@ public abstract class BaseTestHiveCoercion
                 .put("varchar_to_smaller_varchar", ImmutableList.of(
                         "ab",
                         "\uD83D\uDCB0\uD83D\uDCB0"))
+                .put("varchar_to_date", ImmutableList.of(
+                        java.sql.Date.valueOf("2023-09-28"),
+                        java.sql.Date.valueOf("2023-09-27")))
+                .put("varchar_to_distant_date", ImmutableList.of(
+                        java.sql.Date.valueOf("8000-04-13"),
+                        java.sql.Date.valueOf("1900-01-01")))
                 .put("char_to_bigger_char", ImmutableList.of(
                         "abc ",
                         "\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0 "))
@@ -786,6 +799,8 @@ public abstract class BaseTestHiveCoercion
                 row("long_decimal_to_bounded_varchar", "varchar(30)"),
                 row("varchar_to_bigger_varchar", "varchar(4)"),
                 row("varchar_to_smaller_varchar", "varchar(2)"),
+                row("varchar_to_date", "date"),
+                row("varchar_to_distant_date", "date"),
                 row("char_to_bigger_char", "char(4)"),
                 row("char_to_smaller_char", "char(2)"),
                 row("timestamp_to_string", "varchar"),
@@ -840,6 +855,8 @@ public abstract class BaseTestHiveCoercion
                 .put("long_decimal_to_bounded_varchar", VARCHAR)
                 .put("varchar_to_bigger_varchar", VARCHAR)
                 .put("varchar_to_smaller_varchar", VARCHAR)
+                .put("varchar_to_date", DATE)
+                .put("varchar_to_distant_date", DATE)
                 .put("char_to_bigger_char", CHAR)
                 .put("char_to_smaller_char", CHAR)
                 .put("id", BIGINT)
@@ -893,6 +910,8 @@ public abstract class BaseTestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN long_decimal_to_bounded_varchar long_decimal_to_bounded_varchar varchar(30)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_bigger_varchar varchar_to_bigger_varchar varchar(4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_smaller_varchar varchar_to_smaller_varchar varchar(2)", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_date varchar_to_date date", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_distant_date varchar_to_distant_date date", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_bigger_char char_to_bigger_char char(4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN char_to_smaller_char char_to_smaller_char char(2)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN timestamp_to_string timestamp_to_string string", tableName));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -129,6 +129,8 @@ public class TestHiveCoercionOnPartitionedTable
                         "    long_decimal_to_bounded_varchar    DECIMAL(20,12)," +
                         "    varchar_to_bigger_varchar          VARCHAR(3)," +
                         "    varchar_to_smaller_varchar         VARCHAR(3)," +
+                        "    varchar_to_date                    VARCHAR(10)," +
+                        "    varchar_to_distant_date            VARCHAR(12)," +
                         "    char_to_bigger_char                CHAR(3)," +
                         "    char_to_smaller_char               CHAR(3)," +
                         "    timestamp_to_string                TIMESTAMP," +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -119,6 +119,16 @@ public class TestHiveCoercionOnPartitionedTable
                         "    shortdecimal_to_longdecimal           DECIMAL(10,2)," +
                         "    longdecimal_to_shortdecimal           DECIMAL(20,12)," +
                         "    longdecimal_to_longdecimal            DECIMAL(20,12)," +
+                        "    longdecimal_to_tinyint                DECIMAL(20,12)," +
+                        "    shortdecimal_to_tinyint               DECIMAL(10,2)," +
+                        "    longdecimal_to_smallint               DECIMAL(20,12)," +
+                        "    shortdecimal_to_smallint              DECIMAL(10,2)," +
+                        "    too_big_shortdecimal_to_smallint      DECIMAL(10,2)," +
+                        "    longdecimal_to_int                    DECIMAL(20,12)," +
+                        "    shortdecimal_to_int                   DECIMAL(10,2)," +
+                        "    shortdecimal_with_0_scale_to_int      DECIMAL(10,0)," +
+                        "    longdecimal_to_bigint                 DECIMAL(20,4)," +
+                        "    shortdecimal_to_bigint                DECIMAL(10,2)," +
                         "    float_to_decimal           " + floatType + "," +
                         "    double_to_decimal          DOUBLE," +
                         "    decimal_to_float                   DECIMAL(10,5)," +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -78,6 +78,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                             long_decimal_to_bounded_varchar    DECIMAL(20,12),
                             varchar_to_bigger_varchar          VARCHAR(3),
                             varchar_to_smaller_varchar         VARCHAR(3),
+                            varchar_to_date                    VARCHAR(10),
+                            varchar_to_distant_date            VARCHAR(12),
                             char_to_bigger_char                CHAR(3),
                             char_to_smaller_char               CHAR(3),
                             timestamp_to_string                TIMESTAMP,

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -68,6 +68,16 @@ public class TestHiveCoercionOnUnpartitionedTable
                             shortdecimal_to_longdecimal        DECIMAL(10,2),
                             longdecimal_to_shortdecimal        DECIMAL(20,12),
                             longdecimal_to_longdecimal         DECIMAL(20,12),
+                            longdecimal_to_tinyint             DECIMAL(20,12),
+                            shortdecimal_to_tinyint            DECIMAL(10,2),
+                            longdecimal_to_smallint            DECIMAL(20,12),
+                            shortdecimal_to_smallint           DECIMAL(10,2),
+                            too_big_shortdecimal_to_smallint   DECIMAL(10,2),
+                            longdecimal_to_int                 DECIMAL(20,12),
+                            shortdecimal_to_int                DECIMAL(10,2),
+                            shortdecimal_with_0_scale_to_int   DECIMAL(10,0),
+                            longdecimal_to_bigint              DECIMAL(20,4),
+                            shortdecimal_to_bigint             DECIMAL(10,2),
                             float_to_decimal                   FLOAT,
                             double_to_decimal                  DOUBLE,
                             decimal_to_float                   DECIMAL(10,5),
@@ -153,6 +163,16 @@ public class TestHiveCoercionOnUnpartitionedTable
                 .put(columnContext("orc", "decimal_to_double"), "Cannot read SQL type 'double' from ORC stream '.decimal_to_double' of type DECIMAL")
                 .put(columnContext("orc", "short_decimal_to_varchar"), "Cannot read SQL type 'varchar' from ORC stream '.short_decimal_to_varchar' of type DECIMAL")
                 .put(columnContext("orc", "long_decimal_to_varchar"), "Cannot read SQL type 'varchar' from ORC stream '.long_decimal_to_varchar' of type DECIMAL")
+                .put(columnContext("orc", "longdecimal_to_tinyint"), "Cannot read SQL type 'tinyint' from ORC stream '.longdecimal_to_tinyint' of type DECIMAL")
+                .put(columnContext("orc", "shortdecimal_to_tinyint"), "Cannot read SQL type 'tinyint' from ORC stream '.shortdecimal_to_tinyint' of type DECIMAL")
+                .put(columnContext("orc", "longdecimal_to_smallint"), "Cannot read SQL type 'smallint' from ORC stream '.longdecimal_to_smallint' of type DECIMAL")
+                .put(columnContext("orc", "shortdecimal_to_smallint"), "Cannot read SQL type 'smallint' from ORC stream '.shortdecimal_to_smallint' of type DECIMAL")
+                .put(columnContext("orc", "too_big_shortdecimal_to_smallint"), "Cannot read SQL type 'smallint' from ORC stream '.too_big_shortdecimal_to_smallint' of type DECIMAL")
+                .put(columnContext("orc", "longdecimal_to_int"), "Cannot read SQL type 'integer' from ORC stream '.longdecimal_to_int' of type DECIMAL")
+                .put(columnContext("orc", "shortdecimal_to_int"), "Cannot read SQL type 'integer' from ORC stream '.shortdecimal_to_int' of type DECIMAL")
+                .put(columnContext("orc", "shortdecimal_with_0_scale_to_int"), "Cannot read SQL type 'integer' from ORC stream '.shortdecimal_with_0_scale_to_int' of type DECIMAL")
+                .put(columnContext("orc", "longdecimal_to_bigint"), "Cannot read SQL type 'bigint' from ORC stream '.longdecimal_to_bigint' of type DECIMAL")
+                .put(columnContext("orc", "shortdecimal_to_bigint"), "Cannot read SQL type 'bigint' from ORC stream '.shortdecimal_to_bigint' of type DECIMAL")
                 .put(columnContext("orc", "short_decimal_to_bounded_varchar"), "Cannot read SQL type 'varchar(30)' from ORC stream '.short_decimal_to_bounded_varchar' of type DECIMAL")
                 .put(columnContext("orc", "long_decimal_to_bounded_varchar"), "Cannot read SQL type 'varchar(30)' from ORC stream '.long_decimal_to_bounded_varchar' of type DECIMAL")
                 .put(columnContext("orc", "timestamp_row_to_row"), "Cannot read SQL type 'varchar' from ORC stream '.timestamp_row_to_row.timestamp2string' of type TIMESTAMP with attributes {}")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hive connector was missing Varchar to Date and Decimal to integer types coercions.
This PR adds them, specifically:
- VARCHAR to DATE
- DECIMAL to TINYINT
- DECIMAL to SMALLINT
- DECIMAL to INTEGER
- DECIMAL to BIGINT
Coercions work only when they make sense:
- VARCHAR is a correctly formatted date in YYYY-MM-DD format. In case of overflows - too high value in days, months or years field  hive would do a strange conversion:
```
2023-09-50 => 2023-10-20
```
What Hive does is counterintuitive so I decided not to follow the logic and throw an exception.
Also Hive reads null when the value is not in a date format for example
```
'testValue' => null
```
This logic is also not followed and an exception is thrown.
We will only support dates no older than 1900-01-01 similarly to what we do with timestamps.

- for DECIMAL types if the number is too big for a provided integer type then trino will return null, hive will either put `null` in such a column or trim some digits.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add varchar to date coercion for hive tables.
* Add decimal to numeric coercions for hive partitioned tables.
```
