### PR TITLE
Split metastore timeout config for connect and read

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -74,9 +74,6 @@ are also available. They are discussed later in this topic.
     * - ``hive.metastore-refresh-max-threads``
       - Maximum threads used to refresh cached metastore data.
       - ``10``
-    * - ``hive.metastore-timeout``
-      - Timeout for Hive metastore requests.
-      - ``10s``
     * - ``hive.hide-delta-lake-tables``
       - Controls whether to hide Delta Lake tables in table listings. Currently
         applies only when using the AWS Glue metastore.
@@ -113,6 +110,12 @@ properties:
      - Hive metastore authentication type. Possible values are ``NONE`` or
        ``KERBEROS``.
      - ``NONE``
+   * - ``hive.metastore.thrift.client.connect-timeout``
+     - Socket connect timeout for metastore client.
+     - ``10s``
+   * - ``hive.metastore.thrift.client.read-timeout``
+     - Socket read timeout for metastore client.
+     - ``10s``
    * - ``hive.metastore.thrift.impersonation.enabled``
      - Enable Hive metastore end user impersonation.
      -

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -223,7 +223,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                         .put("delta.metadata.live-files.cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .put("hive.metastore-cache-ttl", TEST_METADATA_CACHE_TTL_SECONDS + "s")
                         .put("delta.register-table-procedure.enabled", "true")
-                        .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
+                        .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                         .putAll(deltaStorageConfiguration())
                         .buildOrThrow(),
                 hiveHadoop,

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -170,7 +170,7 @@ public final class DeltaLakeQueryRunner
                         .put("s3.endpoint", minioAddress)
                         .put("s3.path-style-access", "true")
                         .put("s3.streaming.part-size", "5MB") // minimize memory usage
-                        .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
+                        .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                         .putAll(connectorProperties)
                         .buildOrThrow(),
                 testingHadoop,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/DefaultThriftMetastoreClientFactory.java
@@ -54,7 +54,8 @@ public class DefaultThriftMetastoreClientFactory
 {
     private final Optional<SSLContext> sslContext;
     private final Optional<HostAndPort> socksProxy;
-    private final int timeoutMillis;
+    private final int connectTimeoutMillis;
+    private final int readTimeoutMillis;
     private final HiveMetastoreAuthentication metastoreAuthentication;
     private final String hostname;
 
@@ -70,13 +71,15 @@ public class DefaultThriftMetastoreClientFactory
     public DefaultThriftMetastoreClientFactory(
             Optional<SSLContext> sslContext,
             Optional<HostAndPort> socksProxy,
-            Duration timeout,
+            Duration connectTimeout,
+            Duration readTimeout,
             HiveMetastoreAuthentication metastoreAuthentication,
             String hostname)
     {
         this.sslContext = requireNonNull(sslContext, "sslContext is null");
         this.socksProxy = requireNonNull(socksProxy, "socksProxy is null");
-        this.timeoutMillis = toIntExact(timeout.toMillis());
+        this.connectTimeoutMillis = toIntExact(connectTimeout.toMillis());
+        this.readTimeoutMillis = toIntExact(readTimeout.toMillis());
         this.metastoreAuthentication = requireNonNull(metastoreAuthentication, "metastoreAuthentication is null");
         this.hostname = requireNonNull(hostname, "hostname is null");
     }
@@ -95,7 +98,8 @@ public class DefaultThriftMetastoreClientFactory
                         config.getTruststorePath(),
                         Optional.ofNullable(config.getTruststorePassword())),
                 Optional.ofNullable(config.getSocksProxy()),
-                config.getMetastoreTimeout(),
+                config.getConnectTimeout(),
+                config.getReadTimeout(),
                 metastoreAuthentication,
                 nodeManager.getCurrentNode().getHost());
     }
@@ -126,7 +130,7 @@ public class DefaultThriftMetastoreClientFactory
     private TTransport createTransport(HostAndPort address, Optional<String> delegationToken)
             throws TTransportException
     {
-        return Transport.create(address, sslContext, socksProxy, timeoutMillis, metastoreAuthentication, delegationToken);
+        return Transport.create(address, sslContext, socksProxy, connectTimeoutMillis, readTimeoutMillis, metastoreAuthentication, delegationToken);
     }
 
     private static Optional<SSLContext> buildSslContext(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -30,7 +30,8 @@ import java.util.concurrent.TimeUnit;
 
 public class ThriftMetastoreConfig
 {
-    private Duration metastoreTimeout = new Duration(10, TimeUnit.SECONDS);
+    private Duration connectTimeout = new Duration(10, TimeUnit.SECONDS);
+    private Duration readTimeout = new Duration(10, TimeUnit.SECONDS);
     private HostAndPort socksProxy;
     private int maxRetries = RetryDriver.DEFAULT_MAX_ATTEMPTS - 1;
     private double backoffScaleFactor = RetryDriver.DEFAULT_SCALE_FACTOR;
@@ -54,15 +55,32 @@ public class ThriftMetastoreConfig
     private boolean batchMetadataFetchEnabled = true;
 
     @NotNull
-    public Duration getMetastoreTimeout()
+    public Duration getConnectTimeout()
     {
-        return metastoreTimeout;
+        return connectTimeout;
     }
 
-    @Config("hive.metastore-timeout")
-    public ThriftMetastoreConfig setMetastoreTimeout(Duration metastoreTimeout)
+    @Config("hive.metastore.thrift.client.connect-timeout")
+    @LegacyConfig("hive.metastore-timeout")
+    @ConfigDescription("Socket connect timeout for metastore client")
+    public ThriftMetastoreConfig setConnectTimeout(Duration connectTimeout)
     {
-        this.metastoreTimeout = metastoreTimeout;
+        this.connectTimeout = connectTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Duration getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    @Config("hive.metastore.thrift.client.read-timeout")
+    @LegacyConfig("hive.metastore-timeout")
+    @ConfigDescription("Socket read timeout for metastore client")
+    public ThriftMetastoreConfig setReadTimeout(Duration readTimeout)
+    {
+        this.readTimeout = readTimeout;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -38,7 +38,7 @@ public class TestingTokenAwareMetastoreClientFactory
 
     public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout)
     {
-        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, AUTHENTICATION, "localhost");
+        this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost");
         this.address = requireNonNull(address, "address is null");
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -69,7 +69,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
                                 .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
-                                .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
+                                .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")
                                 .put("s3.aws-access-key", MINIO_ACCESS_KEY)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
@@ -90,7 +90,7 @@ public class TestIcebergAbfsConnectorSmokeTest
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
                                 .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
-                                .put("hive.metastore-timeout", "1m") // read timed out sometimes happens with the default timeout
+                                .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("hive.azure.abfs-storage-account", account)
                                 .put("hive.azure.abfs-access-key", accessKey)
                                 .put("iceberg.register-table-procedure.enabled", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/hms/TestTrinoHiveCatalogWithHiveMetastore.java
@@ -99,7 +99,7 @@ public class TestTrinoHiveCatalogWithHiveMetastore
         ThriftMetastore thriftMetastore = testingThriftHiveMetastoreBuilder()
                 .thriftMetastoreConfig(new ThriftMetastoreConfig()
                         // Read timed out sometimes happens with the default timeout
-                        .setMetastoreTimeout(new Duration(1, MINUTES)))
+                        .setReadTimeout(new Duration(1, MINUTES)))
                 .metastoreClient(dataLake.getHiveHadoop().getHiveMetastoreEndpoint())
                 .build();
         CachingHiveMetastore metastore = memoizeMetastore(new BridgingHiveMetastore(thriftMetastore), 1000);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
@@ -34,6 +34,7 @@ public final class TestHiveMetastoreClientFactory
             Optional.empty(),
             Optional.empty(),
             new Duration(10, SECONDS),
+            new Duration(10, SECONDS),
             new NoHiveMetastoreAuthentication(),
             "localhost");
 


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta Lake, Iceberg, Hudi
* The Hive metastore configuration property `hive.metastore-timeout` has been
  replaced by the `hive.metastore.thrift.client.connect-timeout`
  and `hive.metastore.thrift.client.read-timeout` properties. ({issue}`19390`)
```
