### PR TITLE
Track INPUT_FILE_LAST_MODIFIED operations in TrackingFileSystemFactory

### DIFF
--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.Verify.verify;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_EXISTS;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_LAST_MODIFIED;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_NEW_STREAM;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.OUTPUT_FILE_CREATE;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.OUTPUT_FILE_CREATE_EXCLUSIVE;
@@ -50,6 +51,7 @@ public class TrackingFileSystemFactory
         OUTPUT_FILE_CREATE_OR_OVERWRITE,
         OUTPUT_FILE_CREATE_EXCLUSIVE,
         OUTPUT_FILE_TO_INPUT_FILE,
+        INPUT_FILE_LAST_MODIFIED,
     }
 
     private final AtomicInteger fileId = new AtomicInteger();
@@ -251,6 +253,7 @@ public class TrackingFileSystemFactory
         public Instant lastModified()
                 throws IOException
         {
+            tracker.accept(INPUT_FILE_LAST_MODIFIED);
             return delegate.lastModified();
         }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -39,6 +39,7 @@ import static com.google.common.collect.ImmutableMultiset.toImmutableMultiset;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.trino.SystemSessionProperties.MIN_INPUT_SIZE_PER_TASK;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_LAST_MODIFIED;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.INPUT_FILE_NEW_STREAM;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.OUTPUT_FILE_CREATE;
 import static io.trino.filesystem.TrackingFileSystemFactory.OperationType.OUTPUT_FILE_CREATE_OR_OVERWRITE;
@@ -276,6 +277,7 @@ public class TestIcebergMetadataFileOperations
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH))
                         .add(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM))
                         .addCopies(new FileOperation(DATA, INPUT_FILE_NEW_STREAM), 4)
+                        .addCopies(new FileOperation(DATA, INPUT_FILE_LAST_MODIFIED), 4)
                         .build());
 
         assertUpdate("DROP TABLE test_read_part_key");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Getting last modified time usually requires a metadata call to the file system so is worth tracking.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Extracted from https://github.com/trinodb/trino/pull/18719


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
