### PR TITLE
Enable node cleanup for product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -875,6 +875,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache: restore
+          cleanup-node: true
       - uses: dorny/paths-filter@v2
         id: filter
         with:


### PR DESCRIPTION
## Description

Product tests (build-pt) are building product test launcher and product tests jar.  This makes the agent go out of available disk space. We have no idea what exactly is causing the issue, but the fix has been experimentally proven to help.

Example job that failed:
https://github.com/trinodb/trino/actions/runs/6479250735/job/17592431438
with message:
```
Error:  Failed to execute goal io.takari.maven.plugins:takari-lifecycle-plugin:2.1.1:install (default-install) on project trino-server: Failed to install artifact io.trino:trino-server:tar.gz:429-SNAPSHOT: No space left on device -> [Help 1]
```

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
