### PR TITLE
Switch ensureTestNamingConvention to run in JUnit to reduce test setups

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseCaseInsensitiveMappingTest.java
@@ -52,6 +52,15 @@ public abstract class BaseCaseInsensitiveMappingTest
         logging.setLevel(IdentifierMappingModule.class.getName(), WARN);
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testNonLowerCaseSchemaName()
             throws Exception

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectionCreationTest.java
@@ -56,6 +56,15 @@ public abstract class BaseJdbcConnectionCreationTest
         connectionFactory = null;
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     protected void assertJdbcConnections(@Language("SQL") String query, int expectedJdbcConnectionsCount, Optional<String> errorMessage)
     {
         int before = connectionFactory.openConnections.get();

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcTableStatisticsTest.java
@@ -65,6 +65,14 @@ public abstract class BaseJdbcTableStatisticsTest
         }
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test@Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public abstract void testNotAnalyzed();
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryTypeMapping.java
@@ -68,6 +68,15 @@ public abstract class BaseBigQueryTypeMapping
         bigQuerySqlExecutor = new BigQueryQueryRunner.BigQuerySqlExecutor();
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testBoolean()
     {

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/BaseClickHouseTypeMapping.java
@@ -100,6 +100,15 @@ public abstract class BaseClickHouseTypeMapping
         verify(zone.getRules().getValidOffsets(dateTime).size() == 2, "Expected %s to be doubled in %s", dateTime, zone);
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testTinyint()
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeCompatibility.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeCompatibility.java
@@ -69,6 +69,15 @@ public abstract class BaseDeltaLakeCompatibility
         return queryRunner;
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test(dataProvider = "tpchTablesDataProvider")
     public void testSelectAll(String tableName)
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAdlsStorage.java
@@ -126,6 +126,15 @@ public class TestDeltaLakeAdlsStorage
         }
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testQuery()
     {

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveThriftMetastoreWithS3.java
@@ -121,6 +121,15 @@ public class TestHiveThriftMetastoreWithS3
         assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testRecreateTable()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
@@ -83,6 +83,15 @@ public abstract class BaseS3AndGlueMetastoreTest
         }
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @DataProvider
     public Object[][] locationPatternsDataProvider()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveOnDataLake.java
@@ -119,6 +119,15 @@ public abstract class BaseTestHiveOnDataLake
                 bucketName));
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testInsertOverwriteInTransaction()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/BaseCachingDirectoryListerTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/BaseCachingDirectoryListerTest.java
@@ -69,6 +69,15 @@ public abstract class BaseCachingDirectoryListerTest<C extends DirectoryLister>
 
     protected abstract boolean isCached(C directoryLister, Location location);
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testCacheInvalidationIsAppliedSpecificallyOnTheNonPartitionedTableBeingChanged()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMaterializedViewTest.java
@@ -69,6 +69,15 @@ public abstract class BaseIcebergMaterializedViewTest
         assertUpdate("CREATE SCHEMA " + storageSchemaName);
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testShowTables()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergSystemTables.java
@@ -101,6 +101,15 @@ public abstract class BaseIcebergSystemTables
         assertUpdate("DROP SCHEMA IF EXISTS test_schema");
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testPartitionTable()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseSharedMetastoreTest.java
@@ -36,6 +36,15 @@ public abstract class BaseSharedMetastoreTest
 
     protected abstract String getExpectedIcebergCreateSchema(String catalogName);
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testSelect()
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTransactionIsolationTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTransactionIsolationTest.java
@@ -44,6 +44,15 @@ public abstract class BaseSqlServerTransactionIsolationTest
 
     protected abstract void configureDatabase(SqlExecutor executor, String databaseName);
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testCreateReadTable()
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerTypeMapping.java
@@ -97,6 +97,15 @@ public abstract class BaseSqlServerTypeMapping
         checkIsGap(kathmandu, timeGapInKathmandu);
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testTrinoBoolean()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -50,13 +50,13 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.query.QueryAssertions.QueryAssert;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.TestingAccessControlManager.TestingPrivilege;
-import io.trino.testng.services.ReportBadTestAnnotations;
 import io.trino.transaction.TransactionBuilder;
 import io.trino.util.AutoCloseableCloser;
 import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -270,8 +270,7 @@ public abstract class AbstractTestQueryFramework
         }
     }
 
-    // TODO @Test - Temporarily disabled to avoid test classes running twice. Re-enable once all tests migrated to JUnit.
-    @ReportBadTestAnnotations.Suppress
+    @Test
     public void ensureTestNamingConvention()
     {
         // Enforce a naming convention to make code navigation easier.

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseComplexTypesPredicatePushDownTest.java
@@ -21,6 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class BaseComplexTypesPredicatePushDownTest
         extends AbstractTestQueryFramework
 {
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testRowTypeOnlyNullsRowGroupPruning()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -220,7 +220,7 @@ public abstract class BaseConnectorTest
         return connectorBehavior.hasBehaviorByDefault(this::hasBehavior);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void ensureTestNamingConvention()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseDynamicPartitionPruningTest.java
@@ -95,6 +95,15 @@ public abstract class BaseDynamicPartitionPruningTest
                 .build();
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test(timeOut = 30_000)
     public void testJoinWithEmptyBuildSide()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseFailureRecoveryTest.java
@@ -190,6 +190,15 @@ public abstract class BaseFailureRecoveryTest
         }
     }
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @DataProvider(name = "parallelTests", parallel = true)
     public Object[][] parallelTests()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseOrcWithBloomFiltersTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseOrcWithBloomFiltersTest.java
@@ -27,6 +27,15 @@ public abstract class BaseOrcWithBloomFiltersTest
 {
     protected abstract String getTableProperties(String bloomFilterColumnName, String bucketingColumnName);
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void testOrcBloomFilterIsWrittenDuringCreate()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseTestParquetWithBloomFilters.java
@@ -34,6 +34,15 @@ public abstract class BaseTestParquetWithBloomFilters
     private static final List<Integer> TEST_VALUES = Arrays.asList(Integer.MIN_VALUE, Integer.MAX_VALUE, 1, 3, 7, 10, 15);
     private static final int MISSING_VALUE = 0;
 
+    // Override to prevent the class from being recognized as JUnit test class
+    // TODO remove override once the class itself is migrated
+    @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        super.ensureTestNamingConvention();
+    }
+
     @Test
     public void verifyBloomFilterEnabled()
     {


### PR DESCRIPTION
For many test classes, this it the last method that is not converted. For example, running `TestInformationSchemaConnector` with TestNG will run only this method. Moving this will make tests like `TestInformationSchemaConnector` JUnit-only and improve test overall time (fewer `createQueryRunner` invocations).

Obviously, it can be the first JUnit test method for some other classes, but

- the train cannot be stopped. We do this sooner or later.
- `AbstractTestQueries` are already JUnit; `BaseConnectorTest` extends from `AbstractTestQueries` and `BaseConnectorTest` are most likely to most expensive setups, because they create dependant services.

Resubmitting https://github.com/trinodb/trino/pull/19329 from within the repo.