### PR TITLE
Support tracing when connection pool is enabled in Oracle

### DIFF
--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-base-jdbc</artifactId>
         </dependency>

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
@@ -72,7 +72,8 @@ public class OracleClientModule
                     credentialProvider,
                     oracleConfig.getConnectionPoolMinSize(),
                     oracleConfig.getConnectionPoolMaxSize(),
-                    oracleConfig.getInactiveConnectionTimeout());
+                    oracleConfig.getInactiveConnectionTimeout(),
+                    openTelemetry);
         }
 
         return new RetryingConnectionFactory(new DriverConnectionFactory(


### PR DESCRIPTION
## Description

Support tracing when connection pool is enabled in Oracle. 
<img width="1504" alt="Screenshot 2023-10-03 at 13 58 36" src="https://github.com/trinodb/trino/assets/6237050/d4cd41f6-700b-4a19-bdca-9bc1a2d9011f">


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.