### PR TITLE
Handle camelCase naming in externally provided Avro Schemas

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPagePositionDataWriter.java
@@ -45,6 +45,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.hive.formats.avro.AvroTypeUtils.SimpleUnionNullIndex;
 import static io.trino.hive.formats.avro.AvroTypeUtils.getSimpleNullableUnionNullIndex;
 import static io.trino.hive.formats.avro.AvroTypeUtils.isSimpleNullableUnion;
+import static io.trino.hive.formats.avro.AvroTypeUtils.lowerCaseAllFieldsForWriter;
 import static io.trino.hive.formats.avro.AvroTypeUtils.unwrapNullableUnion;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -74,7 +75,10 @@ public class AvroPagePositionDataWriter
     @Override
     public void setSchema(Schema schema)
     {
-        verify(this.schema == requireNonNull(schema, "schema is null"), "Unable to change schema for this data writer");
+        requireNonNull(schema, "schema is null");
+        if (this.schema != schema) {
+            verify(this.schema.equals(lowerCaseAllFieldsForWriter(schema)), "Unable to change schema for this data writer");
+        }
     }
 
     public void setPage(Page page)

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroBase.java
@@ -320,7 +320,7 @@ public abstract class TestAvroBase
                 compressionKind,
                 ImmutableMap.of(),
                 schema.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
-                AvroTypeUtils.typeFromAvro(schema, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+                AvroTypeUtils.typeFromAvro(schema, NoOpAvroTypeManager.INSTANCE).getTypeParameters(), false)) {
             for (Page p : pages.build()) {
                 fileWriter.write(p);
             }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataReaderWithAvroNativeTypeManagement.java
@@ -248,7 +248,7 @@ public class TestAvroPageDataReaderWithAvroNativeTypeManagement
                 AvroCompressionKind.NULL,
                 ImmutableMap.of(),
                 ALL_SUPPORTED_TYPES_SCHEMA.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
-                AvroTypeUtils.typeFromAvro(ALL_SUPPORTED_TYPES_SCHEMA, new NativeLogicalTypesAvroTypeManager()).getTypeParameters())) {
+                AvroTypeUtils.typeFromAvro(ALL_SUPPORTED_TYPES_SCHEMA, new NativeLogicalTypesAvroTypeManager()).getTypeParameters(), false)) {
             fileWriter.write(ALL_SUPPORTED_PAGE);
         }
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/avro/TestAvroPageDataWriterWithoutTypeManager.java
@@ -75,7 +75,7 @@ public class TestAvroPageDataWriterWithoutTypeManager
                 AvroCompressionKind.NULL,
                 ImmutableMap.of(),
                 ALL_TYPES_RECORD_SCHEMA.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
-                AvroTypeUtils.typeFromAvro(ALL_TYPES_RECORD_SCHEMA, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+                AvroTypeUtils.typeFromAvro(ALL_TYPES_RECORD_SCHEMA, NoOpAvroTypeManager.INSTANCE).getTypeParameters(), false)) {
             fileWriter.write(ALL_TYPES_PAGE);
         }
 
@@ -140,7 +140,7 @@ public class TestAvroPageDataWriterWithoutTypeManager
                 AvroCompressionKind.NULL,
                 ImmutableMap.of(),
                 testBlocksSchema.getFields().stream().map(Schema.Field::name).collect(toImmutableList()),
-                AvroTypeUtils.typeFromAvro(testBlocksSchema, NoOpAvroTypeManager.INSTANCE).getTypeParameters())) {
+                AvroTypeUtils.typeFromAvro(testBlocksSchema, NoOpAvroTypeManager.INSTANCE).getTypeParameters(), false)) {
             avroFileWriter.write(toWrite);
         }
 
@@ -204,7 +204,7 @@ public class TestAvroPageDataWriterWithoutTypeManager
                 AvroCompressionKind.NULL,
                 ImmutableMap.of(),
                 ImmutableList.of("byteToInt", "shortToInt", "byteToLong", "shortToLong", "intToLong"),
-                ImmutableList.of(TINYINT, SMALLINT, TINYINT, SMALLINT, INTEGER))) {
+                ImmutableList.of(TINYINT, SMALLINT, TINYINT, SMALLINT, INTEGER), false)) {
             avroFileWriter.write(toWrite);
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroHiveFileUtils.java
@@ -39,10 +39,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.avro.AvroHiveConstants.CHAR_TYPE_LOGICAL_NAME;
 import static io.trino.plugin.hive.avro.AvroHiveConstants.SCHEMA_DOC;
@@ -59,6 +62,7 @@ import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_COMMENTS;
 import static java.util.Collections.emptyList;
 import static java.util.function.Predicate.not;
+import static java.util.function.UnaryOperator.identity;
 
 public final class AvroHiveFileUtils
 {
@@ -278,6 +282,14 @@ public final class AvroHiveFileUtils
         }
 
         return prunedSchemas;
+    }
+
+    static Map<String, String> getCanonicalToGivenFieldName(Schema schema)
+    {
+        // Lower case top level fields to allow for manually set avro schema (passed in via avro_schema_literal or avro_schema_url) to have uppercase field names
+        return schema.getFields().stream()
+                .map(Schema.Field::name)
+                .collect(toImmutableMap(fieldName -> fieldName.toLowerCase(Locale.ENGLISH), identity()));
     }
 
     private static Schema.Parser getSchemaParser()

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/avro/camelCaseSchema.avsc
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/avro/camelCaseSchema.avsc
@@ -1,0 +1,8 @@
+{
+  "namespace": "io.trino.test",
+  "name": "product_tests_avro_table",
+  "type": "record",
+  "fields": [
+    { "name":"stringCol", "type":"string"},
+    { "name":"intCol", "type":"int" }
+]}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
@@ -55,6 +55,7 @@ public class TestAvroSchemaUrl
         hdfsClient.createDirectory("/user/hive/warehouse/TestAvroSchemaUrl/schemas");
         saveResourceOnHdfs("avro/original_schema.avsc", "/user/hive/warehouse/TestAvroSchemaUrl/schemas/original_schema.avsc");
         saveResourceOnHdfs("avro/column_with_long_type_definition_schema.avsc", "/user/hive/warehouse/TestAvroSchemaUrl/schemas/column_with_long_type_definition_schema.avsc");
+        saveResourceOnHdfs("avro/camelCaseSchema.avsc", "/user/hive/warehouse/TestAvroSchemaUrl/schemas/camelCaseSchema.avsc");
 
         hdfsClient.createDirectory("/user/hive/warehouse/TestAvroSchemaUrl/data");
         saveResourceOnHdfs("avro/column_with_long_type_definition_data.avro", "/user/hive/warehouse/TestAvroSchemaUrl/data/column_with_long_type_definition_data.avro");
@@ -237,6 +238,34 @@ public class TestAvroSchemaUrl
                         "... \",\"record_field499\":\"val499\"}"));
 
         onHive().executeQuery("DROP TABLE IF EXISTS test_avro_schema_url_partitioned_long_column");
+    }
+
+    @Test(groups = {AVRO, STORAGE_FORMATS})
+    @Flaky(issue = RETRYABLE_FAILURES_ISSUES, match = RETRYABLE_FAILURES_MATCH)
+    public void testHiveCreatedCamelCaseColumnTable()
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS test_camelCase_avro_schema_url_hive");
+        onHive().executeQuery("" +
+                "CREATE TABLE test_camelCase_avro_schema_url_hive " +
+                "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.avro.AvroSerDe' " +
+                "STORED AS " +
+                "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat' " +
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' " +
+                "TBLPROPERTIES ('avro.schema.url'='/user/hive/warehouse/TestAvroSchemaUrl/schemas/camelCaseSchema.avsc')");
+        //both able to insert with camel case
+        onHive().executeQuery("INSERT INTO test_camelCase_avro_schema_url_hive VALUES ('hi', 1)");
+        onTrino().executeQuery("INSERT INTO test_camelCase_avro_schema_url_hive VALUES ('bye', 2)");
+        // both can select *
+        assertThat(onHive().executeQuery("SELECT * FROM test_camelCase_avro_schema_url_hive")).containsOnly(row("hi", 1), row("bye", 2));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_camelCase_avro_schema_url_hive")).containsOnly(row("hi", 1), row("bye", 2));
+        // column names lower-cased in the engine, can be used as uppercase
+        assertThat(onHive().executeQuery("SELECT intCol, stringCol FROM test_camelCase_avro_schema_url_hive")).containsOnly(row(1, "hi"), row(2, "bye"));
+        assertThat(onTrino().executeQuery("SELECT intCol, stringCol FROM test_camelCase_avro_schema_url_hive")).containsOnly(row(1, "hi"), row(2, "bye"));
+        // Table and column names returned as lowercase
+        assertThat(onTrino().executeQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_camelcase_avro_schema_url_hive'"))
+                .containsOnly(row("stringcol"), row("intcol"));
+
+        onHive().executeQuery("DROP TABLE IF EXISTS test_camelCase_avro_schema_url_hive");
     }
 
     private boolean isOnHdp()

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
@@ -252,16 +252,12 @@ public class TestAvroSchemaUrl
                 "INPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat' " +
                 "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat' " +
                 "TBLPROPERTIES ('avro.schema.url'='/user/hive/warehouse/TestAvroSchemaUrl/schemas/camelCaseSchema.avsc')");
-        //both able to insert with camel case
         onHive().executeQuery("INSERT INTO test_camelCase_avro_schema_url_hive VALUES ('hi', 1)");
         onTrino().executeQuery("INSERT INTO test_camelCase_avro_schema_url_hive VALUES ('bye', 2)");
-        // both can select *
         assertThat(onHive().executeQuery("SELECT * FROM test_camelCase_avro_schema_url_hive")).containsOnly(row("hi", 1), row("bye", 2));
         assertThat(onTrino().executeQuery("SELECT * FROM test_camelCase_avro_schema_url_hive")).containsOnly(row("hi", 1), row("bye", 2));
-        // column names lower-cased in the engine, can be used as uppercase
         assertThat(onHive().executeQuery("SELECT intCol, stringCol FROM test_camelCase_avro_schema_url_hive")).containsOnly(row(1, "hi"), row(2, "bye"));
         assertThat(onTrino().executeQuery("SELECT intCol, stringCol FROM test_camelCase_avro_schema_url_hive")).containsOnly(row(1, "hi"), row(2, "bye"));
-        // Table and column names returned as lowercase
         assertThat(onTrino().executeQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_camelcase_avro_schema_url_hive'"))
                 .containsOnly(row("stringcol"), row("intcol"));
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Internally all Hive column names are stored and provided to the hive readers/writers as lowercase. The Native Avro File reader uses columns names to preform projection / selective decoding. This is not an issue for any table that generates its own schema, but for cases where the schema is provided via table property this could mean that the fields in the provided schema don't match the casing of the table metadata / columns passed in. This was not a problem in the previous reader when projection happened via row positions after a full read of the record.

This was missed due to:
1) A bug where the reader projection was silently ignoring requested columns it didn't have (only happening in cases where the provided schema has Upper casing)
2) No unit or product tests with upper casing in the fields

This PR includes a commit with product tests that pass using previous reader and writer. And the corresponding commit to make the new reader and writer preform identically. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:
Bug fix for avro native readers and writers in situations where provided schema has camelCase (any uppercasing) in fields

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
