### PR TITLE
Add "test" environment tag to temporary S3 test buckets used by CI

### DIFF
--- a/.github/bin/s3/setup-empty-s3-bucket.sh
+++ b/.github/bin/s3/setup-empty-s3-bucket.sh
@@ -38,6 +38,9 @@ echo "The AWS S3 bucket ${S3_BUCKET_IDENTIFIER} in the region ${AWS_REGION} exis
 
 echo "Tagging the AWS S3 bucket ${S3_BUCKET_IDENTIFIER} with TTL tags"
 
+# "test" environment tag is needed so that the bucket gets cleaned up by the daily AWS resource cleanup job in case the
+# temporary bucket is not properly cleaned up by delete-s3-bucket.sh. The ttl tag tells the AWS resource cleanup job
+# when the bucket is expired and should be cleaned up
 aws s3api put-bucket-tagging \
   --bucket "${S3_BUCKET_IDENTIFIER}" \
-  --tagging "TagSet=[{Key=ttl,Value=${S3_BUCKET_TTL}}]"
+  --tagging "TagSet=[{Key=environment,Value=test},{Key=ttl,Value=${S3_BUCKET_TTL}}]"


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The tag with key "environment" and value "test" is needed so that the temporary S3 buckets used for testing can be cleaned up by the daily AWS resource cleanup job if they aren't deleted by the ci workflow run.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/pull/19060
https://github.com/trinodb/trino/pull/19248

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
