### PR TITLE
Improve Limit Pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -415,7 +415,6 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(columnPruningRules)
                                 .addAll(projectionPushdownRules)
-                                .addAll(limitPushdownRules)
                                 .addAll(new UnwrapRowSubscript().rules())
                                 .addAll(new PushCastIntoRow().rules())
                                 .addAll(ImmutableSet.of(
@@ -430,6 +429,7 @@ public class PlanOptimizers
                                         new RemoveFullSample(),
                                         new EvaluateZeroSample(),
                                         new PushOffsetThroughProject(),
+                                        new MergeUnion(),
                                         new MergeLimits(),
                                         new MergeLimitWithSort(),
                                         new MergeLimitOverProjectWithSort(),
@@ -456,6 +456,29 @@ public class PlanOptimizers
                                         new RewriteSpatialPartitioningAggregation(plannerContext),
                                         new SimplifyCountOverConstant(plannerContext),
                                         new PreAggregateCaseAggregations(plannerContext, typeAnalyzer)))
+                                .build()),
+                // MergeUnion and related projection pruning rules must run before limit pushdown rules, otherwise
+                // an intermediate limit node will prevent unions from being merged later on
+                new IterativeOptimizer(
+                        plannerContext,
+                        ruleStats,
+                        statsCalculator,
+                        costCalculator,
+                        ImmutableSet.<Rule<?>>builder()
+                                .addAll(projectionPushdownRules)
+                                .addAll(columnPruningRules)
+                                .addAll(limitPushdownRules)
+                                .addAll(ImmutableSet.of(
+                                        new MergeUnion(),
+                                        new RemoveEmptyUnionBranches(),
+                                        new MergeFilters(metadata),
+                                        new RemoveTrivialFilters(),
+                                        new MergeLimits(),
+                                        new MergeLimitWithSort(),
+                                        new MergeLimitOverProjectWithSort(),
+                                        new MergeLimitWithTopN(),
+                                        new InlineProjections(plannerContext, typeAnalyzer),
+                                        new RemoveRedundantIdentityProjections()))
                                 .build()),
                 new IterativeOptimizer(
                         plannerContext,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -643,7 +643,7 @@ public class AddExchanges
 
             PlanWithProperties child = planChild(node, PreferredProperties.any());
 
-            if (!child.getProperties().isSingleNode()) {
+            if (!node.isPartial() && !child.getProperties().isSingleNode()) {
                 child = withDerivedProperties(
                         new LimitNode(idAllocator.getNextId(), child.getNode(), node.getCount(), true),
                         child.getProperties());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/LimitPushDown.java
@@ -135,8 +135,10 @@ public class LimitPushDown
             }
 
             if (!node.requiresPreSortedInputs() && (!node.isWithTies() || (limit != null && node.getCount() >= limit.getCount()))) {
+                // The new limit context is partial if neither the existing context nor this limit node is final
+                boolean partial = node.isPartial() && (limit == null || limit.isPartial());
                 // default visitPlan logic will insert the limit node
-                return context.rewrite(node.getSource(), new LimitContext(count, false));
+                return context.rewrite(node.getSource(), new LimitContext(count, partial));
             }
 
             return context.defaultRewrite(node, context.get());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/planprinter/TestJsonRepresentation.java
@@ -100,14 +100,14 @@ public class TestJsonRepresentation
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "98",
+                                "100",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(typedSymbol("quantity", "double")),
                                 ImmutableList.of(),
                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "147",
+                                        "149",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "SINGLE",
@@ -125,7 +125,7 @@ public class TestJsonRepresentation
                                                 ImmutableList.of("quantity := tpch:quantity"),
                                                 ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                                 ImmutableList.of()))))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2058))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(2059))
                 .row(DISTRIBUTED_PLAN_JSON_CODEC.toJson(distributedPlan))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);
@@ -143,14 +143,14 @@ public class TestJsonRepresentation
                 ImmutableList.of(),
                 ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 0, 0, 0)),
                 ImmutableList.of(new JsonRenderedNode(
-                        "98",
+                        "100",
                         "Limit",
                         ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                         ImmutableList.of(typedSymbol("quantity", "double")),
                         ImmutableList.of(),
                         ImmutableList.of(new PlanNodeStatsAndCostSummary(10, 90, 90, 0, 0)),
                         ImmutableList.of(new JsonRenderedNode(
-                                "147",
+                                "149",
                                 "LocalExchange",
                                 ImmutableMap.of(
                                         "partitioning", "SINGLE",
@@ -168,7 +168,7 @@ public class TestJsonRepresentation
                                         ImmutableList.of("quantity := tpch:quantity"),
                                         ImmutableList.of(new PlanNodeStatsAndCostSummary(60175, 541575, 541575, 0, 0)),
                                         ImmutableList.of())))))));
-        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1884))
+        MaterializedResult expectedPlan = resultBuilder(queryRunner.getDefaultSession(), createVarcharType(1885))
                 .row(JSON_RENDERED_NODE_CODEC.toJson(expectedJsonNode))
                 .build();
         assertThat(actualPlan).isEqualTo(expectedPlan);

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
@@ -226,7 +226,7 @@ public class TestSelectAll
         assertThat(assertions.query("SELECT t.a, t2.d FROM (VALUES (0, 1), (2, 3)) t(a, b), LATERAL (SELECT t.*) t2(c, d)")).matches("VALUES (0, 1), (2, 3)");
         // limit in lateral relation
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t.* LIMIT 5)")).matches("VALUES (0, 0), (1, 1)");
-        assertThatThrownBy(() -> assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t.* LIMIT 0)")).hasMessageMatching(UNSUPPORTED_DECORRELATION_MESSAGE);
+        assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t.* LIMIT 0)")).matches(result -> result.getMaterializedRows().isEmpty());
         // filter in lateral relation
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t.* WHERE true)")).matches("VALUES (0, 0), (1, 1)");
         assertThat(assertions.query("SELECT * FROM (VALUES 0, 1) t(a), LATERAL (SELECT t.* WHERE 0 = 0)")).matches("VALUES (0, 0), (1, 1)");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -3696,7 +3696,7 @@ public abstract class AbstractTestEngineOnlyQueries
         assertQuery("SELECT * FROM region r, LATERAL (SELECT r.*)", "SELECT *, * FROM region");
         assertQuery("SELECT * FROM region r, LATERAL (SELECT r.* LIMIT 2)", "SELECT *, * FROM region");
         assertQuery("SELECT r.name, t.a FROM region r, LATERAL (SELECT r.* LIMIT 2) t(a, b, c)", "SELECT name, regionkey FROM region");
-        assertQueryFails("SELECT * FROM region r, LATERAL (SELECT r.* LIMIT 0)", UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
+        assertQuery("SELECT * FROM region r, LATERAL (SELECT r.* LIMIT 0)", "SELECT *, * FROM region LIMIT 0");
         assertQuery("SELECT * FROM region r, LATERAL (SELECT r.* WHERE true)", "SELECT *, * FROM region");
         assertQuery("SELECT region.* FROM region, LATERAL (SELECT region.*) region", "SELECT *, * FROM region");
         assertQueryFails("SELECT * FROM region r, LATERAL (SELECT r.* WHERE false)", UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -1238,14 +1238,14 @@ public class TestEventListenerBasic
                         ImmutableList.of(),
                         ImmutableList.of(),
                         ImmutableList.of(new JsonRenderedNode(
-                                "98",
+                                "100",
                                 "Limit",
                                 ImmutableMap.of("count", "10", "withTies", "", "inputPreSortedBy", "[]"),
                                 ImmutableList.of(typedSymbol("symbol_1", "double")),
                                 ImmutableList.of(),
                                 ImmutableList.of(),
                                 ImmutableList.of(new JsonRenderedNode(
-                                        "171",
+                                        "173",
                                         "LocalExchange",
                                         ImmutableMap.of(
                                                 "partitioning", "[connectorHandleType = SystemPartitioningHandle, partitioning = SINGLE, function = SINGLE]",
@@ -1256,7 +1256,7 @@ public class TestEventListenerBasic
                                         ImmutableList.of(),
                                         ImmutableList.of(),
                                         ImmutableList.of(new JsonRenderedNode(
-                                                "138",
+                                                "140",
                                                 "RemoteSource",
                                                 ImmutableMap.of("sourceFragmentIds", "[1]"),
                                                 ImmutableList.of(typedSymbol("symbol_1", "double")),
@@ -1264,7 +1264,7 @@ public class TestEventListenerBasic
                                                 ImmutableList.of(),
                                                 ImmutableList.of()))))))),
                 "1", new JsonRenderedNode(
-                        "137",
+                        "139",
                         "LimitPartial",
                         ImmutableMap.of(
                                 "count", "10",


### PR DESCRIPTION
## Description
Fixes several issues with `LimitNode` pushdown logic that could result in extremely long planning time and unnecessary complex plans, especially in the presence of `UNION ALL`:
1. Prevents `PushLimitThroughUnion` from inserting partial limit nodes until after `MergeUnion` has a chance to run. Before this change, the inserted limit nodes would prevent merging of chained `UNION ALL` subplans.
2. Fixes `LimitPushDown` to correctly push partial instead of full limit nodes where appropriate
3. Prevents `AddExchanges` from inserting duplicate partial limit nodes that previously would result in multiple layers of local exchanges when a single gathering exchange should be preferred.

Given a query like:
```
SELECT col0 FROM (
    SELECT n_nationkey as col0 FROM tpch.tiny.nation
    UNION ALL
    SELECT n_nationkey as col0 FROM tpch.tiny.nation
    UNION ALL
    SELECT n_nationkey as col0 FROM tpch.tiny.nation) limit 2;
```

The previous resulting plan without these changes is as follows:
```
                                         Query Plan
---------------------------------------------------------------------------------------------
 Trino version: dev
 Fragment 0 [SINGLE]
     Output layout: [col0]
     Output partitioning: SINGLE []
     Output[columnNames = [col0]]
     │   Layout: [col0:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
     └─ Limit[count = 2]
        │   Layout: [col0:bigint]
        │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
        └─ LocalExchange[partitioning = SINGLE]
           │   Layout: [col0:bigint]
           │   Estimates: {rows: 4 (36B), cpu: 0, memory: 0B, network: 0B}
           └─ LocalExchange[partitioning = ROUND_ROBIN]
              │   Layout: [col0:bigint]
              │   Estimates: {rows: 4 (36B), cpu: 36, memory: 0B, network: 0B}
              ├─ Limit[count = 2]
              │  │   Layout: [col0_0:bigint]
              │  │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
              │  └─ LocalExchange[partitioning = SINGLE]
              │     │   Layout: [col0_0:bigint]
              │     │   Estimates: {rows: 4 (36B), cpu: 0, memory: 0B, network: 0B}
              │     └─ LocalExchange[partitioning = ROUND_ROBIN]
              │        │   Layout: [col0_0:bigint]
              │        │   Estimates: {rows: 4 (36B), cpu: 36, memory: 0B, network: 0B}
              │        ├─ Limit[count = 2]
              │        │  │   Layout: [n_nationkey:bigint]
              │        │  │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
              │        │  └─ LocalExchange[partitioning = SINGLE]
              │        │     │   Layout: [n_nationkey:bigint]
              │        │     │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
              │        │     └─ RemoteSource[sourceFragmentIds = [1]]
              │        │            Layout: [n_nationkey:bigint]
              │        └─ Limit[count = 2]
              │           │   Layout: [n_nationkey_2:bigint]
              │           │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
              │           └─ LocalExchange[partitioning = SINGLE]
              │              │   Layout: [n_nationkey_2:bigint]
              │              │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
              │              └─ RemoteSource[sourceFragmentIds = [2]]
              │                     Layout: [n_nationkey_2:bigint]
              └─ Limit[count = 2]
                 │   Layout: [n_nationkey_7:bigint]
                 │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
                 └─ LocalExchange[partitioning = SINGLE]
                    │   Layout: [n_nationkey_7:bigint]
                    │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
                    └─ RemoteSource[sourceFragmentIds = [3]]
                           Layout: [n_nationkey_7:bigint]

 Fragment 1 [SOURCE]
     Output layout: [n_nationkey]
     Output partitioning: SINGLE []
     LimitPartial[count = 2]
     │   Layout: [n_nationkey:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
     └─ TableScan[table = tpch:tiny:nation]
            Layout: [n_nationkey:bigint]
            Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
            n_nationkey := tpch:n_nationkey

 Fragment 2 [SOURCE]
     Output layout: [n_nationkey_2]
     Output partitioning: SINGLE []
     LimitPartial[count = 2]
     │   Layout: [n_nationkey_2:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
     └─ TableScan[table = tpch:tiny:nation]
            Layout: [n_nationkey_2:bigint]
            Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
            n_nationkey_2 := tpch:n_nationkey

 Fragment 3 [SOURCE]
     Output layout: [n_nationkey_7]
     Output partitioning: SINGLE []
     LimitPartial[count = 2]
     │   Layout: [n_nationkey_7:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
     └─ TableScan[table = tpch:tiny:nation]
            Layout: [n_nationkey_7:bigint]
            Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
            n_nationkey_7 := tpch:n_nationkey
```

With these changes, the new plan is:
```
                                    Query Plan
----------------------------------------------------------------------------------
 Trino version: dev
 Fragment 0 [SINGLE]
     Output layout: [col0]
     Output partitioning: SINGLE []
     Output[columnNames = [col0]]
     │   Layout: [col0:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
     └─ Limit[count = 2]
        │   Layout: [col0:bigint]
        │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
        └─ LocalExchange[partitioning = SINGLE]
           │   Layout: [col0:bigint]
           │   Estimates: {rows: 2 (18B), cpu: 0, memory: 0B, network: 0B}
           └─ RemoteSource[sourceFragmentIds = [1]]
                  Layout: [col0:bigint]

 Fragment 1 [SOURCE]
     Output layout: [col0]
     Output partitioning: SINGLE []
     LimitPartial[count = 2]
     │   Layout: [col0:bigint]
     │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
     └─ LocalExchange[partitioning = ROUND_ROBIN]
        │   Layout: [col0:bigint]
        │   Estimates: {rows: 6 (54B), cpu: 54, memory: 0B, network: 0B}
        ├─ LimitPartial[count = 2]
        │  │   Layout: [n_nationkey:bigint]
        │  │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
        │  └─ TableScan[table = tpch:tiny:nation]
        │         Layout: [n_nationkey:bigint]
        │         Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
        │         n_nationkey := tpch:n_nationkey
        ├─ LimitPartial[count = 2]
        │  │   Layout: [n_nationkey_2:bigint]
        │  │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
        │  └─ TableScan[table = tpch:tiny:nation]
        │         Layout: [n_nationkey_2:bigint]
        │         Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
        │         n_nationkey_2 := tpch:n_nationkey
        └─ LimitPartial[count = 2]
           │   Layout: [n_nationkey_7:bigint]
           │   Estimates: {rows: 2 (18B), cpu: 18, memory: 0B, network: 0B}
           └─ TableScan[table = tpch:tiny:nation]
                  Layout: [n_nationkey_7:bigint]
                  Estimates: {rows: 25 (225B), cpu: 225, memory: 0B, network: 0B}
                  n_nationkey_7 := tpch:n_nationkey
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Relates to https://github.com/trinodb/trino/issues/19239 and appears to greatly reduce planning time specifically for `UNION ALL` with `LIMIT` plans, but does not generally address the quadratic plan traversal problem from https://github.com/trinodb/trino/issues/18491


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve planning time and resulting plan efficiency for queries involving UNION ALL with LIMIT
```
