### PR TITLE
Skip calculating table_type when not needed

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -621,6 +621,12 @@ public class TestDeltaLakeFileOperations
         };
     }
 
+    @Test
+    public void testShowTables()
+    {
+        assertFileSystemAccesses("SHOW TABLES", ImmutableMultiset.of());
+    }
+
     private int countCdfFilesForKey(String partitionValue)
     {
         String path = (String) computeScalar("SELECT \"$path\" FROM table_changes_file_system_access WHERE key = '" + partitionValue + "'");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -36,8 +36,11 @@ import java.util.Optional;
 
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.CREATE_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.DROP_TABLE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_DATABASES;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLES_WITH_PARAMETER;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
@@ -248,6 +251,17 @@ public class TestDeltaLakeMetastoreAccessOperations
                 ImmutableMultiset.builder()
                         .add(GET_TABLE)
                         .add(DROP_TABLE)
+                        .build());
+    }
+
+    @Test
+    public void testShowTables()
+    {
+        assertMetastoreInvocations("SHOW TABLES",
+                ImmutableMultiset.builder()
+                        .add(GET_ALL_DATABASES)
+                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_TABLES_WITH_PARAMETER)
                         .build());
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -40,7 +40,6 @@ import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLES_WITH_PARAMETER;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
@@ -261,7 +260,6 @@ public class TestDeltaLakeMetastoreAccessOperations
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
                         .add(GET_ALL_TABLES_FROM_DATABASE)
-                        .add(GET_TABLES_WITH_PARAMETER)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -610,6 +610,12 @@ public class TestIcebergMetadataFileOperations
         };
     }
 
+    @Test
+    public void testShowTables()
+    {
+        assertFileSystemAccesses("SHOW TABLES", ImmutableMultiset.of());
+    }
+
     private void assertFileSystemAccesses(@Language("SQL") String query, Multiset<FileOperation> expectedAccesses)
     {
         assertFileSystemAccesses(getSession(), query, expectedAccesses);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -419,6 +419,17 @@ public class TestIcebergMetastoreAccessOperations
         };
     }
 
+    @Test
+    public void testShowTables()
+    {
+        assertMetastoreInvocations("SHOW TABLES",
+                ImmutableMultiset.builder()
+                        .add(GET_DATABASE)
+                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_TABLES_WITH_PARAMETER)
+                        .build());
+    }
+
     private void assertMetastoreInvocations(@Language("SQL") String query, Multiset<?> expectedInvocations)
     {
         assertMetastoreInvocations(getSession(), query, expectedInvocations);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -426,7 +426,6 @@ public class TestIcebergMetastoreAccessOperations
                 ImmutableMultiset.builder()
                         .add(GET_DATABASE)
                         .add(GET_ALL_TABLES_FROM_DATABASE)
-                        .add(GET_TABLES_WITH_PARAMETER)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -586,7 +586,7 @@ public class TestIcebergGlueCatalogAccessOperations
         assertGlueMetastoreApiInvocations("SHOW TABLES",
                 ImmutableMultiset.builder()
                         .add(GET_DATABASE)
-                        .addCopies(GET_TABLES, 2)
+                        .add(GET_TABLES)
                         .build());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -580,6 +580,16 @@ public class TestIcebergGlueCatalogAccessOperations
         }
     }
 
+    @Test
+    public void testShowTables()
+    {
+        assertGlueMetastoreApiInvocations("SHOW TABLES",
+                ImmutableMultiset.builder()
+                        .add(GET_DATABASE)
+                        .addCopies(GET_TABLES, 2)
+                        .build());
+    }
+
     private void assertGlueMetastoreApiInvocations(@Language("SQL") String query, Multiset<?> expectedInvocations)
     {
         assertGlueMetastoreApiInvocations(getSession(), query, expectedInvocations);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.CountingMockConnector;
 import io.trino.testing.DistributedQueryRunner;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -342,7 +343,7 @@ public class TestInformationSchemaConnector
                 "Error listing table columns for catalog broken_catalog: Catalog is broken");
     }
 
-    private void assertMetadataCalls(String actualSql, String expectedSql, Multiset<String> expectedMetadataCallsCount)
+    private void assertMetadataCalls(@Language("SQL") String actualSql, @Language("SQL") String expectedSql, Multiset<String> expectedMetadataCallsCount)
     {
         expectedMetadataCallsCount = ImmutableMultiset.<String>builder()
                 // Every query involves beginQuery and cleanupQuery, so expect them implicitly.

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -164,30 +164,30 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.listSchemaNames")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables",
-                "VALUES 3008",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables",
+                "VALUES (3008, 3008)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listTables")
                         .add("ConnectorMetadata.listViews")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
-                "VALUES 1000",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
+                "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listTables(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
-                "VALUES 1000",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
+                "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.listTables(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
-                "VALUES 1000",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
+                "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listTables(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
@@ -195,8 +195,8 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.listViews(schema=test_schema2)")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'",
-                "VALUES 2",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'",
+                "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
@@ -211,8 +211,8 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.getTableHandle(schema=test_schema2, table=test_table1)")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1'",
-                "VALUES 2",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1'",
+                "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
                         .add("ConnectorMetadata.listTables(schema=test_schema1)")
@@ -221,8 +221,8 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.listViews(schema=test_schema2)")
                         .build());
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1' AND table_name IN ('test_table1', 'test_table2')",
-                "VALUES 2",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1' AND table_name IN ('test_table1', 'test_table2')",
+                "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
                         .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
@@ -297,14 +297,14 @@ public class TestInformationSchemaConnector
 
         // Empty table schema and table name
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema = '' AND table_name = ''",
-                "VALUES 0",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = '' AND table_name = ''",
+                "VALUES (0, 0)",
                 ImmutableMultiset.of());
 
         // Empty table schema
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_schema = ''",
-                "VALUES 0",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = ''",
+                "VALUES (0, 0)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listTables(schema=)")
                         .add("ConnectorMetadata.listViews(schema=)")
@@ -312,10 +312,20 @@ public class TestInformationSchemaConnector
 
         // Empty table name
         assertMetadataCalls(
-                "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name = ''",
-                "VALUES 0",
+                "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name = ''",
+                "VALUES (0, 0)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
+                        .build());
+
+        // Subset of tables' columns: table_type not selected
+        assertMetadataCalls(
+                "SELECT count(table_name) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
+                "VALUES 1000",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.listSchemaNames")
+                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        // view-related methods such as listViews not being called
                         .build());
     }
 


### PR DESCRIPTION
## Description

`ConnectorMetadata.listTables` returns all relations (tables, views,
materialzied views). Thus, when reading `information_schema.table` and
`table_type` column is not needed, the `getViews` call can be skipped.
`getViews` can be expensive as it pulls view information sometimes even
converting it (e.g. in case of Hive views).