### PR TITLE
Update jjwt and nimbus-jwt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,7 +572,7 @@
             <dependency>
                 <groupId>com.nimbusds</groupId>
                 <artifactId>nimbus-jose-jwt</artifactId>
-                <version>9.36</version>
+                <version>9.37</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dep.takari.version>2.1.1</dep.takari.version>
         <dep.aws-sdk.version>1.12.566</dep.aws-sdk.version>
         <dep.aws-sdk-v2.version>2.21.0</dep.aws-sdk-v2.version>
-        <dep.jsonwebtoken.version>0.12.2</dep.jsonwebtoken.version>
+        <dep.jsonwebtoken.version>0.12.3</dep.jsonwebtoken.version>
         <dep.oracle.version>21.9.0.0</dep.oracle.version>
         <dep.drift.version>1.21</dep.drift.version>
         <dep.tempto.version>201</dep.tempto.version>


### PR DESCRIPTION
jjwt:
```
[0.12.3](https://github.com/jwtk/jjwt/blob/master/CHANGELOG.md#0123)
This patch release:

Upgrades the org.json dependency to 20231013 to address that library's [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072) vulnerability.
```

nimbus:
```
version 9.37 (2023-10-16)
    * Adds JWTClaimsSet.getListClaim method.
```