### PR TITLE
Add date to varchar coercion for hive

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -656,6 +656,8 @@ type conversions.
 * - `DECIMAL`
   - `DOUBLE`, `REAL`, `VARCHAR`, `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, as
     well as narrowing and widening conversions for `DECIMAL`
+* - `DATE`
+  - `VARCHAR`
 * - `TIMESTAMP`
   - `VARCHAR`
 :::

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
+import io.trino.plugin.hive.coercions.DateCoercer.DateToVarcharCoercer;
 import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToDateCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
@@ -198,6 +199,9 @@ public final class CoercionUtils
                 return Optional.of(new LongTimestampToDateCoercer(TIMESTAMP_NANOS, toDateType));
             }
             return Optional.empty();
+        }
+        if (fromType instanceof DateType && toType instanceof VarcharType toVarcharType) {
+            return Optional.of(new DateToVarcharCoercer(toVarcharType));
         }
         if (fromType == DOUBLE && toType instanceof VarcharType toVarcharType) {
             return Optional.of(new DoubleToVarcharCoercer(toVarcharType, coercionContext.treatNaNAsNull()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DateCoercer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/DateCoercer.java
@@ -13,16 +13,23 @@
  */
 package io.trino.plugin.hive.coercions;
 
+import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.DateType;
 import io.trino.spi.type.VarcharType;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 
+import static io.airlift.slice.SliceUtf8.countCodePoints;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_TIMESTAMP_COERCION;
+import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static io.trino.spi.type.DateType.DATE;
+import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
 
 public final class DateCoercer
@@ -52,6 +59,34 @@ public final class DateCoercer
             }
             catch (DateTimeParseException ignored) {
                 throw new IllegalArgumentException("Invalid date value: " + value + " is not a valid date");
+            }
+        }
+    }
+
+    public static class DateToVarcharCoercer
+            extends TypeCoercer<DateType, VarcharType>
+    {
+        public DateToVarcharCoercer(VarcharType toType)
+        {
+            super(DATE, toType);
+        }
+
+        @Override
+        protected void applyCoercedValue(BlockBuilder blockBuilder, Block block, int position)
+        {
+            int value = fromType.getInt(block, position);
+            try {
+                if (value < START_OF_MODERN_ERA_DAYS) {
+                    throw new TrinoException(HIVE_INVALID_TIMESTAMP_COERCION, "Coercion on historical dates is not supported");
+                }
+                Slice converted = utf8Slice(ISO_LOCAL_DATE.format(LocalDate.ofEpochDay(value)));
+                if (!toType.isUnbounded() && countCodePoints(converted) > toType.getBoundedLength()) {
+                    throw new TrinoException(INVALID_ARGUMENTS, format("Varchar representation of '%s' exceeds %s bounds", converted.toStringUtf8(), toType));
+                }
+                toType.writeSlice(blockBuilder, converted);
+            }
+            catch (DateTimeException ignored) {
+                throw new IllegalArgumentException("Invalid date value: " + value + " is exceeding supported date range");
             }
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.orc;
 
 import io.trino.orc.metadata.OrcType.OrcTypeKind;
 import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
+import io.trino.plugin.hive.coercions.DateCoercer.DateToVarcharCoercer;
 import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
 import io.trino.plugin.hive.coercions.DoubleToVarcharCoercer;
 import io.trino.plugin.hive.coercions.IntegerNumberToDoubleCoercer;
@@ -34,6 +35,7 @@ import java.util.Optional;
 
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.BOOLEAN;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.BYTE;
+import static io.trino.orc.metadata.OrcType.OrcTypeKind.DATE;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.DOUBLE;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.INT;
 import static io.trino.orc.metadata.OrcType.OrcTypeKind.LONG;
@@ -62,6 +64,9 @@ public final class OrcTypeTranslator
                 return Optional.of(new LongTimestampToDateCoercer(TIMESTAMP_NANOS, toDateType));
             }
             return Optional.empty();
+        }
+        if (fromOrcType == DATE && toTrinoType instanceof VarcharType varcharType) {
+            return Optional.of(new DateToVarcharCoercer(varcharType));
         }
         if (isVarcharType(fromOrcType)) {
             if (toTrinoType instanceof TimestampType timestampType) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -81,6 +81,7 @@ public final class HiveCoercionPolicy
                     fromHiveType.equals(HIVE_LONG) ||
                     fromHiveType.equals(HIVE_TIMESTAMP) ||
                     fromHiveType.equals(HIVE_DOUBLE) ||
+                    fromHiveType.equals(HIVE_DATE) ||
                     fromType instanceof DecimalType;
         }
         if (toHiveType.equals(HIVE_DATE)) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestHiveCoercion.java
@@ -147,6 +147,8 @@ public abstract class BaseTestHiveCoercion
                 "string_to_double",
                 "varchar_to_double_infinity",
                 "varchar_to_special_double",
+                "date_to_string",
+                "date_to_bounded_varchar",
                 "char_to_bigger_char",
                 "char_to_smaller_char",
                 "timestamp_millis_to_date",
@@ -237,6 +239,8 @@ public abstract class BaseTestHiveCoercion
                         "  '1234.01234', " +
                         "  'Infinity'," +
                         "  'NaN'," +
+                        "  DATE '2023-09-28', " +
+                        "  DATE '2000-04-13', " +
                         "  'abc', " +
                         "  'abc', " +
                         "  TIMESTAMP '2022-12-31 23:59:59.999', " +
@@ -299,6 +303,8 @@ public abstract class BaseTestHiveCoercion
                         "  '0', " +
                         "  '-Infinity'," +
                         "  'Invalid Double'," +
+                        "  DATE '2123-09-27', " +
+                        "  DATE '1900-01-01', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  '\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0', " +
                         "  TIMESTAMP '1970-01-01 00:00:00.123', " +
@@ -519,6 +525,12 @@ public abstract class BaseTestHiveCoercion
                 .put("varchar_to_special_double", Arrays.asList(
                         coercedNaN == null ? null : Double.NaN,
                         null))
+                .put("date_to_string", ImmutableList.of(
+                        "2023-09-28",
+                        "2123-09-27"))
+                .put("date_to_bounded_varchar", ImmutableList.of(
+                        "2000-04-13",
+                        "1900-01-01"))
                 .put("char_to_bigger_char", ImmutableList.of(
                         "abc ",
                         "\uD83D\uDCB0\uD83D\uDCB0\uD83D\uDCB0 "))
@@ -977,6 +989,8 @@ public abstract class BaseTestHiveCoercion
                 row("string_to_double", "double"),
                 row("varchar_to_double_infinity", "double"),
                 row("varchar_to_special_double", "double"),
+                row("date_to_string", "varchar"),
+                row("date_to_bounded_varchar", "varchar(12)"),
                 row("char_to_bigger_char", "char(4)"),
                 row("char_to_smaller_char", "char(2)"),
                 row("timestamp_millis_to_date", "date"),
@@ -1055,6 +1069,8 @@ public abstract class BaseTestHiveCoercion
                 .put("string_to_double", DOUBLE)
                 .put("varchar_to_double_infinity", DOUBLE)
                 .put("varchar_to_special_double", DOUBLE)
+                .put("date_to_string", VARCHAR)
+                .put("date_to_bounded_varchar", VARCHAR)
                 .put("char_to_bigger_char", CHAR)
                 .put("char_to_smaller_char", CHAR)
                 .put("id", BIGINT)
@@ -1128,6 +1144,8 @@ public abstract class BaseTestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_bigger_varchar varchar_to_bigger_varchar varchar(4)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_smaller_varchar varchar_to_smaller_varchar varchar(2)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_date varchar_to_date date", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN date_to_string date_to_string string", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN date_to_bounded_varchar date_to_bounded_varchar varchar(12)", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_distant_date varchar_to_distant_date date", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN varchar_to_double varchar_to_double double", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN string_to_double string_to_double double", tableName));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -150,6 +150,8 @@ public class TestHiveCoercionOnPartitionedTable
                         "    string_to_double                   STRING," +
                         "    varchar_to_double_infinity         VARCHAR(40)," +
                         "    varchar_to_special_double          VARCHAR(40)," +
+                        "    date_to_string                     DATE," +
+                        "    date_to_bounded_varchar            DATE," +
                         "    char_to_bigger_char                CHAR(3)," +
                         "    char_to_smaller_char               CHAR(3)," +
                         "    timestamp_millis_to_date           TIMESTAMP," +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -99,6 +99,8 @@ public class TestHiveCoercionOnUnpartitionedTable
                             string_to_double                   STRING,
                             varchar_to_double_infinity         VARCHAR(40),
                             varchar_to_special_double          VARCHAR(40),
+                            date_to_string                     DATE,
+                            date_to_bounded_varchar            DATE,
                             char_to_bigger_char                CHAR(3),
                             char_to_smaller_char               CHAR(3),
                             timestamp_millis_to_date           TIMESTAMP,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description


Add date to varchar coercion for hive.

Enable the Hive users to retrieve the information from their tables after performing queries which change `date` columns to `varchar`.

Hive sample DDL query:

```
ALTER TABLE mytable CHANGE COLUMN mycolumn mycolumn varchar(12);
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

After changing the column type, dates to far in the future are displayed as expected in Trino, but not in Hive:
```
0: jdbc:hive2://localhost:10000/default> select * from test2;
+-------------+
|   test2.d   |
+-------------+
| 2023-01-10  |
| 000-01-24  |
+-------------+
```

```
trino> select * from hive.default.test2;
      d       
--------------
 +10000-01-24 
 2023-01-10   
(2 rows)
```

In any case, dates to far in the future seem not to be queryable anyway even when working with `date` column type in Hive

```
0: jdbc:hive2://localhost:10000/default> insert into test3 values (date '10000-01-24');
0: jdbc:hive2://localhost:10000/default> select * from test3;
java.lang.IllegalArgumentException
	at java.sql.Date.valueOf(Date.java:143)
	at org.apache.hive.jdbc.HiveBaseResultSet.evaluate(HiveBaseResultSet.java:451)
	at org.apache.hive.jdbc.HiveBaseResultSet.getColumnValue(HiveBaseResultSet.java:425)
	at org.apache.hive.jdbc.HiveBaseResultSet.getObject(HiveBaseResultSet.java:467)
	at org.apache.hive.beeline.Rows$Row.<init>(Rows.java:160)
	at org.apache.hive.beeline.BufferedRows.<init>(BufferedRows.java:57)
	at org.apache.hive.beeline.IncrementalRowsWithNormalization.<init>(IncrementalRowsWithNormalization.java:50)
	at org.apache.hive.beeline.BeeLine.print(BeeLine.java:2305)

```



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add date to varchar coercion for hive. ({issue}`issuenumber`)
```
