### PR TITLE
Don't set s3api create-bucket LocationConstraint configuration option for us-east-1 region

### DIFF
--- a/.github/bin/s3/setup-empty-s3-bucket.sh
+++ b/.github/bin/s3/setup-empty-s3-bucket.sh
@@ -10,10 +10,17 @@ S3_BUCKET_IDENTIFIER=trino-s3fs-ci-$(openssl rand -hex 8)
 S3_BUCKET_TTL=$(date -u -d "+2 hours" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -v "+2H" +"%Y-%m-%dT%H:%M:%SZ")
 
 echo "Creating an empty AWS S3 bucket ${S3_BUCKET_IDENTIFIER} in the region ${AWS_REGION}"
+
+OPTIONAL_BUCKET_CONFIGURATION=()
+# LocationConstraint configuration property is not allowed for us-east-1 AWS region
+if [ "${AWS_REGION}" != 'us-east-1' ]; then
+    OPTIONAL_BUCKET_CONFIGURATION+=("--create-bucket-configuration" "LocationConstraint=${AWS_REGION}")
+fi
+
 S3_CREATE_BUCKET_OUTPUT=$(aws s3api create-bucket \
   --bucket "${S3_BUCKET_IDENTIFIER}" \
   --region "${AWS_REGION}" \
-  --create-bucket-configuration LocationConstraint="${AWS_REGION}")
+  "${OPTIONAL_BUCKET_CONFIGURATION[@]}")
 
 if [ -z "${S3_CREATE_BUCKET_OUTPUT}" ]; then
     echo "Unexpected error while attempting to create the S3 bucket ${S3_BUCKET_IDENTIFIER} in the region ${AWS_REGION}"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Make the `LocationConstraint` create-bucket-configuration property optional depending on which aws region is used for ci. `LocationConstraint` can't be set if the AWS region used is `us-east-1`. This doesn't affect Trino, but could affect forks

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
