### PR TITLE
Require JDK 11 to use CLI and JDBC driver

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <project.build.targetJdk>8</project.build.targetJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
         <main-class>io.trino.cli.Trino</main-class>
         <dep.jline.version>3.21.0</dep.jline.version>
     </properties>

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <project.build.targetJdk>8</project.build.targetJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
     </properties>
 
     <dependencies>

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <project.build.targetJdk>8</project.build.targetJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
         <shadeBase>io.trino.jdbc.\$internal</shadeBase>
     </properties>
 

--- a/docs/src/main/sphinx/client/cli.md
+++ b/docs/src/main/sphinx/client/cli.md
@@ -8,7 +8,7 @@ JAR file, which means it acts like a normal UNIX executable.
 ## Requirements
 
 The CLI requires a Java virtual machine available on the path.
-It can be used with Java version 8 and higher.
+It can be used with Java version 11 and higher.
 
 The CLI uses the {doc}`Trino client REST API </develop/client-protocol>` over
 HTTP/HTTPS to communicate with the coordinator on the cluster.

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -9,7 +9,7 @@ as those used for reporting and database development, use the JDBC driver.
 
 The Trino JDBC driver has the following requirements:
 
-- Java version 8 or higher.
+- Java version 11 or higher.
 - All users that connect to Trino with the JDBC driver must be granted access to
   query tables in the `system.jdbc` schema.
 


### PR DESCRIPTION
Release notes: Require JDK 11 to use client library, CLI and JDBC driver.