### PR TITLE
Accelerate Iceberg when reading partition columns only

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -54,6 +54,7 @@ import static java.lang.String.format;
 public final class IcebergSessionProperties
         implements SessionPropertiesProvider
 {
+    public static final String SPLIT_SIZE = "experimental_split_size";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String USE_FILE_SIZE_FROM_METADATA = "use_file_size_from_metadata";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
@@ -103,6 +104,13 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(dataSizeProperty(
+                        SPLIT_SIZE,
+                        "Target split size",
+                        // Note: this is null by default & hidden, currently mainly for tests.
+                        // See https://github.com/trinodb/trino/issues/9018#issuecomment-1752929193 for further discussion.
+                        null,
+                        true))
                 .add(enumProperty(
                         COMPRESSION_CODEC,
                         "Compression codec to use when writing files",
@@ -402,6 +410,11 @@ public final class IcebergSessionProperties
     public static DataSize getOrcWriterMaxDictionaryMemory(ConnectorSession session)
     {
         return session.getProperty(ORC_WRITER_MAX_DICTIONARY_MEMORY, DataSize.class);
+    }
+
+    public static Optional<DataSize> getSplitSize(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(SPLIT_SIZE, DataSize.class));
     }
 
     public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -40,6 +40,7 @@ public class IcebergSplit
     private final long start;
     private final long length;
     private final long fileSize;
+    private final long fileRecordCount;
     private final IcebergFileFormat fileFormat;
     private final String partitionSpecJson;
     private final String partitionDataJson;
@@ -52,6 +53,7 @@ public class IcebergSplit
             @JsonProperty("start") long start,
             @JsonProperty("length") long length,
             @JsonProperty("fileSize") long fileSize,
+            @JsonProperty("fileRecordCount") long fileRecordCount,
             @JsonProperty("fileFormat") IcebergFileFormat fileFormat,
             @JsonProperty("partitionSpecJson") String partitionSpecJson,
             @JsonProperty("partitionDataJson") String partitionDataJson,
@@ -62,6 +64,7 @@ public class IcebergSplit
         this.start = start;
         this.length = length;
         this.fileSize = fileSize;
+        this.fileRecordCount = fileRecordCount;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.partitionSpecJson = requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
@@ -104,6 +107,12 @@ public class IcebergSplit
     public long getFileSize()
     {
         return fileSize;
+    }
+
+    @JsonProperty
+    public long getFileRecordCount()
+    {
+        return fileRecordCount;
     }
 
     @JsonProperty

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -124,6 +124,7 @@ public class TableChangesFunctionProcessor
                 split.start(),
                 split.length(),
                 split.fileSize(),
+                split.fileRecordCount(),
                 split.partitionDataJson(),
                 split.fileFormat(),
                 functionHandle.nameMappingJson().map(NameMappingParser::fromJson));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Multiset;
 import com.google.inject.Key;
 import io.trino.Session;
+import io.trino.SystemSessionProperties;
 import io.trino.filesystem.TrackingFileSystemFactory;
 import io.trino.filesystem.TrackingFileSystemFactory.OperationType;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
@@ -251,7 +252,6 @@ public class TestIcebergMetadataFileOperations
                         .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
-                        .addCopies(new FileOperation(DATA, INPUT_FILE_NEW_STREAM), 4)
                         .build());
 
         // Read partition column only, one partition only
@@ -263,7 +263,6 @@ public class TestIcebergMetadataFileOperations
                         .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
-                        .addCopies(new FileOperation(DATA, INPUT_FILE_NEW_STREAM), 2)
                         .build());
 
         // Read partition and synthetic columns
@@ -275,10 +274,70 @@ public class TestIcebergMetadataFileOperations
                         .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
+                        // TODO return synthetic columns without opening the data files
                         .addCopies(new FileOperation(DATA, INPUT_FILE_NEW_STREAM), 4)
                         .build());
 
+        // Read only row count
+        assertFileSystemAccesses(
+                "SELECT count(*) FROM test_read_part_key",
+                ALL_FILES,
+                ImmutableMultiset.<FileOperation>builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
+                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
+                        .build());
+
         assertUpdate("DROP TABLE test_read_part_key");
+    }
+
+    @Test
+    public void testReadWholePartitionSplittableFile()
+    {
+        String catalog = getSession().getCatalog().orElseThrow();
+
+        assertUpdate("DROP TABLE IF EXISTS test_read_whole_splittable_file");
+        assertUpdate("CREATE TABLE test_read_whole_splittable_file(key varchar, data varchar) WITH (partitioning=ARRAY['key'])");
+
+        assertUpdate(
+                Session.builder(getSession())
+                        .setSystemProperty(SystemSessionProperties.WRITER_SCALING_MIN_DATA_PROCESSED, "1PB")
+                        .setCatalogSessionProperty(catalog, "parquet_writer_block_size", "1kB")
+                        .setCatalogSessionProperty(catalog, "orc_writer_max_stripe_size", "1kB")
+                        .setCatalogSessionProperty(catalog, "orc_writer_max_stripe_rows", "1000")
+                        .build(),
+                "INSERT INTO test_read_whole_splittable_file SELECT 'single partition', comment FROM tpch.tiny.orders", 15000);
+
+        Session session = Session.builder(getSession())
+                .setCatalogSessionProperty(catalog, IcebergSessionProperties.SPLIT_SIZE, "1kB")
+                .build();
+
+        // Read partition column only
+        assertFileSystemAccesses(
+                session,
+                "SELECT key, count(*) FROM test_read_whole_splittable_file GROUP BY key",
+                ALL_FILES,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
+                        .build());
+
+        // Read only row count
+        assertFileSystemAccesses(
+                session,
+                "SELECT count(*) FROM test_read_whole_splittable_file",
+                ALL_FILES,
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
+                        .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
+                        .build());
+
+        assertUpdate("DROP TABLE test_read_whole_splittable_file");
     }
 
     @Test

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -160,6 +160,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 0,
                 inputFile.length(),
                 inputFile.length(),
+                -1, // invalid; normally known
                 ORC,
                 PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
                 PartitionData.toJson(new PartitionData(new Object[] {})),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -22,11 +22,16 @@ import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.TrinoViewHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.cache.CachingHiveMetastore;
+import io.trino.plugin.hive.orc.OrcReaderConfig;
+import io.trino.plugin.hive.orc.OrcWriterConfig;
+import io.trino.plugin.hive.parquet.ParquetReaderConfig;
+import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.plugin.iceberg.catalog.file.FileMetastoreTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.hms.TrinoHiveCatalog;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
@@ -38,6 +43,7 @@ import io.trino.spi.type.TestingTypeManager;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
+import io.trino.testing.TestingConnectorSession;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
@@ -67,7 +73,6 @@ import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.creat
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.tpch.TpchTable.NATION;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,6 +84,16 @@ import static org.testng.Assert.assertTrue;
 public class TestIcebergSplitSource
         extends AbstractTestQueryFramework
 {
+    private static final ConnectorSession SESSION = TestingConnectorSession.builder()
+            .setPropertyMetadata(new IcebergSessionProperties(
+                    new IcebergConfig(),
+                    new OrcReaderConfig(),
+                    new OrcWriterConfig(),
+                    new ParquetReaderConfig(),
+                    new ParquetWriterConfig())
+                    .getSessionProperties())
+            .build();
+
     private File metastoreDir;
     private TrinoFileSystemFactory fileSystemFactory;
     private TrinoCatalog catalog;


### PR DESCRIPTION
## Description

Avoid data files I/O when

- reading only partitioning columns
- doing `count(*)` queries on Iceberg tables (with no group by, or grouping by partitioning columns)

