### PR TITLE
Add hive metastore-timeout to Thrift config properties

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -110,6 +110,9 @@ properties:
      - Hive metastore authentication type. Possible values are ``NONE`` or
        ``KERBEROS``.
      - ``NONE``
+   * - ``hive.metastore-timeout``
+     - Timeout for metastore requests.
+     - ``10s``
    * - ``hive.metastore.thrift.client.connect-timeout``
      - Socket connect timeout for metastore client.
      - ``10s``


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The hive.metastore-timeout configuration is available for the [Thrift metastore](https://docs.starburst.io/latest/connector/metastores.html#thrift-metastore-configuration-properties) as the setting is found in the [ThriftMetastoreConfig.java](https://github.com/trinodb/trino/blob/9adb3ca9776a5f1325d1e202feba92aea3fe0e6f/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java#L61)

It is not in [GlueHiveMetastoreConfig.java](https://github.com/trinodb/trino/blob/9adb3ca9776a5f1325d1e202feba92aea3fe0e6f/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
