### PR TITLE
Remove deprecated task writer properties

### DIFF
--- a/docs/src/main/sphinx/admin/properties-task.md
+++ b/docs/src/main/sphinx/admin/properties-task.md
@@ -104,18 +104,6 @@ the task has remaining splits to process.
 
 - **Description:** see details at {ref}`prop-task-scale-writers`
 
-## `task.writer-count`
-
-Deprecated and replaced by {ref}`prop-task-min-writer-count`.
-
-## `task.partitioned-writer-count`
-
-Deprecated and replaced by {ref}`prop-task-max-writer-count`.
-
-## `task.scale-writers.max-writer-count`
-
-Deprecated and replaced by {ref}`prop-task-max-writer-count`.
-
 (prop-task-min-writer-count)=
 ## `task.min-writer-count`
 

--- a/docs/src/main/sphinx/admin/properties-writer-scaling.md
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.md
@@ -28,19 +28,11 @@ the cluster.
 - **Default value:** `true`
 - **Session property:** `task_scale_writers_enabled`
 
-Enable scaling the number of concurrent writers within a task. The maximum writer
-count per task for scaling is `task.scale-writers.max-writer-count`. Additional
-writers are added only when the average amount of uncompressed data processed per writer
-is above the minimum threshold of `writer-scaling-min-data-processed` and query is bottlenecked on
-writing.
-
-## `task.scale-writers.max-writer-count`
-
-Deprecated and replaced by {ref}`prop-task-max-writer-count`.
-
-## `writer-min-size`
-
-Deprecated and replaced by {ref}`writer-scaling-min-data-processed`.
+Enable scaling the number of concurrent writers within a task. The maximum
+writer count per task for scaling is [](prop-task-max-writer-count). Additional
+writers are added only when the average amount of uncompressed data processed
+per writer is above the minimum threshold of `writer-scaling-min-data-processed`
+and query is bottlenecked on writing.
 
 (writer-scaling-min-data-processed)=
 ## `writer-scaling-min-data-processed`


### PR DESCRIPTION
## Description

In the removal PR this was left behind instead of being removed from docs as well. Problem noticed by @kokosing 

cc @gaurav8297 @sopel39 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
