### PR TITLE
Ensure signaling when there are no elements left in HiveFileIterator

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/HiveFileIterator.java
@@ -145,7 +145,7 @@ public class HiveFileIterator
     }
 
     private static class FileStatusIterator
-            implements Iterator<TrinoFileStatus>
+            extends AbstractIterator<TrinoFileStatus>
     {
         private final Location location;
         private final HdfsNamenodeStats namenodeStats;
@@ -179,21 +179,17 @@ public class HiveFileIterator
         }
 
         @Override
-        public boolean hasNext()
+        protected TrinoFileStatus computeNext()
         {
             try {
-                return fileStatusIterator.hasNext();
-            }
-            catch (IOException e) {
-                throw processException(e);
-            }
-        }
-
-        @Override
-        public TrinoFileStatus next()
-        {
-            try {
-                return fileStatusIterator.next();
+                if (!fileStatusIterator.hasNext()) {
+                    return endOfData();
+                }
+                TrinoFileStatus trinoFileStatus = fileStatusIterator.next();
+                if (trinoFileStatus == null) {
+                    return endOfData();
+                }
+                return trinoFileStatus;
             }
             catch (IOException e) {
                 throw processException(e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In some obscure cases it may happen that the HiveFileIterator receives from the underlying `fileStatusIterator` implementation `null` values. Ensure signaling in such cases the end of data.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
