### PR TITLE
Avoid redundant calculation of columnsWithMinMaxStats

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -136,7 +136,7 @@ public class CheckpointEntryIterator
     private final boolean checkpointRowStatisticsWritingEnabled;
     private MetadataEntry metadataEntry;
     private ProtocolEntry protocolEntry;
-    private List<DeltaLakeColumnMetadata> schema; // Use DeltaLakeColumnMetadata?
+    private List<DeltaLakeColumnMetadata> schema;
     private List<DeltaLakeColumnMetadata> columnsWithMinMaxStats;
     private Page page;
     private long pageIndex;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The method `parseStatisticsFromParquet()` is being called for building each `add` file entry.
Avoid redundant calculation of `columnsWithMinMaxStats`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
