### PR TITLE
Avoid extra file status call in orc reader

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -257,7 +257,7 @@ public class OrcPageSourceFactory
         boolean originalFilesPresent = acidInfo.isPresent() && !acidInfo.get().getOriginalFiles().isEmpty();
         try {
             TrinoFileSystem fileSystem = fileSystemFactory.create(session.getIdentity());
-            TrinoInputFile inputFile = fileSystem.newInputFile(path);
+            TrinoInputFile inputFile = fileSystem.newInputFile(path, estimatedFileSize);
             orcDataSource = new HdfsOrcDataSource(
                     new OrcDataSourceId(path.toString()),
                     estimatedFileSize,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystemAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestTrinoS3FileSystemAccessOperations.java
@@ -125,7 +125,6 @@ public class TestTrinoS3FileSystemAccessOperations
                 ImmutableMultiset.<String>builder()
                         .add("S3.GetObject")
                         .add("S3.ListObjectsV2")
-                        .addCopies("S3.GetObjectMetadata", occurrences(format, 1, 0))
                         .build());
 
         assertFileSystemAccesses(
@@ -134,7 +133,6 @@ public class TestTrinoS3FileSystemAccessOperations
                 ImmutableMultiset.<String>builder()
                         .addCopies("S3.GetObject", occurrences(format, 3, 2))
                         .add("S3.ListObjectsV2")
-                        .addCopies("S3.GetObjectMetadata", occurrences(format, 1, 0))
                         .build());
 
         assertUpdate("DROP TABLE test_select_from_where");
@@ -154,14 +152,12 @@ public class TestTrinoS3FileSystemAccessOperations
                 ImmutableMultiset.<String>builder()
                         .addCopies("S3.GetObject", 2)
                         .addCopies("S3.ListObjectsV2", 2)
-                        .addCopies("S3.GetObjectMetadata", occurrences(format, 2, 0))
                         .build());
 
         assertFileSystemAccesses("SELECT * FROM test_select_from_partition WHERE key = 'part1'",
                 ImmutableMultiset.<String>builder()
                         .add("S3.GetObject")
                         .add("S3.ListObjectsV2")
-                        .addCopies("S3.GetObjectMetadata", occurrences(format, 1, 0))
                         .build());
 
         assertUpdate("INSERT INTO test_select_from_partition VALUES (11, 'part1')", 1);
@@ -169,7 +165,6 @@ public class TestTrinoS3FileSystemAccessOperations
                 ImmutableMultiset.<String>builder()
                         .addCopies("S3.GetObject", 2)
                         .addCopies("S3.ListObjectsV2", 1)
-                        .addCopies("S3.GetObjectMetadata", occurrences(format, 2, 0))
                         .build());
 
         assertUpdate("DROP TABLE test_select_from_partition");


### PR DESCRIPTION
## Description
Avoid extra file status call in orc reader


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Iceberg
* Improve performance of reading ORC files. ({issue}`19295`)
```
