### PR TITLE
Report stats for dynamic-filter only ScanFilter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -49,6 +49,7 @@ public class TableScanOperator
             implements SourceOperatorFactory, WorkProcessorSourceOperatorFactory
     {
         private final int operatorId;
+        private final PlanNodeId planNodeId;
         private final PlanNodeId sourceId;
         private final PageSourceProvider pageSourceProvider;
         private final TableHandle table;
@@ -58,6 +59,7 @@ public class TableScanOperator
 
         public TableScanOperatorFactory(
                 int operatorId,
+                PlanNodeId planNodeId,
                 PlanNodeId sourceId,
                 PageSourceProvider pageSourceProvider,
                 TableHandle table,
@@ -65,6 +67,7 @@ public class TableScanOperator
                 DynamicFilter dynamicFilter)
         {
             this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.sourceId = requireNonNull(sourceId, "sourceId is null");
             this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
             this.table = requireNonNull(table, "table is null");
@@ -87,7 +90,7 @@ public class TableScanOperator
         @Override
         public PlanNodeId getPlanNodeId()
         {
-            return sourceId;
+            return planNodeId;
         }
 
         @Override
@@ -100,7 +103,7 @@ public class TableScanOperator
         public SourceOperator createOperator(DriverContext driverContext)
         {
             checkState(!closed, "Factory is already closed");
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, sourceId, getOperatorType());
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, getOperatorType());
             return new TableScanOperator(
                     operatorContext,
                     sourceId,
@@ -135,7 +138,7 @@ public class TableScanOperator
     }
 
     private final OperatorContext operatorContext;
-    private final PlanNodeId planNodeId;
+    private final PlanNodeId sourceId;
     private final PageSourceProvider pageSourceProvider;
     private final TableHandle table;
     private final List<ColumnHandle> columns;
@@ -156,14 +159,14 @@ public class TableScanOperator
 
     public TableScanOperator(
             OperatorContext operatorContext,
-            PlanNodeId planNodeId,
+            PlanNodeId sourceId,
             PageSourceProvider pageSourceProvider,
             TableHandle table,
             Iterable<ColumnHandle> columns,
             DynamicFilter dynamicFilter)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        this.sourceId = requireNonNull(sourceId, "planNodeId is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
@@ -180,7 +183,7 @@ public class TableScanOperator
     @Override
     public PlanNodeId getSourceId()
     {
-        return planNodeId;
+        return sourceId;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1980,7 +1980,7 @@ public class LocalExecutionPlanner
 
             if (node.getSource() instanceof TableScanNode && getStaticFilter(node.getPredicate()).isEmpty()) {
                 // filter node contains only dynamic filter, fallback to normal table scan
-                return visitTableScan((TableScanNode) node.getSource(), node.getPredicate(), context);
+                return visitTableScan(node.getId(), (TableScanNode) node.getSource(), node.getPredicate(), context);
             }
 
             Expression filterExpression = node.getPredicate();
@@ -2137,10 +2137,10 @@ public class LocalExecutionPlanner
         @Override
         public PhysicalOperation visitTableScan(TableScanNode node, LocalExecutionPlanContext context)
         {
-            return visitTableScan(node, TRUE_LITERAL, context);
+            return visitTableScan(node.getId(), node, TRUE_LITERAL, context);
         }
 
-        private PhysicalOperation visitTableScan(TableScanNode node, Expression filterExpression, LocalExecutionPlanContext context)
+        private PhysicalOperation visitTableScan(PlanNodeId planNodeId, TableScanNode node, Expression filterExpression, LocalExecutionPlanContext context)
         {
             List<ColumnHandle> columns = new ArrayList<>();
             for (Symbol symbol : node.getOutputSymbols()) {
@@ -2148,7 +2148,7 @@ public class LocalExecutionPlanner
             }
 
             DynamicFilter dynamicFilter = getDynamicFilter(node, filterExpression, context);
-            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), node.getId(), pageSourceProvider, node.getTable(), columns, dynamicFilter);
+            OperatorFactory operatorFactory = new TableScanOperatorFactory(context.getNextOperatorId(), planNodeId, node.getId(), pageSourceProvider, node.getTable(), columns, dynamicFilter);
             return new PhysicalOperation(operatorFactory, makeLayout(node), context);
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -591,6 +591,7 @@ public class TestOrcPageSourceMemoryTracking
             SourceOperatorFactory sourceOperatorFactory = new TableScanOperatorFactory(
                     0,
                     new PlanNodeId("0"),
+                    new PlanNodeId("0"),
                     (session, split, table, columnHandles, dynamicFilter) -> pageSource,
                     TEST_TABLE_HANDLE,
                     columns.stream().map(ColumnHandle.class::cast).collect(toImmutableList()),


### PR DESCRIPTION
BEFORE

     ├─ ScanFilter[table = tpch:sf1:nation, dynamicFilters = {"n_nationkey" = #df_307}]
     │      Layout: [n_nationkey:bigint, n_name:varchar(25), n_regionkey:bigint, n_comment:varchar(152)]
     │      Estimates: {rows: 25 (2.67kB), cpu: 2.67k, memory: 0B, network: 0B}/{rows: 25 (2.67kB), cpu: 2.67k, memory: 0B, network: 0B}
     │      Dynamic filters:
     │          - df_307, [ SortedRangeSet[type=bigint, ranges=25, {[0], ..., [24]}] ], collection time=1.19s

AFTER

     ├─ ScanFilter[table = tpch:sf1:nation, dynamicFilters = {"n_nationkey" = #df_307}]
     │      Layout: [n_nationkey:bigint, n_name:varchar(25), n_regionkey:bigint, n_comment:varchar(152)]
     │      Estimates: {rows: 25 (2.67kB), cpu: 2.67k, memory: 0B, network: 0B}/{rows: 25 (2.67kB), cpu: 2.67k, memory: 0B, network: 0B}
     │      CPU: 1.00ms (0.10%), Scheduled: 1.00ms (0.10%), Blocked: 0.00ns (0.00%), Output: 25 rows (2.67kB)
     │      Input avg.: 6.25 rows, Input std.dev.: 173.21%
     │      Input: 25 rows (2.67kB), Filtered: 0.00%
     │      Dynamic filters:
     │          - df_307, [ SortedRangeSet[type=bigint, ranges=25, {[0], ..., [24]}] ], collection time=1.15s

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
