### PR TITLE
Make MySQL JDBC driver strictly follow JDBC

### DIFF
--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -74,6 +74,7 @@ public class MySqlClientModule
     {
         Properties connectionProperties = new Properties();
         connectionProperties.setProperty("useInformationSchema", Boolean.toString(mySqlConfig.isDriverUseInformationSchema()));
+        connectionProperties.setProperty("pedantic", "true");
         connectionProperties.setProperty("useUnicode", "true");
         connectionProperties.setProperty("characterEncoding", "utf8");
         connectionProperties.setProperty("tinyInt1isBit", "false");

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -627,4 +627,22 @@ public abstract class BaseMySqlConnectorTest
             }
         }
     }
+
+    @Test
+    public void testQuotedIdentifiers()
+    {
+        assertUpdate("""
+                CREATE TABLE tpch."`back``quoted`" ("`back``quoted`" BIGINT)""");
+        assertThat(computeActual("SHOW CREATE TABLE tpch.\"`back``quoted`\"").getOnlyValue())
+                .isEqualTo("""
+                        CREATE TABLE mysql.tpch."`back``quoted`" (
+                           "`back``quoted`" bigint
+                        )""");
+
+        assertUpdate("INSERT INTO tpch.\"`back``quoted`\" VALUES (1)", 1);
+        assertThat(query("SELECT * FROM \"`back``quoted`\""))
+                .matches("VALUES (BIGINT '1')");
+
+        assertQuery("SHOW COLUMNS FROM tpch.\"`back``quoted`\"", "VALUES ('`back``quoted`', 'bigint', '', '')");
+    }
 }


### PR DESCRIPTION
pedantic configuration property changes the MySQL JDBC driver to more strictly follow the JDBC specification.

The one behaviour we're most interested in is handling of quoted identifiers. Without this property if an identifier like `ab``c` is left as it is instead of being properly quoted like ```ab````c```.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

FYI @findepi 