### PR TITLE
Avoid redundantly doubled test setup

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -50,6 +50,7 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.query.QueryAssertions.QueryAssert;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.TestingAccessControlManager.TestingPrivilege;
+import io.trino.testng.services.ReportBadTestAnnotations;
 import io.trino.transaction.TransactionBuilder;
 import io.trino.util.AutoCloseableCloser;
 import org.assertj.core.api.AssertProvider;
@@ -59,7 +60,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -270,7 +270,8 @@ public abstract class AbstractTestQueryFramework
         }
     }
 
-    @Test
+    // TODO @Test - Temporarily disabled to avoid test classes running twice. Re-enable once all tests migrated to JUnit.
+    @ReportBadTestAnnotations.Suppress
     public void ensureTestNamingConvention()
     {
         // Enforce a naming convention to make code navigation easier.


### PR DESCRIPTION
Disable `AbstractTestQueryFramework.ensureTestNamingConvention` TestNG test to avoid redundant test setups.

For many test classes, this it the last method that is not converted. For example, running `TestInformationSchemaConnector` with TestNG will run only this method. Disabling this will make tests like `TestInformationSchemaConnector` JUnit-only and improve test overall time (fewer `createQueryRunner` invocations).

The test remains enabled for `BaseConnectorTest` and `BaseConnectorSmokeTest`, which already use JUnit and thus are either all-JUnit or do setup twice anyway.

This change also makes it easier to run all-JUnit test classes from an IDE, since now IDE will offer only the "Run with JUnit" option.

Alternative to https://github.com/trinodb/trino/pull/19400.