### PR TITLE
Fix typo: tax_max_writer_count -> task_max_writer_count

### DIFF
--- a/docs/src/main/sphinx/release/release-428.md
+++ b/docs/src/main/sphinx/release/release-428.md
@@ -5,7 +5,7 @@
 * Reduce memory usage for queries involving `GROUP BY` clauses. ({issue}`19187`)
 * Simplify writer count configuration. Add the new `task.min-writer-count`
   and `task.max-writer-count` configuration properties along with the
-  `task_min_writer_count` and `tax_max_writer_count` session properties, which
+  `task_min_writer_count` and `task_max_writer_count` session properties, which
   control the number of writers depending on scenario. Deprecate the
   `task.writer-count`, `task.scale-writers.max-writer-count`, and
   `task.partitioned-writer-count` configuration properties, which will be


### PR DESCRIPTION
## Description

Fix typo in 428 release notes: `tax_max_writer_count` -> `task_max_writer_count`

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.