### PR TITLE
Add docs for MySQL timestamptz handling

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.md
+++ b/docs/src/main/sphinx/connector/mysql.md
@@ -276,6 +276,21 @@ this table:
 
 No other types are supported.
 
+### Timestamp type handling
+
+MySQL `TIMESTAMP` types are mapped to Trino `TIMESTAMP WITH TIME ZONE`.
+To preserve time instants, Trino sets the session time zone
+of the MySQL connection to match the JVM time zone.
+As a result, error messages similar to the following example occur when
+a timezone from the JVM does not exist on the MySQL server:
+
+```
+com.mysql.cj.exceptions.CJException: Unknown or incorrect time zone: 'UTC'
+```
+
+To avoid the errors, you must use a time zone that is known on both systems,
+or [install the missing time zone on the MySQL server](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html#time-zone-installation).
+
 (mysql-decimal-handling)=
 
 ```{include} decimal-type-handling.fragment


### PR DESCRIPTION
## Description

This adds a note in the MySQL connector documentation about an error users may experience when using timestamptz types due to mismatches between JVM/time zone and what is installed on the MySQL server.

## Additional context and related issues

Relates to #18470 

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
