### PR TITLE
Restore test lost in migration

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/BaseQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/BaseQueryAssertionsTest.java
@@ -101,6 +101,18 @@ public abstract class BaseQueryAssertionsTest
     }
 
     @Test
+    public void testWrongTypeWithEmptyResult()
+    {
+        QueryAssert queryAssert = assertThat(query("SELECT X'001234' WHERE false"));
+        assertThatThrownBy(() -> queryAssert.matches("SELECT '001234' WHERE false"))
+                .hasMessageContaining("""
+                        [Output types for query [SELECT X'001234' WHERE false]]\s
+                        expected: [varchar(6)]
+                         but was: [varbinary]
+                        """);
+    }
+
+    @Test
     public void testReturnsEmptyResult()
     {
         assertThat(query("SELECT 'foobar' WHERE false")).returnsEmptyResult();


### PR DESCRIPTION
The test `testWrongTypeWithEmptyResult` was removed in 21d74e125eaa0c098e96fa192ae55363fd4c32aa which looks incidental, given the commit was just migrating tests from TestNG to JUnit.
