### PR TITLE
Handle timeouts in Trino client when decoding response body

### DIFF
--- a/client/trino-client/src/test/java/io/trino/client/TestRetry.java
+++ b/client/trino-client/src/test/java/io/trino/client/TestRetry.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
+import io.airlift.units.Duration;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.client.StatementClientFactory.newStatementClient;
+import static io.trino.spi.type.StandardTypes.INTEGER;
+import static io.trino.spi.type.StandardTypes.VARCHAR;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestRetry
+{
+    private MockWebServer server;
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup()
+            throws Exception
+    {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown()
+            throws IOException
+    {
+        server.close();
+        server = null;
+    }
+
+    @Test
+    public void testRetryOnBrokenStream()
+    {
+        java.time.Duration timeout = java.time.Duration.ofMillis(100);
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .connectTimeout(timeout)
+                .readTimeout(timeout)
+                .writeTimeout(timeout)
+                .callTimeout(timeout)
+                .build();
+        ClientSession session = ClientSession.builder()
+                .server(URI.create("http://" + server.getHostName() + ":" + server.getPort()))
+                .timeZone(ZoneId.of("UTC"))
+                .clientRequestTimeout(Duration.valueOf("2s"))
+                .build();
+
+        server.enqueue(statusAndBody(HTTP_OK, newQueryResults("RUNNING")));
+        server.enqueue(statusAndBody(HTTP_OK, newQueryResults("FINISHED"))
+                .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY));
+        server.enqueue(statusAndBody(HTTP_OK, newQueryResults("FINISHED")));
+
+        try (StatementClient client = newStatementClient(httpClient, session, "SELECT 1", Optional.empty())) {
+            while (client.advance()) {
+                // consume all client data
+            }
+            assertTrue(client.isFinished());
+        }
+        assertThat(server.getRequestCount()).isEqualTo(3);
+    }
+
+    private String newQueryResults(String state)
+    {
+        String queryId = "20160128_214710_00012_rk68b";
+        int numRecords = 10;
+
+        QueryResults queryResults = new QueryResults(
+                queryId,
+                server.url("/query.html?" + queryId).uri(),
+                null,
+                state.equals("RUNNING") ? server.url(format("/v1/statement/%s/%s", queryId, "aa")).uri() : null,
+                Stream.of(new Column("id", INTEGER, new ClientTypeSignature("integer")),
+                                new Column("name", VARCHAR, new ClientTypeSignature("varchar")))
+                        .collect(toList()),
+                IntStream.range(0, numRecords)
+                        .mapToObj(index -> Stream.of((Object) index, "a").collect(toList()))
+                        .collect(toList()),
+                new StatementStats(state, state.equals("QUEUED"), true, OptionalDouble.of(0), OptionalDouble.of(0), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                null,
+                ImmutableList.of(),
+                null,
+                null);
+
+        return QUERY_RESULTS_CODEC.toJson(queryResults);
+    }
+
+    private static MockResponse statusAndBody(int status, String body)
+    {
+        return new MockResponse()
+                .setResponseCode(status)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8)
+                .setBody(body);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When a timeout happens when reading the response body, the JsonResponse will still be created with a correct response code of 200, but with an exception. The client should check for timeout exceptions and do a retry.

I've tested this manually, by setting a breakpoint when the response is decoded, and pausing a Trino container, so it stops responding. I'm not sure if we can write a regular test for this.

Here's an example stack trace:
```
Caused by: java.sql.SQLException: Error fetching results
at io.trino.jdbc.AbstractTrinoResultSet.next(AbstractTrinoResultSet.java:232)
at io.trino.jdbc.TrinoResultSet.next(TrinoResultSet.java:46)
at io.trino.plugin.jdbc.JdbcRecordCursor.advanceNextPosition(JdbcRecordCursor.java:185)
... 33 more
Caused by: java.lang.RuntimeException: Error fetching next at https://localhost:10000/v1/statement/executing/20230918_161543_00015_f96jp/y0f9a104769e7214d17192fc0be5ebc3465181105/1515 returned an invalid response: JsonResponse{statusCode=200, headers={alt-svc=[h3=":443"; ma=2592000,h3-29=":443"; ma=2592000], content-type=[application/json], date=[Mon, 18 Sep 2023 16:19:16 GMT], vary=[Accept-Encoding], via=[1.1 envoy], x-content-type-options=[nosniff]}, hasValue=false} [Error: <Response Too Large>]
at io.trino.jdbc.$internal.client.StatementClientV1.requestFailedException(StatementClientV1.java:457)
at io.trino.jdbc.$internal.client.StatementClientV1.advance(StatementClientV1.java:396)
at io.trino.jdbc.TrinoResultSet$ResultsPageIterator.computeNext(TrinoResultSet.java:279)
at io.trino.jdbc.TrinoResultSet$ResultsPageIterator.computeNext(TrinoResultSet.java:255)
at io.trino.jdbc.$internal.guava.collect.AbstractIterator.tryToComputeNext(AbstractIterator.java:146)
at io.trino.jdbc.$internal.guava.collect.AbstractIterator.hasNext(AbstractIterator.java:141)
at java.base/java.util.Spliterators$IteratorSpliterator.tryAdvance(Spliterators.java:1855)
at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.lambda$initPartialTraversalState$0(StreamSpliterators.java:292)
at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.fillBuffer(StreamSpliterators.java:206)
at java.base/java.util.stream.StreamSpliterators$AbstractWrappingSpliterator.doAdvance(StreamSpliterators.java:169)
at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.tryAdvance(StreamSpliterators.java:298)
at java.base/java.util.Spliterators$1Adapter.hasNext(Spliterators.java:681)
at io.trino.jdbc.TrinoResultSet$AsyncIterator.lambda$new$1(TrinoResultSet.java:180)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
... 3 more
Caused by: java.lang.IllegalArgumentException: Unable to create class io.trino.jdbc.$internal.client.QueryResults from JSON response
at io.trino.jdbc.$internal.client.JsonResponse.execute(JsonResponse.java:150)
at io.trino.jdbc.$internal.client.StatementClientV1.advance(StatementClientV1.java:382)
... 16 more
Caused by: io.trino.jdbc.$internal.jackson.databind.JsonMappingException: timeout (through reference chain: io.trino.jdbc.$internal.client.QueryResults["data"]->java.util.ArrayList[3204]->java.util.ArrayList[1])
at io.trino.jdbc.$internal.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:402)
at io.trino.jdbc.$internal.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:373)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:375)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:359)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:244)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:28)
at io.trino.jdbc.$internal.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
at io.trino.jdbc.$internal.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:564)
at io.trino.jdbc.$internal.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:439)
at io.trino.jdbc.$internal.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
at io.trino.jdbc.$internal.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:352)
at io.trino.jdbc.$internal.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:185)
at io.trino.jdbc.$internal.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
at io.trino.jdbc.$internal.jackson.databind.ObjectReader._bind(ObjectReader.java:2079)
at io.trino.jdbc.$internal.jackson.databind.ObjectReader.readValue(ObjectReader.java:1229)
at io.trino.jdbc.$internal.client.JsonCodec.fromJson(JsonCodec.java:90)
at io.trino.jdbc.$internal.client.JsonResponse.execute(JsonResponse.java:134)
... 17 more
Caused by: java.net.SocketTimeoutException: timeout
at io.trino.jdbc.$internal.okhttp3.internal.http2.Http2Stream$StreamTimeout.newTimeoutException(Http2Stream.java:678)
at io.trino.jdbc.$internal.okhttp3.internal.http2.Http2Stream$StreamTimeout.exitAndThrowIfTimedOut(Http2Stream.java:686)
at io.trino.jdbc.$internal.okhttp3.internal.http2.Http2Stream$FramingSource.read(Http2Stream.java:409)
at io.trino.jdbc.$internal.okhttp3.internal.connection.Exchange$ResponseBodySource.read(Exchange.java:286)
at io.trino.jdbc.$internal.okio.RealBufferedSource.read(RealBufferedSource.java:51)
at io.trino.jdbc.$internal.okio.RealBufferedSource.exhausted(RealBufferedSource.java:61)
at io.trino.jdbc.$internal.okio.InflaterSource.refill(InflaterSource.java:102)
at io.trino.jdbc.$internal.okio.InflaterSource.read(InflaterSource.java:62)
at io.trino.jdbc.$internal.okio.GzipSource.read(GzipSource.java:80)
at io.trino.jdbc.$internal.okio.RealBufferedSource$1.read(RealBufferedSource.java:447)
at io.trino.jdbc.$internal.jackson.core.json.UTF8StreamJsonParser._loadMore(UTF8StreamJsonParser.java:257)
at io.trino.jdbc.$internal.jackson.core.json.UTF8StreamJsonParser._loadMoreGuaranteed(UTF8StreamJsonParser.java:2491)
at io.trino.jdbc.$internal.jackson.core.json.UTF8StreamJsonParser._finishString2(UTF8StreamJsonParser.java:2574)
at io.trino.jdbc.$internal.jackson.core.json.UTF8StreamJsonParser._finishAndReturnString(UTF8StreamJsonParser.java:2554)
at io.trino.jdbc.$internal.jackson.core.json.UTF8StreamJsonParser.getText(UTF8StreamJsonParser.java:334)
at io.trino.jdbc.$internal.jackson.databind.deser.std.UntypedObjectDeserializerNR.deserialize(UntypedObjectDeserializerNR.java:82)
at io.trino.jdbc.$internal.jackson.databind.deser.std.CollectionDeserializer._deserializeFromArray(CollectionDeserializer.java:359)
... 33 more
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
