### PR TITLE
Fix RunningQueries metric to represent all running queries

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -289,6 +289,14 @@ public class DispatchManager
     public long getRunningQueries()
     {
         return queryTracker.getAllQueries().stream()
+                .filter(query -> query.getState() == RUNNING)
+                .count();
+    }
+
+    @Managed
+    public long getProgressingQueries()
+    {
+        return queryTracker.getAllQueries().stream()
                 .filter(query -> query.getState() == RUNNING && !query.getBasicQueryInfo().getQueryStats().isFullyBlocked())
                 .count();
     }


### PR DESCRIPTION
It's confusing when running queries represents something else than the queries in RUNNING state.

Let's capture current semantics (running & not blocked) as a separate metric with a different name.
