### PR TITLE
Use bulk merging of metrics in PlanNodeStatsSummarizer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/BasicOperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/BasicOperatorStats.java
@@ -15,6 +15,8 @@ package io.trino.sql.planner.planprinter;
 
 import io.trino.spi.metrics.Metrics;
 
+import java.util.List;
+
 import static java.util.Objects.requireNonNull;
 
 class BasicOperatorStats
@@ -72,5 +74,22 @@ class BasicOperatorStats
                 first.sumSquaredInputPositions + second.sumSquaredInputPositions,
                 first.metrics.mergeWith(second.metrics),
                 first.connectorMetrics.mergeWith(second.connectorMetrics));
+    }
+
+    public static BasicOperatorStats merge(List<BasicOperatorStats> operatorStats)
+    {
+        long totalDrivers = 0;
+        long inputPositions = 0;
+        double sumSquaredInputPositions = 0;
+        Metrics.Accumulator metricsAccumulator = Metrics.accumulator();
+        Metrics.Accumulator connectorMetricsAccumulator = Metrics.accumulator();
+        for (BasicOperatorStats stats : operatorStats) {
+            totalDrivers += stats.totalDrivers;
+            inputPositions += stats.inputPositions;
+            sumSquaredInputPositions += stats.sumSquaredInputPositions;
+            metricsAccumulator.add(stats.metrics);
+            connectorMetricsAccumulator.add(stats.connectorMetrics);
+        }
+        return new BasicOperatorStats(totalDrivers, inputPositions, sumSquaredInputPositions, metricsAccumulator.get(), connectorMetricsAccumulator.get());
     }
 }


### PR DESCRIPTION
## Description
Reduces memory allocations from merging of TDigestHistogram


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
