### PR TITLE
Fix correctness issue when query contains some not-equals in MongoDB

### DIFF
--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -379,6 +379,20 @@ public class TestMongoConnectorTest
     }
 
     @Test
+    public void testPredicatePushdownMultipleNotEquals()
+    {
+        // Regression test for https://github.com/trinodb/trino/issues/19404
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_predicate_pushdown_with_multiple_not_equals",
+                "(id, value) AS VALUES (1, 10), (2, 20), (3, 30)")) {
+            assertThat(query("SELECT * FROM " + table.getName() + " WHERE id != 1 AND value != 20"))
+                    .matches("VALUES (3, 30)")
+                    .isFullyPushedDown();
+        }
+    }
+
+    @Test
     public void testHighPrecisionDecimalPredicate()
     {
         try (TestTable table = new TestTable(

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoSession.java
@@ -86,8 +86,9 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document()
-                .append(COL1.getBaseName(), new Document().append("$gt", 100L).append("$lte", 200L))
-                .append(COL2.getBaseName(), new Document("$eq", "a value"));
+                .append("$and", ImmutableList.of(
+                        new Document(COL1.getBaseName(), new Document().append("$gt", 100L).append("$lte", 200L)),
+                        new Document(COL2.getBaseName(), new Document("$eq", "a value"))));
         assertEquals(query, expected);
     }
 
@@ -100,8 +101,9 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document()
-                .append(COL3.getBaseName(), new Document().append("$gt", "hello").append("$lte", "world"))
-                .append(COL2.getBaseName(), new Document("$gte", "a value"));
+                .append("$and", ImmutableList.of(
+                        new Document(COL3.getBaseName(), new Document().append("$gt", "hello").append("$lte", "world")),
+                        new Document(COL2.getBaseName(), new Document("$gte", "a value"))));
         assertEquals(query, expected);
     }
 
@@ -161,10 +163,11 @@ public class TestMongoSession
 
         Document query = MongoSession.buildQuery(tupleDomain);
         Document expected = new Document()
-                .append("$or", asList(
-                        new Document(COL5.getQualifiedName(), new Document("$gt", 200L)),
-                        new Document(COL5.getQualifiedName(), new Document("$eq", null))))
-                .append(COL6.getQualifiedName(), new Document("$eq", "a value"));
+                .append("$and", ImmutableList.of(
+                        new Document("$or", asList(
+                                new Document(COL5.getQualifiedName(), new Document("$gt", 200L)),
+                                new Document(COL5.getQualifiedName(), new Document("$eq", null)))),
+                        new Document(COL6.getQualifiedName(), new Document("$eq", "a value"))));
         assertEquals(query, expected);
     }
 


### PR DESCRIPTION
## Description

Fixes #19404

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Fix incorrect results when a query contains several `!=` or `NOT IN` predicates. ({issue}`19404`)
```
