### PR TITLE
Add regression test for sort elimination

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestEliminateSorts.java
@@ -76,7 +76,14 @@ public class TestEliminateSorts
     @Test
     public void testNotEliminateSortsIfFilterExists()
     {
-        @Language("SQL") String sql = "SELECT * FROM (SELECT quantity, row_number() OVER (ORDER BY quantity) FROM lineitem) WHERE quantity > 10 ORDER BY quantity";
+        @Language("SQL") String sql = """
+            SELECT * FROM (
+                SELECT quantity, row_number() OVER (ORDER BY quantity) 
+                FROM lineitem
+            )
+            WHERE quantity > 10 
+            ORDER BY quantity
+            """;
 
         PlanMatchPattern pattern =
                 anyTree(


### PR DESCRIPTION
## Description
Regression test for https://github.com/trinodb/trino/pull/19387

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Sort elimination optimization was removed in https://github.com/trinodb/trino/pull/19387 because that optimization could produce a wrongly sorted query result. This PR adds a test case to prevent future regression.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
