### PR TITLE
Expand docs for Hive schema evolution type conversions

### DIFF
--- a/docs/src/main/sphinx/connector/hive.md
+++ b/docs/src/main/sphinx/connector/hive.md
@@ -628,14 +628,41 @@ Hive directly, most operations can be performed using Trino.
 
 #### Schema evolution
 
-Hive allows the partitions in a table to have a different schema than the
-table. This occurs when the column types of a table are changed after
-partitions already exist (that use the original column types). The Hive
-connector supports this by allowing the same conversions as Hive:
+Hive table partitions can differ from the current table schema. This occurs when
+the data types of columns of a table are changed from the data types of columns
+of preexisting partitions. The Hive connector supports this schema evolution by
+allowing the same conversions as Hive. The following table lists possible data
+type conversions.
 
-- `VARCHAR` to and from `TINYINT`, `SMALLINT`, `INTEGER` and `BIGINT`
-- `REAL` to `DOUBLE`
-- Widening conversions for integers, such as `TINYINT` to `SMALLINT`
+:::{list-table} Hive schema evolution type conversion
+:widths: 25, 75
+:header-rows: 1
+
+* - Data type
+  - Converted to
+* - `VARCHAR`
+  - `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, `TIMESTAMP`, `DATE`, as well as
+    narrowing conversions for `VARCHAR`
+* - `CHAR`
+  - narrowing conversions for `CHAR`
+* - `TINYINT`
+  - `VARCHAR`, `SMALLINT`, `INTEGER`, `BIGINT`
+* - `SMALLINT`
+  - `VARCHAR`, `INTEGER`, `BIGINT`
+* - `INTEGER`
+  - `VARCHAR`, `BIGINT`
+* - `BIGINT`
+  - `VARCHAR`
+* - `REAL`
+  - `DOUBLE`, `DECIMAL`
+* - `DOUBLE`
+  - `FLOAT`, `DECIMAL`
+* - `DECIMAL`
+  - `DOUBLE`, `REAL`, `VARCHAR`, `TINYINT`, `SMALLINT`, `INTEGER`, `BIGINT`, as
+    well as narrowing and widening conversions for `DECIMAL`
+* - `TIMESTAMP`
+  - `VARCHAR`
+:::
 
 Any conversion failure results in null, which is the same behavior
 as Hive. For example, converting the string `'foo'` to a number,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* This PR creates a matrix in the Hive connector's schema evolution section detailing supported type conversions. It adds additional conversions that were not listed in the documentation.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

* Fixes #19459 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
