### PR TITLE
Remove base type check to accommodate nested types such as ROW(MAP)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DereferencePushdown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DereferencePushdown.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
-import io.trino.spi.type.RowType;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
@@ -114,10 +113,6 @@ class DereferencePushdown
 
     private static boolean isRowSubscriptChain(SubscriptExpression expression, Session session, TypeAnalyzer typeAnalyzer, TypeProvider types)
     {
-        if (!(typeAnalyzer.getType(session, types, expression.getBase()) instanceof RowType)) {
-            return false;
-        }
-
         return (expression.getBase() instanceof SymbolReference) ||
                 ((expression.getBase() instanceof SubscriptExpression) && isRowSubscriptChain((SubscriptExpression) (expression.getBase()), session, typeAnalyzer, types));
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This is to fix the issue when selecting a nested ROW type column, the nested type is not properly pushed down to table scan. More details can be found [here](https://github.com/trinodb/trino/issues/19286)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Sample table:

```
trino> SHOW CREATE TABLE u_wliu2.row_table_complex6;
                      Create Table                      
--------------------------------------------------------
 CREATE TABLE hive.u_wliu2.row_table_complex6 (         
    id integer,                                         
    r ROW(x integer, y map(varchar(255), varchar(255))) 
 )                                                      
 WITH (                                                 
    format = 'ORC'                                      
 )                                                      
(1 row)

Query 20231005_225148_00004_q7n6q, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.82 [0 rows, 0B] [0 rows/s, 0B/s]
```

The column in focus is `r`, it's of type `ROW(INT, MAP)`

Sample query:

```
SELECT r.y['location'] FROM u_wliu2.row_table_complex6 WHERE id = 1;
```

With 406 implementation, this query will produce the following physical plan:

```
---------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Trino version: dev                                                                                                                                                   >
 Fragment 1 [SOURCE]                                                                                                                                                  >
     CPU: 29.04ms, Scheduled: 733.01ms, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1 row (78B); per task: avg.: 1.00 std.dev.: 0.00, Output: 1 row (7B)   >
     Output layout: [expr]                                                                                                                                            >
     Output partitioning: SINGLE []                                                                                                                                   >
     ScanFilterProject[table = hive:u_wliu2:row_table_complex6, filterPredicate = ("id" = 1)]                                                                         >
         Layout: [expr:varchar(255)]                                                                                                                                  >
         Estimates: {rows: 2 (110B), cpu: 120, memory: 0B, network: 0B}/{rows: ? (?), cpu: 120, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B>
         CPU: 28.00ms (100.00%), Scheduled: 732.00ms (100.00%), Blocked: 0.00ns (?%), Output: 1 row (7B)                                                              >
         Input avg.: 0.50 rows, Input std.dev.: 100.00%                                                                                                               >
         expr := "r"[2][CAST('location' AS varchar(255))]                                                                                                             >
         r := r:struct<x:int,y:map<varchar(255),varchar(255)>>:REGULAR                                                                                                >
         id := id:int:REGULAR                                                                                                                                         >
         Input: 1 row (78B), Filtered: 0.00%, Physical input: 631B, Physical input time: 298020000.00ns                                                               >
                                                                                                                                                                      >
                                                                                                                                                                      >
(1 row)

Query 20231004_214408_00001_j9p6v, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
1.95 [1 rows, 631B] [0 rows/s, 324B/s]
```

The `r#y:map<varchar(255),varchar(255)>:REGULAR` is not pushed down to table scan because he iterative optimizer skips 'PushDownDereferenceThroughFilter', as shown in the following log:

```
2023-10-04T14:44:08.725-0700    DEBUG   Query-20231004_214408_00001_j9p6v-687   io.trino.sql.planner.iterative.IterativeOptimizer   Rule: io.trino.sql.planner.iterative.rule.PruneFilterColumns
Before:
Project[]
│   Layout: [expr:varchar(255)]
│   expr := "r"[2][CAST('location' AS varchar(255))]
└─ GroupReference[groupId = 7]
       Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), $path:varchar, $file_size:bigint, $file_modified_time:timestamp(3) with time zone]

After:
FilterProject[filterPredicate = ("id" = 1)]
│   Layout: [expr:varchar(255)]
│   expr := "r"[2][CAST('location' AS varchar(255))]
└─ Project[]
   │   Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]
   └─ GroupReference[groupId = 8]
          Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), $path:varchar, $file_size:bigint, $file_modified_time:timestamp(3) with time zone]

2023-10-04T14:44:08.728-0700    DEBUG   Query-20231004_214408_00001_j9p6v-687   io.trino.sql.planner.iterative.IterativeOptimizer   Rule: io.trino.sql.planner.iterative.rule.PruneTableScanColumns
Before:
Project[]
│   Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]
└─ GroupReference[groupId = 8]
       Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), $path:varchar, $file_size:bigint, $file_modified_time:timestamp(3) with time zone]

After:
ScanProject[table = hive:u_wliu2:row_table_complex6]
    Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]
    id := id:int:REGULAR
    r := r:struct<x:int,y:map<varchar(255),varchar(255)>>:REGULAR
```

This is because when the optimizer tries to apply the `PushDownDereferenceThroughFilter` rule, `isRowSubscriptChain` restricts the base type to be ROW and ignores other complex types such as MAP. This would lead to the fact that the MAP subfield is not pushed down to table scan.

Once this is removed, the physical plan looks correct again:

```
                                                                               Query Plan                                                                             >
---------------------------------------------------------------------------------------------------------------------------------------------------------------------->
 Trino version: dev                                                                                                                                                   >
 Fragment 1 [SOURCE]                                                                                                                                                  >
     CPU: 18.91ms, Scheduled: 1.02s, Blocked 0.00ns (Input: 0.00ns, Output: 0.00ns), Input: 1 row (68B); per task: avg.: 1.00 std.dev.: 0.00, Output: 1 row (7B)      >
     Output layout: [expr_5]                                                                                                                                          >
     Output partitioning: SINGLE []                                                                                                                                   >
     ScanFilterProject[table = hive:u_wliu2:row_table_complex6, filterPredicate = ("id_3" = 1)]                                                                       >
         Layout: [expr_5:varchar(255)]                                                                                                                                >
         Estimates: {rows: 2 (110B), cpu: 120, memory: 0B, network: 0B}/{rows: ? (?), cpu: 120, memory: 0B, network: 0B}/{rows: ? (?), cpu: ?, memory: 0B, network: 0B>
         CPU: 18.00ms (100.00%), Scheduled: 1.02s (100.00%), Blocked: 0.00ns (?%), Output: 1 row (7B)                                                                 >
         Input avg.: 0.50 rows, Input std.dev.: 100.00%                                                                                                               >
         expr_5 := "r#y"[CAST('location' AS varchar(255))]                                                                                                            >
         r#y := r#y:map<varchar(255),varchar(255)>:REGULAR                                                                                                            >
         id_3 := id:int:REGULAR                                                                                                                                       >
         Input: 1 row (68B), Filtered: 0.00%, Physical input: 631B, Physical input time: 399180000.00ns                                                               >
                                                                                                                                                                      >
                                                                                                                                                                      >
(1 row)

Query 20231004_212520_00001_b5inq, FINISHED, 1 node
Splits: 19 total, 19 done (100.00%)
2.89 [1 rows, 631B] [0 rows/s, 219B/s]
```

The MAP field `r#y:map<varchar(255),varchar(255)>:REGULAR` is pushed down to table scan, because the `PushDownDereferenceThroughFilter` can be applied properly, as shown in the iterative optimizer log:

```
2023-10-04T14:25:20.495-0700    DEBUG   Query-20231004_212520_00001_b5inq-688   io.trino.sql.planner.iterative.IterativeOptimizer   Rule: io.trino.sql.planner.iterative.rule.PruneFilterColumns
Before:
Project[]
│   Layout: [expr:varchar(255)]
│   expr := "r"[2][CAST('location' AS varchar(255))]
└─ GroupReference[groupId = 7]
       Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), $path:varchar, $file_size:bigint, $file_modified_time:timestamp(3) with time zone]

After:
FilterProject[filterPredicate = ("id" = 1)]
│   Layout: [expr:varchar(255)]
│   expr := "r"[2][CAST('location' AS varchar(255))]
└─ Project[]
   │   Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]
   └─ GroupReference[groupId = 8]
          Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), $path:varchar, $file_size:bigint, $file_modified_time:timestamp(3) with time zone]

2023-10-04T14:25:20.499-0700    DEBUG   Query-20231004_212520_00001_b5inq-688   io.trino.sql.planner.iterative.IterativeOptimizer   Rule: io.trino.sql.planner.iterative.rule.PushDownDereferenceThroughFilter
Before:
Project[]
│   Layout: [expr:varchar(255)]
│   expr := "r"[2][CAST('location' AS varchar(255))]
└─ GroupReference[groupId = 14]
       Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]

After:
FilterProject[filterPredicate = ("id" = 1)]
│   Layout: [expr:varchar(255)]
│   expr := "expr_0"
└─ Project[]
   │   Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255))), expr_0:varchar(255)]
   │   expr_0 := "r"[2][CAST('location' AS varchar(255))]
   └─ GroupReference[groupId = 15]
          Layout: [id:integer, r:row(x integer, y map(varchar(255), varchar(255)))]
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`19286`)
```
