### PR TITLE
Remove unnecessary test

### DIFF
--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTableStatistics.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTableStatistics.java
@@ -30,6 +30,7 @@ import static io.trino.testing.sql.TestTable.fromColumns;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestPostgreSqlTableStatistics
         extends BaseJdbcTableStatisticsTest
@@ -57,39 +58,7 @@ public class TestPostgreSqlTableStatistics
     @Override
     public void testNotAnalyzed()
     {
-        String tableName = "test_stats_not_analyzed";
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-        computeActual(format("CREATE TABLE %s AS SELECT * FROM tpch.tiny.orders", tableName));
-
-        Exception failure = null;
-        try {
-            for (int i = 0; i < 10; i++) {
-                try {
-                    assertQuery(
-                            "SHOW STATS FOR " + tableName,
-                            "VALUES " +
-                                    "('orderkey', null, null, null, null, null, null)," +
-                                    "('custkey', null, null, null, null, null, null)," +
-                                    "('orderstatus', null, null, null, null, null, null)," +
-                                    "('totalprice', null, null, null, null, null, null)," +
-                                    "('orderdate', null, null, null, null, null, null)," +
-                                    "('orderpriority', null, null, null, null, null, null)," +
-                                    "('clerk', null, null, null, null, null, null)," +
-                                    "('shippriority', null, null, null, null, null, null)," +
-                                    "('comment', null, null, null, null, null, null)," +
-                                    "(null, null, null, null, 15000, null, null)");
-                    return;
-                }
-                catch (Exception e) {
-                    failure = e;
-                }
-            }
-
-            throw new AssertionError(failure);
-        }
-        finally {
-            assertUpdate("DROP TABLE " + tableName);
-        }
+        abort("PostgreSQL analyzes tables automatically");
     }
 
     @Override


### PR DESCRIPTION
The test is supposed to ensure that the table is not analyzed, but PostgreSQL analyzes tables automatically.
Therefore, the test is not applicable for it.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
