### PR TITLE
Fix silently ignored tests in TestLocalQueryAssertions

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueryAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueryAssertions.java
@@ -44,6 +44,7 @@ public class TestLocalQueryAssertions
         return queryRunner;
     }
 
+    @Test
     @Override
     public void testIsFullyPushedDown()
     {
@@ -52,6 +53,7 @@ public class TestLocalQueryAssertions
                 .hasMessage("isFullyPushedDown() currently does not work with LocalQueryRunner");
     }
 
+    @Test
     @Override
     public void testIsFullyPushedDownWithSession()
     {


### PR DESCRIPTION
The test were not being run since the migration to JUnit. In TestNG, when a `@Test` method is overridden, it still runs. In JUnit 5, the overridden method needs to be annotated with `@Test` too, or else is ignored. Given the difference, and also given the fact tools like IntelliJ will generate `@Override` but won't copy annotations onto the overriding methods, this is a pitfall too easy to fall into.
