### PR TITLE
Fix running TestNG tests on CI

### DIFF
--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -153,4 +153,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -134,4 +134,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -158,4 +158,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugin/trino-teradata-functions/pom.xml
+++ b/plugin/trino-teradata-functions/pom.xml
@@ -105,6 +105,28 @@
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -176,4 +176,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -96,4 +96,31 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/testing/trino-plugin-reader/pom.xml
+++ b/testing/trino-plugin-reader/pom.xml
@@ -139,6 +139,29 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -414,6 +414,28 @@
                     </ignoredResourcePatterns>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dep.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/partitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_39"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_40"])
+                                remote exchange (REPARTITION, HASH, ["substring_39"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_31"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/hive/unpartitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_39"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_40"])
+                                remote exchange (REPARTITION, HASH, ["substring_39"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_31"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/partitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_34"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_35"])
+                                remote exchange (REPARTITION, HASH, ["substring_34"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_26"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/orc/unpartitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_34"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_35"])
+                                remote exchange (REPARTITION, HASH, ["substring_34"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_26"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/partitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_34"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_35"])
+                                remote exchange (REPARTITION, HASH, ["substring_34"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_26"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg/parquet/unpartitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_34"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_35"])
+                                remote exchange (REPARTITION, HASH, ["substring_34"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_26"])

--- a/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q08.plan.txt
+++ b/testing/trino-tests/src/test/resources/sql/presto/tpcds/iceberg_small_files/parquet/unpartitioned/q08.plan.txt
@@ -5,7 +5,7 @@ local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, ["s_store_name"])
                     partial aggregation over (s_store_name)
                         join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, ["substr_34"])
+                            remote exchange (REPARTITION, HASH, ["substring"])
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
                                         dynamic filter (["ss_sold_date_sk", "ss_store_sk"])
@@ -17,7 +17,7 @@ local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, ["substr_35"])
+                                remote exchange (REPARTITION, HASH, ["substring_34"])
                                     final aggregation over (ca_zip)
                                         local exchange (REPARTITION, HASH, ["ca_zip"])
                                             remote exchange (REPARTITION, HASH, ["ca_zip_26"])


### PR DESCRIPTION
TestNG tests from at least `trino-tests` and `trino-tpcds` were not being run on CI, silently ignored.

This commit adds necessary configuration to make those tests running again.

```bash
function modules_with {
    local dependency="$1"
    ./mvnw dependency:tree -T1 \
        | grep '\[INFO\] --- dependency:3.6.0:tree (default-cli) @\|'"${dependency}" \
        | grep -B1 "${dependency}" \
        | sed -ne 's/.*dependency:3.6.0:tree.* @ \([^ ]\+\) ---/\1/p'
}

modules_with 'org.testng:testng' \
    | grep -xf <( modules_with ':junit-jupiter-api' ) \
    `# filter out those already having surefire-testng` \
    | grep -vxf <( find -name pom.xml -exec grep '<artifactId>surefire-testng</artifactId>' -l {} + | sed -ne 's@.*/\(trino-[^/]\+\)/pom.xml@\1@p' )
```

Except that `trino-server-rpm` was skipped.

Note that this can have false positives: a module can use TestNG for assertions only (like `trino-teradata-functions` currently does). it is hard to fully correctly identify modules that have TestNG on classpath but do not use it for tests. For instance, canning `@Test` annotations is not enough because of base test classes.

