### PR TITLE
Support OR-ed condition in Delta checkpoint iterator

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -504,7 +504,7 @@ public class DeltaLakeMergeSink
                 dataColumns.stream()
                         .map(DeltaLakeColumnHandle::toHiveColumnHandle)
                         .collect(toImmutableList()),
-                TupleDomain.all(),
+                ImmutableList.of(TupleDomain.all()),
                 true,
                 parquetDateTimeZone,
                 new FileFormatDataSourceStats(),

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePageSourceProvider.java
@@ -230,7 +230,7 @@ public class DeltaLakePageSourceProvider
                 split.getStart(),
                 split.getLength(),
                 hiveColumnHandles.build(),
-                parquetPredicate,
+                ImmutableList.of(parquetPredicate),
                 true,
                 parquetDateTimeZone,
                 fileFormatDataSourceStats,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -196,7 +196,7 @@ public class TableChangesFunctionProcessor
                 0,
                 split.fileSize(),
                 splitColumns.stream().filter(column -> column.getColumnType() == REGULAR).map(DeltaLakeColumnHandle::toHiveColumnHandle).collect(toImmutableList()),
-                TupleDomain.all(), // TODO add predicate pushdown https://github.com/trinodb/trino/issues/16990
+                ImmutableList.of(TupleDomain.all()), // TODO add predicate pushdown https://github.com/trinodb/trino/issues/16990
                 true,
                 parquetDateTimeZone,
                 fileFormatDataSourceStats,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/DeltaLakeTransactionLogEntry.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.annotation.Nullable;
 
+import java.util.Objects;
+
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeTransactionLogEntry
@@ -154,6 +156,31 @@ public class DeltaLakeTransactionLogEntry
     public DeltaLakeTransactionLogEntry withCommitInfo(CommitInfoEntry commitInfo)
     {
         return new DeltaLakeTransactionLogEntry(txn, add, remove, metaData, protocol, commitInfo, cdcEntry);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeltaLakeTransactionLogEntry that = (DeltaLakeTransactionLogEntry) o;
+        return Objects.equals(txn, that.txn) &&
+                Objects.equals(add, that.add) &&
+                Objects.equals(remove, that.remove) &&
+                Objects.equals(metaData, that.metaData) &&
+                Objects.equals(protocol, that.protocol) &&
+                Objects.equals(commitInfo, that.commitInfo) &&
+                Objects.equals(cdcEntry, that.cdcEntry);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(txn, add, remove, metaData, protocol, commitInfo, cdcEntry);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -61,6 +61,7 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -80,6 +81,16 @@ public class TestCheckpointEntryIterator
     public void tearDown()
     {
         checkpointSchemaManager = null;
+    }
+
+    @Test
+    public void testReadNoEntries()
+            throws Exception
+    {
+        URI checkpointUri = getResource(TEST_CHECKPOINT).toURI();
+        assertThatThrownBy(() -> createCheckpointEntryIterator(checkpointUri, ImmutableSet.of(), Optional.empty(), Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("fields is empty");
     }
 
     @Test
@@ -132,6 +143,49 @@ public class TestCheckpointEntryIterator
                         2,
                         Optional.empty(),
                         Optional.empty()));
+    }
+
+    @Test
+    public void testReadMetadataAndProtocolEntry()
+            throws Exception
+    {
+        URI checkpointUri = getResource(TEST_CHECKPOINT).toURI();
+        CheckpointEntryIterator checkpointEntryIterator = createCheckpointEntryIterator(checkpointUri, ImmutableSet.of(METADATA, PROTOCOL), Optional.empty(), Optional.empty());
+        List<DeltaLakeTransactionLogEntry> entries = ImmutableList.copyOf(checkpointEntryIterator);
+
+        assertThat(entries).hasSize(2);
+        assertThat(entries).containsExactlyInAnyOrder(
+                DeltaLakeTransactionLogEntry.metadataEntry(new MetadataEntry(
+                        "b6aeffad-da73-4dde-b68e-937e468b1fde",
+                        null,
+                        null,
+                        new MetadataEntry.Format("parquet", Map.of()),
+                        "{\"type\":\"struct\",\"fields\":[" +
+                                "{\"name\":\"name\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"age\",\"type\":\"integer\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"married\",\"type\":\"boolean\",\"nullable\":true,\"metadata\":{}}," +
+
+                                "{\"name\":\"phones\",\"type\":{\"type\":\"array\",\"elementType\":{\"type\":\"struct\",\"fields\":[" +
+                                "{\"name\":\"number\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"label\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]}," +
+                                "\"containsNull\":true},\"nullable\":true,\"metadata\":{}}," +
+
+                                "{\"name\":\"address\",\"type\":{\"type\":\"struct\",\"fields\":[" +
+                                "{\"name\":\"street\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"city\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"state\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}," +
+                                "{\"name\":\"zip\",\"type\":\"string\",\"nullable\":true,\"metadata\":{}}]},\"nullable\":true,\"metadata\":{}}," +
+
+                                "{\"name\":\"income\",\"type\":\"double\",\"nullable\":true,\"metadata\":{}}]}",
+                        List.of("age"),
+                        Map.of(),
+                        1579190100722L)),
+                DeltaLakeTransactionLogEntry.protocolEntry(
+                        new ProtocolEntry(
+                                1,
+                                2,
+                                Optional.empty(),
+                                Optional.empty())));
     }
 
     @Test
@@ -309,6 +363,8 @@ public class TestCheckpointEntryIterator
         targetFile.delete(); // file must not exist when writer is called
         writer.write(entries, createOutputFile(targetPath));
 
+        CheckpointEntryIterator metadataAndProtocolEntryIterator =
+                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(METADATA, PROTOCOL), Optional.empty(), Optional.empty());
         CheckpointEntryIterator addEntryIterator = createCheckpointEntryIterator(
                 URI.create(targetPath),
                 ImmutableSet.of(ADD),
@@ -319,10 +375,12 @@ public class TestCheckpointEntryIterator
         CheckpointEntryIterator txnEntryIterator =
                 createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(TRANSACTION), Optional.empty(), Optional.empty());
 
+        assertThat(Iterators.size(metadataAndProtocolEntryIterator)).isEqualTo(2);
         assertThat(Iterators.size(addEntryIterator)).isEqualTo(1);
         assertThat(Iterators.size(removeEntryIterator)).isEqualTo(numRemoveEntries);
         assertThat(Iterators.size(txnEntryIterator)).isEqualTo(0);
 
+        assertThat(metadataAndProtocolEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(3L);
         assertThat(addEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(2L);
         assertThat(removeEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(100L);
         assertThat(txnEntryIterator.getCompletedPositions().orElseThrow()).isEqualTo(0L);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Relates to https://github.com/trinodb/trino/issues/19156

Very much inspired from https://github.com/trinodb/trino/pull/19240


The problem this PR is solving is that it avoids working with `TupleDomain.all()` as tuple domain when there are more predicates specified for the `CheckpointEntryIterator`:

https://github.com/trinodb/trino/blob/d23921d86777fbf778e7c3f63edcbd293c501971/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java#L186-L187

What this means is that in such cases, all the entries from the Delta Lake Parquet checkpoint file will be returned as results even though the code flow is interested in a small subset of the entries.

A common use-case  of specifying more predicates (entry types) for the `CheckpointEntryIterator` is `DeltaLakeMetadata.getTableHandle()`:

https://github.com/trinodb/trino/blob/d23921d86777fbf778e7c3f63edcbd293c501971/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java#L495-L498

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


The `ParquetPageSourceFactory` has been slightly refactored to expose a method handling multiple tuple domains.
The results returned in the page source are corresponding to any of the specified tuple domains.


To put things in perspective, the changes from this PR have been tested against a 300MB checkpoint file  to see how it performs.
The example showcased below depends on a local file, but the changes have been tested as well against a S3 bucket and for retrieving `metadata` & `protocol` together there is no relevant performance gain.

tldr; performance wise the changes coming with this PR are rather modest because the amount of bytes read from the Parquet columnar file for `metadata`  and `protocol` is pretty small compared to the bytes needed to encode the `add` entries.


```
    @Test
    public void testBytesRead()
            throws IOException
    {
        String targetPath = "file:///home/marius/Downloads/00000000000000000003.checkpoint.parquet";

        CheckpointEntryIterator metadataEntryIterator =
                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(METADATA), Optional.empty(), Optional.empty());
        CheckpointEntryIterator protocolEntryIterator =
                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(PROTOCOL), Optional.empty(), Optional.empty());
        MetadataEntry metadataEntry = getOnlyElement(metadataEntryIterator).getMetaData();
        ProtocolEntry protocolEntry = getOnlyElement(protocolEntryIterator).getProtocol();

        CheckpointEntryIterator metadataAndProtocolEntryIterator =
                createCheckpointEntryIterator(URI.create(targetPath), ImmutableSet.of(METADATA, PROTOCOL), Optional.empty(), Optional.empty());
        CheckpointEntryIterator addEntryIterator = createCheckpointEntryIterator(
                URI.create(targetPath),
                ImmutableSet.of(ADD),
                Optional.of(metadataEntry),
                Optional.of(protocolEntry));

        System.out.println("METADATA");
        System.out.println("completed positions: " + metadataEntryIterator.getCompletedPositions());
        System.out.println("completed bytes: " + metadataEntryIterator.getCompletedBytes());
        System.out.println("PROTOCOL");
        System.out.println("completed positions: " + protocolEntryIterator.getCompletedPositions());
        System.out.println("completed bytes: " + protocolEntryIterator.getCompletedBytes());
        System.out.println("METADATA&PROTOCOL");
        long startMetadataAndProtocol = System.currentTimeMillis();
        System.out.println("size: " + Iterators.size(metadataAndProtocolEntryIterator));
        long endMetadataAndProtocol = System.currentTimeMillis();
        System.out.println("Elapsed Time in milli seconds: " + (endMetadataAndProtocol - startMetadataAndProtocol));
        System.out.println("completed positions: " + metadataAndProtocolEntryIterator.getCompletedPositions());
        System.out.println("completed bytes: " + metadataAndProtocolEntryIterator.getCompletedBytes());
        System.out.println("ADD");
        long startAdd = System.currentTimeMillis();
        System.out.println("size: " + Iterators.size(addEntryIterator));
        long endAdd = System.currentTimeMillis();
        System.out.println("Elapsed Time in milli seconds: " + (endAdd - startAdd));
        System.out.println("completed positions: " + addEntryIterator.getCompletedPositions());
        System.out.println("completed bytes: " + addEntryIterator.getCompletedBytes());
    }
```

The results on testing with `master`
```
METADATA
completed positions: OptionalLong[470000]
completed bytes: 49876
PROTOCOL
completed positions: OptionalLong[470000]
completed bytes: 49224
METADATA&PROTOCOL
size: 2
Elapsed Time in milli seconds: 261
completed positions: OptionalLong[1235156]
completed bytes: 50782
ADD
size: 1235154
Elapsed Time in milli seconds: 14040
completed positions: OptionalLong[1235156]
completed bytes: 329586188
```

The results on testing with the changes from this PR:
```
METADATA
completed positions: OptionalLong[470000]
completed bytes: 49876
PROTOCOL
completed positions: OptionalLong[470000]
completed bytes: 49224
METADATA&PROTOCOL
size: 2
Elapsed Time in milli seconds: 121
completed positions: OptionalLong[470000]
completed bytes: 49948
ADD
size: 1235154
Elapsed Time in milli seconds: 14194
completed positions: OptionalLong[1235156]
completed bytes: 329586188
```

I slightly modified the example above to test against MinIO and check what kind of conversations are made with the object storage:

```
        MinioClient minioClient = new MinioClient("http://localhost:9080", "minio-access-key", "minio-secret-key");
        minioClient.captureBucketNotifications(BUCKET_NAME, event -> {
            System.out.println(event.eventType() + " - " + event.requestParameters());
        });
```

Relevant output while running with this PR

```
METADATA
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=4-727, region=, sourceIPAddress=172.28.0.1}
completed positions: OptionalLong[470000]
completed bytes: 49876
PROTOCOL
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=728-799, region=, sourceIPAddress=172.28.0.1}
completed positions: OptionalLong[470000]
completed bytes: 49224
METADATA&PROTOCOL
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=4-799, region=, sourceIPAddress=172.28.0.1}
size: 2
Elapsed Time in milli seconds: 126
completed positions: OptionalLong[470000]
completed bytes: 49948
```

Relevant output while running on `master`


```
METADATA
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=4-727, region=, sourceIPAddress=172.28.0.1}
completed positions: OptionalLong[470000]
completed bytes: 49876
PROTOCOL
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=728-799, region=, sourceIPAddress=172.28.0.1}
completed positions: OptionalLong[470000]
completed bytes: 49224
METADATA&PROTOCOL
s3:ObjectAccessed:Head - {principalId=minio-access-key, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=-49152, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=4-799, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=125355536-125355952, region=, sourceIPAddress=172.28.0.1}
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=250711810-250712226, region=, sourceIPAddress=172.28.0.1}
size: 2
Elapsed Time in milli seconds: 355
completed positions: OptionalLong[1235156]
completed bytes: 50782
```

For `METADATA` & `PROTOCOL` when specified together, for the file I am using for testing, the `CheckpointEntryIterator makes currently (in `master`) the extra call:
```
s3:ObjectAccessed:Get - {principalId=minio-access-key, range=bytes=125355536-125355952, region=, sourceIPAddress=172.28.0.1}
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
#
* ({issue}`issuenumber`)
```
