### PR TITLE
Enforce Client capabilities when Session Authorization is not supported

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientCapabilities.java
@@ -23,5 +23,7 @@ public enum ClientCapabilities
     //   time(p) without time zone
     //   interval X(p1) to Y(p2)
     // When this capability is not set, the server returns datetime types with precision = 3
-    PARAMETRIC_DATETIME;
+    PARAMETRIC_DATETIME,
+    // Whether clients support the session authorization set/reset feature
+    SESSION_AUTHORIZATION;
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestServer.java
@@ -68,6 +68,7 @@ import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.MAX_HASH_PARTITION_COUNT;
 import static io.trino.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static io.trino.client.ClientCapabilities.PATH;
+import static io.trino.client.ClientCapabilities.SESSION_AUTHORIZATION;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.StandardErrorCode.INCOMPATIBLE_CLIENT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -288,6 +289,34 @@ public class TestServer
 
         try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of(PATH.name())).build())) {
             testingClient.execute("SET PATH foo");
+        }
+    }
+
+    @Test
+    public void testSetSessionSupportByClient()
+    {
+        try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of()).build())) {
+            assertThatThrownBy(() -> testingClient.execute("SET SESSION AUTHORIZATION userA"))
+                    .hasMessage("SET SESSION AUTHORIZATION not supported by client");
+        }
+
+        try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of(
+                SESSION_AUTHORIZATION.name())).build())) {
+            testingClient.execute("SET SESSION AUTHORIZATION userA");
+        }
+    }
+
+    @Test
+    public void testResetSessionSupportByClient()
+    {
+        try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of()).build())) {
+            assertThatThrownBy(() -> testingClient.execute("RESET SESSION AUTHORIZATION"))
+                    .hasMessage("RESET SESSION AUTHORIZATION not supported by client");
+        }
+
+        try (TestingTrinoClient testingClient = new TestingTrinoClient(server, testSessionBuilder().setClientCapabilities(Set.of(
+                SESSION_AUTHORIZATION.name())).build())) {
+            testingClient.execute("RESET SESSION AUTHORIZATION");
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Given that `SET SESSION AUTHORIZATION` requires a client side changes we need to enforce and fail any client missing this capability. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
This Pull request is a follow up to https://github.com/trinodb/trino/pull/16067
Fixes Comment https://github.com/trinodb/trino/pull/16067#issuecomment-1720040698


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X) Release notes are required, with the following suggested text:
```markdown
# General
* Clients with version less than this release will fail when issuing commands `RESET / SET SESSION AUTHORIZIATION`. ({issue}`19217 `)
```
