### PR TITLE
Use assertEventually in BigQuery assertLabelForTable

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -679,10 +679,10 @@ public abstract class BaseBigQueryConnectorTest
                         SELECT * FROM UNNEST(labels) AS label WHERE label.key = 'trino_query' AND label.value = '%s'
                     )""".formatted(expectedLabel);
 
-        assertThat(bigQuerySqlExecutor.executeQuery(checkForLabelQuery).getValues())
+        assertEventually(() -> assertThat(bigQuerySqlExecutor.executeQuery(checkForLabelQuery).getValues())
                 .extracting(values -> values.get("query").getStringValue())
                 .singleElement()
-                .matches(statement -> statement.contains(expectedView));
+                .matches(statement -> statement.contains(expectedView)));
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #17867
Assuming there's a lag until the job appears in INFORMATION_SCHEMA.JOBS_BY_USER table. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
