### PR TITLE
Add limitation for not supporting COMMENT statements on existing tables

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -193,11 +193,8 @@ properties:
 
 ## AWS Glue catalog configuration properties
 
-In order to use an AWS Glue catalog, you must configure your catalog file as
-follows:
-
-`hive.metastore=glue` and provide further details with the following
-properties:
+In order to use an AWS Glue catalog, you must configure your catalog with
+`hive.metastore=glue` and provide further details with the following properties:
 
 ```{eval-rst}
 .. list-table:: AWS Glue catalog configuration properties
@@ -467,3 +464,8 @@ using Hive 3.x:
      <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
  </property>
 ```
+
+## Limitations
+
+Glue does not support setting comments on existing tables. You must set comments
+when [creating tables](/sql/create-table).


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add the limitation that Glue does not support setting COMMENT statements on existing tables

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
