### PR TITLE
Simplify how SQL injection is detected when using query.comment-format

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/logging/FormatBasedRemoteQueryModifier.java
@@ -39,11 +39,14 @@ public class FormatBasedRemoteQueryModifier
     @Override
     public String apply(ConnectorSession session, String query)
     {
-        try {
-            return query + " /*" + interpolator.interpolate(session) + "*/";
+        return query + " /*" + checkForSqlInjection(interpolator.interpolate(session)) + "*/";
+    }
+
+    private String checkForSqlInjection(String sql)
+    {
+        if (sql.contains("*/")) {
+            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, "Rendering metadata using 'query.comment-format' does not meet security criteria: " + sql);
         }
-        catch (SecurityException e) {
-            throw new TrinoException(JDBC_NON_TRANSIENT_ERROR, e.getMessage());
-        }
+        return sql;
     }
 }


### PR DESCRIPTION
## Description

Instead of failing the query in case a character NOT in the allowlist is detected, now we search for occurence of the closing comment '*/' and only then fail the query.

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
