### PR TITLE
Fix description of Delta Lake checkpoint intervals

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -592,7 +592,7 @@ The following table properties are available for use:
   * - ``partitioned_by``
     - Set partition columns.
   * - ``checkpoint_interval``
-    - Set the checkpoint interval in seconds.
+    - Set the checkpoint interval in number of table writes.
   * - ``change_data_feed_enabled``
     - Enables storing change data feed entries.
   * - ``column_mapping_mode``


### PR DESCRIPTION
## Description

The documentation currently states that checkpoint intervals are specified in seconds whereas it should specify the number of table writes. `delta.default-checkpoint-writing-interval` has the correct description.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.