### PR TITLE
Enable writing to full ACID tables in Hive connector when the table has no partitions

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2131,7 +2131,11 @@ public class HiveMetadata
         if (isFullAcidTable(table.getParameters())) {
             for (PartitionUpdate update : partitionUpdates) {
                 String deltaSubdir = deltaSubdir(handle.getTransaction().getWriteId(), 0);
-                String directory = "%s/%s/%s".formatted(table.getStorage().getLocation(), update.getName(), deltaSubdir);
+                String directory = table.getStorage().getLocation();
+                if (!update.getName().isEmpty()) {
+                    directory += "/" + update.getName();
+                }
+                directory += "/" + deltaSubdir;
                 createOrcAcidVersionFile(session.getIdentity(), directory);
             }
         }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestWriteToHiveTransactionalTableInTrino.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestWriteToHiveTransactionalTableInTrino.java
@@ -47,6 +47,16 @@ public class TestWriteToHiveTransactionalTableInTrino
     }
 
     @Test(groups = {HMS_ONLY, PROFILE_SPECIFIC_TESTS})
+    public void testInsertIntoNonPartitionedTable()
+    {
+        String tableName = "non_partitioned_transactional_insert";
+        onTrino().executeQuery(format("CREATE TABLE %s (column1 INT, column2 INT) WITH (transactional = true)", tableName));
+        onTrino().executeQuery(format("INSERT INTO %s VALUES (11, 12), (111, 121)", tableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s", tableName))).containsOnly(row(11, 12), row(111, 121));
+        onTrino().executeQuery(format("DROP TABLE %s", tableName));
+    }
+
+    @Test(groups = {HMS_ONLY, PROFILE_SPECIFIC_TESTS})
     public void testUpdateOnUnpartitionedTable()
     {
         String tableName = "unpartitioned_transactional_update";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Allow inserting into a full-ACID Hive table without partitions.

See that issue for a full description.

Fixes #19407.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

N/A

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Allow Allow inserting into a full-ACID Hive table without partitions. ({issue}`19407`)
```
