### PR TITLE
Optimize table_comments with schema IN predicate

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -351,6 +351,10 @@ public class TestTrinoDatabaseMetaData
                 assertGetSchemasResult(rs, list());
             }
 
+            try (ResultSet rs = connection.getMetaData().getSchemas(null, "")) {
+                assertGetSchemasResult(rs, list());
+            }
+
             try (ResultSet rs = connection.getMetaData().getSchemas(TEST_CATALOG, "information_schema")) {
                 assertGetSchemasResult(rs, list(list(TEST_CATALOG, "information_schema")));
             }
@@ -1071,13 +1075,22 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, ""),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
                 list(),
-                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+                ImmutableMultiset.of());
 
         // catalog does not exist
         assertMetadataCalls(
                 connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas("wrong", null),
+                        list("TABLE_CATALOG", "TABLE_SCHEM")),
+                list(),
+                ImmutableMultiset.of());
+
+        // empty catalog name (means null filter)
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getSchemas("", null),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
                 list(),
                 ImmutableMultiset.of());
@@ -1205,6 +1218,15 @@ public class TestTrinoDatabaseMetaData
                 list(),
                 ImmutableMultiset.of());
 
+        // empty catalog name (means null filter)
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getTables("", null, null, null),
+                        list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
+                list(),
+                ImmutableMultiset.of());
+
         // empty schema name
         assertMetadataCalls(
                 connection,
@@ -1212,10 +1234,7 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                 list(),
-                ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listViews")
-                        .add("ConnectorMetadata.listTables")
-                        .build());
+                ImmutableMultiset.of());
 
         // empty table name
         assertMetadataCalls(
@@ -1224,10 +1243,7 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, "", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                 list(),
-                ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listViews")
-                        .add("ConnectorMetadata.listTables")
-                        .build());
+                ImmutableMultiset.of());
 
         // no table types selected
         assertMetadataCalls(
@@ -1415,6 +1431,15 @@ public class TestTrinoDatabaseMetaData
                 list(),
                 ImmutableMultiset.of());
 
+        // empty catalog name (means null filter)
+        assertMetadataCalls(
+                connection,
+                readMetaData(
+                        databaseMetaData -> databaseMetaData.getColumns("", null, null, null),
+                        list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
+                list(),
+                ImmutableMultiset.of());
+
         // schema does not exist
         assertMetadataCalls(
                 connection,
@@ -1446,7 +1471,7 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(),
-                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+                ImmutableMultiset.of());
 
         // empty table name
         assertMetadataCalls(
@@ -1455,7 +1480,7 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, null, "", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                 list(),
-                ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+                ImmutableMultiset.of());
 
         // empty column name
         assertMetadataCalls(

--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -107,11 +107,10 @@ public class MaterializedViewSystemTable
             return displayTable.build().cursor();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
         Optional<String> tableFilter = tryGetSingleVarcharValue(tableDomain);
 
-        listCatalogNames(session, metadata, accessControl, catalogFilter).forEach(catalogName -> {
+        listCatalogNames(session, metadata, accessControl, catalogDomain).forEach(catalogName -> {
             QualifiedTablePrefix tablePrefix = tablePrefix(catalogName, schemaFilter, tableFilter);
 
             addMaterializedViewForCatalog(session, displayTable, tablePrefix);

--- a/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
@@ -100,13 +100,12 @@ public class TableCommentSystemTable
             return table.build().cursor();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
         Optional<String> tableFilter = tryGetSingleVarcharValue(tableDomain);
 
         Session session = ((FullConnectorSession) connectorSession).getSession();
 
-        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogFilter)) {
+        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
             addTableCommentForCatalog(session, table, catalog, prefix);

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/AttributeJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/AttributeJdbcTable.java
@@ -23,7 +23,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class AttributeJdbcTable
         extends JdbcTable
@@ -31,26 +31,26 @@ public class AttributeJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "attributes");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("type_cat", createUnboundedVarcharType())
-            .column("type_schem", createUnboundedVarcharType())
-            .column("type_name", createUnboundedVarcharType())
-            .column("attr_name", createUnboundedVarcharType())
+            .column("type_cat", VARCHAR)
+            .column("type_schem", VARCHAR)
+            .column("type_name", VARCHAR)
+            .column("attr_name", VARCHAR)
             .column("data_type", BIGINT)
-            .column("attr_type_name", createUnboundedVarcharType())
+            .column("attr_type_name", VARCHAR)
             .column("attr_size", BIGINT)
             .column("decimal_digits", BIGINT)
             .column("num_prec_radix", BIGINT)
             .column("nullable", BIGINT)
-            .column("remarks", createUnboundedVarcharType())
-            .column("attr_def", createUnboundedVarcharType())
+            .column("remarks", VARCHAR)
+            .column("attr_def", VARCHAR)
             .column("sql_data_type", BIGINT)
             .column("sql_datetime_sub", BIGINT)
             .column("char_octet_length", BIGINT)
             .column("ordinal_position", BIGINT)
-            .column("is_nullable", createUnboundedVarcharType())
-            .column("scope_catalog", createUnboundedVarcharType())
-            .column("scope_schema", createUnboundedVarcharType())
-            .column("scope_table", createUnboundedVarcharType())
+            .column("is_nullable", VARCHAR)
+            .column("scope_catalog", VARCHAR)
+            .column("scope_schema", VARCHAR)
+            .column("scope_table", VARCHAR)
             .column("source_data_type", BIGINT)
             .build();
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
@@ -25,6 +25,7 @@ import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.InMemoryRecordSet.Builder;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataListing.listCatalogNames;
@@ -62,7 +63,7 @@ public class CatalogJdbcTable
     {
         Session session = ((FullConnectorSession) connectorSession).getSession();
         Builder table = InMemoryRecordSet.builder(METADATA);
-        for (String name : listCatalogNames(session, metadata, accessControl)) {
+        for (String name : listCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR))) {
             table.addRow(name);
         }
         return table.build().cursor();

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/CatalogJdbcTable.java
@@ -29,7 +29,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataListing.listCatalogNames;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class CatalogJdbcTable
@@ -38,7 +38,7 @@ public class CatalogJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "catalogs");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_cat", createUnboundedVarcharType())
+            .column("table_cat", VARCHAR)
             .build();
 
     private final Metadata metadata;

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -172,7 +172,6 @@ public class ColumnJdbcTable
             return TupleDomain.none();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
         Optional<String> tableFilter = tryGetSingleVarcharValue(tableDomain);
 
@@ -181,7 +180,7 @@ public class ColumnJdbcTable
             return tupleDomain;
         }
 
-        List<String> catalogs = listCatalogNames(session, metadata, accessControl, catalogFilter).stream()
+        List<String> catalogs = listCatalogNames(session, metadata, accessControl, catalogDomain).stream()
                 .filter(catalogName -> predicate.test(ImmutableMap.of(TABLE_CATALOG_COLUMN, toNullableValue(catalogName))))
                 .collect(toImmutableList());
 
@@ -256,11 +255,10 @@ public class ColumnJdbcTable
             return table.build().cursor();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
         Optional<String> tableFilter = tryGetSingleVarcharValue(tableDomain);
 
-        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogFilter)) {
+        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
             if (!catalogDomain.includesNullableValue(utf8Slice(catalog))) {
                 continue;
             }

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -81,7 +81,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.TypeUtils.getDisplayLabel;
 import static java.lang.Math.min;
 import static java.util.Locale.ENGLISH;
@@ -103,30 +103,30 @@ public class ColumnJdbcTable
     private static final ColumnHandle TABLE_NAME_COLUMN = new SystemColumnHandle("table_name");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_cat", createUnboundedVarcharType())
-            .column("table_schem", createUnboundedVarcharType())
-            .column("table_name", createUnboundedVarcharType())
-            .column("column_name", createUnboundedVarcharType())
+            .column("table_cat", VARCHAR)
+            .column("table_schem", VARCHAR)
+            .column("table_name", VARCHAR)
+            .column("column_name", VARCHAR)
             .column("data_type", BIGINT)
-            .column("type_name", createUnboundedVarcharType())
+            .column("type_name", VARCHAR)
             .column("column_size", BIGINT)
             .column("buffer_length", BIGINT)
             .column("decimal_digits", BIGINT)
             .column("num_prec_radix", BIGINT)
             .column("nullable", BIGINT)
-            .column("remarks", createUnboundedVarcharType())
-            .column("column_def", createUnboundedVarcharType())
+            .column("remarks", VARCHAR)
+            .column("column_def", VARCHAR)
             .column("sql_data_type", BIGINT)
             .column("sql_datetime_sub", BIGINT)
             .column("char_octet_length", BIGINT)
             .column("ordinal_position", BIGINT)
-            .column("is_nullable", createUnboundedVarcharType())
-            .column("scope_catalog", createUnboundedVarcharType())
-            .column("scope_schema", createUnboundedVarcharType())
-            .column("scope_table", createUnboundedVarcharType())
+            .column("is_nullable", VARCHAR)
+            .column("scope_catalog", VARCHAR)
+            .column("scope_schema", VARCHAR)
+            .column("scope_table", VARCHAR)
             .column("source_data_type", BIGINT)
-            .column("is_autoincrement", createUnboundedVarcharType())
-            .column("is_generatedcolumn", createUnboundedVarcharType())
+            .column("is_autoincrement", VARCHAR)
+            .column("is_generatedcolumn", VARCHAR)
             .build();
 
     private final Metadata metadata;
@@ -243,9 +243,9 @@ public class ColumnJdbcTable
         Optional<String> schemaFilter = tryGetSingleVarcharValue(constraint, 1);
         Optional<String> tableFilter = tryGetSingleVarcharValue(constraint, 2);
 
-        Domain catalogDomain = constraint.getDomains().get().getOrDefault(0, Domain.all(createUnboundedVarcharType()));
-        Domain schemaDomain = constraint.getDomains().get().getOrDefault(1, Domain.all(createUnboundedVarcharType()));
-        Domain tableDomain = constraint.getDomains().get().getOrDefault(2, Domain.all(createUnboundedVarcharType()));
+        Domain catalogDomain = constraint.getDomains().get().getOrDefault(0, Domain.all(VARCHAR));
+        Domain schemaDomain = constraint.getDomains().get().getOrDefault(1, Domain.all(VARCHAR));
+        Domain tableDomain = constraint.getDomains().get().getOrDefault(2, Domain.all(VARCHAR));
 
         if (isNonLowercase(schemaFilter) || isNonLowercase(tableFilter)) {
             // Non-lowercase predicate will never match a lowercase name (until TODO https://github.com/trinodb/trino/issues/17)
@@ -541,16 +541,16 @@ public class ColumnJdbcTable
 
     private static NullableValue toNullableValue(String varcharValue)
     {
-        return NullableValue.of(createUnboundedVarcharType(), utf8Slice(varcharValue));
+        return NullableValue.of(VARCHAR, utf8Slice(varcharValue));
     }
 
     private static Collector<String, ?, Domain> toVarcharDomain()
     {
         return Collectors.collectingAndThen(toImmutableSet(), set -> {
             if (set.isEmpty()) {
-                return Domain.none(createUnboundedVarcharType());
+                return Domain.none(VARCHAR);
             }
-            return Domain.multipleValues(createUnboundedVarcharType(), set.stream()
+            return Domain.multipleValues(VARCHAR, set.stream()
                     .map(Slices::utf8Slice)
                     .collect(toImmutableList()));
         });

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/FilterUtil.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/FilterUtil.java
@@ -16,25 +16,21 @@ package io.trino.connector.system.jdbc;
 import io.airlift.slice.Slice;
 import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.spi.predicate.Domain;
-import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.Domain.DiscreteSet;
 
 import java.util.Optional;
+
+import static java.util.Locale.ENGLISH;
 
 public final class FilterUtil
 {
     private FilterUtil() {}
 
-    public static <T> Optional<String> tryGetSingleVarcharValue(TupleDomain<T> constraint, T index)
+    public static <T> Optional<String> tryGetSingleVarcharValue(Domain domain)
     {
-        if (constraint.isNone()) {
+        if (!domain.isSingleValue()) {
             return Optional.empty();
         }
-
-        Domain domain = constraint.getDomains().get().get(index);
-        if ((domain == null) || !domain.isSingleValue()) {
-            return Optional.empty();
-        }
-
         Object value = domain.getSingleValue();
         return Optional.of(((Slice) value).toStringUtf8());
     }
@@ -50,8 +46,20 @@ public final class FilterUtil
         return new QualifiedTablePrefix(catalog);
     }
 
-    public static <T> boolean emptyOrEquals(Optional<T> value, T other)
+    public static boolean isImpossibleObjectName(Domain domain)
     {
-        return value.isEmpty() || value.get().equals(other);
+        if (!domain.isNullableDiscreteSet()) {
+            return false;
+        }
+        DiscreteSet discreteSet = domain.getNullableDiscreteSet();
+        return discreteSet.getNonNullValues().stream()
+                .allMatch(element -> isImpossibleObjectName(((Slice) element).toStringUtf8()));
+    }
+
+    private static boolean isImpossibleObjectName(String candidate)
+    {
+        return candidate.equals("") ||
+                // TODO (https://github.com/trinodb/trino/issues/17) Currently all object names are lowercase in Trino
+                !candidate.equals(candidate.toLowerCase(ENGLISH));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/FilterUtil.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/FilterUtil.java
@@ -56,7 +56,7 @@ public final class FilterUtil
                 .allMatch(element -> isImpossibleObjectName(((Slice) element).toStringUtf8()));
     }
 
-    private static boolean isImpossibleObjectName(String candidate)
+    public static boolean isImpossibleObjectName(String candidate)
     {
         return candidate.equals("") ||
                 // TODO (https://github.com/trinodb/trino/issues/17) Currently all object names are lowercase in Trino

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ProcedureColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ProcedureColumnJdbcTable.java
@@ -23,7 +23,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class ProcedureColumnJdbcTable
         extends JdbcTable
@@ -31,26 +31,26 @@ public class ProcedureColumnJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "procedure_columns");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("procedure_cat", createUnboundedVarcharType())
-            .column("procedure_schem", createUnboundedVarcharType())
-            .column("procedure_name", createUnboundedVarcharType())
-            .column("column_name", createUnboundedVarcharType())
+            .column("procedure_cat", VARCHAR)
+            .column("procedure_schem", VARCHAR)
+            .column("procedure_name", VARCHAR)
+            .column("column_name", VARCHAR)
             .column("column_type", BIGINT)
             .column("data_type", BIGINT)
-            .column("type_name", createUnboundedVarcharType())
+            .column("type_name", VARCHAR)
             .column("precision", BIGINT)
             .column("length", BIGINT)
             .column("scale", BIGINT)
             .column("radix", BIGINT)
             .column("nullable", BIGINT)
-            .column("remarks", createUnboundedVarcharType())
-            .column("column_def", createUnboundedVarcharType())
+            .column("remarks", VARCHAR)
+            .column("column_def", VARCHAR)
             .column("sql_data_type", BIGINT)
             .column("sql_datetime_sub", BIGINT)
             .column("char_octet_length", BIGINT)
             .column("ordinal_position", BIGINT)
-            .column("is_nullable", createUnboundedVarcharType())
-            .column("specific_name", createUnboundedVarcharType())
+            .column("is_nullable", VARCHAR)
+            .column("specific_name", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ProcedureJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ProcedureJdbcTable.java
@@ -23,7 +23,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class ProcedureJdbcTable
         extends JdbcTable
@@ -31,12 +31,12 @@ public class ProcedureJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "procedures");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("procedure_cat", createUnboundedVarcharType())
-            .column("procedure_schem", createUnboundedVarcharType())
-            .column("procedure_name", createUnboundedVarcharType())
-            .column("remarks", createUnboundedVarcharType())
+            .column("procedure_cat", VARCHAR)
+            .column("procedure_schem", VARCHAR)
+            .column("procedure_name", VARCHAR)
+            .column("remarks", VARCHAR)
             .column("procedure_type", BIGINT)
-            .column("specific_name", createUnboundedVarcharType())
+            .column("specific_name", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/PseudoColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/PseudoColumnJdbcTable.java
@@ -23,7 +23,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class PseudoColumnJdbcTable
         extends JdbcTable
@@ -31,16 +31,16 @@ public class PseudoColumnJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "pseudo_columns");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_cat", createUnboundedVarcharType())
-            .column("table_schem", createUnboundedVarcharType())
-            .column("table_name", createUnboundedVarcharType())
-            .column("column_name", createUnboundedVarcharType())
+            .column("table_cat", VARCHAR)
+            .column("table_schem", VARCHAR)
+            .column("table_name", VARCHAR)
+            .column("column_name", VARCHAR)
             .column("data_type", BIGINT)
             .column("column_size", BIGINT)
             .column("decimal_digits", BIGINT)
             .column("num_prec_radix", BIGINT)
-            .column("column_usage", createUnboundedVarcharType())
-            .column("remarks", createUnboundedVarcharType())
+            .column("column_usage", VARCHAR)
+            .column("remarks", VARCHAR)
             .column("char_octet_length", BIGINT)
             .column("is_nullable", BIGINT)
             .build();

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SchemaJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SchemaJdbcTable.java
@@ -28,10 +28,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
-import java.util.Optional;
-
 import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
-import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
@@ -77,9 +74,7 @@ public class SchemaJdbcTable
             return table.build().cursor();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
-
-        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogFilter)) {
+        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
             for (String schema : listSchemas(session, metadata, accessControl, catalog)) {
                 table.addRow(schema, catalog);
             }

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SchemaJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SchemaJdbcTable.java
@@ -33,7 +33,7 @@ import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue
 import static io.trino.metadata.MetadataListing.listCatalogNames;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class SchemaJdbcTable
@@ -42,8 +42,8 @@ public class SchemaJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "schemas");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_schem", createUnboundedVarcharType())
-            .column("table_catalog", createUnboundedVarcharType())
+            .column("table_schem", VARCHAR)
+            .column("table_catalog", VARCHAR)
             .build();
 
     private final Metadata metadata;

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SuperTableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SuperTableJdbcTable.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class SuperTableJdbcTable
         extends JdbcTable
@@ -30,10 +30,10 @@ public class SuperTableJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "super_tables");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_cat", createUnboundedVarcharType())
-            .column("table_schem", createUnboundedVarcharType())
-            .column("table_name", createUnboundedVarcharType())
-            .column("supertable_name", createUnboundedVarcharType())
+            .column("table_cat", VARCHAR)
+            .column("table_schem", VARCHAR)
+            .column("table_name", VARCHAR)
+            .column("supertable_name", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SuperTypeJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/SuperTypeJdbcTable.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class SuperTypeJdbcTable
         extends JdbcTable
@@ -30,12 +30,12 @@ public class SuperTypeJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "super_types");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("type_cat", createUnboundedVarcharType())
-            .column("type_schem", createUnboundedVarcharType())
-            .column("type_name", createUnboundedVarcharType())
-            .column("supertype_cat", createUnboundedVarcharType())
-            .column("supertype_schem", createUnboundedVarcharType())
-            .column("supertype_name", createUnboundedVarcharType())
+            .column("type_cat", VARCHAR)
+            .column("type_schem", VARCHAR)
+            .column("type_name", VARCHAR)
+            .column("supertype_cat", VARCHAR)
+            .column("supertype_schem", VARCHAR)
+            .column("supertype_name", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
@@ -92,7 +92,6 @@ public class TableJdbcTable
             return table.build().cursor();
         }
 
-        Optional<String> catalogFilter = tryGetSingleVarcharValue(catalogDomain);
         Optional<String> schemaFilter = tryGetSingleVarcharValue(schemaDomain);
         Optional<String> tableFilter = tryGetSingleVarcharValue(tableDomain);
 
@@ -102,7 +101,7 @@ public class TableJdbcTable
             return table.build().cursor();
         }
 
-        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogFilter)) {
+        for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
             Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
@@ -38,7 +38,7 @@ import static io.trino.metadata.MetadataListing.listCatalogNames;
 import static io.trino.metadata.MetadataListing.listTables;
 import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -48,16 +48,16 @@ public class TableJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "tables");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_cat", createUnboundedVarcharType())
-            .column("table_schem", createUnboundedVarcharType())
-            .column("table_name", createUnboundedVarcharType())
-            .column("table_type", createUnboundedVarcharType())
-            .column("remarks", createUnboundedVarcharType())
-            .column("type_cat", createUnboundedVarcharType())
-            .column("type_schem", createUnboundedVarcharType())
-            .column("type_name", createUnboundedVarcharType())
-            .column("self_referencing_col_name", createUnboundedVarcharType())
-            .column("ref_generation", createUnboundedVarcharType())
+            .column("table_cat", VARCHAR)
+            .column("table_schem", VARCHAR)
+            .column("table_name", VARCHAR)
+            .column("table_type", VARCHAR)
+            .column("remarks", VARCHAR)
+            .column("type_cat", VARCHAR)
+            .column("type_schem", VARCHAR)
+            .column("type_name", VARCHAR)
+            .column("self_referencing_col_name", VARCHAR)
+            .column("ref_generation", VARCHAR)
             .build();
 
     private final Metadata metadata;

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableTypeJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableTypeJdbcTable.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class TableTypeJdbcTable
         extends JdbcTable
@@ -30,7 +30,7 @@ public class TableTypeJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "table_types");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("table_type", createUnboundedVarcharType())
+            .column("table_type", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TypesJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TypesJdbcTable.java
@@ -35,7 +35,7 @@ import static io.trino.connector.system.jdbc.ColumnJdbcTable.numPrecRadix;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class TypesJdbcTable
@@ -44,19 +44,19 @@ public class TypesJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "types");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("type_name", createUnboundedVarcharType())
+            .column("type_name", VARCHAR)
             .column("data_type", BIGINT)
             .column("precision", BIGINT)
-            .column("literal_prefix", createUnboundedVarcharType())
-            .column("literal_suffix", createUnboundedVarcharType())
-            .column("create_params", createUnboundedVarcharType())
+            .column("literal_prefix", VARCHAR)
+            .column("literal_suffix", VARCHAR)
+            .column("create_params", VARCHAR)
             .column("nullable", BIGINT)
             .column("case_sensitive", BOOLEAN)
             .column("searchable", BIGINT)
             .column("unsigned_attribute", BOOLEAN)
             .column("fixed_prec_scale", BOOLEAN)
             .column("auto_increment", BOOLEAN)
-            .column("local_type_name", createUnboundedVarcharType())
+            .column("local_type_name", VARCHAR)
             .column("minimum_scale", BIGINT)
             .column("maximum_scale", BIGINT)
             .column("sql_data_type", BIGINT)

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/UdtJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/UdtJdbcTable.java
@@ -22,7 +22,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
-import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public class UdtJdbcTable
         extends JdbcTable
@@ -30,13 +30,13 @@ public class UdtJdbcTable
     public static final SchemaTableName NAME = new SchemaTableName("jdbc", "udts");
 
     public static final ConnectorTableMetadata METADATA = tableMetadataBuilder(NAME)
-            .column("type_cat", createUnboundedVarcharType())
-            .column("type_schem", createUnboundedVarcharType())
-            .column("type_name", createUnboundedVarcharType())
-            .column("class_name", createUnboundedVarcharType())
-            .column("data_type", createUnboundedVarcharType())
-            .column("remarks", createUnboundedVarcharType())
-            .column("base_type", createUnboundedVarcharType())
+            .column("type_cat", VARCHAR)
+            .column("type_schem", VARCHAR)
+            .column("type_name", VARCHAR)
+            .column("class_name", VARCHAR)
+            .column("data_type", VARCHAR)
+            .column("remarks", VARCHAR)
+            .column("base_type", VARCHAR)
             .build();
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -50,6 +50,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.FunctionKind;
 import io.trino.spi.function.FunctionMetadata;
 import io.trino.spi.function.SchemaFunctionName;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.session.PropertyMetadata;
@@ -127,6 +128,7 @@ import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.ExpressionUtils.combineConjuncts;
 import static io.trino.sql.QueryUtil.aliased;
 import static io.trino.sql.QueryUtil.aliasedName;
@@ -444,7 +446,7 @@ public final class ShowQueriesRewrite
         @Override
         protected Node visitShowCatalogs(ShowCatalogs node, Void context)
         {
-            List<Expression> rows = listCatalogNames(session, metadata, accessControl).stream()
+            List<Expression> rows = listCatalogNames(session, metadata, accessControl, Domain.all(VARCHAR)).stream()
                     .map(name -> row(new StringLiteral(name)))
                     .collect(toImmutableList());
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -669,6 +669,13 @@ public class MockConnector
         public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting) {}
 
         @Override
+        public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+        {
+            return ImmutableList.copyOf(getMaterializedViews.apply(session, schemaName.map(SchemaTablePrefix::new).orElseGet(SchemaTablePrefix::new))
+                    .keySet());
+        }
+
+        @Override
         public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
         {
             return Optional.ofNullable(getMaterializedViews.apply(session, viewName.toSchemaTablePrefix()).get(viewName));

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -235,6 +235,21 @@ public final class TupleDomain<T>
         return domains;
     }
 
+    public Domain getDomain(T column, Type type)
+    {
+        if (domains.isEmpty()) {
+            return Domain.none(type);
+        }
+        Domain domain = domains.get().get(column);
+        if (domain != null && !domain.getType().equals(type)) {
+            throw new IllegalArgumentException("Provided type %s does not match domain type %s for column %s".formatted(type, domain.getType(), column));
+        }
+        if (domain == null) {
+            return Domain.all(type);
+        }
+        return domain;
+    }
+
     /**
      * Returns the strict intersection of the TupleDomains.
      * The resulting TupleDomain represents the set of tuples that would be valid

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeFileOperations.java
@@ -585,6 +585,16 @@ public class TestDeltaLakeFileOperations
                         .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), tables)
                         .build());
 
+        // Bulk retrieval for two schemas
+        assertFileSystemAccesses(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent') AND table_name LIKE 'test_select_s_m_t_comments%'",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(LAST_CHECKPOINT, "_last_checkpoint", INPUT_FILE_NEW_STREAM), tables * 2)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000000.json", INPUT_FILE_NEW_STREAM), tables * 2)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000001.json", INPUT_FILE_NEW_STREAM), tables * 2)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000002.json", INPUT_FILE_NEW_STREAM), tables)
+                        .addCopies(new FileOperation(TRANSACTION_LOG_JSON, "00000000000000000003.json", INPUT_FILE_NEW_STREAM), tables)
+                        .build());
+
         // Pointed lookup
         assertFileSystemAccesses(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name = CURRENT_SCHEMA AND table_name = 'test_select_s_m_t_comments0'",
                 ImmutableMultiset.<FileOperation>builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -588,6 +588,12 @@ public class TestIcebergMetadataFileOperations
                         .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), tables * 2)
                         .build());
 
+        // Bulk retrieval for two schemas
+        assertFileSystemAccesses(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent') AND table_name LIKE 'test_select_s_m_t_comments%'",
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), tables * 2)
+                        .build());
+
         // Pointed lookup
         assertFileSystemAccesses(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name = CURRENT_SCHEMA AND table_name = 'test_select_s_m_t_comments0'",
                 ImmutableMultiset.<FileOperation>builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -397,6 +397,14 @@ public class TestIcebergMetastoreAccessOperations
                         .addCopies(GET_TABLES_WITH_PARAMETER, 2)
                         .build());
 
+        // Bulk retrieval for two schemas
+        assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent') AND table_name LIKE 'test_select_s_m_t_comments%'",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, 2)
+                        .addCopies(GET_TABLES_WITH_PARAMETER, 4)
+                        .addCopies(GET_TABLE, tables * 2)
+                        .build());
+
         // Pointed lookup
         assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name = CURRENT_SCHEMA AND table_name = 'test_select_s_m_t_comments0'",
                 ImmutableMultiset.builder()

--- a/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
@@ -27,6 +27,7 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.tracing.TracingConnectorMetadata;
 import io.trino.util.AutoCloseableCloser;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -154,6 +155,7 @@ public class CountingMockConnector
                     return defaultGetTableHandle().apply(connectorSession, schemaTableName);
                 })
                 .withGetColumns(schemaTableName -> defaultGetColumns().apply(schemaTableName))
+                .withGetComment(schemaTableName -> Optional.of("comment for " + schemaTableName))
                 .withListRoleGrants((connectorSession, roles, grantees, limit) -> roleGrants)
                 .build();
 

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -13,20 +13,16 @@
  */
 package io.trino.connector.informationschema;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import io.trino.Session;
-import io.trino.connector.MockConnectorFactory;
 import io.trino.plugin.tpch.TpchPlugin;
-import io.trino.spi.Plugin;
-import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.CountingMockConnector;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testng.services.ManageTestResources;
+import io.trino.tests.FailingMockConnectorPlugin;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -36,7 +32,6 @@ import org.junit.jupiter.api.Timeout;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.stream.Collectors.joining;
@@ -427,36 +422,5 @@ public class TestInformationSchemaConnector
         });
 
         assertMultisetsEqual(actualMetadataCallsCount, expectedMetadataCallsCount);
-    }
-
-    private static final class FailingMockConnectorPlugin
-            implements Plugin
-    {
-        @Override
-        public Iterable<ConnectorFactory> getConnectorFactories()
-        {
-            return ImmutableList.of(
-                    MockConnectorFactory.builder()
-                            .withName("failing_mock")
-                            .withListSchemaNames(session -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .withListTables((session, schema) -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .withGetViews((session, prefix) -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .withGetMaterializedViews((session, prefix) -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .withListTablePrivileges((session, prefix) -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .withStreamTableColumns((session, prefix) -> {
-                                throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
-                            })
-                            .build());
-        }
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.tests;
+package io.trino.connector.informationschema;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
@@ -137,9 +137,12 @@ public class TestSystemMetadataConnector
                         .build());
 
         // Two catalogs
-        assertQueryFails(
+        assertMetadataCalls(
                 "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name IN ('test_catalog', 'tpch')",
-                "Catalog is broken");
+                "VALUES (12, 2016, 3000, 3088)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
 
         // Whole schema
         assertMetadataCalls(
@@ -247,10 +250,13 @@ public class TestSystemMetadataConnector
                         .build());
 
         // Specific relation in a schema that does not exist across existing and non-existing catalogs
-        assertQueryFails(
+        assertMetadataCalls(
                 // TODO should succeed, the broken_catalog is not one of the selected catalogs
                 "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name IN ('wrong', 'test_catalog') AND schema_name = 'wrong_schema1' AND name = 'test_table1'",
-                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
+                        .build());
 
         // Whole catalog
         assertMetadataCalls(
@@ -271,9 +277,13 @@ public class TestSystemMetadataConnector
                         .build());
 
         // Two catalogs
-        assertQueryFails(
+        assertMetadataCalls(
                 "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name IN ('test_catalog', 'tpch')",
-                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0, 0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
 
         // Whole schema
         assertMetadataCalls(

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector.system.metadata;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.CountingMockConnector;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryFailedException;
+import io.trino.tests.FailingMockConnectorPlugin;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableMultiset.toImmutableMultiset;
+import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.stream.Collectors.joining;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestSystemMetadataConnector
+        extends AbstractTestQueryFramework
+{
+    private static final int MAX_PREFIXES_COUNT = 10;
+
+    private CountingMockConnector countingMockConnector;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        countingMockConnector = closeAfterClass(new CountingMockConnector());
+        closeAfterClass(() -> countingMockConnector = null);
+        Session session = testSessionBuilder().build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                .setNodeCount(1)
+                .addCoordinatorProperty("optimizer.experimental-max-prefetched-information-schema-prefixes", Integer.toString(MAX_PREFIXES_COUNT))
+                .build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            queryRunner.installPlugin(countingMockConnector.getPlugin());
+            queryRunner.createCatalog("test_catalog", "mock", Map.of());
+
+            queryRunner.installPlugin(new FailingMockConnectorPlugin());
+            queryRunner.createCatalog("broken_catalog", "failing_mock", Map.of());
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+
+    @Test
+    public void testTableCommentsMetadataCalls()
+    {
+        // Specific relation
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1' AND table_name = 'test_table1'",
+                "VALUES 'comment for test_schema1.test_table1'",
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getTableMetadata(handle=test_schema1.test_table1)")
+                        .build());
+
+        // Specific relation that does not exist
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1' AND table_name = 'does_not_exist'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=does_not_exist)", 4)
+                        .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=does_not_exist)")
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=does_not_exist)")
+                        .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=does_not_exist)")
+                        .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=does_not_exist)")
+                        .build());
+
+        // Specific relation in a schema that does not exist
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name = 'wrong_schema1' AND table_name = 'test_table1'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=wrong_schema1, table=test_table1)", 4)
+                        .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.redirectTable(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getTableHandle(schema=wrong_schema1, table=test_table1)")
+                        .build());
+
+        // Specific relation in a schema that does not exist across existing and non-existing catalogs
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name IN ('wrong', 'test_catalog') AND schema_name = 'wrong_schema1' AND table_name = 'test_table1'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=wrong_schema1, table=test_table1)", 4)
+                        .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.redirectTable(schema=wrong_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getTableHandle(schema=wrong_schema1, table=test_table1)")
+                        .build());
+
+        // Whole catalog
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog'",
+                "VALUES (3, 2008, 3000, 3008)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Whole catalog except for information_schema (typical query run by BI tools)
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name != 'information_schema'",
+                "VALUES (2, 2000, 3000, 3000)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Two catalogs
+        assertQueryFails(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name IN ('test_catalog', 'tpch')",
+                "Catalog is broken");
+
+        // Whole schema
+        assertMetadataCalls(
+                "SELECT count(table_name), count(comment) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1'",
+                "VALUES (1000, 1000)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments(schema=test_schema1)")
+                        .build());
+
+        // Two schemas
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name IN ('test_schema1', 'test_schema2')",
+                "VALUES (2, 2000, 3000, 3000)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Multiple schemas
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name IN " +
+                        Stream.concat(
+                                        Stream.of("test_schema1", "test_schema2"),
+                                        IntStream.range(1, MAX_PREFIXES_COUNT + 1)
+                                                .mapToObj(i -> "bogus_schema" + i))
+                                .map("'%s'"::formatted)
+                                .collect(joining(",", "(", ")")),
+                "VALUES (2, 2000, 3000, 3000)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Small LIMIT
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' LIMIT 1)",
+                "VALUES 1",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Big LIMIT
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' LIMIT 1000)",
+                "VALUES 1000",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.streamRelationComments")
+                        .build());
+
+        // Non-existent catalog
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = 'wrong'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.of());
+
+        // Empty catalog name
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE catalog_name = ''",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.of());
+
+        // Empty table schema and table name
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.table_comments WHERE schema_name = '' AND table_name = ''",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.of());
+
+        // Empty table schema TODO should not fail
+        assertThatThrownBy(() -> computeActual("SELECT count(comment) FROM system.metadata.table_comments WHERE schema_name = ''"))
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessage("schemaName is empty");
+
+        // Empty table name TODO should not fail
+        assertQueryFails(
+                "SELECT count(comment) FROM system.metadata.table_comments WHERE table_name = ''",
+                "Catalog is broken");
+    }
+
+    @Test
+    public void testMaterializedViewsMetadataCalls()
+    {
+        // Specific relation
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1' AND name = 'test_table1'",
+                // TODO introduce materialized views in CountingMockConnector
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
+                        .build());
+
+        // Specific relation that does not exist
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1' AND name = 'does_not_exist'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=does_not_exist)")
+                        .build());
+
+        // Specific relation in a schema that does not exist
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name = 'wrong_schema1' AND name = 'test_table1'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedView(schema=wrong_schema1, table=test_table1)")
+                        .build());
+
+        // Specific relation in a schema that does not exist across existing and non-existing catalogs
+        assertQueryFails(
+                // TODO should succeed, the broken_catalog is not one of the selected catalogs
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name IN ('wrong', 'test_catalog') AND schema_name = 'wrong_schema1' AND name = 'test_table1'",
+                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+
+        // Whole catalog
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog'",
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0, 0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Whole catalog except for information_schema (typical query run by BI tools)
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name != 'information_schema'",
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0, 0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Two catalogs
+        assertQueryFails(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name IN ('test_catalog', 'tpch')",
+                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+
+        // Whole schema
+        assertMetadataCalls(
+                "SELECT count(name), count(comment) FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name = 'test_schema1'",
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema1)")
+                        .build());
+
+        // Two schemas
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name IN ('test_schema1', 'test_schema2')",
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0, 0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Multiple schemas
+        assertMetadataCalls(
+                "SELECT count(DISTINCT schema_name), count(DISTINCT name), count(comment), count(*) FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' AND schema_name IN " +
+                        Stream.concat(
+                                        Stream.of("test_schema1", "test_schema2"),
+                                        IntStream.range(1, MAX_PREFIXES_COUNT + 1)
+                                                .mapToObj(i -> "bogus_schema" + i))
+                                .map("'%s'"::formatted)
+                                .collect(joining(",", "(", ")")),
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES (0, 0, 0, 0)",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Small LIMIT
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' LIMIT 1)",
+                // TODO introduce materialized views in CountingMockConnector
+                "VALUES 0",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Big LIMIT
+        assertMetadataCalls(
+                "SELECT count(*) FROM (SELECT * FROM system.metadata.materialized_views WHERE catalog_name = 'test_catalog' LIMIT 1000)",
+                // TODO introduce thousands of materialized views in CountingMockConnector
+                "VALUES 0",
+                ImmutableMultiset.<String>builder()
+                        .add("ConnectorMetadata.getMaterializedViews")
+                        .build());
+
+        // Non-existent catalog
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name = 'wrong'",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.of());
+
+        // Empty catalog name
+        assertMetadataCalls(
+                "SELECT comment FROM system.metadata.materialized_views WHERE catalog_name = ''",
+                "SELECT '' WHERE false",
+                ImmutableMultiset.of());
+
+        // Empty table schema and table name TODO should not fail
+        assertQueryFails(
+                "SELECT comment FROM system.metadata.materialized_views WHERE schema_name = '' AND name = ''",
+                "Error listing materialized views for catalog \\w+: schemaName is empty");
+
+        // Empty table schema TODO should not fail
+        assertThatThrownBy(() -> computeActual("SELECT count(comment) FROM system.metadata.materialized_views WHERE schema_name = ''"))
+                .isInstanceOf(QueryFailedException.class)
+                .hasMessageMatching("Error listing materialized views for catalog \\w+: schemaName is empty");
+
+        // Empty table name
+        assertQueryFails(
+                "SELECT count(comment) FROM system.metadata.materialized_views WHERE name = ''",
+                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+    }
+
+    @Test
+    public void testMetadataListingExceptionHandling()
+    {
+        // TODO this should probably gracefully continue when some catalog is "broken" (does not currently work, e.g. is offline)
+        assertQueryFails(
+                "SELECT * FROM system.metadata.table_comments",
+                "Catalog is broken");
+
+        // TODO this should probably gracefully continue when some catalog is "broken" (does not currently work, e.g. is offline)
+        assertQueryFails(
+                "SELECT * FROM system.metadata.materialized_views",
+                "Error listing materialized views for catalog broken_catalog: Catalog is broken");
+    }
+
+    private void assertMetadataCalls(@Language("SQL") String actualSql, @Language("SQL") String expectedSql, Multiset<String> expectedMetadataCallsCount)
+    {
+        Multiset<String> actualMetadataCallsCount = countingMockConnector.runTracing(() -> {
+            // expectedSql is run on H2, so does not affect counts.
+            assertQuery(actualSql, expectedSql);
+        });
+
+        actualMetadataCallsCount = actualMetadataCallsCount.stream()
+                // Every query involves beginQuery and cleanupQuery, so ignore them.
+                .filter(method -> !"ConnectorMetadata.beginQuery".equals(method) && !"ConnectorMetadata.cleanupQuery".equals(method))
+                .collect(toImmutableMultiset());
+
+        assertMultisetsEqual(actualMetadataCallsCount, expectedMetadataCallsCount);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
@@ -305,7 +305,8 @@ public class TestSystemMetadataConnector
                 // TODO introduce materialized views in CountingMockConnector
                 "VALUES (0, 0, 0, 0)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.getMaterializedViews")
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema2)")
                         .build());
 
         // Multiple schemas
@@ -320,7 +321,11 @@ public class TestSystemMetadataConnector
                 // TODO introduce materialized views in CountingMockConnector
                 "VALUES (0, 0, 0, 0)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.getMaterializedViews")
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getMaterializedViews(schema=test_schema2)")
+                        .addAll(IntStream.range(1, MAX_PREFIXES_COUNT + 1)
+                                .mapToObj("ConnectorMetadata.getMaterializedViews(schema=bogus_schema%s)"::formatted)
+                                .toList())
                         .build());
 
         // Small LIMIT

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/metadata/TestSystemMetadataConnector.java
@@ -157,7 +157,8 @@ public class TestSystemMetadataConnector
                 "SELECT count(DISTINCT schema_name), count(DISTINCT table_name), count(comment), count(*) FROM system.metadata.table_comments WHERE catalog_name = 'test_catalog' AND schema_name IN ('test_schema1', 'test_schema2')",
                 "VALUES (2, 2000, 3000, 3000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.streamRelationComments")
+                        .add("ConnectorMetadata.streamRelationComments(schema=test_schema1)")
+                        .add("ConnectorMetadata.streamRelationComments(schema=test_schema2)")
                         .build());
 
         // Multiple schemas
@@ -171,7 +172,11 @@ public class TestSystemMetadataConnector
                                 .collect(joining(",", "(", ")")),
                 "VALUES (2, 2000, 3000, 3000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.streamRelationComments")
+                        .add("ConnectorMetadata.streamRelationComments(schema=test_schema1)")
+                        .add("ConnectorMetadata.streamRelationComments(schema=test_schema2)")
+                        .addAll(IntStream.range(1, MAX_PREFIXES_COUNT + 1)
+                                .mapToObj("ConnectorMetadata.streamRelationComments(schema=bogus_schema%s)"::formatted)
+                                .toList())
                         .build());
 
         // Small LIMIT

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemRuntimeConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemRuntimeConnector.java
@@ -56,7 +56,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
-public class TestSystemConnector
+public class TestSystemRuntimeConnector
         extends AbstractTestQueryFramework
 {
     private static final Function<SchemaTableName, List<ColumnMetadata>> DEFAULT_GET_COLUMNS = table -> ImmutableList.of(new ColumnMetadata("c", VARCHAR));
@@ -64,7 +64,7 @@ public class TestSystemConnector
 
     private static Function<SchemaTableName, List<ColumnMetadata>> getColumns = DEFAULT_GET_COLUMNS;
 
-    private final ExecutorService executor = Executors.newSingleThreadScheduledExecutor(threadsNamed(TestSystemConnector.class.getSimpleName()));
+    private final ExecutorService executor = Executors.newSingleThreadScheduledExecutor(threadsNamed(TestSystemRuntimeConnector.class.getSimpleName()));
 
     @Override
     protected QueryRunner createQueryRunner()

--- a/testing/trino-tests/src/test/java/io/trino/tests/FailingMockConnectorPlugin.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/FailingMockConnectorPlugin.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.connector.MockConnectorFactory;
+import io.trino.spi.Plugin;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorFactory;
+
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+
+public class FailingMockConnectorPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(
+                MockConnectorFactory.builder()
+                        .withName("failing_mock")
+                        .withListSchemaNames(session -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .withListTables((session, schema) -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .withGetViews((session, prefix) -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .withGetMaterializedViews((session, prefix) -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .withListTablePrivileges((session, prefix) -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .withStreamTableColumns((session, prefix) -> {
+                            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Catalog is broken");
+                        })
+                        .build());
+    }
+}


### PR DESCRIPTION
Before the changes, `system.metadata.table_comments`, `system.metadata.materialized_views` queried with `schema_name IN ...`
    predicate would first process all relations within catalog,
    and only then filter by schema. This commit introduces filtering by
    schema first. For now this is done on the engine side, but with
    something like generified `Constraint` class we could give the connector
    the opportunity to process the information even better.