### PR TITLE
Add timestamp to date schema evolution for hive

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
 import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToDateCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
@@ -189,8 +190,14 @@ public final class CoercionUtils
         if (fromType == REAL && toType instanceof DecimalType toDecimalType) {
             return Optional.of(createRealToDecimalCoercer(toDecimalType));
         }
-        if (fromType instanceof TimestampType && toType instanceof VarcharType varcharType) {
-            return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
+        if (fromType instanceof TimestampType) {
+            if (toType instanceof VarcharType varcharType) {
+                return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
+            }
+            if (toType instanceof DateType toDateType) {
+                return Optional.of(new LongTimestampToDateCoercer(TIMESTAMP_NANOS, toDateType));
+            }
+            return Optional.empty();
         }
         if (fromType == DOUBLE && toType instanceof VarcharType toVarcharType) {
             return Optional.of(new DoubleToVarcharCoercer(toVarcharType, coercionContext.treatNaNAsNull()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/coercions/CoercionUtils.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
 import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
 import io.trino.plugin.hive.type.Category;
@@ -189,7 +190,7 @@ public final class CoercionUtils
             return Optional.of(createRealToDecimalCoercer(toDecimalType));
         }
         if (fromType instanceof TimestampType && toType instanceof VarcharType varcharType) {
-            return Optional.of(new TimestampCoercer.LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
+            return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
         }
         if (fromType == DOUBLE && toType instanceof VarcharType toVarcharType) {
             return Optional.of(new DoubleToVarcharCoercer(toVarcharType, coercionContext.treatNaNAsNull()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeTranslator.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.coercions.BooleanCoercer.BooleanToVarcharCoercer;
 import io.trino.plugin.hive.coercions.DateCoercer.VarcharToDateCoercer;
 import io.trino.plugin.hive.coercions.DoubleToVarcharCoercer;
 import io.trino.plugin.hive.coercions.IntegerNumberToDoubleCoercer;
+import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToDateCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.LongTimestampToVarcharCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToLongTimestampCoercer;
 import io.trino.plugin.hive.coercions.TimestampCoercer.VarcharToShortTimestampCoercer;
@@ -53,8 +54,14 @@ public final class OrcTypeTranslator
 
     public static Optional<TypeCoercer<? extends Type, ? extends Type>> createCoercer(OrcTypeKind fromOrcType, Type toTrinoType)
     {
-        if (fromOrcType == TIMESTAMP && toTrinoType instanceof VarcharType varcharType) {
-            return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
+        if (fromOrcType == TIMESTAMP) {
+            if (toTrinoType instanceof VarcharType varcharType) {
+                return Optional.of(new LongTimestampToVarcharCoercer(TIMESTAMP_NANOS, varcharType));
+            }
+            if (toTrinoType instanceof DateType toDateType) {
+                return Optional.of(new LongTimestampToDateCoercer(TIMESTAMP_NANOS, toDateType));
+            }
+            return Optional.empty();
         }
         if (isVarcharType(fromOrcType)) {
             if (toTrinoType instanceof TimestampType timestampType) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -83,6 +83,9 @@ public final class HiveCoercionPolicy
                     fromHiveType.equals(HIVE_DOUBLE) ||
                     fromType instanceof DecimalType;
         }
+        if (toHiveType.equals(HIVE_DATE)) {
+            return fromHiveType.equals(HIVE_TIMESTAMP);
+        }
         if (fromHiveType.equals(HIVE_BYTE)) {
             return toHiveType.equals(HIVE_SHORT) || toHiveType.equals(HIVE_INT) || toHiveType.equals(HIVE_LONG) || toHiveType.equals(HIVE_DOUBLE);
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -22,8 +22,7 @@ import io.trino.spi.type.SqlTimestamp;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 
@@ -46,24 +45,93 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTimestampCoercer
 {
-    @Test(dataProvider = "timestampValuesProvider")
-    public void testTimestampToVarchar(String timestampValue, String hiveTimestampValue)
+    @Test
+    public void testTimestampToVarchar()
+    {
+        testTimestampToVarchar("1900-01-01T00:00:00.000", "1900-01-01 00:00:00");
+        testTimestampToVarchar("1958-01-01T13:18:03.123", "1958-01-01 13:18:03.123");
+        // after epoch
+        testTimestampToVarchar("2019-03-18T10:01:17.987", "2019-03-18 10:01:17.987");
+        // time doubled in JVM zone
+        testTimestampToVarchar("2018-10-28T01:33:17.456", "2018-10-28 01:33:17.456");
+        // time doubled in JVM zone
+        testTimestampToVarchar("2018-10-28T03:33:33.333", "2018-10-28 03:33:33.333");
+        // epoch
+        testTimestampToVarchar("1970-01-01T00:00:00.000", "1970-01-01 00:00:00");
+        // time gap in JVM zone
+        testTimestampToVarchar("1970-01-01T00:13:42.000", "1970-01-01 00:13:42");
+        testTimestampToVarchar("2018-04-01T02:13:55.123", "2018-04-01 02:13:55.123");
+        // time gap in Vilnius
+        testTimestampToVarchar("2018-03-25T03:17:17.000", "2018-03-25 03:17:17");
+        // time gap in Kathmandu
+        testTimestampToVarchar("1986-01-01T00:13:07.000", "1986-01-01 00:13:07");
+        // before epoch with second fraction
+        testTimestampToVarchar("1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456");
+    }
+
+    private static void testTimestampToVarchar(String timestampValue, String hiveTimestampValue)
     {
         LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
         SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
         assertLongTimestampToVarcharCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), createUnboundedVarcharType(), hiveTimestampValue);
     }
 
-    @Test(dataProvider = "timestampValuesProvider")
-    public void testVarcharToShortTimestamp(String timestampValue, String hiveTimestampValue)
+    @Test
+    public void testVarcharToShortTimestamp()
+    {
+        testVarcharToShortTimestamp("1900-01-01T00:00:00.000", "1900-01-01 00:00:00");
+        testVarcharToShortTimestamp("1958-01-01T13:18:03.123", "1958-01-01 13:18:03.123");
+        // after epoch
+        testVarcharToShortTimestamp("2019-03-18T10:01:17.987", "2019-03-18 10:01:17.987");
+        // time doubled in JVM zone
+        testVarcharToShortTimestamp("2018-10-28T01:33:17.456", "2018-10-28 01:33:17.456");
+        // time doubled in JVM zone
+        testVarcharToShortTimestamp("2018-10-28T03:33:33.333", "2018-10-28 03:33:33.333");
+        // epoch
+        testVarcharToShortTimestamp("1970-01-01T00:00:00.000", "1970-01-01 00:00:00");
+        // time gap in JVM zone
+        testVarcharToShortTimestamp("1970-01-01T00:13:42.000", "1970-01-01 00:13:42");
+        testVarcharToShortTimestamp("2018-04-01T02:13:55.123", "2018-04-01 02:13:55.123");
+        // time gap in Vilnius
+        testVarcharToShortTimestamp("2018-03-25T03:17:17.000", "2018-03-25 03:17:17");
+        // time gap in Kathmandu
+        testVarcharToShortTimestamp("1986-01-01T00:13:07.000", "1986-01-01 00:13:07");
+        // before epoch with second fraction
+        testVarcharToShortTimestamp("1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456");
+    }
+
+    private static void testVarcharToShortTimestamp(String timestampValue, String hiveTimestampValue)
     {
         LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
         SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_MICROS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
         assertVarcharToShortTimestampCoercions(createUnboundedVarcharType(), utf8Slice(hiveTimestampValue), TIMESTAMP_MICROS, timestamp.getEpochMicros());
     }
 
-    @Test(dataProvider = "timestampValuesProvider")
-    public void testVarcharToLongTimestamp(String timestampValue, String hiveTimestampValue)
+    @Test
+    public void testVarcharToLongTimestamp()
+    {
+        testVarcharToLongTimestamp("1900-01-01T00:00:00.000", "1900-01-01 00:00:00");
+        testVarcharToLongTimestamp("1958-01-01T13:18:03.123", "1958-01-01 13:18:03.123");
+        // after epoch
+        testVarcharToLongTimestamp("2019-03-18T10:01:17.987", "2019-03-18 10:01:17.987");
+        // time doubled in JVM zone
+        testVarcharToLongTimestamp("2018-10-28T01:33:17.456", "2018-10-28 01:33:17.456");
+        // time doubled in JVM zone
+        testVarcharToLongTimestamp("2018-10-28T03:33:33.333", "2018-10-28 03:33:33.333");
+        // epoch
+        testVarcharToLongTimestamp("1970-01-01T00:00:00.000", "1970-01-01 00:00:00");
+        // time gap in JVM zone
+        testVarcharToLongTimestamp("1970-01-01T00:13:42.000", "1970-01-01 00:13:42");
+        testVarcharToLongTimestamp("2018-04-01T02:13:55.123", "2018-04-01 02:13:55.123");
+        // time gap in Vilnius
+        testVarcharToLongTimestamp("2018-03-25T03:17:17.000", "2018-03-25 03:17:17");
+        // time gap in Kathmandu
+        testVarcharToLongTimestamp("1986-01-01T00:13:07.000", "1986-01-01 00:13:07");
+        // before epoch with second fraction
+        testVarcharToLongTimestamp("1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456");
+    }
+
+    private static void testVarcharToLongTimestamp(String timestampValue, String hiveTimestampValue)
     {
         LocalDateTime localDateTime = LocalDateTime.parse(timestampValue);
         SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
@@ -122,14 +190,38 @@ public class TestTimestampCoercer
                 .hasMessageContaining("Coercion on historical dates is not supported");
     }
 
-    @Test(dataProvider = "invalidValue")
-    public void testInvalidVarcharToShortTimestamp(String invalidValue)
+    @Test
+    public void testInvalidVarcharToShortTimestamp()
+    {
+        testInvalidVarcharToShortTimestamp("Invalid timestamp"); // Invalid string
+        testInvalidVarcharToShortTimestamp("2022"); // Partial timestamp value
+        testInvalidVarcharToShortTimestamp("2001-04-01T00:13:42.000"); // ISOFormat date
+        testInvalidVarcharToShortTimestamp("2001-14-01 00:13:42.000"); // Invalid month
+        testInvalidVarcharToShortTimestamp("2001-01-32 00:13:42.000"); // Invalid day
+        testInvalidVarcharToShortTimestamp("2001-04-01 23:59:60.000"); // Invalid second
+        testInvalidVarcharToShortTimestamp("2001-04-01 23:60:01.000"); // Invalid minute
+        testInvalidVarcharToShortTimestamp("2001-04-01 27:01:01.000"); // Invalid hour
+    }
+
+    private static void testInvalidVarcharToShortTimestamp(String invalidValue)
     {
         assertVarcharToShortTimestampCoercions(createUnboundedVarcharType(), utf8Slice(invalidValue), TIMESTAMP_MICROS, null);
     }
 
-    @Test(dataProvider = "invalidValue")
-    public void testInvalidVarcharLongTimestamp(String invalidValue)
+    @Test
+    public void testInvalidVarcharLongTimestamp()
+    {
+        testInvalidVarcharLongTimestamp("Invalid timestamp"); // Invalid string
+        testInvalidVarcharLongTimestamp("2022"); // Partial timestamp value
+        testInvalidVarcharLongTimestamp("2001-04-01T00:13:42.000"); // ISOFormat date
+        testInvalidVarcharLongTimestamp("2001-14-01 00:13:42.000"); // Invalid month
+        testInvalidVarcharLongTimestamp("2001-01-32 00:13:42.000"); // Invalid day
+        testInvalidVarcharLongTimestamp("2001-04-01 23:59:60.000"); // Invalid second
+        testInvalidVarcharLongTimestamp("2001-04-01 23:60:01.000"); // Invalid minute
+        testInvalidVarcharLongTimestamp("2001-04-01 27:01:01.000"); // Invalid hour
+    }
+
+    private static void testInvalidVarcharLongTimestamp(String invalidValue)
     {
         assertVarcharToLongTimestampCoercions(createUnboundedVarcharType(), utf8Slice(invalidValue), TIMESTAMP_MICROS, null);
     }
@@ -161,48 +253,6 @@ public class TestTimestampCoercer
                 timestamp.getEpochMicros()))
                 .isInstanceOf(TrinoException.class)
                 .hasMessageContaining("Coercion on historical dates is not supported");
-    }
-
-    @DataProvider
-    public Object[][] timestampValuesProvider()
-    {
-        return new Object[][] {
-                // before epoch
-                {"1900-01-01T00:00:00.000", "1900-01-01 00:00:00"},
-                {"1958-01-01T13:18:03.123", "1958-01-01 13:18:03.123"},
-                // after epoch
-                {"2019-03-18T10:01:17.987", "2019-03-18 10:01:17.987"},
-                // time doubled in JVM zone
-                {"2018-10-28T01:33:17.456", "2018-10-28 01:33:17.456"},
-                // time doubled in JVM zone
-                {"2018-10-28T03:33:33.333", "2018-10-28 03:33:33.333"},
-                // epoch
-                {"1970-01-01T00:00:00.000", "1970-01-01 00:00:00"},
-                // time gap in JVM zone
-                {"1970-01-01T00:13:42.000", "1970-01-01 00:13:42"},
-                {"2018-04-01T02:13:55.123", "2018-04-01 02:13:55.123"},
-                // time gap in Vilnius
-                {"2018-03-25T03:17:17.000", "2018-03-25 03:17:17"},
-                // time gap in Kathmandu
-                {"1986-01-01T00:13:07.000", "1986-01-01 00:13:07"},
-                // before epoch with second fraction
-                {"1969-12-31T23:59:59.123456", "1969-12-31 23:59:59.123456"}
-        };
-    }
-
-    @DataProvider
-    public Object[][] invalidValue()
-    {
-        return new Object[][] {
-                {"Invalid timestamp"}, // Invalid string
-                {"2022"}, // Partial timestamp value
-                {"2001-04-01T00:13:42.000"}, // ISOFormat date
-                {"2001-14-01 00:13:42.000"}, // Invalid month
-                {"2001-01-32 00:13:42.000"}, // Invalid day
-                {"2001-04-01 23:59:60.000"}, // Invalid second
-                {"2001-04-01 23:60:01.000"}, // Invalid minute
-                {"2001-04-01 27:01:01.000"}, // Invalid hour
-        };
     }
 
     public static void assertLongTimestampToVarcharCoercions(TimestampType fromType, LongTimestamp valueToBeCoerced, VarcharType toType, String expectedValue)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/coercions/TestTimestampCoercer.java
@@ -24,6 +24,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import static io.airlift.slice.Slices.utf8Slice;
@@ -33,6 +34,7 @@ import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.coercions.CoercionUtils.createCoercer;
 import static io.trino.spi.predicate.Utils.blockToNativeValue;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_PICOS;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
@@ -45,6 +47,41 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestTimestampCoercer
 {
+    @Test
+    public void testTimestampToDate()
+    {
+        // before epoch
+        assertTimestampToDateCoercion("1900-01-01T00:00:00.000", "1900-01-01");
+        assertTimestampToDateCoercion("1958-01-01T13:18:03.123", "1958-01-01");
+        // after epoch
+        assertTimestampToDateCoercion("2019-03-18T10:01:17.987", "2019-03-18");
+        assertTimestampToDateCoercion("2021-12-31T23:59:59.000", "2021-12-31");
+        assertTimestampToDateCoercion("2021-12-31T23:59:59.999", "2021-12-31");
+        assertTimestampToDateCoercion("2021-12-31T23:59:59.999999", "2021-12-31");
+        assertTimestampToDateCoercion("2021-12-31T23:59:59.999999999", "2021-12-31");
+        // time doubled in JVM zone
+        assertTimestampToDateCoercion("2018-10-28T01:33:17.456", "2018-10-28");
+        // epoch
+        assertTimestampToDateCoercion("1970-01-01T00:00:00.000", "1970-01-01");
+        // time gap in JVM zone
+        assertTimestampToDateCoercion("1970-01-01T00:13:42.000", "1970-01-01");
+        assertTimestampToDateCoercion("2018-04-01T02:13:55.123", "2018-04-01");
+        // time gap in Vilnius
+        assertTimestampToDateCoercion("2018-03-25T03:17:17.000", "2018-03-25");
+        // time gap in Kathmandu
+        assertTimestampToDateCoercion("1986-01-01T00:13:07.000", "1986-01-01");
+        // before epoch with second fraction
+        assertTimestampToDateCoercion("1969-12-31T23:59:59.123456", "1969-12-31");
+    }
+
+    @Test
+    public void testHistoricalLongTimestampToDate()
+    {
+        assertThatThrownBy(() -> assertTimestampToDateCoercion("1899-12-31T23:59:59.999999999", "1899-12-31"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessageContaining("Coercion on historical dates is not supported");
+    }
+
     @Test
     public void testTimestampToVarchar()
     {
@@ -276,5 +313,12 @@ public class TestTimestampCoercer
                 .apply(nativeValueToBlock(fromType, valueToBeCoerced));
         assertThat(blockToNativeValue(toType, coercedValue))
                 .isEqualTo(expectedValue);
+    }
+
+    private static void assertTimestampToDateCoercion(String timestampAsString, String expectedDate)
+    {
+        LocalDateTime localDateTime = LocalDateTime.parse(timestampAsString);
+        SqlTimestamp timestamp = SqlTimestamp.fromSeconds(TIMESTAMP_PICOS.getPrecision(), localDateTime.toEpochSecond(UTC), localDateTime.get(NANO_OF_SECOND));
+        assertCoercions(TIMESTAMP_PICOS, new LongTimestamp(timestamp.getEpochMicros(), timestamp.getPicosOfMicros()), DATE, LocalDate.parse(expectedDate).toEpochDay(), NANOSECONDS);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnPartitionedTable.java
@@ -152,6 +152,9 @@ public class TestHiveCoercionOnPartitionedTable
                         "    varchar_to_special_double          VARCHAR(40)," +
                         "    char_to_bigger_char                CHAR(3)," +
                         "    char_to_smaller_char               CHAR(3)," +
+                        "    timestamp_millis_to_date           TIMESTAMP," +
+                        "    timestamp_micros_to_date           TIMESTAMP," +
+                        "    timestamp_nanos_to_date            TIMESTAMP," +
                         "    timestamp_to_string                TIMESTAMP," +
                         "    timestamp_to_bounded_varchar       TIMESTAMP," +
                         "    timestamp_to_smaller_varchar       TIMESTAMP," +
@@ -169,11 +172,12 @@ public class TestHiveCoercionOnPartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("" +
                         "CREATE TABLE %NAME%(" +
-                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>, " +
-                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>, " +
-                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>," +
+                        "    timestamp_row_to_row                 STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>, " +
+                        "    timestamp_list_to_list               ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>>, " +
+                        "    timestamp_map_to_map                 MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>>," +
                         "    timestamp_to_string                  TIMESTAMP," +
-                        "    string_to_timestamp                  STRING" +
+                        "    string_to_timestamp                  STRING," +
+                        "    timestamp_to_date                    TIMESTAMP" +
                         ") " +
                         "PARTITIONED BY (id BIGINT) " +
                         rowFormat.map(s -> format("ROW FORMAT %s ", s)).orElse("") +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercionOnUnpartitionedTable.java
@@ -101,6 +101,9 @@ public class TestHiveCoercionOnUnpartitionedTable
                             varchar_to_special_double          VARCHAR(40),
                             char_to_bigger_char                CHAR(3),
                             char_to_smaller_char               CHAR(3),
+                            timestamp_millis_to_date           TIMESTAMP,
+                            timestamp_micros_to_date           TIMESTAMP,
+                            timestamp_nanos_to_date            TIMESTAMP,
                             timestamp_to_string                TIMESTAMP,
                             timestamp_to_bounded_varchar       TIMESTAMP,
                             timestamp_to_smaller_varchar       TIMESTAMP,
@@ -116,11 +119,12 @@ public class TestHiveCoercionOnUnpartitionedTable
         return HiveTableDefinition.builder(tableName)
                 .setCreateTableDDLTemplate("""
                          CREATE TABLE %NAME%(
-                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>,
-                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>,
-                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING>>,
+                             timestamp_row_to_row       STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>,
+                             timestamp_list_to_list     ARRAY<STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>>,
+                             timestamp_map_to_map       MAP<SMALLINT, STRUCT<keep: TIMESTAMP, si2i: SMALLINT, timestamp2string: TIMESTAMP, string2timestamp: STRING, timestamp2date: TIMESTAMP>>,
                              timestamp_to_string        TIMESTAMP,
                              string_to_timestamp        STRING,
+                             timestamp_to_date          TIMESTAMP,
                              id                         BIGINT)
                         STORED AS\s""" + fileFormat);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add schema evolution from `timestamp` to `date` column types for hive tables.

Enable the Hive users to retrieve the information from their tables after performing queries which change `timestamp` columns to `date`.

Hive sample DDL query for changing the type of a `timestamp` column towards `date`:
```
ALTER TABLE mytable CHANGE COLUMN mycolumn mycolumn date;
```

This change enables Hive users to read the column data as `date` type even if the underlying type of the data stored in the column from the storage  is `timestamp` .

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is a mere adaptation of https://github.com/trinodb/trino/pull/16869 to match `timestamp` to `date` coercion

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Add timestamp to date schema evolution for hive. ({issue}`issuenumber`)
```
