### PR TITLE
Fix MongoDB mixed/upper case schemas with custom roles

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -241,7 +241,7 @@ public class MongoSession
                 .filter(name -> !name.equals(schemaCollection))
                 .filter(name -> !SYSTEM_TABLES.contains(name))
                 .collect(toSet()));
-        builder.addAll(getTableMetadataNames(schema));
+        builder.addAll(getTableMetadataNames(schemaName));
 
         return builder.build();
     }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/AuthenticatedMongoServer.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.Closeable;
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -30,11 +31,6 @@ public class AuthenticatedMongoServer
     private static final int MONGODB_INTERNAL_PORT = 27017;
     private static final String ROOT_USER = "root";
     private static final String ROOT_PASSWORD = "password";
-    private static final String TEST_USER = "testUser";
-    private static final String TEST_PASSWORD = "pass";
-    private static final String TEST_ROLE = "testRole";
-    public static final String TEST_DATABASE = "test";
-    public static final String TEST_COLLECTION = "testCollection";
     private final GenericContainer<?> dockerContainer;
 
     public AuthenticatedMongoServer(String mongoVersion)
@@ -59,51 +55,51 @@ public class AuthenticatedMongoServer
                 dockerContainer.getMappedPort(MONGODB_INTERNAL_PORT)));
     }
 
-    public ConnectionString testUserConnectionString()
+    public ConnectionString testUserConnectionString(String database, String user, String password)
     {
         return new ConnectionString("mongodb://%s:%s@%s:%d/%s".formatted(
-                TEST_USER,
-                TEST_PASSWORD,
+                user,
+                password,
                 dockerContainer.getHost(),
                 dockerContainer.getMappedPort(MONGODB_INTERNAL_PORT),
-                TEST_DATABASE));
+                database));
     }
 
-    public static Document createTestRole()
+    public static Document createRole(String role, ImmutableList<Document> privileges, ImmutableList<Object> roles)
     {
         return new Document(ImmutableMap.of(
-                "createRole", TEST_ROLE,
-                "privileges", ImmutableList.of(privilege("_schema"), privilege(TEST_COLLECTION)),
-                "roles", ImmutableList.of()));
+                "createRole", role,
+                "privileges", privileges,
+                "roles", roles));
     }
 
-    private static Document privilege(String collectionName)
+    public static Document privilege(Document resource, List<String> actions)
     {
         return new Document(ImmutableMap.of(
-                "resource", resource(collectionName),
-                "actions", ImmutableList.of("find")));
+                "resource", resource,
+                "actions", actions));
     }
 
-    private static Document resource(String collectionName)
+    public static Document resource(String database, String collectionName)
     {
         return new Document(ImmutableMap.of(
-                "db", TEST_DATABASE,
+                "db", database,
                 "collection", collectionName));
     }
 
-    public static Document createTestUser()
+    public static Document createUser(String user, String password, ImmutableList<Document> roles)
     {
         return new Document(ImmutableMap.of(
-                "createUser", TEST_USER,
-                "pwd", TEST_PASSWORD,
-                "roles", ImmutableList.of(role())));
+                "createUser", user,
+                "pwd", password,
+                "roles", roles));
     }
 
-    private static Document role()
+    public static Document role(String database, String role)
     {
         return new Document(ImmutableMap.of(
-                "role", TEST_ROLE,
-                "db", TEST_DATABASE));
+                "role", role,
+                "db", database));
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
@@ -83,6 +83,12 @@ public class TestMongoPrivileges
         assertQuery("SHOW TABLES FROM %s.%s".formatted(getCatalogName(database), database), "VALUES '%s'".formatted(TEST_COLLECTION.toLowerCase(ENGLISH)));
     }
 
+    @Test(dataProvider = "databases")
+    public void testSelectFromTable(String database)
+    {
+        assertQuery("SELECT * from %s.%s.%s".formatted(getCatalogName(database), database, TEST_COLLECTION), "VALUES ('abc', 1)");
+    }
+
     private static AuthenticatedMongoServer setupMongoServer()
     {
         AuthenticatedMongoServer mongoServer = new AuthenticatedMongoServer("4.2.0");
@@ -99,7 +105,7 @@ public class TestMongoPrivileges
         runCommand(testDatabase, createTestRole(database));
         runCommand(testDatabase, createTestUser(database));
         testDatabase.createCollection("_schema");
-        testDatabase.createCollection(TEST_COLLECTION);
+        testDatabase.getCollection(TEST_COLLECTION).insertOne(new Document(ImmutableMap.of("Name", "abc", "Value", 1)));
         testDatabase.createCollection("anotherCollection"); // this collection/table should not be visible
     }
 
@@ -117,10 +123,10 @@ public class TestMongoPrivileges
                 ImmutableList.of(
                         privilege(
                                 resource(database, "_schema"),
-                                ImmutableList.of("find")),
+                                ImmutableList.of("find", "listIndexes", "createIndex", "insert")),
                         privilege(
                                 resource(database, TEST_COLLECTION),
-                                ImmutableList.of("find"))),
+                                ImmutableList.of("find", "listIndexes"))),
                 ImmutableList.of());
     }
 

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoPrivileges.java
@@ -24,7 +24,6 @@ import io.trino.testing.QueryRunner;
 import org.bson.Document;
 import org.testng.annotations.Test;
 
-import java.util.Locale;
 import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -34,6 +33,7 @@ import static io.trino.plugin.mongodb.AuthenticatedMongoServer.privilege;
 import static io.trino.plugin.mongodb.AuthenticatedMongoServer.resource;
 import static io.trino.plugin.mongodb.AuthenticatedMongoServer.role;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestMongoPrivileges
@@ -50,7 +50,23 @@ public class TestMongoPrivileges
             throws Exception
     {
         AuthenticatedMongoServer mongoServer = closeAfterClass(setupMongoServer());
-        return createMongoQueryRunner(mongoServer.testUserConnectionString(TEST_DATABASE, TEST_USER, TEST_PASSWORD).getConnectionString());
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
+                        .setCatalog(Optional.empty())
+                        .setSchema(Optional.empty())
+                        .build())
+                .build();
+        try {
+            queryRunner.installPlugin(new MongoPlugin());
+            String connectionUrl = mongoServer.testUserConnectionString(TEST_DATABASE, TEST_USER, TEST_PASSWORD).getConnectionString();
+            queryRunner.createCatalog("mongodb", "mongodb", ImmutableMap.of(
+                    "mongodb.case-insensitive-name-matching", "true",
+                    "mongodb.connection-url", connectionUrl));
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
     }
 
     @Test
@@ -62,7 +78,7 @@ public class TestMongoPrivileges
     @Test
     public void testTablesVisibility()
     {
-        assertQuery("SHOW TABLES FROM mongodb." + TEST_DATABASE, "VALUES '%s'".formatted(TEST_COLLECTION.toLowerCase(Locale.ENGLISH)));
+        assertQuery("SHOW TABLES FROM mongodb." + TEST_DATABASE, "VALUES '%s'".formatted(TEST_COLLECTION.toLowerCase(ENGLISH)));
     }
 
     private static AuthenticatedMongoServer setupMongoServer()
@@ -87,43 +103,18 @@ public class TestMongoPrivileges
         assertThat(commandStatus).isEqualTo(1.0);
     }
 
-    private static DistributedQueryRunner createMongoQueryRunner(String connectionUrl)
-            throws Exception
-    {
-        DistributedQueryRunner queryRunner = null;
-        try {
-            queryRunner = DistributedQueryRunner.builder(testSessionBuilder()
-                            .setCatalog(Optional.empty())
-                            .setSchema(Optional.empty())
-                            .build())
-                    .build();
-            queryRunner.installPlugin(new MongoPlugin());
-            queryRunner.createCatalog("mongodb", "mongodb", ImmutableMap.of(
-                    "mongodb.case-insensitive-name-matching", "true",
-                    "mongodb.connection-url", connectionUrl));
-            return queryRunner;
-        }
-        catch (Throwable e) {
-            closeAllSuppress(e, queryRunner);
-            throw e;
-        }
-    }
-
     private static Document createTestRole()
     {
         return createRole(
                 TEST_ROLE,
                 ImmutableList.of(
-                        testPrivilege("_schema"),
-                        testPrivilege(TEST_COLLECTION)),
+                        privilege(
+                                resource(TEST_DATABASE, "_schema"),
+                                ImmutableList.of("find")),
+                        privilege(
+                                resource(TEST_DATABASE, TEST_COLLECTION),
+                                ImmutableList.of("find"))),
                 ImmutableList.of());
-    }
-
-    private static Document testPrivilege(String collectionName)
-    {
-        return privilege(
-                resource(TEST_DATABASE, collectionName),
-                ImmutableList.of("find"));
     }
 
     private static Document createTestUser()


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This is a missing part for
https://github.com/ssheikin/trino/commit/43b55cba71bc7345977f292f91b1a082ada72fdf
`Support case insensitive identifiers in MongoDB`

Before:
When using custom roles in mongoDB only lowercase letter schemas are
accessible in Trino
After:
When using custom roles in mongoDB with lowercase and uppercase letter
schemas are accessible in Trino (`case-insensitive-name-matching=true`
is taken into account)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
 * Fix mixed/upper case schemas with custom roles
```
