### PR TITLE
Remove default implementation of withoutSmallFileThreshold

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -6566,7 +6566,7 @@ public abstract class BaseConnectorTest
 
     protected Session withoutSmallFileThreshold(Session session)
     {
-        return session;
+        throw new UnsupportedOperationException();
     }
 
     protected static final class DataMappingTestSetup


### PR DESCRIPTION
The default implementation did not do anything, which is not suitable for the test.
