### PR TITLE
Skip testing JDBC compatibility for versions 422-424

### DIFF
--- a/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
+++ b/testing/trino-test-jdbc-compatibility-old-driver/bin/run_tests.sh
@@ -26,7 +26,8 @@ fi
 echo "Testing every ${version_step}. version between ${first_tested_version} and ${previous_released_version}"
 
 # 404 was skipped
-tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}" | grep -vx 404)
+# 422-424 depend on the incompatible version of the open-telemetry semantic conventions used while invoking tests
+tested_versions=$(seq "${first_tested_version}" ${version_step} "${previous_released_version}" | grep -vx '404\|42[234]')
 
 if (( (previous_released_version - first_tested_version) % version_step != 0 )); then
     tested_versions="${tested_versions} ${previous_released_version}"


### PR DESCRIPTION
This not work with the current open telemetry being a dependency for the JDBC compatibility module