### PR TITLE
Add Trino 431 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -7,6 +7,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-431
 release/release-430
 release/release-429
 release/release-428

--- a/docs/src/main/sphinx/release/release-431.md
+++ b/docs/src/main/sphinx/release/release-431.md
@@ -1,0 +1,61 @@
+# Release 431 (27 Oct 2023)
+
+## General
+
+* Add support for [](/routines). ({issue}`19308`)
+* Add support for [](/sql/create-function) and [](/sql/drop-function) statements. ({issue}`19308`)
+* Add support for the `REPLACE` modifier to the `CREATE TABLE` statement. ({issue}`13180`)
+* Disallow a `null` offset for the {func}`lead` and {func}`lag` functions. ({issue}`19003`)
+* Improve performance of queries with short running splits. ({issue}`19487`)
+
+## Security
+
+* Support defining rules for procedures in file-based access control. ({issue}`19416`)
+* Mask additional sensitive values in log files. ({issue}`19519`)
+
+## JDBC driver
+
+* Improve latency for prepared statements for Trino versions that support
+  `EXECUTE IMMEDIATE` when the `explicitPrepare` parameter to is set to `false`.
+  ({issue}`19541`)
+
+## Delta Lake connector
+
+* Replace the `hive.metastore-timeout` Hive metastore configuration property
+  with the `hive.metastore.thrift.client.connect-timeout` and
+  `hive.metastore.thrift.client.read-timeout` properties. ({issue}`19390`)
+
+## Hive connector
+
+* Add support for [SQL routine management](sql-routine-management). ({issue}`19308`)
+* Replace the `hive.metastore-timeout` Hive metastore configuration property
+  with the `hive.metastore.thrift.client.connect-timeout` and
+  `hive.metastore.thrift.client.read-timeout` properties. ({issue}`19390`)
+* Improve support for concurrent updates of table statistics in Glue. ({issue}`19463`)
+* Fix Hive view translation failures involving comparisons between char and
+  varchar fields. ({issue}`18337`)
+
+## Hudi connector
+
+* Replace the `hive.metastore-timeout` Hive metastore configuration property
+  with the `hive.metastore.thrift.client.connect-timeout` and
+  `hive.metastore.thrift.client.read-timeout` properties. ({issue}`19390`)
+
+## Iceberg connector
+
+* Add support for the `REPLACE` modifier to the `CREATE TABLE` statement. ({issue}`13180`)
+* Replace the `hive.metastore-timeout` Hive metastore configuration property
+  with the `hive.metastore.thrift.client.connect-timeout` and
+  `hive.metastore.thrift.client.read-timeout` properties. ({issue}`19390`)
+
+## Memory connector
+
+* Add support for [SQL routine management](sql-routine-management). ({issue}`19308`)
+
+## SPI
+
+* Add `ValueBlock` abstraction along with `VALUE_BLOCK_POSITION` and
+  `VALUE_BLOCK_POSITION_NOT_NULL` calling conventions. ({issue}`19385`)
+* Require a separate block position for each argument of aggregation functions.
+  ({issue}`19385`)
+* Require implementations of `Block` to implement `ValueBlock`. ({issue}`19480`)


### PR DESCRIPTION
## Description

Assemble the release notes for the 431 release notes.

## Additional context and related issues

Fixes #19475 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.

## Verification for each pull request

Format: maintainer, PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 20 Oct 2023

* #19385 ✅ rn ✅ docs
* #19474 ✅ rn ✅ docs

## 21 Oct 2023

* #19470 ✅ rn ✅ docs
* #19476 ✅ rn ✅ docs
* #19480 ✅ rn ✅ docs

## 22 Oct 2023

* #19390 ✅ rn ✅ docs

## 23 Oct 2023

* #19439 ✅ rn ✅ docs
* #19413 ✅ rn ✅ docs
* #19486 ✅ rn ✅ docs
* #19022 ✅ rn ✅ docs, see #19502 
* #19340 ✅ rn ✅ docs
* #19445 ✅ rn ✅ docs

## 24 Oct 2023

* #19505 ✅ rn ✅ docs
* #19515 ✅ rn ✅ docs
* #19508 ✅ rn ✅ docs
* #19494 ✅ rn ✅ docs
* #19518 ✅ rn ✅ docs
* #19434 ✅ rn ✅ docs
* #19015 ✅ rn ✅ docs
* #19502 ✅ rn ✅ docs
* #19521 ✅ rn ❌ ? docs
* #19519 ??? not sure if we should add rn ✅ docs

## 25 Oct 2023

* #13681 ✅ rn ✅ docs
* #19525 ✅ rn ✅ docs
* #19534 ✅ rn ✅ docs
* #19496 ✅ rn ✅ docs
* #19308 ✅ rn ✅ docs
* #18854 ✅ rn ✅ docs
* #19487 ✅ rn ✅ docs
* #17635 ✅ rn ✅ docs
* #19488 ✅ rn ✅ docs
* #19463 ✅ rn ✅ docs

## 26 Oct 2023

* #18464 ✅ rn ✅ docs
* #19528 ✅ rn ✅ docs
* #19509 ✅ rn ✅ docs
* #19478 ✅ rn ✅ docs
* #19530 ✅ rn ✅ docs
* #19541 ✅ rn ✅ docs

## 27 Oct 2023

* #19275 ✅ rn ✅ docs
* #19537 ✅ rn ✅ docs
* #19542 ✅ rn ✅ docs