### PR TITLE
Generify Constraint

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -182,7 +182,7 @@ public class InformationSchemaMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         InformationSchemaTableHandle table = (InformationSchemaTableHandle) handle;
 
@@ -204,7 +204,7 @@ public class InformationSchemaMetadata
         return ImmutableSet.of(new QualifiedTablePrefix(catalogName));
     }
 
-    private Set<QualifiedTablePrefix> getPrefixes(ConnectorSession session, InformationSchemaTableHandle table, Constraint constraint)
+    private Set<QualifiedTablePrefix> getPrefixes(ConnectorSession session, InformationSchemaTableHandle table, Constraint<ColumnHandle> constraint)
     {
         if (constraint.getSummary().isNone()) {
             return ImmutableSet.of();

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplitManager.java
@@ -16,6 +16,7 @@ package io.trino.connector.informationschema;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -46,7 +47,7 @@ public class InformationSchemaSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         List<HostAddress> localAddress = ImmutableList.of(nodeManager.getCurrentNode().getHostAndPort());
         ConnectorSplit split = new InformationSchemaSplit(localAddress);

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemSplitManager.java
@@ -59,7 +59,7 @@ public class SystemSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         SystemTableHandle table = (SystemTableHandle) tableHandle;
         TupleDomain<ColumnHandle> tableConstraint = table.getConstraint();

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
@@ -139,7 +139,7 @@ public class SystemTablesMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         SystemTableHandle table = (SystemTableHandle) handle;
 
@@ -166,12 +166,12 @@ public class SystemTablesMetadata
         return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary(), false));
     }
 
-    private Constraint effectiveConstraint(TupleDomain<ColumnHandle> oldDomain, Constraint newConstraint, TupleDomain<ColumnHandle> effectiveDomain)
+    private Constraint<ColumnHandle> effectiveConstraint(TupleDomain<ColumnHandle> oldDomain, Constraint<ColumnHandle> newConstraint, TupleDomain<ColumnHandle> effectiveDomain)
     {
         if (effectiveDomain.isNone() || newConstraint.predicate().isEmpty()) {
-            return new Constraint(effectiveDomain);
+            return new Constraint<>(effectiveDomain);
         }
-        return new Constraint(
+        return new Constraint<>(
                 effectiveDomain,
                 oldDomain.asPredicate().and(newConstraint.predicate().get()),
                 Sets.union(

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -146,7 +146,7 @@ public class ColumnJdbcTable
     }
 
     @Override
-    public TupleDomain<ColumnHandle> applyFilter(ConnectorSession connectorSession, Constraint constraint)
+    public TupleDomain<ColumnHandle> applyFilter(ConnectorSession connectorSession, Constraint<ColumnHandle> constraint)
     {
         TupleDomain<ColumnHandle> tupleDomain = constraint.getSummary();
         if (tupleDomain.isNone() || constraint.predicate().isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/JdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/JdbcTable.java
@@ -38,7 +38,7 @@ public abstract class JdbcTable
      * and without column handles it's currently not possible to express Constraint or ConstraintApplicationResult.
      * TODO provide equivalent API in the SystemTable interface
      */
-    public TupleDomain<ColumnHandle> applyFilter(ConnectorSession session, Constraint constraint)
+    public TupleDomain<ColumnHandle> applyFilter(ConnectorSession session, Constraint<ColumnHandle> constraint)
     {
         return constraint.getSummary();
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -508,7 +508,7 @@ public interface Metadata
 
     Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit);
 
-    Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint);
+    Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint);
 
     Optional<ProjectionApplicationResult<TableHandle>> applyProjection(Session session, TableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments);
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1934,7 +1934,7 @@ public final class MetadataManager
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint)
     {
         CatalogHandle catalogHandle = table.getCatalogHandle();
         ConnectorMetadata metadata = getMetadata(session, catalogHandle);

--- a/core/trino-main/src/main/java/io/trino/split/SplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitManager.java
@@ -23,6 +23,7 @@ import io.trino.execution.QueryManagerConfig;
 import io.trino.metadata.TableFunctionHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -54,7 +55,7 @@ public class SplitManager
             Span parentSpan,
             TableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         CatalogHandle catalogHandle = table.getCatalogHandle();
         ConnectorSplitManager splitManager = splitManagerProvider.getService(catalogHandle);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SplitSourceFactory.java
@@ -177,10 +177,10 @@ public class SplitSourceFactory
                 dynamicFilter = dynamicFilterService.createDynamicFilter(session.getQueryId(), dynamicFilters, assignments, typeProvider);
             }
 
-            Constraint constraint = filterPredicate
+            Constraint<ColumnHandle> constraint = filterPredicate
                     .map(predicate -> filterConjuncts(plannerContext.getMetadata(), predicate, expression -> !DynamicFilters.isDynamicFilter(expression)))
                     .map(predicate -> new LayoutConstraintEvaluator(plannerContext, typeAnalyzer, session, typeProvider, assignments, predicate))
-                    .map(evaluator -> new Constraint(TupleDomain.all(), evaluator::isCandidate, evaluator.getArguments())) // we are interested only in functional predicate here, so we set the summary to ALL.
+                    .map(evaluator -> new Constraint<>(TupleDomain.all(), evaluator::isCandidate, evaluator.getArguments())) // we are interested only in functional predicate here, so we set the summary to ALL.
                     .orElse(alwaysTrue());
 
             // get dataSource for table

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -192,7 +192,7 @@ public class PushPredicateIntoTableScan
 
         Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
-        Constraint constraint;
+        Constraint<ColumnHandle> constraint;
         // use evaluator only when there is some predicate which could not be translated into tuple domain
         if (pruneWithPredicateExpression && !TRUE_LITERAL.equals(decomposedPredicate.getRemainingExpression())) {
             LayoutConstraintEvaluator evaluator = new LayoutConstraintEvaluator(
@@ -207,12 +207,12 @@ public class PushPredicateIntoTableScan
                             // Simplify the tuple domain to avoid creating an expression with too many nodes,
                             // which would be expensive to evaluate in the call to isCandidate below.
                             domainTranslator.toPredicate(newDomain.simplify().transformKeys(assignments::get))));
-            constraint = new Constraint(newDomain, expressionTranslation.connectorExpression(), connectorExpressionAssignments, evaluator::isCandidate, evaluator.getArguments());
+            constraint = new Constraint<>(newDomain, expressionTranslation.connectorExpression(), connectorExpressionAssignments, evaluator::isCandidate, evaluator.getArguments());
         }
         else {
             // Currently, invoking the expression interpreter is very expensive.
             // TODO invoke the interpreter unconditionally when the interpreter becomes cheap enough.
-            constraint = new Constraint(newDomain, expressionTranslation.connectorExpression(), connectorExpressionAssignments);
+            constraint = new Constraint<>(newDomain, expressionTranslation.connectorExpression(), connectorExpressionAssignments);
         }
 
         // check if new domain is wider than domain already provided by table scan

--- a/core/trino-main/src/main/java/io/trino/testing/TestingSplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.testing;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -44,7 +45,7 @@ public class TestingSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         return new FixedSplitSource(splits);
     }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1085,7 +1085,7 @@ public class TracingConnectorMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         Span span = startSpan("applyFilter", handle);
         try (var ignored = scopedSpan(span)) {

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -922,7 +922,7 @@ public class TracingMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint)
     {
         Span span = startSpan("applyFilter", table);
         try (var ignored = scopedSpan(span)) {

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -324,7 +324,7 @@ public class MockConnector
                     ConnectorSession session,
                     ConnectorTableHandle table,
                     DynamicFilter dynamicFilter,
-                    Constraint constraint)
+                    Constraint<ColumnHandle> constraint)
             {
                 return new FixedSplitSource(MOCK_CONNECTOR_SPLIT);
             }
@@ -466,7 +466,7 @@ public class MockConnector
         }
 
         @Override
-        public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+        public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
         {
             return applyFilter.apply(session, handle, constraint);
         }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -378,7 +378,7 @@ public class MockConnectorFactory
     @FunctionalInterface
     public interface ApplyFilter
     {
-        Optional<ConstraintApplicationResult<ConnectorTableHandle>> apply(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint);
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> apply(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint);
     }
 
     @FunctionalInterface

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -627,7 +627,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
@@ -118,7 +118,7 @@ public class TestInformationSchemaMetadata
         ImmutableMap.Builder<ColumnHandle, Domain> domains = ImmutableMap.builder();
         domains.put(new InformationSchemaColumnHandle("table_schema"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_schema")));
         domains.put(new InformationSchemaColumnHandle("table_name"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_view")));
-        Constraint constraint = new Constraint(TupleDomain.withColumnDomains(domains.buildOrThrow()));
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.withColumnDomains(domains.buildOrThrow()));
 
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
@@ -135,7 +135,7 @@ public class TestInformationSchemaMetadata
     public void testInformationSchemaPredicatePushdownWithConstraintPredicate()
     {
         TransactionId transactionId = transactionManager.beginTransaction(false);
-        Constraint constraint = new Constraint(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
 
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
@@ -157,7 +157,7 @@ public class TestInformationSchemaMetadata
         // predicate without schema predicates should cause schemas to be enumerated when table predicates are present
         ImmutableMap.Builder<ColumnHandle, Domain> domains = ImmutableMap.builder();
         domains.put(new InformationSchemaColumnHandle("table_name"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_view")));
-        Constraint constraint = new Constraint(TupleDomain.withColumnDomains(domains.buildOrThrow()));
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.withColumnDomains(domains.buildOrThrow()));
 
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
@@ -181,7 +181,7 @@ public class TestInformationSchemaMetadata
         // predicate without table name predicates should not cause table level prefixes to be evaluated
         ImmutableMap.Builder<ColumnHandle, Domain> domains = ImmutableMap.builder();
         domains.put(new InformationSchemaColumnHandle("table_schema"), Domain.singleValue(VARCHAR, Slices.utf8Slice("test_schema")));
-        Constraint constraint = new Constraint(TupleDomain.withColumnDomains(domains.buildOrThrow()));
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.withColumnDomains(domains.buildOrThrow()));
 
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
@@ -200,7 +200,7 @@ public class TestInformationSchemaMetadata
         TransactionId transactionId = transactionManager.beginTransaction(false);
 
         // predicate on non columns enumerating table should not cause tables to be enumerated
-        Constraint constraint = new Constraint(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
         InformationSchemaTableHandle tableHandle = (InformationSchemaTableHandle)
@@ -220,7 +220,7 @@ public class TestInformationSchemaMetadata
 
         // Predicate pushdown shouldn't work for catalog-wise tables because the table prefixes for them are always
         // ImmutableSet.of(new QualifiedTablePrefix(catalogName));
-        Constraint constraint = new Constraint(TupleDomain.all());
+        Constraint<ColumnHandle> constraint = new Constraint<>(TupleDomain.all());
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata, MAX_PREFIXES_COUNT);
         InformationSchemaTableHandle tableHandle = (InformationSchemaTableHandle)
@@ -240,7 +240,7 @@ public class TestInformationSchemaMetadata
         ConnectorTableHandle tableHandle = metadata.getTableHandle(session, new SchemaTableName("information_schema", "tables"));
 
         // Empty schema name
-        InformationSchemaTableHandle filtered = metadata.applyFilter(session, tableHandle, new Constraint(TupleDomain.withColumnDomains(
+        InformationSchemaTableHandle filtered = metadata.applyFilter(session, tableHandle, new Constraint<>(TupleDomain.withColumnDomains(
                         ImmutableMap.of(tableSchemaColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
                 .map(ConstraintApplicationResult::getHandle)
                 .map(InformationSchemaTableHandle.class::cast)
@@ -250,7 +250,7 @@ public class TestInformationSchemaMetadata
         assertEquals(filtered.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "")));
 
         // Empty table name
-        filtered = metadata.applyFilter(session, tableHandle, new Constraint(TupleDomain.withColumnDomains(
+        filtered = metadata.applyFilter(session, tableHandle, new Constraint<>(TupleDomain.withColumnDomains(
                         ImmutableMap.of(tableNameColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
                 .map(ConstraintApplicationResult::getHandle)
                 .map(InformationSchemaTableHandle.class::cast)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
@@ -169,7 +169,7 @@ public class TestRemoveEmptyUnionBranches
 
     // This method tries to detect whether we encountered a domain and a predicate that yields no values - and hence
     // results in a "none" domain effectively.
-    private boolean discoveredNonePredicateOnPushdownColumn(TupleDomain<ColumnHandle> domain, Constraint constraint)
+    private boolean discoveredNonePredicateOnPushdownColumn(TupleDomain<ColumnHandle> domain, Constraint<ColumnHandle> constraint)
     {
         if (domain.isNone() || constraint.predicate().isEmpty()) {
             // We're not discovering a new "none" domain if the domain is already none OR

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -213,6 +213,150 @@
                                 <!-- Any exclusions below can be deleted after each release -->
                                 <item>
                                     <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter java.util.Optional&lt;io.trino.spi.connector.ConstraintApplicationResult&lt;io.trino.spi.connector.ConnectorTableHandle&gt;&gt; io.trino.spi.connector.ConnectorMetadata::applyFilter(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableHandle, ===io.trino.spi.connector.Constraint===)</old>
+                                    <new>parameter java.util.Optional&lt;io.trino.spi.connector.ConstraintApplicationResult&lt;io.trino.spi.connector.ConnectorTableHandle&gt;&gt; io.trino.spi.connector.ConnectorMetadata::applyFilter(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableHandle, ===io.trino.spi.connector.Constraint&lt;io.trino.spi.connector.ColumnHandle&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter io.trino.spi.connector.ConnectorSplitSource io.trino.spi.connector.ConnectorSplitManager::getSplits(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableHandle, io.trino.spi.connector.DynamicFilter, ===io.trino.spi.connector.Constraint===)</old>
+                                    <new>parameter io.trino.spi.connector.ConnectorSplitSource io.trino.spi.connector.ConnectorSplitManager::getSplits(io.trino.spi.connector.ConnectorTransactionHandle, io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.ConnectorTableHandle, io.trino.spi.connector.DynamicFilter, ===io.trino.spi.connector.Constraint&lt;io.trino.spi.connector.ColumnHandle&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;===)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;T&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;===, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;T&gt;===, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.expression.ConnectorExpression, ===java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;===)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, io.trino.spi.expression.ConnectorExpression, ===java.util.Map&lt;java.lang.String, T&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;===, java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;T&gt;===, java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, ===java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;===, java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, ===java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;===, java.util.Set&lt;T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;, ===java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;===)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;, ===java.util.Set&lt;T&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;===, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;, java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(===io.trino.spi.predicate.TupleDomain&lt;T&gt;===, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, T&gt;, java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.expression.ConnectorExpression, ===java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;===, java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, io.trino.spi.expression.ConnectorExpression, ===java.util.Map&lt;java.lang.String, T&gt;===, java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;, java.util.Set&lt;T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;, ===java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;===, java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, T&gt;, ===java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;===, java.util.Set&lt;T&gt;)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.parameterTypeParameterChanged</code>
+                                    <old>parameter void io.trino.spi.connector.Constraint::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt;, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt;, java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;, ===java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;===)</old>
+                                    <new>parameter void io.trino.spi.connector.Constraint&lt;T&gt;::&lt;init&gt;(io.trino.spi.predicate.TupleDomain&lt;T&gt;, io.trino.spi.expression.ConnectorExpression, java.util.Map&lt;java.lang.String, T&gt;, java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;, ===java.util.Set&lt;T&gt;===)</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysFalse()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysFalse()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.elementNowParameterized</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysFalse()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysFalse()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.formalTypeParameterAdded</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysFalse()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysFalse()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysTrue()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysTrue()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.elementNowParameterized</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysTrue()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysTrue()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.formalTypeParameterAdded</code>
+                                    <old>method io.trino.spi.connector.Constraint io.trino.spi.connector.Constraint::alwaysTrue()</old>
+                                    <new>method &lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::alwaysTrue()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method java.util.Map&lt;java.lang.String, io.trino.spi.connector.ColumnHandle&gt; io.trino.spi.connector.Constraint::getAssignments()</old>
+                                    <new>method java.util.Map&lt;java.lang.String, T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::getAssignments()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method java.util.Optional&lt;java.util.Set&lt;io.trino.spi.connector.ColumnHandle&gt;&gt; io.trino.spi.connector.Constraint::getPredicateColumns()</old>
+                                    <new>method java.util.Optional&lt;java.util.Set&lt;T&gt;&gt; io.trino.spi.connector.Constraint&lt;T&gt;::getPredicateColumns()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method io.trino.spi.predicate.TupleDomain&lt;io.trino.spi.connector.ColumnHandle&gt; io.trino.spi.connector.Constraint::getSummary()</old>
+                                    <new>method io.trino.spi.predicate.TupleDomain&lt;T&gt; io.trino.spi.connector.Constraint&lt;T&gt;::getSummary()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.method.returnTypeTypeParametersChanged</code>
+                                    <old>method java.util.Optional&lt;java.util.function.Predicate&lt;java.util.Map&lt;io.trino.spi.connector.ColumnHandle, io.trino.spi.predicate.NullableValue&gt;&gt;&gt; io.trino.spi.connector.Constraint::predicate()</old>
+                                    <new>method java.util.Optional&lt;java.util.function.Predicate&lt;java.util.Map&lt;T, io.trino.spi.predicate.NullableValue&gt;&gt;&gt; io.trino.spi.connector.Constraint&lt;T&gt;::predicate()</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.elementNowParameterized</code>
+                                    <old>class io.trino.spi.connector.Constraint</old>
+                                    <new>class io.trino.spi.connector.Constraint&lt;T&gt;</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.generics.formalTypeParameterAdded</code>
+                                    <old>class io.trino.spi.connector.Constraint</old>
+                                    <new>class io.trino.spi.connector.Constraint&lt;T&gt;</new>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
                                     <code>java.method.removed</code>
                                     <old>method java.util.Optional&lt;io.trino.spi.type.Type&gt; io.trino.spi.connector.ConnectorMetadata::getSupportedType(io.trino.spi.connector.ConnectorSession, io.trino.spi.type.Type)</old>
                                 </item>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1228,7 +1228,7 @@ public interface ConnectorMetadata
      *
      * @param constraint constraint to be applied to the table. {@link Constraint#getSummary()} is guaranteed not to be {@link TupleDomain#isNone() none}.
      */
-    default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         // applyFilter is expected not to be invoked with a "false" constraint
         if (constraint.getSummary().isNone()) {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitManager.java
@@ -23,7 +23,7 @@ public interface ConnectorSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
@@ -26,58 +26,60 @@ import java.util.function.Predicate;
 import static io.trino.spi.expression.Constant.TRUE;
 import static java.util.Objects.requireNonNull;
 
-public class Constraint
+public class Constraint<T>
 {
-    private static final Constraint ALWAYS_TRUE = new Constraint(TupleDomain.all());
-    private static final Constraint ALWAYS_FALSE = new Constraint(TupleDomain.none(), bindings -> false, Set.of());
+    private static final Constraint<?> ALWAYS_TRUE = new Constraint<>(TupleDomain.all());
+    private static final Constraint<?> ALWAYS_FALSE = new Constraint<>(TupleDomain.none(), bindings -> false, Set.of());
 
-    private final TupleDomain<ColumnHandle> summary;
+    private final TupleDomain<T> summary;
     private final ConnectorExpression expression;
-    private final Map<String, ColumnHandle> assignments;
-    private final Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate;
-    private final Optional<Set<ColumnHandle>> predicateColumns;
+    private final Map<String, T> assignments;
+    private final Optional<Predicate<Map<T, NullableValue>>> predicate;
+    private final Optional<Set<T>> predicateColumns;
 
-    public static Constraint alwaysTrue()
+    @SuppressWarnings("unchecked")
+    public static <T> Constraint<T> alwaysTrue()
     {
-        return ALWAYS_TRUE;
+        return (Constraint<T>) ALWAYS_TRUE;
     }
 
-    public static Constraint alwaysFalse()
+    @SuppressWarnings("unchecked")
+    public static <T> Constraint<T> alwaysFalse()
     {
-        return ALWAYS_FALSE;
+        return (Constraint<T>) ALWAYS_FALSE;
     }
 
-    public Constraint(TupleDomain<ColumnHandle> summary)
+    public Constraint(TupleDomain<T> summary)
     {
         this(summary, TRUE, Map.of(), Optional.empty(), Optional.empty());
     }
 
-    public Constraint(TupleDomain<ColumnHandle> summary, Predicate<Map<ColumnHandle, NullableValue>> predicate, Set<ColumnHandle> predicateColumns)
+    public Constraint(TupleDomain<T> summary, Predicate<Map<T, NullableValue>> predicate, Set<T> predicateColumns)
     {
         this(summary, TRUE, Map.of(), Optional.of(predicate), Optional.of(predicateColumns));
     }
 
-    public Constraint(TupleDomain<ColumnHandle> summary, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    public Constraint(TupleDomain<T> summary, ConnectorExpression expression, Map<String, T> assignments)
     {
         this(summary, expression, assignments, Optional.empty(), Optional.empty());
     }
 
     public Constraint(
-            TupleDomain<ColumnHandle> summary,
+            TupleDomain<T> summary,
             ConnectorExpression expression,
-            Map<String, ColumnHandle> assignments,
-            Predicate<Map<ColumnHandle, NullableValue>> predicate,
-            Set<ColumnHandle> predicateColumns)
+            Map<String, T> assignments,
+            Predicate<Map<T, NullableValue>> predicate,
+            Set<T> predicateColumns)
     {
         this(summary, expression, assignments, Optional.of(predicate), Optional.of(predicateColumns));
     }
 
     private Constraint(
-            TupleDomain<ColumnHandle> summary,
+            TupleDomain<T> summary,
             ConnectorExpression expression,
-            Map<String, ColumnHandle> assignments,
-            Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate,
-            Optional<Set<ColumnHandle>> predicateColumns)
+            Map<String, T> assignments,
+            Optional<Predicate<Map<T, NullableValue>>> predicate,
+            Optional<Set<T>> predicateColumns)
     {
         this.summary = requireNonNull(summary, "summary is null");
         this.expression = requireNonNull(expression, "expression is null");
@@ -96,7 +98,7 @@ public class Constraint
     /**
      * @return a predicate which is equivalent to, or looser than {@link #predicate} (if present), and should be AND-ed with, {@link #getExpression}.
      */
-    public TupleDomain<ColumnHandle> getSummary()
+    public TupleDomain<T> getSummary()
     {
         return summary;
     }
@@ -113,7 +115,7 @@ public class Constraint
      * @return mappings from variable names to table column handles
      * It is guaranteed that all the required mappings for {@link #getExpression} will be provided but not necessarily *all* the column handles of the table
      */
-    public Map<String, ColumnHandle> getAssignments()
+    public Map<String, T> getAssignments()
     {
         return assignments;
     }
@@ -126,7 +128,7 @@ public class Constraint
      *
      * @see #getPredicateColumns()
      */
-    public Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate()
+    public Optional<Predicate<Map<T, NullableValue>>> predicate()
     {
         return predicate;
     }
@@ -134,7 +136,7 @@ public class Constraint
     /**
      * Set of columns the {@link #predicate()} result depends on. It's present if and only if {@link #predicate()} is present.
      */
-    public Optional<Set<ColumnHandle>> getPredicateColumns()
+    public Optional<Set<T>> getPredicateColumns()
     {
         return predicateColumns;
     }

--- a/docs/src/main/sphinx/develop/connectors.md
+++ b/docs/src/main/sphinx/develop/connectors.md
@@ -363,7 +363,7 @@ The following is a simple example which only looks at `TupleDomain`:
 public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
         ConnectorSession session,
         ConnectorTableHandle tableHandle,
-        Constraint constraint)
+        Constraint<ColumnHandle> constraint)
 {
     ExampleTableHandle handle = (ExampleTableHandle) tableHandle;
 
@@ -401,7 +401,7 @@ not available directly in the underlying data source, and must be mapped:
 public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
         ConnectorSession session,
         ConnectorTableHandle table,
-        Constraint constraint)
+        Constraint<ColumnHandle> constraint)
 {
     JdbcTableHandle handle = (JdbcTableHandle) table;
 
@@ -488,7 +488,7 @@ The following example adds expression pushdown enabled by a session flag:
 public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
         ConnectorSession session,
         ConnectorTableHandle table,
-        Constraint constraint)
+        Constraint<ColumnHandle> constraint)
 {
     JdbcTableHandle handle = (JdbcTableHandle) table;
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -924,7 +924,7 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applyFilter(session, table, constraint);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.base.classloader;
 
 import com.google.inject.Inject;
 import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -45,7 +46,7 @@ public final class ClassLoaderSafeConnectorSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getSplits(transaction, session, table, dynamicFilter, constraint);

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
@@ -368,7 +368,7 @@ public class AccumuloMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         AccumuloTableHandle handle = (AccumuloTableHandle) table;
 

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloSplitManager.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloSplitManager.java
@@ -58,7 +58,7 @@ public class AccumuloSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         AccumuloTableHandle handle = (AccumuloTableHandle) tableHandle;
 

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
@@ -148,7 +148,7 @@ public class AtopMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         AtopTableHandle handle = (AtopTableHandle) table;
 

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopSplitManager.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopSplitManager.java
@@ -16,6 +16,7 @@ package io.trino.plugin.atop;
 import com.google.inject.Inject;
 import io.trino.spi.Node;
 import io.trino.spi.NodeManager;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -60,7 +61,7 @@ public class AtopSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         AtopTableHandle tableHandle = (AtopTableHandle) table;
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -164,7 +164,7 @@ public class DefaultJdbcMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         if (isTableHandleForProcedure(table)) {
             return Optional.empty();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDynamicFilteringSplitManager.java
@@ -18,6 +18,7 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -66,7 +67,7 @@ public class JdbcDynamicFilteringSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         // JdbcProcedureHandle doesn't support any pushdown operation, so we rely on delegateSplitManager
         if (table instanceof JdbcProcedureHandle) {
@@ -90,7 +91,7 @@ public class JdbcDynamicFilteringSplitManager
         private final ConnectorSession session;
         private final JdbcTableHandle table;
         private final DynamicFilter dynamicFilter;
-        private final Constraint constraint;
+        private final Constraint<ColumnHandle> constraint;
         private final long dynamicFilteringTimeoutNanos;
         private final long startNanos;
 
@@ -102,7 +103,7 @@ public class JdbcDynamicFilteringSplitManager
                 ConnectorSession session,
                 JdbcTableHandle table,
                 DynamicFilter dynamicFilter,
-                Constraint constraint)
+                Constraint<ColumnHandle> constraint)
         {
             this.transaction = requireNonNull(transaction, "transaction is null");
             this.session = requireNonNull(session, "session is null");

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -42,7 +43,7 @@ public class JdbcSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         if (table instanceof JdbcProcedureHandle procedureHandle) {
             return jdbcClient.getSplits(session, procedureHandle);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -313,7 +313,7 @@ public class TestDefaultJdbcMetadata
         ConnectorTableHandle aggregatedTable = applyCountAggregation(session, baseTableHandle, ImmutableList.of(ImmutableList.of(groupByColumn)));
 
         Domain domain = Domain.singleValue(VARCHAR, utf8Slice("one"));
-        JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, domain))));
+        JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, domain))));
 
         assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(groupByColumn, domain)));
     }
@@ -328,12 +328,12 @@ public class TestDefaultJdbcMetadata
         ConnectorTableHandle baseTableHandle = metadata.getTableHandle(session, new SchemaTableName("example", "numbers"));
 
         Domain firstDomain = Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("one"), utf8Slice("two")));
-        JdbcTableHandle filterResult = applyFilter(session, baseTableHandle, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, firstDomain))));
+        JdbcTableHandle filterResult = applyFilter(session, baseTableHandle, new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, firstDomain))));
 
         ConnectorTableHandle aggregatedTable = applyCountAggregation(session, filterResult, ImmutableList.of(ImmutableList.of(groupByColumn)));
 
         Domain secondDomain = Domain.multipleValues(VARCHAR, ImmutableList.of(utf8Slice("one"), utf8Slice("three")));
-        JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, secondDomain))));
+        JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, secondDomain))));
         assertThat(tableHandleWithFilter.getConstraint().getDomains())
                 .isEqualTo(
                     // The query effectively intersects firstDomain and secondDomain, but this is not visible in JdbcTableHandle.constraint,
@@ -363,7 +363,7 @@ public class TestDefaultJdbcMetadata
         JdbcTableHandle tableHandleWithFilter = applyFilter(
                 session,
                 aggregatedTable,
-                new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(nonGroupByColumn, domain))));
+                new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(nonGroupByColumn, domain))));
         assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(nonGroupByColumn, domain)));
         assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
                 .isEqualTo("SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
@@ -389,7 +389,7 @@ public class TestDefaultJdbcMetadata
         JdbcTableHandle tableHandleWithFilter = applyFilter(
                 session,
                 aggregatedTable,
-                new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(valueColumn, domain))));
+                new Constraint<>(TupleDomain.withColumnDomains(ImmutableMap.of(valueColumn, domain))));
         assertThat(tableHandleWithFilter.getConstraint().getDomains()).isEqualTo(Optional.of(ImmutableMap.of(valueColumn, domain)));
         assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
                 .isEqualTo("SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_0\" " +
@@ -437,7 +437,7 @@ public class TestDefaultJdbcMetadata
         return (JdbcTableHandle) aggResult.get().getHandle();
     }
 
-    private JdbcTableHandle applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    private JdbcTableHandle applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
     {
         Optional<ConstraintApplicationResult<ConnectorTableHandle>> filterResult = metadata.applyFilter(
                 session,

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -774,7 +774,7 @@ public class BigQueryMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(
             ConnectorSession session,
             ConnectorTableHandle handle,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         log.debug("applyFilter(session=%s, handle=%s, summary=%s, predicate=%s, columns=%s)",
                 session, handle, constraint.getSummary(), constraint.predicate(), constraint.getPredicateColumns());

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -93,7 +93,7 @@ public class BigQuerySplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         log.debug("getSplits(transaction=%s, session=%s, table=%s)", transaction, session, table);
         BigQueryTableHandle bigQueryTableHandle = (BigQueryTableHandle) table;

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleSplitManager.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleSplitManager.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.blackhole;
 
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -33,7 +34,7 @@ public final class BlackHoleSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         int splitCount = ((BlackHoleTableHandle) table).getSplitCount();
         return new FixedSplitSource(nCopies(splitCount, BlackHoleSplit.INSTANCE));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -227,7 +227,7 @@ public class CassandraMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle connectorTableHandle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle connectorTableHandle, Constraint<ColumnHandle> constraint)
     {
         CassandraTableHandle tableHandle = (CassandraTableHandle) connectorTableHandle;
         if (tableHandle.isSynthetic()) {

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java
@@ -25,6 +25,7 @@ import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.plugin.cassandra.util.HostAddressFactory;
 import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -80,7 +81,7 @@ public class CassandraSplitManager
             ConnectorSession session,
             ConnectorTableHandle connectorTableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         CassandraTableHandle tableHandle = (CassandraTableHandle) connectorTableHandle;
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2644,7 +2644,7 @@ public class DeltaLakeMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) handle;
         SchemaTableName tableName = tableHandle.getSchemaTableName();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -110,7 +110,7 @@ public class DeltaLakeSplitManager
             ConnectorSession session,
             ConnectorTableHandle handle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         DeltaLakeTableHandle deltaLakeTableHandle = (DeltaLakeTableHandle) handle;
         if (deltaLakeTableHandle.getEnforcedPartitionConstraint().isNone() || deltaLakeTableHandle.getNonPartitionConstraint().isNone()) {
@@ -147,7 +147,7 @@ public class DeltaLakeSplitManager
             ConnectorSession session,
             Optional<DataSize> maxScannedFileSize,
             Set<ColumnHandle> columnsCoveredByDynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         TableSnapshot tableSnapshot;
         try {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -488,7 +488,7 @@ public class ElasticsearchMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         ElasticsearchTableHandle handle = (ElasticsearchTableHandle) table;
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplitManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.elasticsearch;
 
 import com.google.inject.Inject;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -48,7 +49,7 @@ public class ElasticsearchSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         ElasticsearchTableHandle tableHandle = (ElasticsearchTableHandle) table;
 

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplitManager.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.example;
 
 import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -49,7 +50,7 @@ public class ExampleSplitManager
             ConnectorSession session,
             ConnectorTableHandle connectorTableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         ExampleTableHandle tableHandle = (ExampleTableHandle) connectorTableHandle;
         ExampleTable table = exampleClient.getTable(tableHandle.getSchemaName(), tableHandle.getTableName());

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.google.sheets;
 
 import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -48,7 +49,7 @@ public class SheetsSplitManager
             ConnectorSession session,
             ConnectorTableHandle connectorTableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         SheetsConnectorTableHandle tableHandle = (SheetsConnectorTableHandle) connectorTableHandle;
         SheetsTable table = sheetsClient.getTable(tableHandle)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -894,7 +894,7 @@ public class HiveMetadata
 
         Map<String, Type> columnTypes = columns.entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
-        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, new Constraint(hiveTableHandle.getEnforcedConstraint()));
+        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, new Constraint<>(hiveTableHandle.getEnforcedConstraint()));
         // If partitions are not loaded, then don't generate table statistics.
         // Note that the computation is not persisted in the table handle, so can be redone many times
         // TODO: https://github.com/trinodb/trino/issues/10980.
@@ -2916,7 +2916,7 @@ public class HiveMetadata
                         // We load the partitions to compute the predicates enforced by the table.
                         // Note that the computation is not persisted in the table handle, so can be redone many times
                         // TODO: https://github.com/trinodb/trino/issues/10980.
-                        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, table, new Constraint(hiveTable.getEnforcedConstraint()));
+                        HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, table, new Constraint<>(hiveTable.getEnforcedConstraint()));
                         return partitionManager.tryLoadPartitions(partitionResult);
                     });
 
@@ -2976,7 +2976,7 @@ public class HiveMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
     {
         HiveTableHandle handle = (HiveTableHandle) tableHandle;
         checkArgument(handle.getAnalyzePartitionValues().isEmpty() || constraint.getSummary().isAll(), "Analyze should not have a constraint");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
@@ -67,7 +67,7 @@ public class HivePartitionManager
         this.domainCompactionThreshold = domainCompactionThreshold;
     }
 
-    public HivePartitionResult getPartitions(SemiTransactionalHiveMetastore metastore, ConnectorTableHandle tableHandle, Constraint constraint)
+    public HivePartitionResult getPartitions(SemiTransactionalHiveMetastore metastore, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
     {
         HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
         TupleDomain<ColumnHandle> effectivePredicate = constraint.getSummary()
@@ -140,7 +140,7 @@ public class HivePartitionManager
         return new HivePartitionResult(partitionColumns, Optional.empty(), partitionList, TupleDomain.all(), TupleDomain.all(), bucketHandle, Optional.empty());
     }
 
-    public HiveTableHandle applyPartitionResult(HiveTableHandle handle, HivePartitionResult partitions, Constraint constraint)
+    public HiveTableHandle applyPartitionResult(HiveTableHandle handle, HivePartitionResult partitions, Constraint<ColumnHandle> constraint)
     {
         Optional<List<String>> partitionNames = partitions.getPartitionNames();
         TupleDomain<ColumnHandle> enforcedConstraint = handle.getEnforcedConstraint();
@@ -183,7 +183,7 @@ public class HivePartitionManager
         TupleDomain<ColumnHandle> summary = table.getEnforcedConstraint().intersect(
                 table.getCompactEffectivePredicate()
                         .transformKeys(ColumnHandle.class::cast));
-        return table.getPartitions().map(List::iterator).orElseGet(() -> getPartitions(metastore, table, new Constraint(summary)).getPartitions());
+        return table.getPartitions().map(List::iterator).orElseGet(() -> getPartitions(metastore, table, new Constraint<>(summary)).getPartitions());
     }
 
     public Optional<List<HivePartition>> tryLoadPartitions(HivePartitionResult partitionResult)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -33,6 +33,7 @@ import io.trino.plugin.hive.util.HiveBucketing.HiveBucketFilter;
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.VersionEmbedder;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -189,7 +190,7 @@ public class HiveSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         HiveTableHandle hiveTable = (HiveTableHandle) tableHandle;
         SchemaTableName tableName = hiveTable.getSchemaTableName();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
@@ -110,7 +110,7 @@ public class PartitionsSystemTableProvider
         return Optional.of(createSystemTable(
                 new ConnectorTableMetadata(tableName, partitionSystemTableColumns),
                 constraint -> {
-                    Constraint targetConstraint = new Constraint(constraint.transformKeys(partitionColumns::get));
+                    Constraint targetConstraint = new Constraint<>(constraint.transformKeys(partitionColumns::get));
                     Iterable<List<Object>> records = () ->
                             stream(partitionManager.getPartitions(metadata.getMetastore(), sourceTableHandle, targetConstraint).getPartitions())
                                     .map(hivePartition ->

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -158,7 +158,7 @@ public class HudiMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint<ColumnHandle> constraint)
     {
         HudiTableHandle handle = (HudiTableHandle) tableHandle;
         HudiPredicates predicates = HudiPredicates.from(constraint.getSummary());

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitManager.java
@@ -20,6 +20,7 @@ import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HiveTransactionHandle;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -83,7 +84,7 @@ public class HudiSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         HudiTableHandle hudiTableHandle = (HudiTableHandle) tableHandle;
         HudiMetadata hudiMetadata = transactionManager.get(transaction, session.getIdentity());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
@@ -66,7 +66,7 @@ public final class ConstraintExtractor
 {
     private ConstraintExtractor() {}
 
-    public static ExtractionResult extractTupleDomain(Constraint constraint)
+    public static ExtractionResult extractTupleDomain(Constraint<ColumnHandle> constraint)
     {
         TupleDomain<IcebergColumnHandle> result = constraint.getSummary()
                 .transformKeys(IcebergColumnHandle.class::cast);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2404,7 +2404,7 @@ public class IcebergMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
         ConstraintExtractor.ExtractionResult extractionResult = extractTupleDomain(constraint);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -20,6 +20,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionHandle;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesSplitSource;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -68,7 +69,7 @@ public class IcebergSplitManager
             ConnectorSession session,
             ConnectorTableHandle handle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -107,7 +107,7 @@ public class IcebergSplitSource
     private final DynamicFilter dynamicFilter;
     private final long dynamicFilteringWaitTimeoutMillis;
     private final Stopwatch dynamicFilterWaitStopwatch;
-    private final Constraint constraint;
+    private final Constraint<ColumnHandle> constraint;
     private final TypeManager typeManager;
     private final Closer closer = Closer.create();
     private final double minimumAssignedSplitWeight;
@@ -135,7 +135,7 @@ public class IcebergSplitSource
             Optional<DataSize> maxScannedFileSize,
             DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeout,
-            Constraint constraint,
+            Constraint<ColumnHandle> constraint,
             TypeManager typeManager,
             boolean recordScannedFiles,
             double minimumAssignedSplitWeight)
@@ -422,7 +422,7 @@ public class IcebergSplitSource
     static boolean partitionMatchesConstraint(
             Set<IcebergColumnHandle> identityPartitionColumns,
             Supplier<Map<ColumnHandle, NullableValue>> partitionValues,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         // We use Constraint just to pass functional predicate here from DistributedExecutionPlanner
         verify(constraint.getSummary().isAll());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3911,7 +3911,7 @@ public abstract class BaseIcebergConnectorTest
                     filter.entrySet().stream()
                             .collect(toImmutableMap(entry -> columns.get(entry.getKey()), Map.Entry::getValue)));
 
-            Optional<ConstraintApplicationResult<TableHandle>> result = metadata.applyFilter(session, table, new Constraint(domains));
+            Optional<ConstraintApplicationResult<TableHandle>> result = metadata.applyFilter(session, table, new Constraint<>(domains));
 
             assertEquals((expectedUnenforcedPredicate == null && expectedEnforcedPredicate == null), result.isEmpty());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestConstraintExtractor.java
@@ -93,7 +93,7 @@ public class TestConstraintExtractor
     public void testExtractSummary()
     {
         assertThat(extract(
-                new Constraint(
+                new Constraint<>(
                         TupleDomain.withColumnDomains(Map.of(A_BIGINT, Domain.singleValue(BIGINT, 1L))),
                         Constant.TRUE,
                         Map.of(),
@@ -380,7 +380,7 @@ public class TestConstraintExtractor
                 Optional.empty());
     }
 
-    private static TupleDomain<IcebergColumnHandle> extract(Constraint constraint)
+    private static TupleDomain<IcebergColumnHandle> extract(Constraint<ColumnHandle> constraint)
     {
         ConstraintExtractor.ExtractionResult result = extractTupleDomain(constraint);
         assertThat(result.remainingExpression())
@@ -388,17 +388,17 @@ public class TestConstraintExtractor
         return result.tupleDomain();
     }
 
-    private static Constraint constraint(Expression expression, Map<String, IcebergColumnHandle> assignments)
+    private static Constraint<ColumnHandle> constraint(Expression expression, Map<String, IcebergColumnHandle> assignments)
     {
         return constraint(TupleDomain.all(), expression, assignments);
     }
 
-    private static Constraint constraint(TupleDomain<ColumnHandle> summary, Expression expression, Map<String, IcebergColumnHandle> assignments)
+    private static Constraint<ColumnHandle> constraint(TupleDomain<ColumnHandle> summary, Expression expression, Map<String, IcebergColumnHandle> assignments)
     {
         Map<String, Type> symbolTypes = assignments.entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getType()));
         ConnectorExpression connectorExpression = connectorExpression(expression, symbolTypes);
-        return new Constraint(summary, connectorExpression, ImmutableMap.copyOf(assignments));
+        return new Constraint<>(summary, connectorExpression, ImmutableMap.copyOf(assignments));
     }
 
     private static ConnectorExpression connectorExpression(Expression expression, Map<String, Type> symbolTypes)

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
@@ -260,7 +260,7 @@ public class JmxMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         Map<ColumnHandle, Domain> domains = constraint.getSummary().getDomains().orElseThrow(() -> new IllegalArgumentException("constraint summary is NONE"));
 

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxSplitManager.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxSplitManager.java
@@ -58,7 +58,7 @@ public class JmxSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         JmxTableHandle tableHandle = (JmxTableHandle) table;
 

--- a/plugin/trino-jmx/src/test/java/io/trino/plugin/jmx/TestJmxMetadata.java
+++ b/plugin/trino-jmx/src/test/java/io/trino/plugin/jmx/TestJmxMetadata.java
@@ -135,7 +135,7 @@ public class TestJmxMetadata
     public void testApplyFilterWithoutConstraint()
     {
         JmxTableHandle handle = metadata.getTableHandle(SESSION, new SchemaTableName(JMX_SCHEMA_NAME, "java.lang:*"));
-        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, handle, new Constraint(TupleDomain.all()));
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, handle, new Constraint<>(TupleDomain.all()));
 
         assertThat(result).isNotPresent();
     }
@@ -153,7 +153,7 @@ public class TestJmxMetadata
 
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.fromFixedValues(ImmutableMap.of(nodeColumnHandle, nodeColumnValue, objectNameColumnHandle, objectNameColumnValue));
 
-        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, handle, new Constraint(tupleDomain));
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, handle, new Constraint<>(tupleDomain));
 
         assertThat(result).isPresent();
         assertThat(result.get().getRemainingFilter())
@@ -172,7 +172,7 @@ public class TestJmxMetadata
 
         JmxTableHandle newTableHandle = new JmxTableHandle(handle.getTableName(), handle.getObjectNames(), handle.getColumnHandles(), handle.isLiveData(), nodeTupleDomain);
 
-        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, newTableHandle, new Constraint(nodeTupleDomain));
+        Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(SESSION, newTableHandle, new Constraint<>(nodeTupleDomain));
         assertThat(result).isNotPresent();
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -230,7 +230,7 @@ public class KafkaMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         KafkaTableHandle handle = (KafkaTableHandle) table;
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
@@ -18,6 +18,7 @@ import com.google.inject.Inject;
 import io.trino.plugin.kafka.schema.ContentSchemaProvider;
 import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -62,7 +63,7 @@ public class KafkaSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         KafkaTableHandle kafkaTableHandle = (KafkaTableHandle) table;
         try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.kinesis.model.Shard;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.units.Duration;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -101,7 +102,7 @@ public class KinesisSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         KinesisTableHandle kinesisTableHandle = (KinesisTableHandle) table;
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -443,7 +443,7 @@ public class KuduMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         KuduTableHandle handle = (KuduTableHandle) table;
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.kudu;
 
 import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -49,7 +50,7 @@ public class KuduSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         long timeoutMillis = getDynamicFilteringWaitTimeout(session).toMillis();
         if (timeoutMillis == 0 || !dynamicFilter.isAwaitable()) {

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileMetadata.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileMetadata.java
@@ -132,7 +132,7 @@ public class LocalFileMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         LocalFileTableHandle handle = (LocalFileTableHandle) table;
 

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileSplitManager.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileSplitManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.localfile;
 
 import com.google.inject.Inject;
 import io.trino.spi.NodeManager;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -47,7 +48,7 @@ public class LocalFileSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         List<ConnectorSplit> splits = nodeManager.getAllNodes().stream()
                 .map(node -> new LocalFileSplit(node.getHostAndPort()))

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplitManager.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplitManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.memory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -53,7 +54,7 @@ public final class MemorySplitManager
             ConnectorSession session,
             ConnectorTableHandle handle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         MemoryTableHandle table = (MemoryTableHandle) handle;
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -587,7 +587,7 @@ public class MongoMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         MongoTableHandle handle = (MongoTableHandle) table;
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplitManager.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplitManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.inject.Inject;
 import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -43,7 +44,7 @@ public class MongoSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         MongoSplit split = new MongoSplit(addresses);
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -21,6 +21,7 @@ import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -74,7 +75,7 @@ public class PhoenixSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
         try (Connection connection = phoenixClient.getConnection(session)) {

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -271,7 +271,7 @@ public class PinotMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         PinotTableHandle handle = (PinotTableHandle) table;
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
@@ -21,6 +21,7 @@ import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.ErrorType;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -162,7 +163,7 @@ public class PinotSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         PinotTableHandle pinotTableHandle = (PinotTableHandle) tableHandle;
         Supplier<TrinoException> errorSupplier = () -> new QueryNotAdequatelyPushedDownException(QueryNotAdequatelyPushedDownErrorCode.PQL_NOT_PRESENT, pinotTableHandle, "");

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
@@ -154,7 +154,7 @@ public class PrometheusMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         PrometheusTableHandle tableHandle = ((PrometheusTableHandle) handle)
                 .withPredicate(constraint.getSummary());

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplitManager.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplitManager.java
@@ -79,7 +79,7 @@ public class PrometheusSplitManager
             ConnectorSession session,
             ConnectorTableHandle connectorTableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         PrometheusTableHandle tableHandle = (PrometheusTableHandle) connectorTableHandle;
         PrometheusTable table = prometheusClient.getTable(tableHandle.getSchemaName(), tableHandle.getTableName());

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -307,7 +307,7 @@ public class RaptorMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint<ColumnHandle> constraint)
     {
         RaptorTableHandle table = (RaptorTableHandle) handle;
         TupleDomain<RaptorColumnHandle> newDomain = constraint.getSummary().transformKeys(RaptorColumnHandle.class::cast);

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplitManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplitManager.java
@@ -25,6 +25,7 @@ import io.trino.plugin.raptor.legacy.util.SynchronizedResultIterator;
 import io.trino.spi.HostAddress;
 import io.trino.spi.Node;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -95,7 +96,7 @@ public class RaptorSplitManager
             ConnectorSession session,
             ConnectorTableHandle handle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         RaptorTableHandle table = (RaptorTableHandle) handle;
         long tableId = table.getTableId();

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -188,7 +188,7 @@ public class RedisMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         RedisTableHandle handle = (RedisTableHandle) table;
         TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -64,7 +65,7 @@ public class RedisSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         RedisTableHandle redisTableHandle = (RedisTableHandle) table;
 

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
@@ -163,7 +163,7 @@ public class ThriftMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         ThriftTableHandle handle = (ThriftTableHandle) table;
 

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftSplitManager.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftSplitManager.java
@@ -74,7 +74,7 @@ public class ThriftSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         ThriftTableHandle tableHandle = (ThriftTableHandle) table;
         return new ThriftSplitSource(

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/TpcdsSplitManager.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.trino.spi.Node;
 import io.trino.spi.NodeManager;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -54,7 +55,7 @@ public class TpcdsSplitManager
             ConnectorSession session,
             ConnectorTableHandle tableHandle,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
         checkState(!nodes.isEmpty(), "No TPCDS nodes available");

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -202,7 +202,7 @@ public class TpchMetadata
         return new TpchTableHandle(tableName.getSchemaName(), tableName.getTableName(), scaleFactor);
     }
 
-    private Set<NullableValue> filterValues(Set<NullableValue> nullableValues, TpchColumn<?> column, Constraint constraint)
+    private Set<NullableValue> filterValues(Set<NullableValue> nullableValues, TpchColumn<?> column, Constraint<ColumnHandle> constraint)
     {
         return nullableValues.stream()
                 .filter(convertToPredicate(constraint.getSummary(), toColumnHandle(column)))
@@ -470,7 +470,7 @@ public class TpchMetadata
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint)
     {
         TpchTableHandle handle = (TpchTableHandle) table;
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplitManager.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchSplitManager.java
@@ -16,6 +16,7 @@ package io.trino.plugin.tpch;
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.Node;
 import io.trino.spi.NodeManager;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitManager;
@@ -52,7 +53,7 @@ public class TpchSplitManager
             ConnectorSession session,
             ConnectorTableHandle table,
             DynamicFilter dynamicFilter,
-            Constraint constraint)
+            Constraint<ColumnHandle> constraint)
     {
         Set<Node> nodes = nodeManager.getRequiredWorkerNodes();
 

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
@@ -170,7 +170,7 @@ public class TestTpchMetadata
         testTableStats(schema, table, alwaysTrue(), expectedRowCount);
     }
 
-    private void testTableStats(String schema, TpchTable<?> table, Constraint constraint, double expectedRowCount)
+    private void testTableStats(String schema, TpchTable<?> table, Constraint<ColumnHandle> constraint, double expectedRowCount)
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
         Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = tpchMetadata.applyFilter(session, tableHandle, constraint);
@@ -275,7 +275,7 @@ public class TestTpchMetadata
         testColumnStats(schema, table, column, alwaysTrue(), expectedStatistics);
     }
 
-    private void testColumnStats(String schema, TpchTable<?> table, TpchColumn<?> column, Constraint constraint, ColumnStatistics expected)
+    private void testColumnStats(String schema, TpchTable<?> table, TpchColumn<?> column, Constraint<ColumnHandle> constraint, ColumnStatistics expected)
     {
         TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
         Optional<ConstraintApplicationResult<ConnectorTableHandle>> result = tpchMetadata.applyFilter(session, tableHandle, constraint);
@@ -304,12 +304,12 @@ public class TestTpchMetadata
         ConstraintApplicationResult<ConnectorTableHandle> result;
 
         domain = fixedValueTupleDomain(tpchMetadata, ORDER_STATUS, utf8Slice("P"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(domain, convertToPredicate(domain, ORDER_STATUS), Set.of(tpchMetadata.toColumnHandle(ORDER_STATUS)))).get();
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(domain, convertToPredicate(domain, ORDER_STATUS), Set.of(tpchMetadata.toColumnHandle(ORDER_STATUS)))).get();
         assertTupleDomainEquals(result.getRemainingFilter(), TupleDomain.all(), session);
         assertTupleDomainEquals(((TpchTableHandle) result.getHandle()).getConstraint(), domain, session);
 
         domain = fixedValueTupleDomain(tpchMetadata, ORDER_KEY, 42L);
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(domain, convertToPredicate(domain, ORDER_STATUS), Set.of(tpchMetadata.toColumnHandle(ORDER_STATUS)))).get();
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(domain, convertToPredicate(domain, ORDER_STATUS), Set.of(tpchMetadata.toColumnHandle(ORDER_STATUS)))).get();
         assertTupleDomainEquals(result.getRemainingFilter(), domain, session);
         assertTupleDomainEquals(
                 ((TpchTableHandle) result.getHandle()).getConstraint(),
@@ -331,7 +331,7 @@ public class TestTpchMetadata
         ConstraintApplicationResult<ConnectorTableHandle> result;
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.TYPE, utf8Slice("SMALL BRUSHED COPPER"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.TYPE),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.TYPE)))).get();
@@ -342,7 +342,7 @@ public class TestTpchMetadata
                 session);
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.TYPE, utf8Slice("UNKNOWN"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.TYPE),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.TYPE)))).get();
@@ -350,7 +350,7 @@ public class TestTpchMetadata
         assertTupleDomainEquals(((TpchTableHandle) result.getHandle()).getConstraint(), TupleDomain.none(), session);
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.CONTAINER, utf8Slice("SM BAG"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.CONTAINER),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.CONTAINER)))).get();
@@ -361,7 +361,7 @@ public class TestTpchMetadata
                 session);
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.CONTAINER, utf8Slice("UNKNOWN"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.CONTAINER),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.CONTAINER)))).get();
@@ -369,7 +369,7 @@ public class TestTpchMetadata
         assertTupleDomainEquals(((TpchTableHandle) result.getHandle()).getConstraint(), TupleDomain.none(), session);
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.TYPE, utf8Slice("SMALL BRUSHED COPPER"), PartColumn.CONTAINER, utf8Slice("SM BAG"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.CONTAINER),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.CONTAINER)))).get();
@@ -377,7 +377,7 @@ public class TestTpchMetadata
         assertTupleDomainEquals(((TpchTableHandle) result.getHandle()).getConstraint(), domain, session);
 
         domain = fixedValueTupleDomain(tpchMetadata, PartColumn.TYPE, utf8Slice("UNKNOWN"), PartColumn.CONTAINER, utf8Slice("UNKNOWN"));
-        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint(
+        result = tpchMetadata.applyFilter(session, tableHandle, new Constraint<>(
                 domain,
                 convertToPredicate(domain, PartColumn.TYPE, PartColumn.CONTAINER),
                 Set.of(tpchMetadata.toColumnHandle(PartColumn.TYPE), tpchMetadata.toColumnHandle(PartColumn.CONTAINER)))).get();
@@ -409,13 +409,13 @@ public class TestTpchMetadata
         }
     }
 
-    private Constraint constraint(TpchColumn<?> column, String... values)
+    private Constraint<ColumnHandle> constraint(TpchColumn<?> column, String... values)
     {
         List<TupleDomain<ColumnHandle>> valueDomains = stream(values)
                 .map(value -> fixedValueTupleDomain(tpchMetadata, column, utf8Slice(value)))
                 .collect(toList());
         TupleDomain<ColumnHandle> domain = TupleDomain.columnWiseUnion(valueDomains);
-        return new Constraint(domain, convertToPredicate(domain, column), Set.of(tpchMetadata.toColumnHandle(column)));
+        return new Constraint<>(domain, convertToPredicate(domain, column), Set.of(tpchMetadata.toColumnHandle(column)));
     }
 
     private static TupleDomain<ColumnHandle> fixedValueTupleDomain(TpchMetadata tpchMetadata, TpchColumn<?> column, Object value)

--- a/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/AbstractTestCoordinatorDynamicFiltering.java
@@ -492,7 +492,7 @@ public abstract class AbstractTestCoordinatorDynamicFiltering
                         ConnectorSession session,
                         ConnectorTableHandle table,
                         DynamicFilter dynamicFilter,
-                        Constraint constraint)
+                        Constraint<ColumnHandle> constraint)
                 {
                     if (!isTaskRetryMode) {
                         // In task retry mode, dynamic filter collection is done outside the join stage,


### PR DESCRIPTION
Currently the `TupleDomain` and `ConnectorExpression` are the only class which can be used for API methods where some generic constraint can be provided. None of these fits needs of metadata listing APIs. There a class similar to `Constraint` would fit perfectly. Make the `Constraint` generic so that is can be used in those new places.
