### PR TITLE
Always check execute access for function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -49,7 +49,6 @@ import java.util.function.Function;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.metadata.FunctionBinder.functionNotFound;
-import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
 import static io.trino.metadata.SignatureBinder.applyBoundVariables;
 import static io.trino.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
@@ -286,9 +285,6 @@ public class FunctionResolver
 
     private static boolean canExecuteFunction(Session session, AccessControl accessControl, CatalogSchemaFunctionName functionName)
     {
-        if (isBuiltinFunctionName(functionName)) {
-            return true;
-        }
         return accessControl.canExecuteFunction(
                 SecurityContext.of(session),
                 new QualifiedObjectName(functionName.getCatalogName(), functionName.getSchemaName(), functionName.getFunctionName()));

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionResolver.java
@@ -81,24 +81,24 @@ public class FunctionResolver
      * Is the named function an aggregation function?
      * This does not need type parameters because overloads between aggregation and other function types are not allowed.
      */
-    public boolean isAggregationFunction(Session session, QualifiedName name, AccessControl accessControl)
+    public boolean isAggregationFunction(Session session, QualifiedName name)
     {
-        return isFunctionKind(session, name, AGGREGATE, accessControl);
+        return isFunctionKind(session, name, AGGREGATE);
     }
 
-    public boolean isWindowFunction(Session session, QualifiedName name, AccessControl accessControl)
+    public boolean isWindowFunction(Session session, QualifiedName name)
     {
-        return isFunctionKind(session, name, WINDOW, accessControl);
+        return isFunctionKind(session, name, WINDOW);
     }
 
-    private boolean isFunctionKind(Session session, QualifiedName name, FunctionKind functionKind, AccessControl accessControl)
+    private boolean isFunctionKind(Session session, QualifiedName name, FunctionKind functionKind)
     {
         Optional<ResolvedFunction> resolvedFunction = functionDecoder.fromQualifiedName(name);
         if (resolvedFunction.isPresent()) {
             return resolvedFunction.get().getFunctionKind() == functionKind;
         }
 
-        for (CatalogSchemaFunctionName catalogSchemaFunctionName : toPath(session, name, accessControl)) {
+        for (CatalogSchemaFunctionName catalogSchemaFunctionName : toPath(session, name)) {
             Collection<CatalogFunctionMetadata> candidates = metadata.getFunctions(session, catalogSchemaFunctionName);
             if (!candidates.isEmpty()) {
                 return candidates.stream()
@@ -161,7 +161,7 @@ public class FunctionResolver
             AccessControl accessControl)
     {
         ImmutableList.Builder<CatalogFunctionMetadata> allCandidates = ImmutableList.builder();
-        List<CatalogSchemaFunctionName> fullPath = toPath(session, name, accessControl);
+        List<CatalogSchemaFunctionName> fullPath = toPath(session, name);
         List<CatalogSchemaFunctionName> authorizedPath = fullPath.stream()
                 .filter(catalogSchemaFunctionName -> canExecuteFunction(session, accessControl, catalogSchemaFunctionName))
                 .collect(toImmutableList());
@@ -259,7 +259,7 @@ public class FunctionResolver
     }
 
     // this is visible for the table function resolution, which should be merged into this class
-    public static List<CatalogSchemaFunctionName> toPath(Session session, QualifiedName name, AccessControl accessControl)
+    public static List<CatalogSchemaFunctionName> toPath(Session session, QualifiedName name)
     {
         List<String> parts = name.getParts();
         if (parts.size() > 3) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -374,9 +374,9 @@ class AggregationAnalyzer
         @Override
         protected Boolean visitFunctionCall(FunctionCall node, Void context)
         {
-            if (functionResolver.isAggregationFunction(session, node.getName(), accessControl)) {
+            if (functionResolver.isAggregationFunction(session, node.getName())) {
                 if (node.getWindow().isEmpty()) {
-                    List<FunctionCall> aggregateFunctions = extractAggregateFunctions(node.getArguments(), session, functionResolver, accessControl);
+                    List<FunctionCall> aggregateFunctions = extractAggregateFunctions(node.getArguments(), session, functionResolver);
                     List<Expression> windowExpressions = extractWindowExpressions(node.getArguments());
 
                     if (!aggregateFunctions.isEmpty()) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -112,9 +112,9 @@ public class Analyzer
 
     static void verifyNoAggregateWindowOrGroupingFunctions(Session session, FunctionResolver functionResolver, AccessControl accessControl, Expression predicate, String clause)
     {
-        List<FunctionCall> aggregates = extractAggregateFunctions(ImmutableList.of(predicate), session, functionResolver, accessControl);
+        List<FunctionCall> aggregates = extractAggregateFunctions(ImmutableList.of(predicate), session, functionResolver);
 
-        List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, functionResolver, accessControl);
+        List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, functionResolver);
 
         List<GroupingOperation> groupingOperations = extractExpressions(ImmutableList.of(predicate), GroupingOperation.class);
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1189,7 +1189,7 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitFunctionCall(FunctionCall node, StackableAstVisitorContext<Context> context)
         {
-            boolean isAggregation = functionResolver.isAggregationFunction(session, node.getName(), accessControl);
+            boolean isAggregation = functionResolver.isAggregationFunction(session, node.getName());
             boolean isRowPatternCount = context.getContext().isPatternRecognition() &&
                     isAggregation &&
                     node.getName().getSuffix().equalsIgnoreCase("count");
@@ -1927,7 +1927,7 @@ public class ExpressionAnalyzer
         private void checkNoNestedAggregations(FunctionCall node)
         {
             extractExpressions(node.getArguments(), FunctionCall.class).stream()
-                    .filter(function -> functionResolver.isAggregationFunction(session, function.getName(), accessControl))
+                    .filter(function -> functionResolver.isAggregationFunction(session, function.getName()))
                     .findFirst()
                     .ifPresent(aggregation -> {
                         throw semanticException(

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -284,7 +284,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.SystemSessionProperties.getMaxGroupingSets;
 import static io.trino.SystemSessionProperties.isLegacyMaterializedViewGracePeriod;
 import static io.trino.metadata.FunctionResolver.toPath;
-import static io.trino.metadata.GlobalFunctionCatalog.isBuiltinFunctionName;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.spi.StandardErrorCode.AMBIGUOUS_NAME;
@@ -1781,7 +1780,7 @@ class StatementAnalyzer
                 CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, name.getCatalogName());
                 Optional<ConnectorTableFunction> resolved = tableFunctionRegistry.resolve(catalogHandle, name.getSchemaFunctionName());
                 if (resolved.isPresent()) {
-                    if (isBuiltinFunctionName(name) || accessControl.canExecuteFunction(SecurityContext.of(session), new QualifiedObjectName(name.getCatalogName(), name.getSchemaName(), name.getFunctionName()))) {
+                    if (accessControl.canExecuteFunction(SecurityContext.of(session), new QualifiedObjectName(name.getCatalogName(), name.getSchemaName(), name.getFunctionName()))) {
                         return Optional.of(new TableFunctionMetadata(catalogHandle, resolved.get()));
                     }
                     unauthorized = true;

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1777,7 +1777,7 @@ class StatementAnalyzer
         private Optional<TableFunctionMetadata> resolveTableFunction(TableFunctionInvocation node)
         {
             boolean unauthorized = false;
-            for (CatalogSchemaFunctionName name : toPath(session, node.getName(), accessControl)) {
+            for (CatalogSchemaFunctionName name : toPath(session, node.getName())) {
                 CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, name.getCatalogName());
                 Optional<ConnectorTableFunction> resolved = tableFunctionRegistry.resolve(catalogHandle, name.getSchemaFunctionName());
                 if (resolved.isPresent()) {
@@ -3091,7 +3091,7 @@ class StatementAnalyzer
             if (analysis.isAggregation(node) && node.getOrderBy().isPresent()) {
                 ImmutableList.Builder<Expression> aggregates = ImmutableList.<Expression>builder()
                         .addAll(groupByAnalysis.getOriginalExpressions())
-                        .addAll(extractAggregateFunctions(orderByExpressions, session, functionResolver, accessControl))
+                        .addAll(extractAggregateFunctions(orderByExpressions, session, functionResolver))
                         .addAll(extractExpressions(orderByExpressions, GroupingOperation.class));
 
                 analysis.setOrderByAggregates(node.getOrderBy().get(), aggregates.build());
@@ -4050,7 +4050,7 @@ class StatementAnalyzer
             if (node.getHaving().isPresent()) {
                 Expression predicate = node.getHaving().get();
 
-                List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, functionResolver, accessControl);
+                List<Expression> windowExpressions = extractWindowExpressions(ImmutableList.of(predicate), session, functionResolver);
                 if (!windowExpressions.isEmpty()) {
                     throw semanticException(NESTED_WINDOW, windowExpressions.get(0), "HAVING clause cannot contain window functions or row pattern measures");
                 }
@@ -4202,7 +4202,7 @@ class StatementAnalyzer
                     .addAll(getSortItemsFromOrderBy(node.getOrderBy()))
                     .build();
 
-            List<FunctionCall> aggregates = extractAggregateFunctions(toExtract, session, functionResolver, accessControl);
+            List<FunctionCall> aggregates = extractAggregateFunctions(toExtract, session, functionResolver);
 
             return !aggregates.isEmpty();
         }
@@ -4590,7 +4590,7 @@ class StatementAnalyzer
         {
             checkState(orderByExpressions.isEmpty() || orderByScope.isPresent(), "non-empty orderByExpressions list without orderByScope provided");
 
-            List<FunctionCall> aggregates = extractAggregateFunctions(Iterables.concat(outputExpressions, orderByExpressions), session, functionResolver, accessControl);
+            List<FunctionCall> aggregates = extractAggregateFunctions(Iterables.concat(outputExpressions, orderByExpressions), session, functionResolver);
             analysis.setAggregates(node, aggregates);
 
             if (analysis.isAggregation(node)) {

--- a/core/trino-main/src/test/java/io/trino/connector/TestingUdfFunctionsPlugin.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingUdfFunctionsPlugin.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.Plugin;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+
+import java.util.Set;
+
+import static io.trino.spi.type.StandardTypes.BOOLEAN;
+
+public class TestingUdfFunctionsPlugin
+        implements Plugin
+{
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.of(this.getClass());
+    }
+
+    @Description("Testing UDF")
+    @ScalarFunction("testing_udf")
+    @SqlType(BOOLEAN)
+    public static boolean testingUdf()
+    {
+        return false;
+    }
+
+    @Description("Other testing UDF")
+    @ScalarFunction("other_testing_udf")
+    @SqlType(BOOLEAN)
+    public static boolean otherTestingUdf()
+    {
+        return false;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -115,7 +115,6 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -1277,7 +1276,8 @@ public class TestAccessControl
                 List<String> keys = properties.keySet()
                         .stream()
                         .map(Object::toString)
-                        .sorted().collect(toList());
+                        .sorted()
+                        .toList();
                 throw new AccessDeniedException("Cannot access properties: " + keys);
             }
         }


### PR DESCRIPTION
Always check execute access for function

Not verifying access for builtin functions is a good change, however
Trino is not yet ready for this. Notice that custom UDF, which could be
potentially sensitive and dangerous is exposed within `system.builtin`
path. So for now, it is required to restore access
check for builtin functions.
