### PR TITLE
Fix test flakiness

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -277,8 +277,13 @@ public class TestDeltaLakeFileOperations
     public void testSelfJoin()
     {
         assertUpdate("CREATE TABLE test_self_join_table AS SELECT 2 as age, 0 parent, 3 AS id", 1);
+        Session sessionWithoutDynamicFiltering = Session.builder(getSession())
+                // Disable dynamic filtering so that the second table data scan is not being pruned
+                .setSystemProperty("enable_dynamic_filtering", "false")
+                .build();
 
         assertFileSystemAccesses(
+                sessionWithoutDynamicFiltering,
                 "SELECT child.age, parent.age FROM test_self_join_table child JOIN test_self_join_table parent ON child.parent = parent.id",
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM))


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case that the dynamic filtering was finishing fast enough, the second scan on `test_self_join_table` was not being performed anymore because there was no purpose in doing so, given that the result was empty anyway. Adapt the content of the `test_self_join_table` to actually return a result so that the scanning of the data files is actually performed twice for each occurrence of the table in the JOIN operation.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #19198


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
