### PR TITLE
Support injecting system properties into JUnit tests

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java
@@ -14,8 +14,11 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Map;
 
@@ -23,6 +26,7 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
         extends BaseBigQueryConnectorSmokeTest
 {
@@ -31,12 +35,15 @@ public class TestBigQueryWithDifferentProjectIdConnectorSmokeTest
 
     protected String alternateProjectId;
 
+    public TestBigQueryWithDifferentProjectIdConnectorSmokeTest(@SystemProperty("testing.alternate-bq-project-id") String alternateProjectId)
+    {
+        this.alternateProjectId = requireNonNull(alternateProjectId, "alternateProjectId is null");
+    }
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        this.alternateProjectId = requireNonNull(System.getProperty("testing.alternate-bq-project-id"), "testing.alternate-bq-project-id system property not set");
-
         QueryRunner queryRunner = BigQueryQueryRunner.createQueryRunner(
                 ImmutableMap.of(),
                 ImmutableMap.of("bigquery.project-id", alternateProjectId),

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsConnectorSmokeTest.java
@@ -22,10 +22,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.io.Resources;
 import com.google.common.reflect.ClassPath;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -53,6 +56,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.testcontainers.containers.Network.newNetwork;
 
 @TestInstance(PER_CLASS)
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestDeltaLakeAdlsConnectorSmokeTest
         extends BaseDeltaLakeConnectorSmokeTest
 {
@@ -62,11 +66,14 @@ public class TestDeltaLakeAdlsConnectorSmokeTest
     private final BlobContainerClient azureContainerClient;
     private final String adlsDirectory;
 
-    public TestDeltaLakeAdlsConnectorSmokeTest()
+    public TestDeltaLakeAdlsConnectorSmokeTest(
+            @SystemProperty("hive.hadoop2.azure-abfs-container") String container,
+            @SystemProperty("hive.hadoop2.azure-abfs-account") String account,
+            @SystemProperty("hive.hadoop2.azure-abfs-access-key") String accessKey)
     {
-        this.container = requireNonNull(System.getProperty("hive.hadoop2.azure-abfs-container"), "container is null");
-        this.account = requireNonNull(System.getProperty("hive.hadoop2.azure-abfs-account"), "account is null");
-        this.accessKey = requireNonNull(System.getProperty("hive.hadoop2.azure-abfs-access-key"), "accessKey is null");
+        this.container = requireNonNull(container, "container is null");
+        this.account = requireNonNull(account, "account is null");
+        this.accessKey = requireNonNull(accessKey, "accessKey is null");
 
         String connectionString = format("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s;EndpointSuffix=core.windows.net", account, accessKey);
         BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(connectionString).buildClient();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
@@ -16,13 +16,15 @@ package io.trino.plugin.deltalake;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.containers.Network;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.nio.file.Files;
@@ -44,6 +46,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestDeltaLakeAdlsStorage
         extends AbstractTestQueryFramework
 {
@@ -58,11 +61,10 @@ public class TestDeltaLakeAdlsStorage
 
     private HiveHadoop hiveHadoop;
 
-    @Parameters({
-            "hive.hadoop2.azure-abfs-container",
-            "hive.hadoop2.azure-abfs-account",
-            "hive.hadoop2.azure-abfs-access-key"})
-    public TestDeltaLakeAdlsStorage(String container, String account, String accessKey)
+    public TestDeltaLakeAdlsStorage(
+            @SystemProperty("hive.hadoop2.azure-abfs-container") String container,
+            @SystemProperty("hive.hadoop2.azure-abfs-account") String account,
+            @SystemProperty("hive.hadoop2.azure-abfs-access-key") String accessKey)
     {
         requireNonNull(container, "container is null");
         this.account = requireNonNull(account, "account is null");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeGcsConnectorSmokeTest.java
@@ -27,6 +27,7 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.hadoop.ConfigurationInstantiator;
 import io.trino.hdfs.gcs.GoogleGcsConfigurationInitializer;
 import io.trino.hdfs.gcs.HiveGcsConfig;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.testing.QueryRunner;
 import org.apache.hadoop.conf.Configuration;
@@ -76,10 +77,12 @@ public class TestDeltaLakeGcsConnectorSmokeTest
     private String gcpCredentials;
     private TrinoFileSystem fileSystem;
 
-    public TestDeltaLakeGcsConnectorSmokeTest()
+    public TestDeltaLakeGcsConnectorSmokeTest(
+            @SystemProperty("testing.gcp-storage-bucket") String gcpStorageBucket,
+            @SystemProperty("testing.gcp-credentials-key") String gcpCredentialKey)
     {
-        this.gcpStorageBucket = requireNonNull(System.getProperty("testing.gcp-storage-bucket"), "GCP storage bucket is null");
-        this.gcpCredentialKey = requireNonNull(System.getProperty("testing.gcp-credentials-key"), "GCP credential key is null");
+        this.gcpStorageBucket = requireNonNull(gcpStorageBucket, "gcpStorageBucket is null");
+        this.gcpCredentialKey = requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
     }
 
     @Override

--- a/plugin/trino-hive-hadoop2/pom.xml
+++ b/plugin/trino-hive-hadoop2/pom.xml
@@ -199,6 +199,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
@@ -21,14 +21,16 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.s3.S3HiveQueryRunner;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -42,6 +44,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestHiveThriftMetastoreWithS3
         extends AbstractTestQueryFramework
 {
@@ -53,17 +56,11 @@ public class TestHiveThriftMetastoreWithS3
     private final Path hadoopCoreSiteXmlTempFile;
     private final AmazonS3 s3Client;
 
-    @Parameters({
-            "hive.hadoop2.s3.endpoint",
-            "hive.hadoop2.s3.awsAccessKey",
-            "hive.hadoop2.s3.awsSecretKey",
-            "hive.hadoop2.s3.writableBucket",
-    })
     public TestHiveThriftMetastoreWithS3(
-            String s3endpoint,
-            String awsAccessKey,
-            String awsSecretKey,
-            String writableBucket)
+            @SystemProperty("hive.hadoop2.s3.endpoint") String s3endpoint,
+            @SystemProperty("hive.hadoop2.s3.awsAccessKey") String awsAccessKey,
+            @SystemProperty("hive.hadoop2.s3.awsSecretKey") String awsSecretKey,
+            @SystemProperty("hive.hadoop2.s3.writableBucket") String writableBucket)
             throws IOException
     {
         this.s3endpoint = requireNonNull(s3endpoint, "s3endpoint is null");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
@@ -16,12 +16,14 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.trino.filesystem.Location;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
-import org.testng.annotations.Parameters;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -40,6 +42,7 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.FileFormat.ORC;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestIcebergAbfsConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
@@ -51,11 +54,10 @@ public class TestIcebergAbfsConnectorSmokeTest
 
     private HiveHadoop hiveHadoop;
 
-    @Parameters({
-            "hive.hadoop2.azure-abfs-container",
-            "hive.hadoop2.azure-abfs-account",
-            "hive.hadoop2.azure-abfs-access-key"})
-    public TestIcebergAbfsConnectorSmokeTest(String container, String account, String accessKey)
+    public TestIcebergAbfsConnectorSmokeTest(
+            @SystemProperty("hive.hadoop2.azure-abfs-container") String container,
+            @SystemProperty("hive.hadoop2.azure-abfs-account") String account,
+            @SystemProperty("hive.hadoop2.azure-abfs-access-key") String accessKey)
     {
         super(ORC);
         this.container = requireNonNull(container, "container is null");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -17,6 +17,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import io.airlift.log.Logger;
 import io.trino.filesystem.Location;
+import io.trino.junit.SystemPropertyParameterResolver;
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
 import io.trino.plugin.hive.containers.HiveHadoop;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
@@ -25,6 +27,7 @@ import io.trino.testing.TestingConnectorBehavior;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -46,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
+@ExtendWith(SystemPropertyParameterResolver.class)
 public class TestIcebergGcsConnectorSmokeTest
         extends BaseIcebergConnectorSmokeTest
 {
@@ -58,11 +62,13 @@ public class TestIcebergGcsConnectorSmokeTest
 
     private HiveHadoop hiveHadoop;
 
-    public TestIcebergGcsConnectorSmokeTest()
+    public TestIcebergGcsConnectorSmokeTest(
+            @SystemProperty("testing.gcp-storage-bucket") String gcpStorageBucket,
+            @SystemProperty("testing.gcp-credentials-key") String gcpCredentialKey)
     {
         super(ORC);
-        this.gcpStorageBucket = requireNonNull(System.getProperty("testing.gcp-storage-bucket"), "gcpStorageBucket is null");
-        this.gcpCredentialKey = requireNonNull(System.getProperty("testing.gcp-credentials-key"), "gcpCredentialKey is null");
+        this.gcpStorageBucket = requireNonNull(gcpStorageBucket, "gcpStorageBucket is null");
+        this.gcpCredentialKey = requireNonNull(gcpCredentialKey, "gcpCredentialKey is null");
         this.schema = "test_iceberg_gcs_connector_smoke_test_" + randomNameSuffix();
     }
 

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 </project>

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
         </dependency>

--- a/testing/trino-testing-services/src/main/java/io/trino/junit/SystemPropertyParameterResolver.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/junit/SystemPropertyParameterResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.junit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+public class SystemPropertyParameterResolver
+        implements ParameterResolver
+{
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException
+    {
+        return parameterContext.isAnnotated(SystemProperty.class);
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException
+    {
+        SystemProperty annotation = parameterContext.findAnnotation(SystemProperty.class).orElseThrow(() ->
+                new ParameterResolutionException("Missing @SystemProperty for class: %s, parameter: %s".formatted(extensionContext.getRequiredTestClass(), parameterContext.getParameter().getName())));
+
+        String propertyName = annotation.value();
+        String value = System.getProperty(propertyName);
+        if (value == null) {
+            throw new ParameterResolutionException("Could not resolve system property '%s' for class: %s, parameter: %s".formatted(propertyName, extensionContext.getRequiredTestClass(), parameterContext.getParameter().getName()));
+        }
+        return value;
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.PARAMETER)
+    public @interface SystemProperty
+    {
+        String value();
+    }
+}

--- a/testing/trino-testing-services/src/test/java/io/trino/junit/TestSystemPropertyParameterResolver.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/junit/TestSystemPropertyParameterResolver.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.junit;
+
+import io.trino.junit.SystemPropertyParameterResolver.SystemProperty;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(SystemPropertyParameterResolver.class)
+public class TestSystemPropertyParameterResolver
+{
+    private static final String PROPERTY_NAME = "somePropertyNameToPass";
+    private static final String PROPERTY_VALUE = "secretValue";
+
+    @BeforeAll
+    public static void init()
+    {
+        System.setProperty(PROPERTY_NAME, PROPERTY_VALUE);
+    }
+
+    @Test
+    public void testPropertySet(@SystemProperty(PROPERTY_NAME) String property)
+    {
+        assertThat(property).isEqualTo(PROPERTY_VALUE);
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -56,10 +56,10 @@ import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Fixes broken master:

```
Error:  io.trino.plugin.hive.TestHiveThriftMetastoreWithS3 -- Time elapsed: 0.040 s <<< ERROR!
org.junit.jupiter.api.extension.ParameterResolutionException: No ParameterResolver registered for parameter [java.lang.String s3endpoint] in constructor [public io.trino.plugin.hive.TestHiveThriftMetastoreWithS3(java.lang.String,java.lang.String,java.lang.String,java.lang.String) throws java.io.IOException].
	at java.base/java.util.Optional.orElseGet(Optional.java:364)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```