### PR TITLE
Use absolute URL for sitemap

### DIFF
--- a/docs/src/main/sphinx/conf.py
+++ b/docs/src/main/sphinx/conf.py
@@ -139,7 +139,7 @@ html_sidebars = {
 }
 
 html_theme_options = {
-    'base_url': '/',
+    'base_url': 'https://trino.io/docs/current/',
     'globaltoc_depth': -1,
     'theme_color': '2196f3',
     'color_primary': '',  # set in CSS


### PR DESCRIPTION
## Description

Currently the sitemap for the docs uses the root context so links are like `/admin.html` .. however that is invalid and Google Analytics reports this as an issue. A correct URL is either relative to the sitemap or absolute. Sphinx however does not seem to support relative URL. If I leave the baseurl empty .. no sitemap is created at all. 

The current approach sets the full URL. We could also set `/docs/current/` and it would still be valid.

The problem of course in all cases is that the sitemap is now pointing at the current context .. where as the docs are version-specific in the path and "current" is just a changing symlink. This wrong generic sitemap is also part of the JAR that is deployed to Maven Central. However .. both of these items are not really a problem.

Alternatively we could use `get_version` and use that to compose the path .. but then the sitemap would be wrong for the `current` context and we would have to rejig all our robots.txt and so on.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

As found as issue in discussion with @dain and @martint 

Did some more testing and research. Turns out that using `./` works but I also found that the `loc` values in sitemap.xml MUST start with http or https (see https://www.sitemaps.org/protocol.html#urldef ) .. so the sitemap was always invalid the way it was.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
