### PR TITLE
Retry updating the table statistics in the context of concurrent modifications

### DIFF
--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -538,6 +538,7 @@
                             <excludes>
                                 <exclude>**/TestHiveGlueMetastore.java</exclude>
                                 <exclude>**/TestHiveS3AndGlueMetastoreTest.java</exclude>
+                                <exclude>**/TestHiveConcurrentModificationGlueMetastore.java</exclude>
                                 <exclude>**/TestTrinoS3FileSystemAwsS3.java</exclude>
                                 <exclude>**/TestFullParquetReader.java</exclude>
                                 <exclude>**/TestParquetReader.java</exclude>
@@ -595,6 +596,7 @@
                             <includes>
                                 <include>**/TestHiveGlueMetastore.java</include>
                                 <include>**/TestHiveS3AndGlueMetastoreTest.java</include>
+                                <include>**/TestHiveConcurrentModificationGlueMetastore.java</include>
                                 <include>**/TestTrinoS3FileSystemAwsS3.java</include>
                             </includes>
                         </configuration>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -348,6 +348,12 @@ public class GlueHiveMetastore
     @Override
     public void updateTableStatistics(String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
+        Failsafe.with(CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY)
+                .run(() -> updateTableStatisticsInternal(databaseName, tableName, transaction, update));
+    }
+
+    private void updateTableStatisticsInternal(String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
+    {
         Table table = getExistingTable(databaseName, tableName);
         if (transaction.isAcidTransactionRunning()) {
             table = Table.builder(table).setWriteId(OptionalLong.of(transaction.getWriteId())).build();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConcurrentModificationGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConcurrentModificationGlueMetastore.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.model.ConcurrentModificationException;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.glue.DefaultGlueColumnStatisticsProviderFactory;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastore;
+import io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreConfig;
+import io.trino.plugin.hive.metastore.glue.GlueMetastoreStats;
+import io.trino.spi.TrinoException;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.common.reflect.Reflection.newProxy;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.hive.metastore.glue.GlueClientUtil.createAsyncGlueClient;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestHiveConcurrentModificationGlueMetastore
+        extends AbstractTestQueryFramework
+{
+    private static final String CATALOG_NAME = "test_hive_concurrent";
+    private static final String SCHEMA = "test_hive_glue_concurrent_" + randomNameSuffix();
+    private Path dataDirectory;
+    private GlueHiveMetastore metastore;
+    private final AtomicBoolean failNextGlueUpdateTableCall = new AtomicBoolean(false);
+    private final AtomicInteger updateTableCallsCounter = new AtomicInteger();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session deltaLakeSession = testSessionBuilder()
+                .setCatalog(CATALOG_NAME)
+                .setSchema(SCHEMA)
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(deltaLakeSession).build();
+
+        dataDirectory = queryRunner.getCoordinator().getBaseDataDir().resolve("data_hive_concurrent");
+        GlueMetastoreStats stats = new GlueMetastoreStats();
+        GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
+                .setDefaultWarehouseDir(dataDirectory.toUri().toString());
+
+        AWSGlueAsync glueClient = createAsyncGlueClient(glueConfig, DefaultAWSCredentialsProviderChain.getInstance(), ImmutableSet.of(), stats.newRequestMetricsCollector());
+        AWSGlueAsync proxiedGlueClient = newProxy(AWSGlueAsync.class, (proxy, method, args) -> {
+            try {
+                if (method.getName().equals("updateTable")) {
+                    updateTableCallsCounter.incrementAndGet();
+                    if (failNextGlueUpdateTableCall.get()) {
+                        // Simulate concurrent modifications on the table that is about to be dropped
+                        failNextGlueUpdateTableCall.set(false);
+                        throw new TrinoException(HIVE_METASTORE_ERROR, new ConcurrentModificationException("Test-simulated metastore concurrent modification exception"));
+                    }
+                }
+                return method.invoke(glueClient, args);
+            }
+            catch (InvocationTargetException e) {
+                throw e.getCause();
+            }
+        });
+
+        metastore = new GlueHiveMetastore(
+                HDFS_FILE_SYSTEM_FACTORY,
+                glueConfig,
+                directExecutor(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
+                proxiedGlueClient,
+                stats,
+                table -> true);
+
+        queryRunner.installPlugin(new TestingHivePlugin(Optional.of(metastore), Optional.empty(), EMPTY_MODULE, Optional.empty()));
+        queryRunner.createCatalog(CATALOG_NAME, "hive");
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA);
+        return queryRunner;
+    }
+
+    @Test
+    public void testUpdateTableStatsWithConcurrentModifications()
+    {
+        String tableName = "test_glue_table_" + randomNameSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT 1 AS data", 1);
+
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "VALUES " +
+                        "   ('data',  null, 1.0, 0.0, null, 1, 1), " +
+                        "   (null, null, null, null, 1.0, null, null)");
+
+        failNextGlueUpdateTableCall.set(true);
+        resetCounters();
+        assertUpdate("INSERT INTO " + tableName + " VALUES 2", 1);
+        assertThat(updateTableCallsCounter.get()).isEqualTo(2);
+        assertQuery("SELECT * FROM " + tableName, "VALUES 1, 2");
+        assertQuery(
+                "SHOW STATS FOR " + tableName,
+                "VALUES " +
+                        "   ('data',  null, 1.0, 0.0, null, 1, 2), " +
+                        "   (null, null, null, null, 2.0, null, null)");
+    }
+
+    private void resetCounters()
+    {
+        updateTableCallsCounter.set(0);
+    }
+
+    @AfterAll
+    public void cleanup()
+            throws IOException
+    {
+        if (metastore != null) {
+            metastore.dropDatabase(SCHEMA, false);
+            deleteRecursively(dataDirectory, ALLOW_INSECURE);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Retry the updating the statistics of the AWS Glue table, in the situation that another query is also trying to perform concurrently the same action.

e.g. : two or more concurrent INSERT operations in a Hive table.


### Context

```
io.trino.spi.TrinoException: All operations other than the following update operations were completed: replace table parameters myschema.mytable
	at io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore$Committer.executeUpdateStatisticsOperations(SemiTransactionalHiveMetastore.java:2163)
	at io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.commitShared(SemiTransactionalHiveMetastore.java:1567)
	at io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore.commit(SemiTransactionalHiveMetastore.java:1264)
...
 Caused by: com.amazonaws.services.glue.model.ConcurrentModificationException: Update table failed due to concurrent modifications. (Service: AWSGlue; Status Code: 400; Error Code: ConcurrentModificationException; Request ID: 653dcadf-aaa1-4c1a-aaea-49accf729ca0; Proxy: null)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715)
        at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541)
        at com.amazonaws.services.glue.AWSGlueClient.doInvoke(AWSGlueClient.java:13784)
        at com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:13751)
        at com.amazonaws.services.glue.AWSGlueClient.invoke(AWSGlueClient.java:13740)
        at com.amazonaws.services.glue.AWSGlueClient.executeUpdateTable(AWSGlueClient.java:13509)
        at com.amazonaws.services.glue.AWSGlueClient.updateTable(AWSGlueClient.java:13478)
        at io.trino.plugin.hive.metastore.glue.GlueHiveMetastore.lambda$updateTableStatistics$8(GlueHiveMetastore.java:342)
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Same as done already in https://github.com/trinodb/trino/pull/16092 we are doing here retries to eventually succeed in updating the table statistics.

A further potential area which can be improved could be `io.trino.plugin.hive.metastore.glue.GlueHiveMetastore#updatePartitionStatistics`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Hive
* Retry updating the table statistics in Glue in the context of concurrent modfications. ({issue}`issuenumber`)
```
