### PR TITLE
Preserve sourcePartition to Splits mapping in task descriptor 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
@@ -15,6 +15,7 @@ package io.trino.execution.scheduler.faulttolerant;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import io.trino.exchange.SpoolingExchangeInput;
@@ -131,7 +132,7 @@ class ArbitraryDistributionSplitAssigner
                     partitionAssignment.getPartitionId(),
                     planNodeId,
                     false,
-                    splits,
+                    singleSourcePartition(SINGLE_SOURCE_PARTITION_ID, splits),
                     noMoreSplits));
         }
         if (noMoreSplits) {
@@ -157,7 +158,7 @@ class ArbitraryDistributionSplitAssigner
                             0,
                             replicatedSourceId,
                             false,
-                            replicatedSplits.get(replicatedSourceId),
+                            singleSourcePartition(SINGLE_SOURCE_PARTITION_ID, replicatedSplits.get(replicatedSourceId)),
                             true));
                 }
                 for (PlanNodeId partitionedSourceId : partitionedSources) {
@@ -165,7 +166,7 @@ class ArbitraryDistributionSplitAssigner
                             0,
                             partitionedSourceId,
                             false,
-                            ImmutableList.of(),
+                            ImmutableListMultimap.of(),
                             true));
                 }
                 assignment.sealPartition(0);
@@ -179,7 +180,7 @@ class ArbitraryDistributionSplitAssigner
                                     partitionAssignment.getPartitionId(),
                                     partitionedSourceNodeId,
                                     false,
-                                    ImmutableList.of(),
+                                    singleSourcePartition(0, ImmutableList.of()),
                                     true));
                         }
                         // seal partition
@@ -192,6 +193,13 @@ class ArbitraryDistributionSplitAssigner
             assignment.setNoMorePartitions();
         }
         return assignment.build();
+    }
+
+    private ListMultimap<Integer, Split> singleSourcePartition(int sourcePartitionId, List<Split> splits)
+    {
+        ImmutableListMultimap.Builder<Integer, Split> builder = ImmutableListMultimap.builder();
+        builder.putAll(0, splits);
+        return builder.build();
     }
 
     private AssignmentResult assignPartitionedSplits(PlanNodeId planNodeId, List<Split> splits, boolean noMoreSplits)
@@ -210,7 +218,7 @@ class ArbitraryDistributionSplitAssigner
                             partitionAssignment.getPartitionId(),
                             partitionedSourceNodeId,
                             false,
-                            ImmutableList.of(),
+                            ImmutableListMultimap.of(),
                             true));
                 }
                 if (completedSources.containsAll(replicatedSources)) {
@@ -241,7 +249,7 @@ class ArbitraryDistributionSplitAssigner
                             partitionAssignment.getPartitionId(),
                             replicatedSourceId,
                             false,
-                            replicatedSplits.get(replicatedSourceId),
+                            singleSourcePartition(SINGLE_SOURCE_PARTITION_ID, replicatedSplits.get(replicatedSourceId)),
                             completedSources.contains(replicatedSourceId)));
                 }
             }
@@ -249,7 +257,7 @@ class ArbitraryDistributionSplitAssigner
                     partitionAssignment.getPartitionId(),
                     planNodeId,
                     true,
-                    ImmutableList.of(split),
+                    singleSourcePartition(SINGLE_SOURCE_PARTITION_ID, ImmutableList.of(split)),
                     false));
             partitionAssignment.assignSplit(splitSizeInBytes);
         }
@@ -268,7 +276,7 @@ class ArbitraryDistributionSplitAssigner
                             0,
                             replicatedSourceId,
                             false,
-                            replicatedSplits.get(replicatedSourceId),
+                            singleSourcePartition(SINGLE_SOURCE_PARTITION_ID, replicatedSplits.get(replicatedSourceId)),
                             true));
                 }
                 for (PlanNodeId partitionedSourceId : partitionedSources) {
@@ -276,7 +284,7 @@ class ArbitraryDistributionSplitAssigner
                             0,
                             partitionedSourceId,
                             false,
-                            ImmutableList.of(),
+                            ImmutableListMultimap.of(),
                             true));
                 }
 
@@ -290,7 +298,7 @@ class ArbitraryDistributionSplitAssigner
                                 partitionAssignment.getPartitionId(),
                                 partitionedSourceNodeId,
                                 false,
-                                ImmutableList.of(),
+                                ImmutableListMultimap.of(),
                                 true));
                     }
                     // seal partition

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -2014,6 +2014,11 @@ public class EventDrivenFaultTolerantQueryScheduler
                 runningPartitions.remove(partitionId);
             }
 
+            if (!remainingPartitions.contains(partitionId)) {
+                // another task for this partition finished successfully
+                return ImmutableList.of();
+            }
+
             RuntimeException failure = failureInfo.toException();
             ErrorCode errorCode = failureInfo.getErrorCode();
             partitionMemoryEstimator.registerPartitionFinished(

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
@@ -13,7 +13,7 @@
  */
 package io.trino.execution.scheduler.faulttolerant;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import io.trino.metadata.Split;
@@ -57,7 +57,7 @@ class SingleDistributionSplitAssigner
                     0,
                     planNodeId,
                     true,
-                    ImmutableList.copyOf(splits.values()),
+                    ImmutableListMultimap.copyOf(splits),
                     false));
         }
         if (noMoreSplits) {
@@ -65,7 +65,7 @@ class SingleDistributionSplitAssigner
                     0,
                     planNodeId,
                     false,
-                    ImmutableList.of(),
+                    ImmutableListMultimap.of(),
                     true));
             completedSources.add(planNodeId);
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler.faulttolerant;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.primitives.ImmutableIntArray;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -32,6 +33,9 @@ import static java.util.Objects.requireNonNull;
 @NotThreadSafe
 interface SplitAssigner
 {
+    // marker source partition id for data which is not hash distributed
+    int SINGLE_SOURCE_PARTITION_ID = 0;
+
     AssignmentResult assign(PlanNodeId planNodeId, ListMultimap<Integer, Split> splits, boolean noMoreSplits);
 
     AssignmentResult finish();
@@ -48,14 +52,14 @@ interface SplitAssigner
             int partitionId,
             PlanNodeId planNodeId,
             boolean readyForScheduling,
-            List<Split> splits,
+            ListMultimap<Integer, Split> splits, // sourcePartition -> splits
             boolean noMoreSplits)
     {
         public PartitionUpdate
         {
             requireNonNull(planNodeId, "planNodeId is null");
             checkArgument(!(readyForScheduling && splits.isEmpty()), "partition update with empty splits marked as ready for scheduling");
-            splits = ImmutableList.copyOf(requireNonNull(splits, "splits is null"));
+            splits = ImmutableListMultimap.copyOf(requireNonNull(splits, "splits is null"));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitsMapping.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitsMapping.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler.faulttolerant;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
+import io.trino.metadata.Split;
+import io.trino.sql.planner.plan.PlanNodeId;
+import jakarta.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.airlift.slice.SizeOf.INTEGER_INSTANCE_SIZE;
+import static io.airlift.slice.SizeOf.estimatedSizeOf;
+import static io.airlift.slice.SizeOf.instanceSize;
+import static java.util.Objects.requireNonNull;
+
+public final class SplitsMapping
+{
+    private static final int INSTANCE_SIZE = instanceSize(SplitsMapping.class);
+
+    public static final SplitsMapping EMPTY = SplitsMapping.builder().build();
+
+    // not using Multimap to avoid extensive data structure copying when building updated SplitsMapping
+    private final Map<PlanNodeId, Map<Integer, List<Split>>> splits; // plan-node -> hash-partition -> Split
+
+    private SplitsMapping(ImmutableMap<PlanNodeId, Map<Integer, List<Split>>> splits)
+    {
+        // Builder implementations ensure that external map as well as Maps/Lists used in values
+        // are immutable.
+        this.splits = splits;
+    }
+
+    public Set<PlanNodeId> getPlanNodeIds()
+    {
+        return splits.keySet();
+    }
+
+    public ListMultimap<PlanNodeId, Split> getSplitsFlat()
+    {
+        ImmutableListMultimap.Builder<PlanNodeId, Split> splitsFlat = ImmutableListMultimap.builder();
+        for (Map.Entry<PlanNodeId, Map<Integer, List<Split>>> entry : splits.entrySet()) {
+            // TODO can we do less copying?
+            splitsFlat.putAll(entry.getKey(), entry.getValue().values().stream().flatMap(Collection::stream).collect(toImmutableList()));
+        }
+        return splitsFlat.build();
+    }
+
+    public List<Split> getSplitsFlat(PlanNodeId planNodeId)
+    {
+        Map<Integer, List<Split>> splits = this.splits.get(planNodeId);
+        if (splits == null) {
+            return ImmutableList.of();
+        }
+        verify(!splits.isEmpty(), "expected not empty splits list %s", splits);
+
+        if (splits.size() == 1) {
+            return getOnlyElement(splits.values());
+        }
+
+        // TODO improve to not copy here; return view instead
+        ImmutableList.Builder<Split> result = ImmutableList.builder();
+        for (List<Split> partitionSplits : splits.values()) {
+            result.addAll(partitionSplits);
+        }
+        return result.build();
+    }
+
+    @VisibleForTesting
+    ListMultimap<Integer, Split> getSplits(PlanNodeId planNodeId)
+    {
+        Map<Integer, List<Split>> splits = this.splits.get(planNodeId);
+        if (splits == null) {
+            return ImmutableListMultimap.of();
+        }
+        verify(!splits.isEmpty(), "expected not empty splits list %s", splits);
+
+        ImmutableListMultimap.Builder<Integer, Split> result = ImmutableListMultimap.builder();
+        for (Map.Entry<Integer, List<Split>> entry : splits.entrySet()) {
+            result.putAll(entry.getKey(), entry.getValue());
+        }
+        return result.build();
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return INSTANCE_SIZE +
+                estimatedSizeOf(
+                        splits,
+                        PlanNodeId::getRetainedSizeInBytes,
+                        planNodeSplits -> estimatedSizeOf(
+                                planNodeSplits,
+                                partitionId -> INTEGER_INSTANCE_SIZE,
+                                splitList -> estimatedSizeOf(splitList, Split::getRetainedSizeInBytes)));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SplitsMapping that = (SplitsMapping) o;
+        return Objects.equals(splits, that.splits);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(splits);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("splits", splits)
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new NewBuilder();
+    }
+
+    public static Builder builder(SplitsMapping mapping)
+    {
+        return new UpdatingBuilder(mapping);
+    }
+
+    public long size()
+    {
+        return splits.values().stream()
+                .flatMap(sourcePartitionToSplits -> sourcePartitionToSplits.values().stream())
+                .mapToLong(List::size)
+                .sum();
+    }
+
+    public abstract static class Builder
+    {
+        private Builder() {} // close for extension
+
+        public Builder addSplit(PlanNodeId planNodeId, int partitionId, Split split)
+        {
+            return addSplits(planNodeId, partitionId, ImmutableList.of(split));
+        }
+
+        public Builder addSplits(PlanNodeId planNodeId, ListMultimap<Integer, Split> splits)
+        {
+            Multimaps.asMap(splits).forEach((partitionId, partitionSplits) -> addSplits(planNodeId, partitionId, partitionSplits));
+            return this;
+        }
+
+        public Builder addMapping(SplitsMapping updatingMapping)
+        {
+            for (Map.Entry<PlanNodeId, Map<Integer, List<Split>>> entry : updatingMapping.splits.entrySet()) {
+                PlanNodeId planNodeId = entry.getKey();
+                entry.getValue().forEach((partitionId, partitionSplits) -> addSplits(planNodeId, partitionId, partitionSplits));
+            }
+            return this;
+        }
+
+        public abstract Builder addSplits(PlanNodeId planNodeId, int partitionId, List<Split> splits);
+
+        public abstract SplitsMapping build();
+    }
+
+    private static class UpdatingBuilder
+            extends Builder
+    {
+        private final SplitsMapping originalMapping;
+        private final Map<PlanNodeId, Map<Integer, ImmutableList.Builder<Split>>> updates = new HashMap<>();
+
+        public UpdatingBuilder(SplitsMapping originalMapping)
+        {
+            this.originalMapping = requireNonNull(originalMapping, "sourceMapping is null");
+        }
+
+        @Override
+        public Builder addSplits(PlanNodeId planNodeId, int partitionId, List<Split> splits)
+        {
+            if (splits.isEmpty()) {
+                // ensure we do not have empty lists in result splits map.
+                return this;
+            }
+            updates.computeIfAbsent(planNodeId, ignored -> new HashMap<>())
+                    .computeIfAbsent(partitionId, key -> ImmutableList.builder())
+                    .addAll(splits);
+            return this;
+        }
+
+        @Override
+        public SplitsMapping build()
+        {
+            ImmutableMap.Builder<PlanNodeId, Map<Integer, List<Split>>> result = ImmutableMap.builder();
+            for (PlanNodeId planNodeId : Sets.union(originalMapping.splits.keySet(), updates.keySet())) {
+                Map<Integer, List<Split>> planNodeOriginalMapping = originalMapping.splits.getOrDefault(planNodeId, ImmutableMap.of());
+                Map<Integer, ImmutableList.Builder<Split>> planNodeUpdates = updates.getOrDefault(planNodeId, ImmutableMap.of());
+                if (planNodeUpdates.isEmpty()) {
+                    // just use original splits for planNodeId
+                    result.put(planNodeId, planNodeOriginalMapping);
+                    continue;
+                }
+                // create new mapping for planNodeId reusing as much of source as possible
+                ImmutableMap.Builder<Integer, List<Split>> targetSplitsMapBuilder = ImmutableMap.builder();
+                for (Integer sourcePartitionId : Sets.union(planNodeOriginalMapping.keySet(), planNodeUpdates.keySet())) {
+                    @Nullable List<Split> originalSplits = planNodeOriginalMapping.get(sourcePartitionId);
+                    @Nullable ImmutableList.Builder<Split> splitUpdates = planNodeUpdates.get(sourcePartitionId);
+                    targetSplitsMapBuilder.put(sourcePartitionId, mergeIfPresent(originalSplits, splitUpdates));
+                }
+                result.put(planNodeId, targetSplitsMapBuilder.buildOrThrow());
+            }
+            return new SplitsMapping(result.buildOrThrow());
+        }
+
+        private static <T> List<T> mergeIfPresent(@Nullable List<T> list, @Nullable ImmutableList.Builder<T> additionalElements)
+        {
+            if (additionalElements == null) {
+                // reuse source immutable split list
+                return requireNonNull(list, "list is null");
+            }
+            if (list == null) {
+                return additionalElements.build();
+            }
+            return ImmutableList.<T>builder()
+                    .addAll(list)
+                    .addAll(additionalElements.build())
+                    .build();
+        }
+    }
+
+    private static class NewBuilder
+            extends Builder
+    {
+        private final Map<PlanNodeId, Map<Integer, ImmutableList.Builder<Split>>> splitsBuilder = new HashMap<>();
+
+        @Override
+        public Builder addSplits(PlanNodeId planNodeId, int partitionId, List<Split> splits)
+        {
+            if (splits.isEmpty()) {
+                // ensure we do not have empty lists in result splits map.
+                return this;
+            }
+            splitsBuilder.computeIfAbsent(planNodeId, ignored -> new HashMap<>())
+                    .computeIfAbsent(partitionId, ignored -> ImmutableList.builder())
+                    .addAll(splits);
+            return this;
+        }
+
+        @Override
+        public SplitsMapping build()
+        {
+            return new SplitsMapping(splitsBuilder.entrySet().stream()
+                    .collect(toImmutableMap(
+                            Map.Entry::getKey,
+                            planNodeMapping -> planNodeMapping.getValue().entrySet().stream()
+                                    .collect(toImmutableMap(
+                                            Map.Entry::getKey,
+                                            sourcePartitionMapping -> sourcePartitionMapping.getValue().build())))));
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/TaskDescriptorStorage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/TaskDescriptorStorage.java
@@ -330,7 +330,7 @@ public class TaskDescriptorStorage
                             entry -> getDebugInfo(entry.getValue())));
 
             List<String> biggestSplits = descriptorsByStageId.entries().stream()
-                    .flatMap(entry -> entry.getValue().getSplits().entries().stream().map(splitEntry -> Map.entry("%s/%s".formatted(entry.getKey(), splitEntry.getKey()), splitEntry.getValue())))
+                    .flatMap(entry -> entry.getValue().getSplits().getSplitsFlat().entries().stream().map(splitEntry -> Map.entry("%s/%s".formatted(entry.getKey(), splitEntry.getKey()), splitEntry.getValue())))
                     .sorted(Comparator.<Map.Entry<String, Split>>comparingLong(entry -> entry.getValue().getRetainedSizeInBytes()).reversed())
                     .limit(3)
                     .map(entry -> "{nodeId=%s, size=%s, split=%s}".formatted(entry.getKey(), entry.getValue().getRetainedSizeInBytes(), splitJsonCodec.toJson(entry.getValue())))
@@ -344,11 +344,11 @@ public class TaskDescriptorStorage
             int taskDescriptorsCount = taskDescriptors.size();
             Stats taskDescriptorsRetainedSizeStats = Stats.of(taskDescriptors.stream().mapToLong(TaskDescriptor::getRetainedSizeInBytes));
 
-            Set<PlanNodeId> planNodeIds = taskDescriptors.stream().flatMap(taskDescriptor -> taskDescriptor.getSplits().keySet().stream()).collect(toImmutableSet());
+            Set<PlanNodeId> planNodeIds = taskDescriptors.stream().flatMap(taskDescriptor -> taskDescriptor.getSplits().getSplitsFlat().keySet().stream()).collect(toImmutableSet());
             Map<PlanNodeId, String> splitsDebugInfo = new HashMap<>();
             for (PlanNodeId planNodeId : planNodeIds) {
-                Stats splitCountStats = Stats.of(taskDescriptors.stream().mapToLong(taskDescriptor -> taskDescriptor.getSplits().asMap().get(planNodeId).size()));
-                Stats splitSizeStats = Stats.of(taskDescriptors.stream().flatMap(taskDescriptor -> taskDescriptor.getSplits().get(planNodeId).stream()).mapToLong(Split::getRetainedSizeInBytes));
+                Stats splitCountStats = Stats.of(taskDescriptors.stream().mapToLong(taskDescriptor -> taskDescriptor.getSplits().getSplitsFlat().asMap().get(planNodeId).size()));
+                Stats splitSizeStats = Stats.of(taskDescriptors.stream().flatMap(taskDescriptor -> taskDescriptor.getSplits().getSplitsFlat().get(planNodeId).stream()).mapToLong(Split::getRetainedSizeInBytes));
                 splitsDebugInfo.put(
                         planNodeId,
                         "{splitCountMean=%s, splitCountStdDev=%s, splitSizeMean=%s, splitSizeStdDev=%s}".formatted(

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/SplitAssignerTester.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/SplitAssignerTester.java
@@ -38,12 +38,14 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.execution.scheduler.faulttolerant.SplitAssigner.SINGLE_SOURCE_PARTITION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
 
 class SplitAssignerTester
 {
     private final Map<Integer, NodeRequirements> nodeRequirements = new HashMap<>();
-    private final Map<Integer, ListMultimap<PlanNodeId, Split>> splits = new HashMap<>();
+    private final Map<Integer, SplitsMapping> splits = new HashMap<>();
     private final SetMultimap<Integer, PlanNodeId> noMoreSplits = HashMultimap.create();
     private final Set<Integer> sealedTaskPartitions = new HashSet<>();
     private boolean noMoreTaskPartitions;
@@ -68,11 +70,20 @@ class SplitAssignerTester
 
     public synchronized Set<Integer> getSplitIds(int taskPartition, PlanNodeId planNodeId)
     {
-        ListMultimap<PlanNodeId, Split> taskPartitionSplits = splits.getOrDefault(taskPartition, ImmutableListMultimap.of());
-        return taskPartitionSplits.get(planNodeId).stream()
+        SplitsMapping taskPartitionSplits = splits.getOrDefault(taskPartition, SplitsMapping.EMPTY);
+        List<Split> splitsFlat = taskPartitionSplits.getSplitsFlat(planNodeId);
+        return splitsFlat.stream()
                 .map(split -> (TestingConnectorSplit) split.getConnectorSplit())
                 .map(TestingConnectorSplit::getId)
                 .collect(toImmutableSet());
+    }
+
+    public synchronized ListMultimap<Integer, Integer> getSplitIdsBySourcePartition(int taskPartition, PlanNodeId planNodeId)
+    {
+        SplitsMapping taskPartitionSplits = splits.getOrDefault(taskPartition, SplitsMapping.EMPTY);
+        ImmutableListMultimap.Builder<Integer, Integer> builder = ImmutableListMultimap.builder();
+        taskPartitionSplits.getSplits(planNodeId).forEach((sourcePartition, split) -> builder.put(sourcePartition, TestingConnectorSplit.getSplitId(split)));
+        return builder.build();
     }
 
     public synchronized boolean isNoMoreSplits(int taskPartition, PlanNodeId planNodeId)
@@ -109,6 +120,38 @@ class SplitAssignerTester
         }
     }
 
+    public void checkContainsSplits(PlanNodeId planNodeId, ListMultimap<Integer, Split> splitsBySourcePartition, boolean replicated)
+    {
+        ListMultimap<Integer, Integer> expectedSplitIds;
+        if (replicated) {
+            expectedSplitIds = ArrayListMultimap.create();
+            expectedSplitIds.putAll(SINGLE_SOURCE_PARTITION_ID, buildSplitIds(splitsBySourcePartition).values());
+        }
+        else {
+            expectedSplitIds = ArrayListMultimap.create(buildSplitIds(splitsBySourcePartition));
+        }
+
+        for (int taskPartitionId = 0; taskPartitionId < getTaskPartitionCount(); taskPartitionId++) {
+            ListMultimap<Integer, Integer> taskPartitionSplitIds = getSplitIdsBySourcePartition(taskPartitionId, planNodeId);
+            if (replicated) {
+                assertThat(taskPartitionSplitIds).containsAllEntriesOf(expectedSplitIds);
+            }
+            else {
+                taskPartitionSplitIds.forEach(expectedSplitIds::remove);
+            }
+        }
+        if (!replicated) {
+            assertThat(expectedSplitIds).isEmpty();
+        }
+    }
+
+    private ListMultimap<Integer, Integer> buildSplitIds(ListMultimap<Integer, Split> splitsBySourcePartition)
+    {
+        ImmutableListMultimap.Builder<Integer, Integer> builder = ImmutableListMultimap.builder();
+        splitsBySourcePartition.forEach((sourcePartition, split) -> builder.put(sourcePartition, TestingConnectorSplit.getSplitId(split)));
+        return builder.build();
+    }
+
     public void update(AssignmentResult assignment)
     {
         for (Partition taskPartition : assignment.partitionsAdded()) {
@@ -122,7 +165,13 @@ class SplitAssignerTester
             PlanNodeId planNodeId = taskPartitionUpdate.planNodeId();
             if (!taskPartitionUpdate.splits().isEmpty()) {
                 verify(!noMoreSplits.get(taskPartitionId).contains(planNodeId), "noMoreSplits is set for task partition %s and plan node %s", taskPartitionId, planNodeId);
-                splits.computeIfAbsent(taskPartitionId, (key) -> ArrayListMultimap.create()).putAll(planNodeId, taskPartitionUpdate.splits());
+                splits.merge(
+                        taskPartitionId,
+                        SplitsMapping.builder().addSplits(planNodeId, taskPartitionUpdate.splits()).build(),
+                        (originalMapping, updatedMapping) ->
+                                SplitsMapping.builder(originalMapping)
+                                        .addMapping(updatedMapping)
+                                        .build());
             }
             if (taskPartitionUpdate.noMoreSplits()) {
                 noMoreSplits.put(taskPartitionId, planNodeId);
@@ -141,12 +190,12 @@ class SplitAssignerTester
             verify(sealedTaskPartitions.equals(nodeRequirements.keySet()), "unknown sealed partitions: %s", Sets.difference(sealedTaskPartitions, nodeRequirements.keySet()));
             ImmutableList.Builder<TaskDescriptor> result = ImmutableList.builder();
             for (Integer taskPartitionId : sealedTaskPartitions) {
-                ListMultimap<PlanNodeId, Split> taskSplits = splits.getOrDefault(taskPartitionId, ImmutableListMultimap.of());
+                SplitsMapping taskSplits = splits.getOrDefault(taskPartitionId, SplitsMapping.EMPTY);
                 verify(
-                        noMoreSplits.get(taskPartitionId).containsAll(taskSplits.keySet()),
+                        noMoreSplits.get(taskPartitionId).containsAll(taskSplits.getPlanNodeIds()),
                         "no more split is missing for task partition %s: %s",
                         taskPartitionId,
-                        Sets.difference(taskSplits.keySet(), noMoreSplits.get(taskPartitionId)));
+                        Sets.difference(taskSplits.getPlanNodeIds(), noMoreSplits.get(taskPartitionId)));
                 result.add(new TaskDescriptor(
                         taskPartitionId,
                         taskSplits,

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
@@ -113,25 +113,25 @@ public class TestSingleDistributionSplitAssigner
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(0, createSplit(1)), false));
         tester.update(splitAssigner.finish());
         assertEquals(tester.getTaskPartitionCount(), 1);
-        assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactly(1);
+        assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactlyInAnyOrder(1);
         assertTrue(tester.isNoMoreTaskPartitions());
 
         tester.update(splitAssigner.assign(PLAN_NODE_2, ImmutableListMultimap.of(0, createSplit(2), 1, createSplit(3)), false));
         tester.update(splitAssigner.finish());
         assertEquals(tester.getTaskPartitionCount(), 1);
-        assertThat(tester.getSplitIds(0, PLAN_NODE_2)).containsExactly(2, 3);
+        assertThat(tester.getSplitIds(0, PLAN_NODE_2)).containsExactlyInAnyOrder(2, 3);
 
         assertFalse(tester.isNoMoreSplits(0, PLAN_NODE_1));
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(2, createSplit(4)), true));
         tester.update(splitAssigner.finish());
-        assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactly(1, 4);
+        assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactlyInAnyOrder(1, 4);
         assertTrue(tester.isNoMoreSplits(0, PLAN_NODE_1));
 
         assertFalse(tester.isNoMoreSplits(0, PLAN_NODE_2));
         assertFalse(tester.isSealed(0));
         tester.update(splitAssigner.assign(PLAN_NODE_2, ImmutableListMultimap.of(3, createSplit(5)), true));
         tester.update(splitAssigner.finish());
-        assertThat(tester.getSplitIds(0, PLAN_NODE_2)).containsExactly(2, 3, 5);
+        assertThat(tester.getSplitIds(0, PLAN_NODE_2)).containsExactlyInAnyOrder(2, 3, 5);
         assertTrue(tester.isNoMoreSplits(0, PLAN_NODE_2));
         assertTrue(tester.isSealed(0));
     }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSingleDistributionSplitAssigner.java
@@ -43,10 +43,10 @@ public class TestSingleDistributionSplitAssigner
 
         tester.update(splitAssigner.finish());
 
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertEquals(tester.getNodeRequirements(0), new NodeRequirements(Optional.empty(), hostRequirement));
         assertTrue(tester.isSealed(0));
-        assertTrue(tester.isNoMorePartitions());
+        assertTrue(tester.isNoMoreTaskPartitions());
     }
 
     @Test
@@ -61,12 +61,12 @@ public class TestSingleDistributionSplitAssigner
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(), true));
         tester.update(splitAssigner.finish());
 
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertEquals(tester.getNodeRequirements(0), new NodeRequirements(Optional.empty(), hostRequirement));
         assertThat(tester.getSplitIds(0, PLAN_NODE_1)).isEmpty();
         assertTrue(tester.isNoMoreSplits(0, PLAN_NODE_1));
         assertTrue(tester.isSealed(0));
-        assertTrue(tester.isNoMorePartitions());
+        assertTrue(tester.isNoMoreTaskPartitions());
     }
 
     @Test
@@ -77,18 +77,18 @@ public class TestSingleDistributionSplitAssigner
                 ImmutableSet.of(PLAN_NODE_1));
         SplitAssignerTester tester = new SplitAssignerTester();
 
-        assertEquals(tester.getPartitionCount(), 0);
-        assertFalse(tester.isNoMorePartitions());
+        assertEquals(tester.getTaskPartitionCount(), 0);
+        assertFalse(tester.isNoMoreTaskPartitions());
 
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(0, createSplit(1)), false));
         tester.update(splitAssigner.finish());
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactly(1);
-        assertTrue(tester.isNoMorePartitions());
+        assertTrue(tester.isNoMoreTaskPartitions());
 
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(0, createSplit(2), 1, createSplit(3)), false));
         tester.update(splitAssigner.finish());
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactly(1, 2, 3);
 
         assertFalse(tester.isNoMoreSplits(0, PLAN_NODE_1));
@@ -107,18 +107,18 @@ public class TestSingleDistributionSplitAssigner
                 ImmutableSet.of(PLAN_NODE_1, PLAN_NODE_2));
         SplitAssignerTester tester = new SplitAssignerTester();
 
-        assertEquals(tester.getPartitionCount(), 0);
-        assertFalse(tester.isNoMorePartitions());
+        assertEquals(tester.getTaskPartitionCount(), 0);
+        assertFalse(tester.isNoMoreTaskPartitions());
 
         tester.update(splitAssigner.assign(PLAN_NODE_1, ImmutableListMultimap.of(0, createSplit(1)), false));
         tester.update(splitAssigner.finish());
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertThat(tester.getSplitIds(0, PLAN_NODE_1)).containsExactly(1);
-        assertTrue(tester.isNoMorePartitions());
+        assertTrue(tester.isNoMoreTaskPartitions());
 
         tester.update(splitAssigner.assign(PLAN_NODE_2, ImmutableListMultimap.of(0, createSplit(2), 1, createSplit(3)), false));
         tester.update(splitAssigner.finish());
-        assertEquals(tester.getPartitionCount(), 1);
+        assertEquals(tester.getTaskPartitionCount(), 1);
         assertThat(tester.getSplitIds(0, PLAN_NODE_2)).containsExactly(2, 3);
 
         assertFalse(tester.isNoMoreSplits(0, PLAN_NODE_1));

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSplitsMapping.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestSplitsMapping.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution.scheduler.faulttolerant;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ListMultimap;
+import io.trino.metadata.Split;
+import io.trino.sql.planner.plan.PlanNodeId;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.guava.api.Assertions.assertThat;
+
+public class TestSplitsMapping
+{
+    @Test
+    public void testNewSplitMappingBuilder()
+    {
+        SplitsMapping.Builder newBuilder = SplitsMapping.builder();
+        newBuilder.addSplit(new PlanNodeId("N1"), 0, createSplit(1));
+        newBuilder.addSplit(new PlanNodeId("N1"), 1, createSplit(2));
+        newBuilder.addSplits(new PlanNodeId("N1"), 1, ImmutableList.of(createSplit(3), createSplit(4)));
+        newBuilder.addSplits(new PlanNodeId("N1"), 2, ImmutableList.of(createSplit(5), createSplit(6))); // addSplits(list) creating new source partition
+        newBuilder.addSplits(new PlanNodeId("N1"), ImmutableListMultimap.of(
+                0, createSplit(7),
+                1, createSplit(8),
+                3, createSplit(9))); // create new source partition
+        newBuilder.addSplit(new PlanNodeId("N2"), 0, createSplit(10)); // another plan node
+        newBuilder.addSplit(new PlanNodeId("N2"), 3, createSplit(11));
+        newBuilder.addMapping(SplitsMapping.builder()
+                .addSplit(new PlanNodeId("N1"), 0, createSplit(20))
+                .addSplit(new PlanNodeId("N1"), 4, createSplit(21))
+                .addSplit(new PlanNodeId("N3"), 0, createSplit(22))
+                .build());
+
+        SplitsMapping splitsMapping1 = newBuilder.build();
+
+        assertThat(splitsMapping1.getPlanNodeIds()).containsExactlyInAnyOrder(new PlanNodeId("N1"), new PlanNodeId("N2"), new PlanNodeId("N3"));
+        assertThat(splitIds(splitsMapping1, "N1")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .putAll(0, 1, 7, 20)
+                        .putAll(1, 2, 3, 4, 8)
+                        .putAll(2, 5, 6)
+                        .putAll(3, 9)
+                        .put(4, 21)
+                        .build());
+        assertThat(splitIds(splitsMapping1, "N2")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .put(0, 10)
+                        .put(3, 11)
+                        .build());
+        assertThat(splitIds(splitsMapping1, "N3")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .put(0, 22)
+                        .build());
+    }
+
+    @Test
+    public void testUpdatingSplitMappingBuilder()
+    {
+        SplitsMapping.Builder newBuilder = SplitsMapping.builder(SplitsMapping.builder()
+                .addSplit(new PlanNodeId("N1"), 0, createSplit(20))
+                .addSplit(new PlanNodeId("N1"), 4, createSplit(21))
+                .addSplit(new PlanNodeId("N3"), 0, createSplit(22))
+                .build());
+
+        newBuilder.addSplit(new PlanNodeId("N1"), 0, createSplit(1));
+        newBuilder.addSplit(new PlanNodeId("N1"), 1, createSplit(2));
+        newBuilder.addSplits(new PlanNodeId("N1"), 1, ImmutableList.of(createSplit(3), createSplit(4)));
+        newBuilder.addSplits(new PlanNodeId("N1"), 2, ImmutableList.of(createSplit(5), createSplit(6))); // addSplits(list) creating new source partition
+        newBuilder.addSplits(new PlanNodeId("N1"), ImmutableListMultimap.of(
+                0, createSplit(7),
+                1, createSplit(8),
+                3, createSplit(9))); // create new source partition
+        newBuilder.addSplit(new PlanNodeId("N2"), 0, createSplit(10)); // another plan node
+        newBuilder.addSplit(new PlanNodeId("N2"), 3, createSplit(11));
+
+        SplitsMapping splitsMapping1 = newBuilder.build();
+
+        assertThat(splitsMapping1.getPlanNodeIds()).containsExactlyInAnyOrder(new PlanNodeId("N1"), new PlanNodeId("N2"), new PlanNodeId("N3"));
+        assertThat(splitIds(splitsMapping1, "N1")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .putAll(0, 20, 1, 7)
+                        .putAll(1, 2, 3, 4, 8)
+                        .putAll(2, 5, 6)
+                        .putAll(3, 9)
+                        .put(4, 21)
+                        .build());
+        assertThat(splitIds(splitsMapping1, "N2")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .put(0, 10)
+                        .put(3, 11)
+                        .build());
+        assertThat(splitIds(splitsMapping1, "N3")).isEqualTo(
+                ImmutableListMultimap.builder()
+                        .put(0, 22)
+                        .build());
+    }
+
+    private ListMultimap<Integer, Integer> splitIds(SplitsMapping splitsMapping, String planNodeId)
+    {
+        return splitsMapping.getSplits(new PlanNodeId(planNodeId)).entries().stream()
+                .collect(ImmutableListMultimap.toImmutableListMultimap(
+                        Map.Entry::getKey,
+                        entry -> ((TestingConnectorSplit) entry.getValue().getConnectorSplit()).getId()));
+    }
+
+    private static Split createSplit(int id)
+    {
+        return new Split(TEST_CATALOG_HANDLE, new TestingConnectorSplit(id, OptionalInt.empty(), Optional.empty()));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
@@ -14,7 +14,6 @@
 package io.trino.execution.scheduler.faulttolerant;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.trino.exchange.SpoolingExchangeInput;
@@ -199,9 +198,9 @@ public class TestTaskDescriptorStorage
     {
         return new TaskDescriptor(
                 partitionId,
-                ImmutableListMultimap.of(
-                        new PlanNodeId("1"),
-                        new Split(REMOTE_CATALOG_HANDLE, new RemoteSplit(new SpoolingExchangeInput(ImmutableList.of(new TestingExchangeSourceHandle(retainedSize.toBytes())), Optional.empty())))),
+                SplitsMapping.builder()
+                        .addSplit(new PlanNodeId("1"), 1, new Split(REMOTE_CATALOG_HANDLE, new RemoteSplit(new SpoolingExchangeInput(ImmutableList.of(new TestingExchangeSourceHandle(retainedSize.toBytes())), Optional.empty()))))
+                        .build(),
                 new NodeRequirements(catalog, ImmutableSet.of()));
     }
 


### PR DESCRIPTION
## Description

We need to preserve information which splits map to which source
partition id in task descriptor to be able to split task descriptor into
multiple ones. Splitting is important in case we made a scheduling
mistake and packed to many source partitions into single task descriptor
and execution of such task is not possible due to lack of resources.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
