### PR TITLE
Upgrade docker-images to version 87

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <dep.antlr.version>4.13.1</dep.antlr.version>
         <dep.asm.version>9.6</dep.asm.version>
 
-        <dep.docker.images.version>86</dep.docker.images.version>
+        <dep.docker.images.version>87</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDeleteCompatibility.java
@@ -226,14 +226,7 @@ public class TestDeltaLakeDeleteCompatibility
                 "         TBLPROPERTIES ('delta.enableDeletionVectors' = true, 'delta.columnMapping.mode' = '" + mode + "')");
         try {
             onDelta().executeQuery("INSERT INTO default." + tableName + " VALUES (1,11), (2, 22)");
-            if (databricksRuntimeVersion.isEmpty() && (mode.equals("name") || mode.equals("id"))) {
-                assertQueryFailure(() -> onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a = 2"))
-                        .hasMessageContaining("Can't resolve column __delta_internal_row_index in root");
-                throw new SkipException("OSS Delta Lake doesn't support deletion vectors with column mapping mode 'name' and 'id'");
-            }
-            else {
-                onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a = 2");
-            }
+            onDelta().executeQuery("DELETE FROM default." + tableName + " WHERE a = 2");
 
             assertThat(onDelta().executeQuery("SELECT * FROM default." + tableName))
                     .containsOnly(row(1, 11));


### PR DESCRIPTION
## Description

Upgrade docker-images to version 87. 
This upgrades Delta Lake version to 3.0.0.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
