### PR TITLE
Switch ensureTestNamingConvention to run in JUnit to reduce test setups

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -56,11 +56,11 @@ import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
For many test classes, this it the last method that is not converted. For example, running `TestInformationSchemaConnector` with TestNG will run only this method. Moving this will make tests like `TestInformationSchemaConnector` JUnit-only and improve test overall time (fewer `createQueryRunner` invocations).

Obviously, it can be the first JUnit test method for some other classes, but

- the train cannot be stopped. We do this sooner or later.
- `AbstractTestQueries` are already JUnit; `BaseConnectorTest` extends from `AbstractTestQueries` and `BaseConnectorTest` are most likely to most expensive setups, because they create dependant services.
