### PR TITLE
Add Metadata.beginQuery

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -353,6 +353,8 @@ public class QueryStateMachine
             }
         });
 
+        metadata.beginQuery(session);
+
         return queryStateMachine;
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -344,6 +344,11 @@ public interface Metadata
     void finishStatisticsCollection(Session session, AnalyzeTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics);
 
     /**
+     * Initialize before query begins
+     */
+    void beginQuery(Session session);
+
+    /**
      * Cleanup after a query. This is the very last notification after the query finishes, regardless if it succeeds or fails.
      * An exception thrown in this method will not affect the result of the query.
      */

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1020,6 +1020,11 @@ public final class MetadataManager
     }
 
     @Override
+    public void beginQuery(Session session)
+    {
+    }
+
+    @Override
     public void cleanupQuery(Session session)
     {
         QueryCatalogs queryCatalogs = catalogsByQueryId.remove(session.getQueryId());

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -195,7 +195,6 @@ import io.trino.sql.rewrite.ShowStatsRewrite;
 import io.trino.sql.rewrite.StatementRewrite;
 import io.trino.testing.PageConsumerOperator.PageConsumerOutputFactory;
 import io.trino.transaction.InMemoryTransactionManager;
-import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 import io.trino.transaction.TransactionManagerConfig;
 import io.trino.type.BlockTypeOperators;
@@ -222,7 +221,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
@@ -246,6 +244,7 @@ import static io.trino.connector.CatalogServiceProviderModule.createTableProcedu
 import static io.trino.connector.CatalogServiceProviderModule.createTablePropertyManager;
 import static io.trino.execution.ParameterExtractor.bindParameters;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.connector.DynamicFilter.EMPTY;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
@@ -333,7 +332,6 @@ public class LocalQueryRunner
             Session defaultSession,
             FeaturesConfig featuresConfig,
             NodeSpillConfig nodeSpillConfig,
-            boolean withInitialTransaction,
             boolean alwaysRevokeMemory,
             int nodeCountForStats,
             Map<String, List<PropertyMetadata<?>>> defaultSessionProperties,
@@ -342,7 +340,6 @@ public class LocalQueryRunner
     {
         requireNonNull(defaultSession, "defaultSession is null");
         requireNonNull(defaultSessionProperties, "defaultSessionProperties is null");
-        checkArgument(defaultSession.getTransactionId().isEmpty() || !withInitialTransaction, "Already in transaction");
 
         Tracer tracer = noopTracer();
         this.taskManagerConfig = new TaskManagerConfig().setTaskConcurrency(4);
@@ -494,11 +491,10 @@ public class LocalQueryRunner
         catalogManager.registerGlobalSystemConnector(globalSystemConnector);
 
         // rewrite session to use managed SessionPropertyMetadata
-        Optional<TransactionId> transactionId = withInitialTransaction ? Optional.of(transactionManager.beginTransaction(true)) : defaultSession.getTransactionId();
         this.defaultSession = new Session(
                 defaultSession.getQueryId(),
                 Span.getInvalid(),
-                transactionId,
+                defaultSession.getTransactionId(),
                 defaultSession.isClientTransactionSupport(),
                 defaultSession.getIdentity(),
                 defaultSession.getOriginalIdentity(),
@@ -842,7 +838,7 @@ public class LocalQueryRunner
     @Override
     public MaterializedResult execute(Session session, @Language("SQL") String sql)
     {
-        return executeWithPlan(session, sql, WarningCollector.NOOP).getMaterializedResult();
+        return executeWithPlan(session, sql, NOOP).getMaterializedResult();
     }
 
     @Override
@@ -879,7 +875,7 @@ public class LocalQueryRunner
                     .setQueryMaxSpillSize(queryMaxSpillPerNode)
                     .build();
 
-            Plan plan = createPlan(session, sql, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+            Plan plan = createPlan(session, sql, getPlanOptimizers(true), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
             List<Driver> drivers = createDrivers(session, plan, outputFactory, taskContext);
             drivers.forEach(closer::register);
 
@@ -946,13 +942,15 @@ public class LocalQueryRunner
 
     public List<Driver> createDrivers(Session session, @Language("SQL") String sql, OutputFactory outputFactory, TaskContext taskContext)
     {
-        Plan plan = createPlan(session, sql, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
-        return createDrivers(session, plan, outputFactory, taskContext);
+        return inTransaction(session, transactionSession -> {
+            Plan plan = createPlan(transactionSession, sql, getPlanOptimizers(true), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
+            return createDrivers(transactionSession, plan, outputFactory, taskContext);
+        });
     }
 
     public SubPlan createSubPlans(Session session, Plan plan, boolean forceSingleNode)
     {
-        return planFragmenter.createSubPlans(session, plan, forceSingleNode, WarningCollector.NOOP);
+        return planFragmenter.createSubPlans(session, plan, forceSingleNode, NOOP);
     }
 
     private List<Driver> createDrivers(Session session, Plan plan, OutputFactory outputFactory, TaskContext taskContext)
@@ -1073,19 +1071,9 @@ public class LocalQueryRunner
     }
 
     @Override
-    public Plan createPlan(Session session, @Language("SQL") String sql, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
+    public Plan createPlan(Session session, @Language("SQL") String sql)
     {
-        return createPlan(session, sql, OPTIMIZED_AND_VALIDATED, warningCollector, planOptimizersStatsCollector);
-    }
-
-    public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
-    {
-        return createPlan(session, sql, stage, true, warningCollector, planOptimizersStatsCollector);
-    }
-
-    public Plan createPlan(Session session, @Language("SQL") String sql, LogicalPlanner.Stage stage, boolean forceSingleNode, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
-    {
-        return createPlan(session, sql, getPlanOptimizers(forceSingleNode), stage, warningCollector, planOptimizersStatsCollector);
+        return createPlan(session, sql, getPlanOptimizers(true), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
     }
 
     public List<PlanOptimizer> getPlanOptimizers(boolean forceSingleNode)
@@ -1107,13 +1095,11 @@ public class LocalQueryRunner
                 new RuleStatsRecorder()).get();
     }
 
-    public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
-    {
-        return createPlan(session, sql, optimizers, OPTIMIZED_AND_VALIDATED, warningCollector, planOptimizersStatsCollector);
-    }
-
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, LogicalPlanner.Stage stage, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
     {
+        // session must be in a transaction registered with the transaction manager in this query runner
+        transactionManager.getTransactionInfo(session.getRequiredTransactionId());
+
         PreparedQuery preparedQuery = new QueryPreparer(sqlParser).prepareQuery(session, sql);
 
         assertFormattedSql(sqlParser, preparedQuery.getStatement());
@@ -1219,12 +1205,6 @@ public class LocalQueryRunner
             return this;
         }
 
-        public Builder withInitialTransaction()
-        {
-            this.initialTransaction = true;
-            return this;
-        }
-
         public Builder withAlwaysRevokeMemory()
         {
             this.alwaysRevokeMemory = true;
@@ -1266,7 +1246,6 @@ public class LocalQueryRunner
                     defaultSession,
                     featuresConfig,
                     nodeSpillConfig,
-                    initialTransaction,
                     alwaysRevokeMemory,
                     nodeCountForStats,
                     defaultSessionProperties,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -802,7 +802,7 @@ public class LocalQueryRunner
     {
         lock.readLock().lock();
         try {
-            return transaction(transactionManager, accessControl)
+            return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
                         return getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema));
@@ -818,7 +818,7 @@ public class LocalQueryRunner
     {
         lock.readLock().lock();
         try {
-            return transaction(transactionManager, accessControl)
+            return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
                         return MetadataUtil.tableExists(getMetadata(), transactionSession, table);
@@ -854,7 +854,7 @@ public class LocalQueryRunner
 
     public <T> T inTransaction(Session session, Function<Session, T> transactionSessionConsumer)
     {
-        return transaction(transactionManager, accessControl)
+        return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                 .singleStatement()
                 .execute(session, transactionSessionConsumer);
     }

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -16,7 +16,6 @@ package io.trino.testing;
 import io.trino.Session;
 import io.trino.cost.StatsCalculator;
 import io.trino.execution.FailureInjector.InjectedFailureType;
-import io.trino.execution.querystats.PlanOptimizersStatsCollector;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.FunctionBundle;
 import io.trino.metadata.FunctionManager;
@@ -86,7 +85,7 @@ public interface QueryRunner
         throw new UnsupportedOperationException();
     }
 
-    default Plan createPlan(Session session, @Language("SQL") String sql, WarningCollector warningCollector, PlanOptimizersStatsCollector planOptimizersStatsCollector)
+    default Plan createPlan(Session session, @Language("SQL") String sql)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
@@ -43,6 +43,16 @@ public final class TestingSession
 
     private TestingSession() {}
 
+    public static Session testSession()
+    {
+        return testSessionBuilder().build();
+    }
+
+    public static Session testSession(Session session)
+    {
+        return testSessionBuilder(session).build();
+    }
+
     public static SessionBuilder testSessionBuilder()
     {
         return testSessionBuilder(new SessionPropertyManager());
@@ -63,5 +73,11 @@ public final class TestingSession
                         .collect(toImmutableSet()))
                 .setRemoteUserAddress("address")
                 .setUserAgent("agent");
+    }
+
+    public static SessionBuilder testSessionBuilder(Session session)
+    {
+        return Session.builder(session)
+                .setQueryId(queryIdGenerator.createNextQueryId());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -637,6 +637,15 @@ public class TracingMetadata
     }
 
     @Override
+    public void beginQuery(Session session)
+    {
+        Span span = startSpan("beginQuery");
+        try (var ignored = scopedSpan(span)) {
+            delegate.beginQuery(session);
+        }
+    }
+
+    @Override
     public void cleanupQuery(Session session)
     {
         Span span = startSpan("cleanupQuery");

--- a/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
@@ -869,7 +869,7 @@ public class TestCostCalculator
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
     {
-        return transaction(localQueryRunner.getTransactionManager(), new AllowAllAccessControl())
+        return transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(session, session -> {
                     // metadata.getCatalogHandle() registers the catalog for the transaction

--- a/core/trino-main/src/test/java/io/trino/cost/TestStatsCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestStatsCalculator.java
@@ -14,7 +14,6 @@
 package io.trino.cost;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.sql.planner.LogicalPlanner;
 import io.trino.sql.planner.Plan;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
@@ -80,7 +80,7 @@ public class TestStatsCalculator
     private void assertPlan(String sql, LogicalPlanner.Stage stage, PlanMatchPattern pattern)
     {
         queryRunner.inTransaction(transactionSession -> {
-            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, stage, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, queryRunner.getPlanOptimizers(true), stage, NOOP, createPlanOptimizersStatsCollector());
             PlanAssert.assertPlan(
                     transactionSession,
                     queryRunner.getMetadata(),

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropCatalogTask.java
@@ -35,6 +35,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.testing.TestingSession.testSession;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
@@ -104,7 +105,7 @@ public class TestDropCatalogTask
                 Optional.empty(),
                 "test",
                 Optional.empty(),
-                queryRunner.getDefaultSession(),
+                testSession(queryRunner.getDefaultSession()),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,

--- a/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
@@ -52,6 +52,7 @@ import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
 import static io.trino.sql.QueryUtil.table;
 import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
+import static io.trino.testing.TestingSession.testSession;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
 import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
@@ -114,7 +115,7 @@ public class TestPrepareTask
                 Optional.empty(),
                 sqlString,
                 Optional.empty(),
-                session,
+                testSession(session),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -37,9 +37,9 @@ import java.util.concurrent.ExecutorService;
 
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.metadata.MetadataManager.testMetadataManagerBuilder;
+import static io.trino.testing.TestingSession.testSession;
 import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -108,7 +108,7 @@ public class TestSetPathTask
                 Optional.empty(),
                 query,
                 Optional.empty(),
-                TEST_SESSION,
+                testSession(),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -55,6 +55,7 @@ import static io.trino.spi.session.PropertyMetadata.enumProperty;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.TestingSession.testSession;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -203,7 +204,7 @@ public class TestSetSessionTask
                 Optional.empty(),
                 format("set %s = 'old_value'", qualifiedPropName),
                 Optional.empty(),
-                TEST_SESSION,
+                testSession(),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -48,6 +48,7 @@ import static io.trino.sql.tree.IntervalLiteral.IntervalField.HOUR;
 import static io.trino.sql.tree.IntervalLiteral.IntervalField.MINUTE;
 import static io.trino.sql.tree.IntervalLiteral.Sign.NEGATIVE;
 import static io.trino.sql.tree.IntervalLiteral.Sign.POSITIVE;
+import static io.trino.testing.TestingSession.testSession;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -252,7 +253,7 @@ public class TestSetTimeZoneTask
                 Optional.empty(),
                 query,
                 Optional.empty(),
-                TEST_SESSION,
+                testSession(),
                 URI.create("fake://uri"),
                 new ResourceGroupId("test"),
                 false,

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
@@ -83,12 +83,9 @@ public class TestMemoryPools
         Session session = testSessionBuilder()
                 .setCatalog("tpch")
                 .setSchema("tiny")
-                .setSystemProperty("task_default_concurrency", "1")
                 .build();
 
-        localQueryRunner = LocalQueryRunner.builder(session)
-                .withInitialTransaction()
-                .build();
+        localQueryRunner = LocalQueryRunner.create(session);
 
         // add tpch
         localQueryRunner.createCatalog("tpch", new TpchConnectorFactory(1), ImmutableMap.of());

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -441,16 +441,10 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void beginQuery(Session session)
-    {
-        throw new UnsupportedOperationException();
-    }
+    public void beginQuery(Session session) {}
 
     @Override
-    public void cleanupQuery(Session session)
-    {
-        throw new UnsupportedOperationException();
-    }
+    public void cleanupQuery(Session session) {}
 
     @Override
     public InsertTableHandle beginInsert(Session session, TableHandle tableHandle, List<ColumnHandle> columns)

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -441,6 +441,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public void beginQuery(Session session)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void cleanupQuery(Session session)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestingFunctionResolution.java
@@ -150,7 +150,7 @@ public class TestingFunctionResolution
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
     {
-        return transaction(transactionManager, new AllowAllAccessControl())
+        return transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .singleStatement()
                 .execute(TEST_SESSION, session -> {
                     // metadata.getCatalogHandle() registers the catalog for the transaction

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.CreationException;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.plugin.base.security.FileBasedSystemAccessControl;
@@ -183,6 +185,7 @@ public class TestFileBasedSystemAccessControl
     public void testSystemInformation()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "system_information.json");
 
         accessControlManager.checkCanReadSystemInformation(admin);
@@ -192,16 +195,16 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanWriteSystemInformation(nonAsciiUser);
 
         accessControlManager.checkCanReadSystemInformation(admin);
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanWriteSystemInformation(alice);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot write system information");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanReadSystemInformation(bob);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot read system information");
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanWriteSystemInformation(bob);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot write system information");
@@ -211,9 +214,10 @@ public class TestFileBasedSystemAccessControl
     public void testCatalogOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     assertEquals(accessControlManager.filterCatalogs(new SecurityContext(transactionId, admin, queryId, queryStart), allCatalogs), allCatalogs);
                     Set<String> aliceCatalogs = ImmutableSet.of("open-to-all", "alice-catalog", "all-allowed", "staff-catalog");
@@ -229,9 +233,10 @@ public class TestFileBasedSystemAccessControl
     public void testCatalogOperationsReadOnly()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_read_only.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     assertEquals(accessControlManager.filterCatalogs(new SecurityContext(transactionId, admin, queryId, queryStart), allCatalogs), allCatalogs);
                     Set<String> aliceCatalogs = ImmutableSet.of("open-to-all", "alice-catalog", "all-allowed");
@@ -247,9 +252,10 @@ public class TestFileBasedSystemAccessControl
     public void testSchemaOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     Set<String> aliceSchemas = ImmutableSet.of("schema");
                     assertEquals(accessControlManager.filterSchemas(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog", aliceSchemas), aliceSchemas);
@@ -260,7 +266,7 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanRenameSchema(new SecurityContext(transactionId, alice, queryId, queryStart), aliceSchema, "new-schema");
                     accessControlManager.checkCanShowSchemas(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog");
                 });
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateSchema(new SecurityContext(transactionId, bob, queryId, queryStart), aliceSchema, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
@@ -270,9 +276,10 @@ public class TestFileBasedSystemAccessControl
     public void testSchemaOperationsReadOnly()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_read_only.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     Set<String> aliceSchemas = ImmutableSet.of("schema");
                     assertEquals(accessControlManager.filterSchemas(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog", aliceSchemas), aliceSchemas);
@@ -281,22 +288,22 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanShowSchemas(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog");
                 });
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateSchema(new SecurityContext(transactionId, alice, queryId, queryStart), aliceSchema, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot create schema alice-catalog.schema");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanDropSchema(new SecurityContext(transactionId, alice, queryId, queryStart), aliceSchema);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot drop schema alice-catalog.schema");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanRenameSchema(new SecurityContext(transactionId, alice, queryId, queryStart), aliceSchema, "new-schema");
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot rename schema from alice-catalog.schema to new-schema");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateSchema(new SecurityContext(transactionId, bob, queryId, queryStart), aliceSchema, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
@@ -306,9 +313,10 @@ public class TestFileBasedSystemAccessControl
     public void testTableOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     Set<SchemaTableName> aliceTables = ImmutableSet.of(new SchemaTableName("schema", "table"));
                     SecurityContext aliceContext = new SecurityContext(transactionId, alice, queryId, queryStart);
@@ -454,9 +462,10 @@ public class TestFileBasedSystemAccessControl
     public void testTableOperationsReadOnly()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_read_only.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     Set<SchemaTableName> aliceTables = ImmutableSet.of(new SchemaTableName("schema", "table"));
                     assertEquals(accessControlManager.filterTables(new SecurityContext(transactionId, alice, queryId, queryStart), "alice-catalog", aliceTables), aliceTables);
@@ -465,47 +474,47 @@ public class TestFileBasedSystemAccessControl
                     accessControlManager.checkCanSelectFromColumns(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, ImmutableSet.of());
                 });
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, Map.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot create table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanDropTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot drop table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanTruncateTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot truncate table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanInsertIntoTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot insert into table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanDeleteFromTable(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot delete from table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanSetTableProperties(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot set table properties to alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanAddColumns(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot add a column to table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanRenameColumn(new SecurityContext(transactionId, alice, queryId, queryStart), aliceTable);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot rename a column in table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateTable(new SecurityContext(transactionId, bob, queryId, queryStart), aliceTable, Map.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
@@ -515,9 +524,10 @@ public class TestFileBasedSystemAccessControl
     public void testViewOperations()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext aliceContext = new SecurityContext(transactionId, alice, queryId, queryStart);
                     SecurityContext bobContext = new SecurityContext(transactionId, bob, queryId, queryStart);
@@ -631,36 +641,37 @@ public class TestFileBasedSystemAccessControl
     public void testViewOperationsReadOnly()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_read_only.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext context = new SecurityContext(transactionId, alice, queryId, queryStart);
                     accessControlManager.checkCanSelectFromColumns(context, aliceView, ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(context, "alice-catalog", "property");
                 });
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot create view alice-catalog.schema.view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanDropView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot drop view alice-catalog.schema.view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanGrantTablePrivilege(new SecurityContext(transactionId, alice, queryId, queryStart), SELECT, aliceTable, new TrinoPrincipal(USER, "grantee"), true);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot grant privilege SELECT on table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanRevokeTablePrivilege(new SecurityContext(transactionId, alice, queryId, queryStart), SELECT, aliceTable, new TrinoPrincipal(USER, "revokee"), true);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot revoke privilege SELECT on table alice-catalog.schema.table");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateView(new SecurityContext(transactionId, bob, queryId, queryStart), aliceView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
@@ -670,9 +681,10 @@ public class TestFileBasedSystemAccessControl
     public void testMaterializedViewAccess()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext aliceContext = new SecurityContext(transactionId, alice, queryId, queryStart);
                     SecurityContext bobContext = new SecurityContext(transactionId, bob, queryId, queryStart);
@@ -728,46 +740,47 @@ public class TestFileBasedSystemAccessControl
     public void testReadOnlyMaterializedViewAccess()
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_read_only.json");
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     SecurityContext context = new SecurityContext(transactionId, alice, queryId, queryStart);
                     accessControlManager.checkCanSelectFromColumns(context, aliceMaterializedView, ImmutableSet.of());
                     accessControlManager.checkCanSetCatalogSessionProperty(context, "alice-catalog", "property");
                 });
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateMaterializedView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceMaterializedView, Map.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot create materialized view alice-catalog.schema.materialized-view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanDropMaterializedView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceMaterializedView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot drop materialized view alice-catalog.schema.materialized-view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanRefreshMaterializedView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceMaterializedView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot refresh materialized view alice-catalog.schema.materialized-view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanSetMaterializedViewProperties(new SecurityContext(transactionId, alice, queryId, queryStart), aliceMaterializedView, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot set properties of materialized view alice-catalog.schema.materialized-view");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanCreateMaterializedView(new SecurityContext(transactionId, bob, queryId, queryStart), aliceMaterializedView, Map.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanRefreshMaterializedView(new SecurityContext(transactionId, bob, queryId, queryStart), aliceMaterializedView);
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager).execute(transactionId -> {
             accessControlManager.checkCanSetMaterializedViewProperties(new SecurityContext(transactionId, bob, queryId, queryStart), aliceMaterializedView, ImmutableMap.of());
         })).isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot access catalog alice-catalog");
@@ -778,6 +791,7 @@ public class TestFileBasedSystemAccessControl
             throws Exception
     {
         TransactionManager transactionManager = createTestTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
         AccessControlManager accessControlManager = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig(), OpenTelemetry.noop(), DefaultSystemAccessControl.NAME);
         File configFile = newTemporaryFile();
         configFile.deleteOnExit();
@@ -787,7 +801,7 @@ public class TestFileBasedSystemAccessControl
                 SECURITY_CONFIG_FILE, configFile.getAbsolutePath(),
                 SECURITY_REFRESH_PERIOD, "1ms"));
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
@@ -797,14 +811,14 @@ public class TestFileBasedSystemAccessControl
         copy(new File(getResourcePath("security-config-file-with-unknown-rules.json")), configFile);
         sleep(2);
 
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager)
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
                 }))
                 .isInstanceOf(UncheckedIOException.class)
                 .hasMessageStartingWith("Failed to convert JSON tree node");
         // test if file based cached control was not cached somewhere
-        assertThatThrownBy(() -> transaction(transactionManager, accessControlManager)
+        assertThatThrownBy(() -> transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
                 }))
@@ -814,7 +828,7 @@ public class TestFileBasedSystemAccessControl
         copy(new File(getResourcePath("catalog.json")), configFile);
         sleep(2);
 
-        transaction(transactionManager, accessControlManager)
+        transaction(transactionManager, metadata, accessControlManager)
                 .execute(transactionId -> {
                     accessControlManager.checkCanCreateView(new SecurityContext(transactionId, alice, queryId, queryStart), aliceView);
                 });

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -7081,7 +7081,7 @@ public class TestAnalyzer
 
     private void inSetupTransaction(Consumer<Session> consumer)
     {
-        transaction(transactionManager, accessControl)
+        transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                 .singleStatement()
                 .readUncommitted()
                 .execute(SETUP_SESSION, consumer);
@@ -7149,7 +7149,7 @@ public class TestAnalyzer
 
     private Analysis analyze(Session clientSession, @Language("SQL") String query, AccessControl accessControl)
     {
-        return transaction(transactionManager, accessControl)
+        return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                 .singleStatement()
                 .readUncommitted()
                 .execute(clientSession, session -> {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -16,6 +16,8 @@ package io.trino.sql.planner;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.expression.Call;
 import io.trino.spi.expression.ConnectorExpression;
@@ -49,6 +51,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.testing.TestingSession;
 import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionManager;
 import io.trino.type.LikeFunctions;
 import org.junit.jupiter.api.Test;
 
@@ -318,7 +321,9 @@ public class TestConnectorExpressionTranslator
     @Test
     public void testTranslateLike()
     {
-        transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        TransactionManager transactionManager = new TestingTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
+        transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .readOnly()
                 .execute(TEST_SESSION, transactionSession -> {
                     String pattern = "%pattern%";
@@ -399,7 +404,9 @@ public class TestConnectorExpressionTranslator
     @Test
     public void testTranslateResolvedFunction()
     {
-        transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        TransactionManager transactionManager = new TestingTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
+        transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .readOnly()
                 .execute(TEST_SESSION, transactionSession -> {
                     assertTranslationRoundTrips(
@@ -420,7 +427,9 @@ public class TestConnectorExpressionTranslator
         // Regular expression types (JoniRegexpType, Re2JRegexpType) are considered implementation detail of the engine
         // and are not exposed to connectors within ConnectorExpression. Instead, they are replaced with a varchar pattern.
 
-        transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        TransactionManager transactionManager = new TestingTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
+        transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .readOnly()
                 .execute(TEST_SESSION, transactionSession -> {
                     FunctionCall input = BuiltinFunctionCallBuilder.resolve(PLANNER_CONTEXT.getMetadata())

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDomainTranslator.java
@@ -18,6 +18,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.predicate.Domain;
@@ -47,6 +49,7 @@ import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.StringLiteral;
 import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionManager;
 import io.trino.type.LikePattern;
 import io.trino.type.LikePatternType;
 import io.trino.type.TypeCoercion;
@@ -2071,7 +2074,9 @@ public class TestDomainTranslator
 
     private ExtractionResult fromPredicate(Expression originalPredicate)
     {
-        return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        TransactionManager transactionManager = new TestingTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
+        return transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .singleStatement()
                 .execute(TEST_SESSION, transactionSession -> {
                     return DomainTranslator.getExtractionResult(functionResolution.getPlannerContext(), transactionSession, originalPredicate, TYPES);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -760,7 +760,7 @@ public class TestEffectivePredicateExtractor
 
     private Expression extract(TypeProvider types, PlanNode node)
     {
-        return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        return transaction(new TestingTransactionManager(), metadata, new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, transactionSession -> {
                     return effectivePredicateExtractor.extract(transactionSession, node, types, typeAnalyzer);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLiteralEncoder.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.trino.connector.system.GlobalSystemConnector;
 import io.trino.metadata.LiteralFunction;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.MetadataManager;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.operator.scalar.Re2JCastToRegexpFunction;
 import io.trino.security.AllowAllAccessControl;
@@ -36,6 +38,7 @@ import io.trino.sql.ExpressionUtils;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.transaction.TestingTransactionManager;
+import io.trino.transaction.TransactionManager;
 import io.trino.type.Re2JRegexp;
 import org.junit.jupiter.api.Test;
 
@@ -324,7 +327,9 @@ public class TestLiteralEncoder
 
     private Map<NodeRef<Expression>, Type> getExpressionTypes(Expression expression)
     {
-        return transaction(new TestingTransactionManager(), new AllowAllAccessControl())
+        TransactionManager transactionManager = new TestingTransactionManager();
+        Metadata metadata = MetadataManager.testMetadataManagerBuilder().withTransactionManager(transactionManager).build();
+        return transaction(transactionManager, metadata, new AllowAllAccessControl())
                 .singleStatement()
                 .execute(TEST_SESSION, transactionSession -> {
                     return ExpressionUtils.getExpressionTypes(PLANNER_CONTEXT, transactionSession, expression, TypeProvider.empty());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPlanFragmentPartitionCount.java
@@ -148,7 +148,7 @@ public class TestPlanFragmentPartitionCount
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)
     {
-        return transaction(localQueryRunner.getTransactionManager(), new AllowAllAccessControl())
+        return transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(session, session -> {
                     // metadata.getCatalogHandle() registers the catalog for the transaction

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
@@ -17,9 +17,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.spi.type.Type;
 import io.trino.sql.ExpressionTestUtils;
+import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SymbolReference;
+import io.trino.transaction.TestingTransactionManager;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -32,11 +34,15 @@ import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
-import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.sql.planner.TestingPlannerContext.plannerContextBuilder;
 import static org.testng.Assert.assertEquals;
 
 public class TestSortExpressionExtractor
 {
+    private static final TestingTransactionManager TRANSACTION_MANAGER = new TestingTransactionManager();
+    private static final PlannerContext PLANNER_CONTEXT = plannerContextBuilder()
+            .withTransactionManager(TRANSACTION_MANAGER)
+            .build();
     private static final TypeProvider TYPE_PROVIDER = TypeProvider.copyOf(ImmutableMap.<Symbol, Type>builder()
             .put(new Symbol("b1"), DOUBLE)
             .put(new Symbol("b2"), DOUBLE)
@@ -89,7 +95,7 @@ public class TestSortExpressionExtractor
 
     private Expression expression(String sql)
     {
-        return ExpressionTestUtils.planExpression(PLANNER_CONTEXT, TEST_SESSION, TYPE_PROVIDER, PlanBuilder.expression(sql));
+        return ExpressionTestUtils.planExpression(TRANSACTION_MANAGER, PLANNER_CONTEXT, TEST_SESSION, TYPE_PROVIDER, PlanBuilder.expression(sql));
     }
 
     private void assertNoSortExpression(String expression)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
@@ -20,7 +20,6 @@ import io.trino.Session;
 import io.trino.connector.MockConnectorColumnHandle;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorTableHandle;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -55,6 +54,7 @@ import static io.trino.connector.MockConnectorFactory.ApplyFilter;
 import static io.trino.connector.MockConnectorFactory.ApplyProjection;
 import static io.trino.connector.MockConnectorFactory.ApplyTableScanRedirect;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.predicate.Domain.singleValue;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -285,8 +285,15 @@ public class TestTableScanRedirectionWithPushdown
             // Redirection results in Project('dest_col_b') -> Filter('dest_col_d = 1') -> TableScan for such case
             // but dest_col_d has mismatched type compared to source domain
             transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
-                    .execute(MOCK_SESSION, session -> {
-                        assertThatThrownBy(() -> queryRunner.createPlan(session, "SELECT source_col_b FROM test_table WHERE source_col_c = 'foo'", WarningCollector.NOOP, createPlanOptimizersStatsCollector()))
+                    .execute(MOCK_SESSION, transactionSession -> {
+                        assertThatThrownBy(() ->
+                                queryRunner.createPlan(
+                                        transactionSession,
+                                        "SELECT source_col_b FROM test_table WHERE source_col_c = 'foo'",
+                                        queryRunner.getPlanOptimizers(true),
+                                        OPTIMIZED_AND_VALIDATED,
+                                        NOOP,
+                                        createPlanOptimizersStatsCollector()))
                                 .isInstanceOf(TrinoException.class)
                                 .hasMessageMatching("Cast not possible from redirected column mock_catalog.target_schema.target_table.destination_col_d with type Bogus to source column .*mock_catalog.test_schema.test_table.*source_col_c.* with type: varchar");
                     });
@@ -486,7 +493,7 @@ public class TestTableScanRedirectionWithPushdown
         List<PlanOptimizer> optimizers = queryRunner.getPlanOptimizers(true);
 
         queryRunner.inTransaction(transactionSession -> {
-            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers, OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+            Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers, OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
             PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actualPlan, pattern);
             return null;
         });

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BasePlanTest.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.sql.planner.LogicalPlanner;
@@ -44,6 +43,7 @@ import java.util.function.Predicate;
 
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.sql.planner.PlanOptimizers.columnPruningRules;
@@ -152,7 +152,7 @@ public class BasePlanTest
     {
         try {
             queryRunner.inTransaction(transactionSession -> {
-                Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers, stage, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                Plan actualPlan = queryRunner.createPlan(transactionSession, sql, optimizers, stage, NOOP, createPlanOptimizersStatsCollector());
                 PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actualPlan, pattern);
                 return null;
             });
@@ -194,7 +194,13 @@ public class BasePlanTest
     {
         try {
             queryRunner.inTransaction(session, transactionSession -> {
-                Plan actualPlan = queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, forceSingleNode, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                Plan actualPlan = queryRunner.createPlan(
+                        transactionSession,
+                        sql,
+                        queryRunner.getPlanOptimizers(forceSingleNode),
+                        OPTIMIZED_AND_VALIDATED,
+                        NOOP,
+                        createPlanOptimizersStatsCollector());
                 PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actualPlan, pattern);
                 return null;
             });
@@ -209,7 +215,7 @@ public class BasePlanTest
     {
         try {
             queryRunner.inTransaction(session, transactionSession -> {
-                Plan actualPlan = queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, forceSingleNode, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                Plan actualPlan = queryRunner.createPlan(transactionSession, sql, queryRunner.getPlanOptimizers(forceSingleNode), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
                 PlanAssert.assertPlan(transactionSession, queryRunner.getMetadata(), queryRunner.getFunctionManager(), queryRunner.getStatsCalculator(), actualPlan, pattern);
                 planValidator.accept(actualPlan);
                 return null;
@@ -234,7 +240,8 @@ public class BasePlanTest
     protected Plan plan(@Language("SQL") String sql, LogicalPlanner.Stage stage, boolean forceSingleNode)
     {
         try {
-            return queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, sql, stage, forceSingleNode, WarningCollector.NOOP, createPlanOptimizersStatsCollector()));
+            return queryRunner.inTransaction(queryRunner.getDefaultSession(), transactionSession ->
+                    queryRunner.createPlan(transactionSession, sql, queryRunner.getPlanOptimizers(forceSingleNode), stage, NOOP, createPlanOptimizersStatsCollector()));
         }
         catch (RuntimeException e) {
             throw new AssertionError("Planning failed for SQL: " + sql, e);
@@ -250,7 +257,7 @@ public class BasePlanTest
     {
         try {
             return queryRunner.inTransaction(session, transactionSession -> {
-                Plan plan = queryRunner.createPlan(transactionSession, sql, stage, forceSingleNode, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                Plan plan = queryRunner.createPlan(transactionSession, sql, queryRunner.getPlanOptimizers(forceSingleNode), stage, NOOP, createPlanOptimizersStatsCollector());
                 return queryRunner.createSubPlans(transactionSession, plan, forceSingleNode);
             });
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
@@ -57,6 +57,6 @@ public class TestArraySortAfterArrayDistinct
 
     private Expression expression(String sql)
     {
-        return ExpressionTestUtils.planExpression(tester().getPlannerContext(), tester().getSession(), TypeProvider.empty(), PlanBuilder.expression(sql));
+        return ExpressionTestUtils.planExpression(tester().getQueryRunner().getTransactionManager(), tester().getPlannerContext(), tester().getSession(), TypeProvider.empty(), PlanBuilder.expression(sql));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
@@ -134,7 +134,7 @@ public class TestCanonicalizeExpressionRewriter
     private static void assertRewritten(Expression from, String to)
     {
         assertExpressionEquals(
-                transaction(TRANSACTION_MANAGER, ACCESS_CONTROL).execute(TEST_SESSION, transactedSession -> {
+                transaction(TRANSACTION_MANAGER, PLANNER_CONTEXT.getMetadata(), ACCESS_CONTROL).execute(TEST_SESSION, transactedSession -> {
                     return rewrite(
                             from,
                             transactedSession,

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -405,7 +405,7 @@ public class QueryAssertions
         @CanIgnoreReturnValue
         public QueryAssert matches(PlanMatchPattern expectedPlan)
         {
-            transaction(runner.getTransactionManager(), runner.getAccessControl())
+            transaction(runner.getTransactionManager(), runner.getMetadata(), runner.getAccessControl())
                     .execute(session, session -> {
                         Plan plan = runner.createPlan(session, query);
                         assertPlan(
@@ -482,7 +482,7 @@ public class QueryAssertions
         {
             checkState(!(runner instanceof LocalQueryRunner), "isFullyPushedDown() currently does not work with LocalQueryRunner");
 
-            transaction(runner.getTransactionManager(), runner.getAccessControl())
+            transaction(runner.getTransactionManager(), runner.getMetadata(), runner.getAccessControl())
                     .execute(session, session -> {
                         Plan plan = runner.createPlan(session, query);
                         assertPlan(
@@ -567,7 +567,7 @@ public class QueryAssertions
 
         private QueryAssert hasPlan(PlanMatchPattern expectedPlan, Consumer<Plan> additionalPlanVerification)
         {
-            transaction(runner.getTransactionManager(), runner.getAccessControl())
+            transaction(runner.getTransactionManager(), runner.getMetadata(), runner.getAccessControl())
                     .execute(session, session -> {
                         Plan plan = runner.createPlan(session, query);
                         assertPlan(
@@ -589,7 +589,7 @@ public class QueryAssertions
 
         private QueryAssert verifyPlan(Consumer<Plan> planVerification)
         {
-            transaction(runner.getTransactionManager(), runner.getAccessControl())
+            transaction(runner.getTransactionManager(), runner.getMetadata(), runner.getAccessControl())
                     .execute(session, session -> {
                         Plan plan = runner.createPlan(session, query);
                         planVerification.accept(plan);

--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -58,7 +58,6 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static io.trino.cost.StatsCalculator.noopStatsCalculator;
-import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.metadata.OperatorNameUtil.mangleOperatorName;
 import static io.trino.sql.planner.assertions.PlanAssert.assertPlan;
 import static io.trino.sql.query.QueryAssertions.QueryAssert.newQueryAssert;
@@ -408,7 +407,7 @@ public class QueryAssertions
         {
             transaction(runner.getTransactionManager(), runner.getAccessControl())
                     .execute(session, session -> {
-                        Plan plan = runner.createPlan(session, query, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                        Plan plan = runner.createPlan(session, query);
                         assertPlan(
                                 session,
                                 runner.getMetadata(),
@@ -485,7 +484,7 @@ public class QueryAssertions
 
             transaction(runner.getTransactionManager(), runner.getAccessControl())
                     .execute(session, session -> {
-                        Plan plan = runner.createPlan(session, query, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                        Plan plan = runner.createPlan(session, query);
                         assertPlan(
                                 session,
                                 runner.getMetadata(),
@@ -570,7 +569,7 @@ public class QueryAssertions
         {
             transaction(runner.getTransactionManager(), runner.getAccessControl())
                     .execute(session, session -> {
-                        Plan plan = runner.createPlan(session, query, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                        Plan plan = runner.createPlan(session, query);
                         assertPlan(
                                 session,
                                 runner.getMetadata(),
@@ -592,7 +591,7 @@ public class QueryAssertions
         {
             transaction(runner.getTransactionManager(), runner.getAccessControl())
                     .execute(session, session -> {
-                        Plan plan = runner.createPlan(session, query, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                        Plan plan = runner.createPlan(session, query);
                         planVerification.accept(plan);
                     });
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -16,7 +16,6 @@ package io.trino.plugin.jdbc;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.SortOrder;
@@ -37,6 +36,7 @@ import io.trino.sql.query.QueryAssertions.QueryAssert;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedResultWithQueryId;
+import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
@@ -61,7 +61,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.MARK_DISTINCT_STRATEGY;
-import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.plugin.jdbc.JdbcDynamicFilteringSessionProperties.DYNAMIC_FILTERING_ENABLED;
 import static io.trino.plugin.jdbc.JdbcDynamicFilteringSessionProperties.DYNAMIC_FILTERING_WAIT_TIMEOUT;
 import static io.trino.plugin.jdbc.JdbcMetadataSessionProperties.DOMAIN_COMPACTION_THRESHOLD;
@@ -1857,20 +1856,21 @@ public abstract class BaseJdbcConnectorTest
                 .setCatalogSessionProperty(getSession().getCatalog().orElseThrow(), "write_parallelism", String.valueOf(parallelism))
                 .build();
 
+        QueryRunner queryRunner = getQueryRunner();
         try (TestTable table = new TestTable(
-                getQueryRunner()::execute,
+                queryRunner::execute,
                 "write_parallelism",
                 "(a varchar(128), b bigint)")) {
-            Plan plan = getQueryRunner().createPlan(
-                    session,
-                    "INSERT INTO " + table.getName() + " (a, b) SELECT clerk, orderkey FROM tpch.sf100.orders LIMIT " + numberOfRows,
-                    WarningCollector.NOOP,
-                    createPlanOptimizersStatsCollector());
+            Plan plan = newTransaction()
+                    .singleStatement()
+                    .execute(session, (Session transactionSession) -> queryRunner.createPlan(
+                            transactionSession,
+                            "INSERT INTO " + table.getName() + " (a, b) SELECT clerk, orderkey FROM tpch.sf100.orders LIMIT " + numberOfRows));
             TableWriterNode.WriterTarget target = ((TableWriterNode) searchFrom(plan.getRoot())
                     .where(node -> node instanceof TableWriterNode)
                     .findOnlyElement()).getTarget();
 
-            assertThat(target.getMaxWriterTasks(getQueryRunner().getMetadata(), getSession()))
+            assertThat(target.getMaxWriterTasks(queryRunner.getMetadata(), getSession()))
                     .hasValue(parallelism);
         }
     }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -262,7 +262,7 @@ public class TestSpatialJoinPlanning
         LocalQueryRunner queryRunner = getQueryRunner();
         try {
             queryRunner.inTransaction(session, transactionSession -> {
-                queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                queryRunner.createPlan(transactionSession, sql, queryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
                 return null;
             });
             throw new AssertionError(format("Expected query to fail: %s", sql));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -2621,7 +2621,7 @@ public abstract class BaseHiveConnectorTest
             assertUpdate(session, createSourceTable, "SELECT count(*) FROM orders");
             assertUpdate(session, createTargetTable, "SELECT count(*) FROM orders");
 
-            transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl()).execute(
+            transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl()).execute(
                     session,
                     transactionalSession -> {
                         assertUpdate(
@@ -3774,7 +3774,7 @@ public abstract class BaseHiveConnectorTest
         Session session = getSession();
         Metadata metadata = getDistributedQueryRunner().getCoordinator().getMetadata();
 
-        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), metadata, getQueryRunner().getAccessControl())
                 .readOnly()
                 .execute(session, transactionSession -> {
                     Optional<TableHandle> tableHandle = metadata.getTableHandle(transactionSession, new QualifiedObjectName(catalog, schema, tableName));
@@ -3788,7 +3788,7 @@ public abstract class BaseHiveConnectorTest
         Session session = getSession();
         Metadata metadata = getDistributedQueryRunner().getCoordinator().getMetadata();
 
-        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), metadata, getQueryRunner().getAccessControl())
                 .readOnly()
                 .execute(session, transactionSession -> {
                     QualifiedObjectName name = new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName);
@@ -4987,7 +4987,7 @@ public abstract class BaseHiveConnectorTest
                 .getMaterializedRows();
 
         try {
-            transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+            transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                     .execute(session, transactionSession -> {
                         assertUpdate(transactionSession, "DELETE FROM tmp_delete_insert WHERE z >= 2");
                         assertUpdate(transactionSession, "INSERT INTO tmp_delete_insert VALUES (203, 2), (204, 2), (205, 2), (301, 2), (302, 3)", 5);
@@ -5005,7 +5005,7 @@ public abstract class BaseHiveConnectorTest
         MaterializedResult actualAfterRollback = computeActual(session, "SELECT * FROM tmp_delete_insert");
         assertEqualsIgnoreOrder(actualAfterRollback, expectedBefore);
 
-        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                 .execute(session, transactionSession -> {
                     assertUpdate(transactionSession, "DELETE FROM tmp_delete_insert WHERE z >= 2");
                     assertUpdate(transactionSession, "INSERT INTO tmp_delete_insert VALUES (203, 2), (204, 2), (205, 2), (301, 2), (302, 3)", 5);
@@ -5033,7 +5033,7 @@ public abstract class BaseHiveConnectorTest
                 .build()
                 .getMaterializedRows();
 
-        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                 .execute(session, transactionSession -> {
                     assertUpdate(
                             transactionSession,
@@ -7772,7 +7772,7 @@ public abstract class BaseHiveConnectorTest
     private HiveInsertTableHandle getHiveInsertTableHandle(Session session, String tableName)
     {
         Metadata metadata = getDistributedQueryRunner().getCoordinator().getMetadata();
-        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                 .execute(session, transactionSession -> {
                     QualifiedObjectName objectName = new QualifiedObjectName(catalog, TPCH_SCHEMA, tableName);
                     Optional<TableHandle> handle = metadata.getTableHandle(transactionSession, objectName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4091,7 +4091,7 @@ public abstract class BaseIcebergConnectorTest
 
     private void withTransaction(Consumer<Session> consumer)
     {
-        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                 .readCommitted()
                 .execute(getSession(), consumer);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.InternalFunctionBundle;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -43,6 +42,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -136,8 +136,8 @@ public class TestIcebergGetTableStatisticsOperations
     private void planDistributedQuery(@Language("SQL") String sql)
     {
         transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
-                .execute(localQueryRunner.getDefaultSession(), session -> {
-                    localQueryRunner.createPlan(session, sql, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                .execute(localQueryRunner.getDefaultSession(), transactionSession -> {
+                    localQueryRunner.createPlan(transactionSession, sql, localQueryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
                 });
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGetTableStatisticsOperations.java
@@ -46,7 +46,6 @@ import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static io.trino.transaction.TransactionBuilder.transaction;
 import static org.assertj.core.api.Assertions.assertThat;
 
 // Cost-based optimizers' behaviors are affected by the statistics returned by the Connectors. Here is to count the getTableStatistics calls
@@ -135,10 +134,13 @@ public class TestIcebergGetTableStatisticsOperations
 
     private void planDistributedQuery(@Language("SQL") String sql)
     {
-        transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
-                .execute(localQueryRunner.getDefaultSession(), transactionSession -> {
-                    localQueryRunner.createPlan(transactionSession, sql, localQueryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
-                });
+        localQueryRunner.inTransaction(transactionSession -> localQueryRunner.createPlan(
+                transactionSession,
+                sql,
+                localQueryRunner.getPlanOptimizers(false),
+                OPTIMIZED_AND_VALIDATED,
+                NOOP,
+                createPlanOptimizersStatsCollector()));
     }
 
     private long getTableStatisticsMethodInvocations()

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestMinimalFunctionality.java
@@ -142,7 +142,7 @@ public class TestMinimalFunctionality
     {
         QualifiedObjectName name = new QualifiedObjectName("kinesis", "default", streamName);
 
-        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+        transaction(queryRunner.getTransactionManager(), queryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, session -> {
                     Optional<TableHandle> handle = queryRunner.getServer().getMetadata().getTableHandle(session, name);

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
@@ -151,7 +151,7 @@ public class TestRecordAccess
     {
         QualifiedObjectName name = new QualifiedObjectName("kinesis", "default", dummyStreamName);
 
-        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+        transaction(queryRunner.getTransactionManager(), queryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, session -> {
                     Optional<TableHandle> handle = queryRunner.getServer().getMetadata().getTableHandle(session, name);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
@@ -40,7 +40,7 @@ public class TestMinimalFunctionality
     public void testTableExists()
     {
         QualifiedObjectName name = new QualifiedObjectName("redis", "default", tableName);
-        transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+        transaction(queryRunner.getTransactionManager(), queryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(SESSION, session -> {
                     Optional<TableHandle> handle = queryRunner.getServer().getMetadata().getTableHandle(session, name);

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
@@ -99,6 +99,7 @@ public abstract class AbstractOperatorBenchmark
         extends AbstractBenchmark
 {
     protected final LocalQueryRunner localQueryRunner;
+    protected final Session nonTransactionSession;
     protected final Session session;
 
     protected AbstractOperatorBenchmark(
@@ -118,6 +119,7 @@ public abstract class AbstractOperatorBenchmark
             int measuredIterations)
     {
         super(benchmarkName, warmupIterations, measuredIterations);
+        this.nonTransactionSession = requireNonNull(session, "session is null");
         this.localQueryRunner = requireNonNull(localQueryRunner, "localQueryRunner is null");
 
         TransactionId transactionId = localQueryRunner.getTransactionManager().beginTransaction(false);

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractSqlBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractSqlBenchmark.java
@@ -41,6 +41,6 @@ public abstract class AbstractSqlBenchmark
     @Override
     protected List<Driver> createDrivers(TaskContext taskContext)
     {
-        return localQueryRunner.createDrivers(session, query, new NullOutputFactory(), taskContext);
+        return localQueryRunner.createDrivers(nonTransactionSession, query, new NullOutputFactory(), taskContext);
     }
 }

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
@@ -46,7 +46,6 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMaxPartitionCount;
-import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.consumesHashPartitionedInput;
 import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.getMaxPlanFragmentId;
 import static io.trino.sql.planner.RuntimeAdaptivePartitioningRewriter.getMaxPlanId;
@@ -276,10 +275,10 @@ public class TestOverridePartitionCountRecursively
     private SubPlan getSubPlan(Session session, @Language("SQL") String sql)
     {
         QueryRunner queryRunner = getDistributedQueryRunner();
-        Plan plan = queryRunner.createPlan(session, sql, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
         return transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(session, transactionSession -> {
+                    Plan plan = queryRunner.createPlan(transactionSession, sql);
                     // metadata.getCatalogHandle() registers the catalog for the transaction
                     transactionSession.getCatalog().ifPresent(catalog -> queryRunner.getMetadata().getCatalogHandle(transactionSession, catalog));
                     return new PlanFragmenter(

--- a/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
+++ b/testing/trino-faulttolerant-tests/src/test/java/io/trino/faulttolerant/TestOverridePartitionCountRecursively.java
@@ -275,7 +275,7 @@ public class TestOverridePartitionCountRecursively
     private SubPlan getSubPlan(Session session, @Language("SQL") String sql)
     {
         QueryRunner queryRunner = getDistributedQueryRunner();
-        return transaction(queryRunner.getTransactionManager(), new AllowAllAccessControl())
+        return transaction(queryRunner.getTransactionManager(), queryRunner.getMetadata(), new AllowAllAccessControl())
                 .singleStatement()
                 .execute(session, transactionSession -> {
                     Plan plan = queryRunner.createPlan(transactionSession, sql);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -292,7 +292,7 @@ public abstract class AbstractTestQueryFramework
 
     protected TransactionBuilder newTransaction()
     {
-        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl());
+        return transaction(queryRunner.getTransactionManager(), queryRunner.getMetadata(), queryRunner.getAccessControl());
     }
 
     protected void inTransaction(Consumer<Session> callback)
@@ -732,7 +732,7 @@ public abstract class AbstractTestQueryFramework
 
     private <T> T inTransaction(Session session, Function<Session, T> transactionSessionConsumer)
     {
-        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl())
+        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getMetadata(), getQueryRunner().getAccessControl())
                 .singleStatement()
                 .execute(session, transactionSessionConsumer);
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -196,7 +196,7 @@ public abstract class AbstractTestingTrinoClient<T>
 
     private <V> V inTransaction(Session session, Function<Session, V> callback)
     {
-        return transaction(trinoServer.getTransactionManager(), trinoServer.getAccessControl())
+        return transaction(trinoServer.getTransactionManager(), trinoServer.getMetadata(), trinoServer.getAccessControl())
                 .readOnly()
                 .singleStatement()
                 .execute(session, callback);

--- a/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
@@ -14,13 +14,13 @@
 package io.trino.testing;
 
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.planprinter.PlanPrinter;
 
 import java.util.function.Function;
 
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static org.testng.Assert.assertEquals;
 
@@ -59,7 +59,7 @@ public class PlanDeterminismChecker
     private String getPlanText(Session session, String sql)
     {
         return localQueryRunner.inTransaction(session, transactionSession -> {
-            Plan plan = localQueryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+            Plan plan = localQueryRunner.createPlan(transactionSession, sql, localQueryRunner.getPlanOptimizers(true), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
             return PlanPrinter.textLogicalPlan(
                     plan.getRoot(),
                     plan.getTypes(),

--- a/testing/trino-testing/src/main/java/io/trino/testing/statistics/MetricComparator.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/statistics/MetricComparator.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.cost.PlanNodeStatsEstimate;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.OutputNode;
@@ -29,7 +28,6 @@ import java.util.OptionalDouble;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
 import static io.trino.transaction.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -64,7 +62,7 @@ final class MetricComparator
     private static List<OptionalDouble> getEstimatedValuesInternal(List<Metric> metrics, String query, QueryRunner runner, Session session)
     // TODO inline back this method
     {
-        Plan queryPlan = runner.createPlan(session, query, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+        Plan queryPlan = runner.createPlan(session, query);
         OutputNode outputNode = (OutputNode) queryPlan.getRoot();
         PlanNodeStatsEstimate outputNodeStats = queryPlan.getStatsAndCosts().getStats().getOrDefault(queryPlan.getRoot().getId(), PlanNodeStatsEstimate.unknown());
         StatsContext statsContext = buildStatsContext(queryPlan, outputNode);

--- a/testing/trino-testing/src/main/java/io/trino/testing/statistics/MetricComparator.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/statistics/MetricComparator.java
@@ -54,7 +54,7 @@ final class MetricComparator
 
     private static List<OptionalDouble> getEstimatedValues(List<Metric> metrics, String query, QueryRunner runner)
     {
-        return transaction(runner.getTransactionManager(), runner.getAccessControl())
+        return transaction(runner.getTransactionManager(), runner.getMetadata(), runner.getAccessControl())
                 .singleStatement()
                 .execute(runner.getDefaultSession(), (Session session) -> getEstimatedValuesInternal(metrics, query, runner, session));
     }

--- a/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseCostBasedPlanTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/sql/planner/BaseCostBasedPlanTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.airlift.log.Logger;
 import io.trino.Session;
-import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.sql.DynamicFilters;
@@ -57,6 +56,7 @@ import static io.trino.Session.SessionBuilder;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.execution.querystats.PlanOptimizersStatsCollector.createPlanOptimizersStatsCollector;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.sql.DynamicFilters.extractDynamicFilters;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static io.trino.sql.planner.plan.JoinNode.DistributionType.REPLICATED;
@@ -218,7 +218,8 @@ public abstract class BaseCostBasedPlanTest
     {
         try {
             return getQueryRunner().inTransaction(transactionSession -> {
-                Plan plan = getQueryRunner().createPlan(transactionSession, query, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                LocalQueryRunner localQueryRunner = getQueryRunner();
+                Plan plan = localQueryRunner.createPlan(transactionSession, query, localQueryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, NOOP, createPlanOptimizersStatsCollector());
                 JoinOrderPrinter joinOrderPrinter = new JoinOrderPrinter(transactionSession);
                 plan.getRoot().accept(joinOrderPrinter, 0);
                 return joinOrderPrinter.result();

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -102,8 +102,8 @@ public class TestGetTableStatisticsOperations
     private void planDistributedQuery(@Language("SQL") String sql)
     {
         transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
-                .execute(localQueryRunner.getDefaultSession(), session -> {
-                    localQueryRunner.createPlan(session, sql, OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
+                .execute(localQueryRunner.getDefaultSession(), transactionSession -> {
+                    localQueryRunner.createPlan(transactionSession, sql, localQueryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
                 });
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGetTableStatisticsOperations.java
@@ -101,7 +101,7 @@ public class TestGetTableStatisticsOperations
 
     private void planDistributedQuery(@Language("SQL") String sql)
     {
-        transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getAccessControl())
+        transaction(localQueryRunner.getTransactionManager(), localQueryRunner.getMetadata(), localQueryRunner.getAccessControl())
                 .execute(localQueryRunner.getDefaultSession(), transactionSession -> {
                     localQueryRunner.createPlan(transactionSession, sql, localQueryRunner.getPlanOptimizers(false), OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP, createPlanOptimizersStatsCollector());
                 });

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -125,7 +125,7 @@ public class TestMetadataManager
     @Test
     public void testMetadataListTablesReturnsQualifiedView()
     {
-        TransactionBuilder.transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        TransactionBuilder.transaction(queryRunner.getTransactionManager(), metadataManager, queryRunner.getAccessControl())
                 .execute(
                         TEST_SESSION,
                         transactionSession -> {
@@ -169,7 +169,7 @@ public class TestMetadataManager
     @Test
     public void testUpperCaseSchemaIsChangedToLowerCase()
     {
-        TransactionBuilder.transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        TransactionBuilder.transaction(queryRunner.getTransactionManager(), metadataManager, queryRunner.getAccessControl())
                 .execute(
                         TEST_SESSION,
                         transactionSession -> {


### PR DESCRIPTION
## Description

Add a beginQuery call that will be used for inline SQL language function registration.  This call will only happen as part of transaction setup, so tests are updated to properly manage sessions.

This has been tested in #19290 using a modified MetadataManager that enforces registration.  The enforcement is not part of this PR and is part of the sql language funcitons.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
