### PR TITLE
Clarify syntax for role grants

### DIFF
--- a/docs/src/main/sphinx/sql/grant-roles.md
+++ b/docs/src/main/sphinx/sql/grant-roles.md
@@ -1,10 +1,10 @@
-# GRANT ROLES
+# GRANT role
 
 ## Synopsis
 
 ```text
-GRANT role [, ...]
-TO ( user | USER user | ROLE role) [, ...]
+GRANT role_name [, ...]
+TO ( user | USER user_mame | ROLE role_name) [, ...]
 [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
 [ WITH ADMIN OPTION ]
 [ IN catalog ]

--- a/docs/src/main/sphinx/sql/grant.md
+++ b/docs/src/main/sphinx/sql/grant.md
@@ -1,4 +1,4 @@
-# GRANT
+# GRANT privilege
 
 ## Synopsis
 

--- a/docs/src/main/sphinx/sql/revoke-roles.md
+++ b/docs/src/main/sphinx/sql/revoke-roles.md
@@ -1,11 +1,11 @@
-# REVOKE ROLES
+# REVOKE role
 
 ## Synopsis
 
 ```text
 REVOKE
 [ ADMIN OPTION FOR ]
-role [, ...]
+role_name [, ...]
 FROM ( user | USER user | ROLE role) [, ...]
 [ GRANTED BY ( user | USER user | ROLE role | CURRENT_USER | CURRENT_ROLE ) ]
 [ IN catalog ]

--- a/docs/src/main/sphinx/sql/revoke.md
+++ b/docs/src/main/sphinx/sql/revoke.md
@@ -1,4 +1,4 @@
-# REVOKE
+# REVOKE privilege
 
 ## Synopsis
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Clarify syntax for role grants. The current syntax has misled multiple readers to think that this is valid.

```
GRANT ROLE test TO jessie212;
```

We assume that readers think that the lowercase `role` is a typo.

I worked with @mosabua and confirmed in the antlr spec that this is wrong and the syntax is

```
GRANT test TO jessie212;
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
