### PR TITLE
Do not allocate memory for all queries scanning system.* tables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/NoMemoryAwarePartitionMemoryEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/NoMemoryAwarePartitionMemoryEstimator.java
@@ -95,9 +95,7 @@ public class NoMemoryAwarePartitionMemoryEstimator
         private static boolean isMetadataTableScan(TableScanNode tableScanNode)
         {
             return (tableScanNode.getTable().getConnectorHandle() instanceof InformationSchemaTableHandle) ||
-                    (tableScanNode.getTable().getCatalogHandle().getCatalogName().equals(GlobalSystemConnector.NAME) &&
-                            (tableScanNode.getTable().getConnectorHandle() instanceof SystemTableHandle systemHandle) &&
-                            systemHandle.getSchemaName().equals("jdbc"));
+                    (tableScanNode.getTable().getCatalogHandle().getCatalogName().equals(GlobalSystemConnector.NAME) && (tableScanNode.getTable().getConnectorHandle() instanceof SystemTableHandle));
         }
     }
 }


### PR DESCRIPTION
Extend the logic to specially treat metadata queries and not allocate any memory for those, so they are scheduled immediatelly, to cover all schematas from system catalog (previously only jdbc schama was covered).

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.


