### PR TITLE
Remove eliminating sort optimization

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -608,18 +608,6 @@ public class AddExchanges
         {
             PlanWithProperties child = planChild(node, PreferredProperties.undistributed());
 
-            if (child.getProperties().isSingleNode()) {
-                // current plan so far is single node, so local properties are effectively global properties
-                // skip the SortNode if the local properties guarantee ordering on Sort keys
-                // TODO: This should be extracted as a separate optimizer once the planner is able to reason about the ordering of each operator
-                List<LocalProperty<Symbol>> desiredProperties = node.getOrderingScheme().toLocalProperties();
-
-                if (LocalProperties.match(child.getProperties().getLocalProperties(), desiredProperties).stream()
-                        .noneMatch(Optional::isPresent)) {
-                    return child;
-                }
-            }
-
             if (isDistributedSortEnabled(session)) {
                 child = planChild(node, PreferredProperties.any());
                 // insert round robin exchange to eliminate skewness issues

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.functionCall;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -55,21 +54,6 @@ public class TestEliminateSorts
     private static final PlanMatchPattern LINEITEM_TABLESCAN_Q = tableScan(
             "lineitem",
             ImmutableMap.of(QUANTITY_ALIAS, "quantity"));
-
-    @Test
-    public void testEliminateSorts()
-    {
-        @Language("SQL") String sql = "SELECT quantity, row_number() OVER (ORDER BY quantity) FROM lineitem ORDER BY quantity";
-
-        PlanMatchPattern pattern =
-                output(
-                        window(windowMatcherBuilder -> windowMatcherBuilder
-                                        .specification(windowSpec)
-                                        .addFunction(functionCall("row_number", Optional.empty(), ImmutableList.of())),
-                                anyTree(LINEITEM_TABLESCAN_Q)));
-
-        assertUnitPlan(sql, pattern);
-    }
 
     @Test
     public void testNotEliminateSorts()


### PR DESCRIPTION
## Description

`ORDER BY` doesn't work properly in the following case because optimizer eliminates Sort before LocalExchange is added.

```sql
trino> SELECT * FROM (
    ->   SELECT l_quantity, row_number() OVER (ORDER BY l_quantity) as row_number 
    ->   FROM tpch.sf1.lineitem
    -> ) WHERE mod(row_number, 1000000) = 0 ORDER BY l_quantity;
 l_quantity | row_number
------------+------------
      26.00 |    3000000
      50.00 |    6000000
      17.00 |    2000000
       9.00 |    1000000
      42.00 |    5000000
      34.00 |    4000000
(6 rows)
```


## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```


Fixes https://github.com/trinodb/trino/issues/19399