### PR TITLE
Avoid redundant MV freshness calculation when result unused

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SystemTable.java
@@ -15,6 +15,8 @@ package io.trino.spi.connector;
 
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Set;
+
 /**
  * Exactly one of {@link #cursor} or {@link #pageSource} must be implemented.
  */
@@ -38,6 +40,11 @@ public interface SystemTable
     default RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
         throw new UnsupportedOperationException();
+    }
+
+    default RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint, Set<Integer> requiredColumns)
+    {
+        return cursor(transactionHandle, session, constraint);
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
@@ -23,6 +23,8 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.util.Set;
+
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeSystemTable
@@ -59,6 +61,14 @@ public class ClassLoaderSafeSystemTable
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.cursor(transactionHandle, session, constraint);
+        }
+    }
+
+    @Override
+    public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint, Set<Integer> requiredColumns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.cursor(transactionHandle, session, constraint, requiredColumns);
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -43,6 +43,7 @@ public class CountingAccessHiveMetastore
     public enum Method
     {
         CREATE_DATABASE,
+        DROP_DATABASE,
         CREATE_TABLE,
         GET_ALL_DATABASES,
         GET_DATABASE,
@@ -144,7 +145,8 @@ public class CountingAccessHiveMetastore
     @Override
     public void dropDatabase(String databaseName, boolean deleteData)
     {
-        throw new UnsupportedOperationException();
+        methodInvocations.add(Method.DROP_DATABASE);
+        delegate.dropDatabase(databaseName, deleteData);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -715,7 +715,7 @@ public class TestIcebergMetadataFileOperations
         // Bulk retrieval without selecting freshness
         assertFileSystemAccesses(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 4)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
                         .build());
 
         // Bulk retrieval for two schemas
@@ -733,7 +733,7 @@ public class TestIcebergMetadataFileOperations
         // Pointed lookup without selecting freshness
         assertFileSystemAccesses(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
                 ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 3)
+                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .build());
 
         assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -456,7 +456,7 @@ public class TestIcebergMetastoreAccessOperations
         assertMetastoreInvocations(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
                 ImmutableMultiset.builder()
                         .add(GET_TABLES_WITH_PARAMETER)
-                        .addCopies(GET_TABLE, 6)
+                        .addCopies(GET_TABLE, 4)
                         .build());
 
         // Bulk retrieval for two schemas
@@ -475,7 +475,7 @@ public class TestIcebergMetastoreAccessOperations
         // Pointed lookup without selecting freshness
         assertMetastoreInvocations(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 4)
+                        .addCopies(GET_TABLE, 2)
                         .build());
 
         assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -428,6 +428,60 @@ public class TestIcebergMetastoreAccessOperations
     }
 
     @Test
+    public void testSystemMetadataMaterializedViews()
+    {
+        String schemaName = "test_materialized_views_" + randomNameSuffix();
+        assertUpdate("CREATE SCHEMA " + schemaName);
+        Session session = Session.builder(getSession())
+                .setSchema(schemaName)
+                .build();
+
+        assertUpdate(session, "CREATE TABLE test_table1 AS SELECT 1 a", 1);
+        assertUpdate(session, "CREATE TABLE test_table2 AS SELECT 1 a", 1);
+
+        assertUpdate(session, "CREATE MATERIALIZED VIEW mv1 AS SELECT * FROM test_table1 JOIN test_table2 USING (a)");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW mv1", 1);
+
+        assertUpdate(session, "CREATE MATERIALIZED VIEW mv2 AS SELECT count(*) c FROM test_table1 JOIN test_table2 USING (a)");
+        assertUpdate(session, "REFRESH MATERIALIZED VIEW mv2", 1);
+
+        // Bulk retrieval
+        assertMetastoreInvocations(session, "SELECT * FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
+                ImmutableMultiset.builder()
+                        .add(GET_TABLES_WITH_PARAMETER)
+                        .addCopies(GET_TABLE, 6)
+                        .build());
+
+        // Bulk retrieval without selecting freshness
+        assertMetastoreInvocations(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
+                ImmutableMultiset.builder()
+                        .add(GET_TABLES_WITH_PARAMETER)
+                        .addCopies(GET_TABLE, 6)
+                        .build());
+
+        // Bulk retrieval for two schemas
+        assertMetastoreInvocations(session, "SELECT * FROM system.metadata.materialized_views WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent')",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLES_WITH_PARAMETER, 2)
+                        .addCopies(GET_TABLE, 6)
+                        .build());
+
+        // Pointed lookup
+        assertMetastoreInvocations(session, "SELECT * FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 4)
+                        .build());
+
+        // Pointed lookup without selecting freshness
+        assertMetastoreInvocations(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 4)
+                        .build());
+
+        assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");
+    }
+
+    @Test
     public void testShowTables()
     {
         assertMetastoreInvocations("SHOW TABLES",


### PR DESCRIPTION
Avoid `getMaterializedViewFreshness` call when reading `system.metadata.materialized_views` and `freshness`, `last_fresh_time` columns are neither predicated on, nor selected by the query.
