### PR TITLE
Switch to JDK 21 for forward compatibility testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         java-version:
           - 17
-          - 20
+          - 21
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
21 temurin was released so we can move forward with additional testing