### PR TITLE
Extract trino-resource-group-managers from test-other-modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,7 @@ jobs:
             !:trino-raptor-legacy,
             !:trino-redis,
             !:trino-redshift,
+            !:trino-resource-group-managers,
             !:trino-server,
             !:trino-server-rpm,
             !:trino-singlestore,
@@ -602,6 +603,7 @@ jobs:
             - { modules: plugin/trino-redshift }
             - { modules: plugin/trino-redshift, profile: cloud-tests }
             - { modules: plugin/trino-redshift, profile: fte-tests }
+            - { modules: plugin/trino-resource-group-managers }
             - { modules: plugin/trino-singlestore }
             - { modules: plugin/trino-sqlserver }
             - { modules: testing/trino-faulttolerant-tests, profile: default }


### PR DESCRIPTION
`test-other-modules` is failing on CI for quite some time. This went unnoticed because apparently it was taking down the github actions worker, and the job was being marked as "Skipped".

Extract `trino-resource-group-managers` out of the problematic job. The module pulls a few docker containers.


See https://github.com/trinodb/trino/pull/19305