### PR TITLE
Seal Block interface

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -1036,6 +1036,169 @@
                                     <code>java.method.removed</code>
                                     <old>method void io.trino.spi.block.VariableWidthBlock::writeSliceTo(int, int, int, io.airlift.slice.SliceOutput)</old>
                                 </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.ArrayBlock</old>
+                                    <new>class io.trino.spi.block.ArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.ByteArrayBlock</old>
+                                    <new>class io.trino.spi.block.ByteArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.DictionaryBlock</old>
+                                    <new>class io.trino.spi.block.DictionaryBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.Fixed12Block</old>
+                                    <new>class io.trino.spi.block.Fixed12Block</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.Int128ArrayBlock</old>
+                                    <new>class io.trino.spi.block.Int128ArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.IntArrayBlock</old>
+                                    <new>class io.trino.spi.block.IntArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.LazyBlock</old>
+                                    <new>class io.trino.spi.block.LazyBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.LongArrayBlock</old>
+                                    <new>class io.trino.spi.block.LongArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.MapBlock</old>
+                                    <new>class io.trino.spi.block.MapBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.RowBlock</old>
+                                    <new>class io.trino.spi.block.RowBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.RunLengthEncodedBlock</old>
+                                    <new>class io.trino.spi.block.RunLengthEncodedBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.ShortArrayBlock</old>
+                                    <new>class io.trino.spi.block.ShortArrayBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.class.nowFinal</code>
+                                    <old>class io.trino.spi.block.VariableWidthBlock</old>
+                                    <new>class io.trino.spi.block.VariableWidthBlock</new>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int io.trino.spi.block.ArrayBlock::getOffsetBase()</old>
+                                    <new>method int io.trino.spi.block.ArrayBlock::getOffsetBase()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int[] io.trino.spi.block.ArrayBlock::getOffsets()</old>
+                                    <new>method int[] io.trino.spi.block.ArrayBlock::getOffsets()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlock::getRawElementBlock()</old>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.ArrayBlock::getRawElementBlock()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method void io.trino.spi.block.MapBlock::ensureHashTableLoaded()</old>
+                                    <new>method void io.trino.spi.block.MapBlock::ensureHashTableLoaded()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method io.trino.spi.block.MapHashTables io.trino.spi.block.MapBlock::getHashTables()</old>
+                                    <new>method io.trino.spi.block.MapHashTables io.trino.spi.block.MapBlock::getHashTables()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method io.trino.spi.type.MapType io.trino.spi.block.MapBlock::getMapType()</old>
+                                    <new>method io.trino.spi.type.MapType io.trino.spi.block.MapBlock::getMapType()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int io.trino.spi.block.MapBlock::getOffsetBase()</old>
+                                    <new>method int io.trino.spi.block.MapBlock::getOffsetBase()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int[] io.trino.spi.block.MapBlock::getOffsets()</old>
+                                    <new>method int[] io.trino.spi.block.MapBlock::getOffsets()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawKeyBlock()</old>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawKeyBlock()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawValueBlock()</old>
+                                    <new>method io.trino.spi.block.Block io.trino.spi.block.MapBlock::getRawValueBlock()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int[] io.trino.spi.block.RowBlock::getFieldBlockOffsets()</old>
+                                    <new>method int[] io.trino.spi.block.RowBlock::getFieldBlockOffsets()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int io.trino.spi.block.RowBlock::getOffsetBase()</old>
+                                    <new>method int io.trino.spi.block.RowBlock::getOffsetBase()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method java.util.List&lt;io.trino.spi.block.Block&gt; io.trino.spi.block.RowBlock::getRawFieldBlocks()</old>
+                                    <new>method java.util.List&lt;io.trino.spi.block.Block&gt; io.trino.spi.block.RowBlock::getRawFieldBlocks()</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
+                                <item>
+                                    <code>java.method.visibilityReduced</code>
+                                    <old>method int io.trino.spi.block.VariableWidthBlock::getPositionOffset(int)</old>
+                                    <new>method int io.trino.spi.block.VariableWidthBlock::getPositionOffset(int)</new>
+                                    <oldVisibility>protected</oldVisibility>
+                                    <newVisibility>package</newVisibility>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ArrayBlock.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
-public class ArrayBlock
+public final class ArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(ArrayBlock.class);
@@ -73,7 +73,7 @@ public class ArrayBlock
     }
 
     /**
-     * Create an array block directly without per element validations.
+     * Create an array block directly without per-element validations.
      */
     static ArrayBlock createArrayBlockInternal(int arrayOffset, int positionCount, @Nullable boolean[] valueIsNull, int[] offsets, Block values)
     {
@@ -167,23 +167,23 @@ public class ArrayBlock
         consumer.accept(this, INSTANCE_SIZE);
     }
 
-    protected Block getRawElementBlock()
+    Block getRawElementBlock()
     {
         return values;
     }
 
-    protected int[] getOffsets()
+    int[] getOffsets()
     {
         return offsets;
     }
 
-    protected int getOffsetBase()
+    int getOffsetBase()
     {
         return arrayOffset;
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return singletonList(values);
     }
@@ -310,7 +310,7 @@ public class ArrayBlock
     }
 
     @Override
-    public final long getPositionsSizeInBytes(boolean[] positions, int selectedArrayPositions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedArrayPositions)
     {
         int positionCount = getPositionCount();
         checkValidPositions(positions, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -23,7 +23,8 @@ import java.util.function.ObjLongConsumer;
 import static io.trino.spi.block.BlockUtil.checkArrayRange;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 
-public interface Block
+public sealed interface Block
+        permits DictionaryBlock, RunLengthEncodedBlock, LazyBlock, ValueBlock
 {
     /**
      * Gets the length of the value at the {@code position}.

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ByteArrayBlock.java
@@ -30,7 +30,7 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 
-public class ByteArrayBlock
+public final class ByteArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(ByteArrayBlock.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -32,7 +32,7 @@ import static java.lang.Math.min;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
-public class DictionaryBlock
+public final class DictionaryBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = instanceSize(DictionaryBlock.class) + instanceSize(DictionaryId.class);
@@ -526,7 +526,7 @@ public class DictionaryBlock
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return singletonList(getDictionary());
     }
@@ -694,7 +694,7 @@ public class DictionaryBlock
                         positionCount,
                         compactDictionary,
                         newIds,
-                        !(compactDictionary instanceof DictionaryBlock),
+                        true,
                         false,
                         newDictionaryId));
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Fixed12Block.java
@@ -28,7 +28,7 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 
-public class Fixed12Block
+public final class Fixed12Block
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(Fixed12Block.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Int128ArrayBlock.java
@@ -29,7 +29,7 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 
-public class Int128ArrayBlock
+public final class Int128ArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(Int128ArrayBlock.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/IntArrayBlock.java
@@ -29,7 +29,7 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 
-public class IntArrayBlock
+public final class IntArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(IntArrayBlock.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -30,7 +30,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 // This class is not considered thread-safe.
-public class LazyBlock
+public final class LazyBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = instanceSize(LazyBlock.class) + instanceSize(LazyData.class);
@@ -213,7 +213,7 @@ public class LazyBlock
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return singletonList(getBlock());
     }
@@ -390,7 +390,7 @@ public class LazyBlock
         }
 
         /**
-         * If block is unloaded, add the listeners; otherwise call this method on child blocks
+         * If the block is unloaded, add the listeners; otherwise call this method on child blocks
          */
         @SuppressWarnings("AccessingNonPublicFieldOfAnotherObject")
         private static void addListenersRecursive(Block block, List<Consumer<Block>> listeners)

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LongArrayBlock.java
@@ -29,7 +29,7 @@ import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 import static java.lang.Math.toIntExact;
 
-public class LongArrayBlock
+public final class LongArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(LongArrayBlock.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/MapBlock.java
@@ -40,7 +40,7 @@ import static io.trino.spi.block.MapHashTables.HashBuildMode.DUPLICATE_NOT_CHECK
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class MapBlock
+public final class MapBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(MapBlock.class);
@@ -187,27 +187,27 @@ public class MapBlock
         this.retainedSizeInBytes = INSTANCE_SIZE + sizeOf(offsets) + sizeOf(mapIsNull);
     }
 
-    protected Block getRawKeyBlock()
+    Block getRawKeyBlock()
     {
         return keyBlock;
     }
 
-    protected Block getRawValueBlock()
+    Block getRawValueBlock()
     {
         return valueBlock;
     }
 
-    protected MapHashTables getHashTables()
+    MapHashTables getHashTables()
     {
         return hashTables;
     }
 
-    protected int[] getOffsets()
+    int[] getOffsets()
     {
         return offsets;
     }
 
-    protected int getOffsetBase()
+    int getOffsetBase()
     {
         return startOffset;
     }
@@ -302,7 +302,7 @@ public class MapBlock
                 hashTables);
     }
 
-    protected void ensureHashTableLoaded()
+    void ensureHashTableLoaded()
     {
         hashTables.buildAllHashTablesIfNecessary(keyBlock, offsets, mapIsNull);
     }
@@ -325,12 +325,12 @@ public class MapBlock
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return List.of(keyBlock, valueBlock);
     }
 
-    protected MapType getMapType()
+    MapType getMapType()
     {
         return mapType;
     }
@@ -460,7 +460,7 @@ public class MapBlock
     }
 
     @Override
-    public final long getPositionsSizeInBytes(boolean[] positions, int selectedMapPositions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedMapPositions)
     {
         int positionCount = getPositionCount();
         checkValidPositions(positions, positionCount);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -35,7 +35,7 @@ import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class RowBlock
+public final class RowBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(RowBlock.class);
@@ -144,18 +144,18 @@ public class RowBlock
         this.retainedSizeInBytes = INSTANCE_SIZE + sizeOf(fieldBlockOffsets) + sizeOf(rowIsNull);
     }
 
-    protected List<Block> getRawFieldBlocks()
+    List<Block> getRawFieldBlocks()
     {
         return fieldBlocksList;
     }
 
     @Nullable
-    protected int[] getFieldBlockOffsets()
+    int[] getFieldBlockOffsets()
     {
         return fieldBlockOffsets;
     }
 
-    protected int getOffsetBase()
+    int getOffsetBase()
     {
         return startOffset;
     }
@@ -281,13 +281,13 @@ public class RowBlock
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return List.of(fieldBlocks);
     }
 
     // the offset in each field block, it can also be viewed as the "entry-based" offset in the RowBlock
-    public final int getFieldBlockOffset(int position)
+    public int getFieldBlockOffset(int position)
     {
         int[] offsets = fieldBlockOffsets;
         if (offsets != null) {
@@ -363,14 +363,14 @@ public class RowBlock
     }
 
     @Override
-    public final OptionalInt fixedSizeInBytesPerPosition()
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
         if (!mayHaveNull()) {
             // when null rows are present, we can't use the fixed field sizes to infer the correct
             // size for arbitrary position selection
             OptionalInt fieldSize = fixedSizeInBytesPerFieldPosition();
             if (fieldSize.isPresent()) {
-                // must include the row block overhead in addition to the per position size in bytes
+                // must include the row block overhead in addition to the per-position size in bytes
                 return OptionalInt.of(fieldSize.getAsInt() + (Integer.BYTES + Byte.BYTES)); // offsets + rowIsNull
             }
         }
@@ -415,7 +415,7 @@ public class RowBlock
     }
 
     @Override
-    public final long getPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
+    public long getPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
     {
         int positionCount = getPositionCount();
         checkValidPositions(positions, positionCount);
@@ -432,7 +432,7 @@ public class RowBlock
             int selectedFieldPositionCount = selectedRowPositions;
             boolean[] rowIsNull = this.rowIsNull;
             if (rowIsNull != null) {
-                // Some positions in usedPositions may be null which must be removed from the selectedFieldPositionCount
+                // Some positions of usedPositions may be null, and these must be removed from the selectedFieldPositionCount
                 int offsetBase = startOffset;
                 for (int i = 0; i < positions.length; i++) {
                     if (positions[i] && rowIsNull[i + offsetBase]) {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -31,7 +31,7 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
-public class RunLengthEncodedBlock
+public final class RunLengthEncodedBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = instanceSize(RunLengthEncodedBlock.class);
@@ -91,7 +91,7 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public final List<Block> getChildren()
+    public List<Block> getChildren()
     {
         return singletonList(value);
     }
@@ -102,7 +102,7 @@ public class RunLengthEncodedBlock
     }
 
     /**
-     * Positions count will always be at least 2
+     * Position count will always be at least 2
      */
     @Override
     public int getPositionCount()

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ShortArrayBlock.java
@@ -28,7 +28,7 @@ import static io.trino.spi.block.BlockUtil.compactArray;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.ensureCapacity;
 
-public class ShortArrayBlock
+public final class ShortArrayBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(ShortArrayBlock.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/block/ValueBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/ValueBlock.java
@@ -13,7 +13,7 @@
  */
 package io.trino.spi.block;
 
-public interface ValueBlock
+public non-sealed interface ValueBlock
         extends Block
 {
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/VariableWidthBlock.java
@@ -34,7 +34,7 @@ import static io.trino.spi.block.BlockUtil.compactSlice;
 import static io.trino.spi.block.BlockUtil.copyIsNullAndAppendNull;
 import static io.trino.spi.block.BlockUtil.copyOffsetsAndAppendNull;
 
-public class VariableWidthBlock
+public final class VariableWidthBlock
         implements ValueBlock
 {
     private static final int INSTANCE_SIZE = instanceSize(VariableWidthBlock.class);
@@ -101,7 +101,7 @@ public class VariableWidthBlock
         return getPositionOffset(position);
     }
 
-    protected final int getPositionOffset(int position)
+    int getPositionOffset(int position)
     {
         return offsets[position + arrayOffset];
     }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryBuilder.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestDictionaryBuilder.java
@@ -14,7 +14,6 @@
 package io.trino.orc;
 
 import com.google.common.collect.ImmutableSet;
-import io.airlift.slice.Slice;
 import io.trino.orc.writer.DictionaryBuilder;
 import io.trino.spi.block.VariableWidthBlock;
 import org.testng.annotations.Test;
@@ -34,18 +33,9 @@ public class TestDictionaryBuilder
         Set<Integer> positions = new HashSet<>();
         DictionaryBuilder dictionaryBuilder = new DictionaryBuilder(64);
         for (int i = 0; i < 64; i++) {
-            positions.add(dictionaryBuilder.putIfAbsent(new TestHashCollisionBlock(1, wrappedBuffer(new byte[] {1}), new int[] {0, 1}, new boolean[] {false}), 0));
-            positions.add(dictionaryBuilder.putIfAbsent(new TestHashCollisionBlock(1, wrappedBuffer(new byte[] {2}), new int[] {0, 1}, new boolean[] {false}), 0));
+            positions.add(dictionaryBuilder.putIfAbsent(new VariableWidthBlock(1, wrappedBuffer(new byte[] {1}), new int[] {0, 1}, Optional.of(new boolean[] {false})), 0));
+            positions.add(dictionaryBuilder.putIfAbsent(new VariableWidthBlock(1, wrappedBuffer(new byte[] {2}), new int[] {0, 1}, Optional.of(new boolean[] {false})), 0));
         }
         assertEquals(positions, ImmutableSet.of(1, 2));
-    }
-
-    private static class TestHashCollisionBlock
-            extends VariableWidthBlock
-    {
-        public TestHashCollisionBlock(int positionCount, Slice slice, int[] offsets, boolean[] valueIsNull)
-        {
-            super(positionCount, slice, offsets, Optional.of(valueIsNull));
-        }
     }
 }


### PR DESCRIPTION
## Description

The synthetic dictionary, rle, and lazy blocks require special handling
in the codebase, and new synthetic blocks cannot reasonable be added
without updating the existing code. This commit blocks direct extensions
of Block, only allowing extensions to ValueBlock.

Major changes:
- Seal `Block` interface
- Mark `ValueBlock` interface `non-sealed`
- Mark all current `ValueBlock` implementations as `final`


This is part of Project Hummingbird #14237 

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# SPI
* Implementations of `Block` must now implement `ValueBlock`. ({issue}`19480`)
```
