### PR TITLE
Migrate BaseConnectorTest to JUnit

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -78,8 +78,7 @@ public class TestAccumuloConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Accumulo connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Accumulo connector does not support column default values");
     }
 
     @org.junit.jupiter.api.Test

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloConnectorTest.java
@@ -21,7 +21,6 @@ import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.testng.SkipException;
 
 import java.util.Optional;
 
@@ -29,6 +28,7 @@ import static io.trino.plugin.accumulo.AccumuloQueryRunner.createAccumuloQueryRu
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -78,9 +78,11 @@ public class TestAccumuloConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Accumulo connector does not support column default values");
+        abort("Accumulo connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableAsSelect()
     {
@@ -115,6 +117,7 @@ public class TestAccumuloConnectorTest
                 "SELECT 0");
     }
 
+    @Test
     @Override
     public void testInsert()
     {
@@ -151,6 +154,7 @@ public class TestAccumuloConnectorTest
         assertUpdate("DROP TABLE test_insert");
     }
 
+    @Test
     @Override // Overridden because we currently do not support arrays with null elements
     public void testInsertArray()
     {
@@ -297,6 +301,7 @@ public class TestAccumuloConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -116,6 +116,7 @@ import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 public abstract class BaseJdbcConnectorTest
         extends BaseConnectorTest
@@ -1512,6 +1513,7 @@ public abstract class BaseJdbcConnectorTest
         throw new UnsupportedOperationException();
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateNotNullColumn()
     {
@@ -1538,6 +1540,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateRowType()
     {
@@ -1555,6 +1558,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateRowConcurrently()
             throws Exception
@@ -1571,6 +1575,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateAllValues()
     {
@@ -1586,6 +1591,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateWithPredicates()
     {
@@ -1744,6 +1750,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithComplexPredicate()
     {
@@ -1756,6 +1763,7 @@ public abstract class BaseJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSubquery()
     {
@@ -1768,6 +1776,7 @@ public abstract class BaseJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
@@ -1780,6 +1789,7 @@ public abstract class BaseJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSemiJoin()
     {
@@ -1792,10 +1802,11 @@ public abstract class BaseJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithVarcharPredicate()
     {
-        throw new SkipException("This is implemented by testDeleteWithVarcharEqualityPredicate");
+        abort("This is implemented by testDeleteWithVarcharEqualityPredicate");
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1398,18 +1398,10 @@ public abstract class BaseJdbcConnectorTest
             // TODO (https://github.com/trinodb/trino/issues/6967) support join pushdown for IS NOT DISTINCT FROM
             return false;
         }
-        switch (toJoinConditionOperator(operator)) {
-            case EQUAL:
-            case NOT_EQUAL:
-            case LESS_THAN:
-            case LESS_THAN_OR_EQUAL:
-            case GREATER_THAN:
-            case GREATER_THAN_OR_EQUAL:
-                return true;
-            case IS_DISTINCT_FROM:
-                return hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM);
-        }
-        throw new AssertionError(); // unreachable
+        return switch (toJoinConditionOperator(operator)) {
+            case EQUAL, NOT_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> true;
+            case IS_DISTINCT_FROM -> hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM);
+        };
     }
 
     protected boolean expectJoinPushdowOnInequalityOperator(JoinOperator joinOperator)
@@ -1424,19 +1416,11 @@ public abstract class BaseJdbcConnectorTest
             // TODO (https://github.com/trinodb/trino/issues/6967) support join pushdown for IS NOT DISTINCT FROM
             return false;
         }
-        switch (toJoinConditionOperator(operator)) {
-            case EQUAL:
-            case NOT_EQUAL:
-                return hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY);
-            case LESS_THAN:
-            case LESS_THAN_OR_EQUAL:
-            case GREATER_THAN:
-            case GREATER_THAN_OR_EQUAL:
-                return hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_INEQUALITY);
-            case IS_DISTINCT_FROM:
-                return hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM) && hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY);
-        }
-        throw new AssertionError(); // unreachable
+        return switch (toJoinConditionOperator(operator)) {
+            case EQUAL, NOT_EQUAL -> hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY);
+            case LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL -> hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_INEQUALITY);
+            case IS_DISTINCT_FROM -> hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM) && hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_VARCHAR_EQUALITY);
+        };
     }
 
     private JoinCondition.Operator toJoinConditionOperator(String operator)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -20,7 +20,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.JdbcSqlExecutor;
 import io.trino.testing.sql.TestTable;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -37,6 +36,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 // Single-threaded because H2 DDL operations can sometimes take a global lock, leading to apparent deadlocks
 // like in https://github.com/trinodb/trino/issues/7209.
@@ -76,6 +76,7 @@ public class TestJdbcConnectorTest
     }
 
     @Override
+    @Test(enabled = false) // this is a JUnit test
     @org.junit.jupiter.api.Test
     public void testLargeIn()
     {
@@ -121,6 +122,7 @@ public class TestJdbcConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -128,12 +130,14 @@ public class TestJdbcConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
+    @Test(enabled = false) // this is a JUnit test
     @Override
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
         // Under concurrently, H2 sometimes returns null table name in DatabaseMetaData.getTables's ResultSet
         // See https://github.com/trinodb/trino/issues/16658 for more information
-        throw new SkipException("Skipped due to H2 problems");
+        abort("Skipped due to H2 problems");
     }
 
     @Test
@@ -271,11 +275,13 @@ public class TestJdbcConnectorTest
         assertThat(e).hasMessageContaining("NULL not allowed for column");
     }
 
+    @org.junit.jupiter.api.Test
+    @Test(enabled = false) // this is a JUnit test
     @Override
     public void testAddColumnConcurrently()
     {
         // TODO: Difficult to determine whether the exception is concurrent issue or not from the error message
-        throw new SkipException("TODO: Enable this test after finding the failure cause");
+        abort("TODO: Enable this test after finding the failure cause");
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -45,6 +45,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -281,6 +282,7 @@ public abstract class BaseBigQueryConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testNoDataSystemTable()
     {
@@ -301,6 +303,7 @@ public abstract class BaseBigQueryConnectorTest
         return nullToEmpty(exception.getMessage()).matches(".*Invalid field name \"%s\". Fields must contain the allowed characters, and be at most 300 characters long..*".formatted(columnName.replace("\\", "\\\\")));
     }
 
+    @org.junit.jupiter.api.Test
     @Override // Override because the base test exceeds rate limits per a table
     public void testCommentColumn()
     {
@@ -528,6 +531,7 @@ public abstract class BaseBigQueryConnectorTest
         onBigQuery(format("DROP VIEW %s.%s", schemaName, viewName));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -545,11 +549,12 @@ public abstract class BaseBigQueryConnectorTest
                         ")");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
         // TODO: Enable this test after fixing "Task did not completed before timeout" (https://github.com/trinodb/trino/issues/14230)
-        throw new SkipException("Test fails with a timeout sometimes and is flaky");
+        abort("Test fails with a timeout sometimes and is flaky");
     }
 
     @Test
@@ -569,7 +574,7 @@ public abstract class BaseBigQueryConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDateYearOfEraPredicate()
     {
@@ -934,6 +939,7 @@ public abstract class BaseBigQueryConnectorTest
                 .hasMessageContaining("Failed to get schema for query");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertArray()
     {
@@ -944,11 +950,12 @@ public abstract class BaseBigQueryConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertRowConcurrently()
     {
         // TODO https://github.com/trinodb/trino/issues/15158 Enable this test after switching to storage write API
-        throw new SkipException("Test fails with a timeout sometimes and is flaky");
+        abort("Test fails with a timeout sometimes and is flaky");
     }
 
     @Override
@@ -976,6 +983,7 @@ public abstract class BaseBigQueryConnectorTest
                         "col_required2 INT64 NOT NULL)");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -131,8 +131,7 @@ public class TestCassandraConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Cassandra connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Cassandra connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -27,7 +27,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
-import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -72,6 +71,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -131,7 +131,8 @@ public class TestCassandraConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Cassandra connector does not support column default values");
+        abort("Cassandra connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override
@@ -194,7 +195,7 @@ public class TestCassandraConnectorTest
                 .build();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -212,6 +213,7 @@ public class TestCassandraConnectorTest
                         ")");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -1232,7 +1234,7 @@ public class TestCassandraConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDelete()
     {
@@ -1297,6 +1299,7 @@ public class TestCassandraConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -1304,6 +1307,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithComplexPredicate()
     {
@@ -1311,6 +1315,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSemiJoin()
     {
@@ -1318,6 +1323,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSubquery()
     {
@@ -1325,6 +1331,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
@@ -1332,6 +1339,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithVarcharPredicate()
     {
@@ -1339,6 +1347,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Delete without primary key or partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteAllDataFromTable()
     {
@@ -1346,6 +1355,7 @@ public class TestCassandraConnectorTest
                 .hasStackTraceContaining("Deleting without partition key is not supported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRowLevelDelete()
     {

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -177,6 +177,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>clickhouse</artifactId>
             <scope>test</scope>

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -172,7 +172,7 @@ public class TestClickHouseConnectorTest
             assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                     .hasMessageContaining("Cannot rename column from nested struct to normal column");
             abort("TODO");
-            throw new AssertionError(); // unreachable
+            return; // unreachable
         }
         assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                 .hasMessageContaining("is not supported by storage Log");

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -22,6 +22,8 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -49,6 +51,7 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -105,13 +108,15 @@ public class TestClickHouseConnectorTest
         assertUpdate("ALTER TABLE test SET PROPERTIES sample_by = 'p2'");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumn()
     {
         // ClickHouse need resets all data in a column for specified column which to be renamed
-        throw new SkipException("TODO: test not implemented yet");
+        abort("TODO: test not implemented yet");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumnWithComment()
     {
@@ -126,6 +131,8 @@ public class TestClickHouseConnectorTest
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("testCommentDataProvider")
     @Override
     public void testAddColumnWithCommentSpecialCharacter(String comment)
     {
@@ -136,6 +143,7 @@ public class TestClickHouseConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropAndAddColumnWithSameName()
     {
@@ -154,6 +162,8 @@ public class TestClickHouseConnectorTest
         return format("CREATE TABLE %s(%s varchar(50), value varchar(50) NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['value'])", tableName, columnNameInSql);
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
@@ -161,11 +171,12 @@ public class TestClickHouseConnectorTest
         if (columnName.equals("a.dot")) {
             assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                     .hasMessageContaining("Cannot rename column from nested struct to normal column");
-            throw new SkipException("TODO");
+            abort("TODO");
+            throw new AssertionError(); // unreachable
         }
         assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                 .hasMessageContaining("is not supported by storage Log");
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Override
@@ -178,6 +189,7 @@ public class TestClickHouseConnectorTest
         return Optional.of(columnName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropColumn()
     {
@@ -215,6 +227,7 @@ public class TestClickHouseConnectorTest
         return "(x VARCHAR NOT NULL) WITH (engine = 'MergeTree', order_by = ARRAY['x'])";
     }
 
+    @org.junit.jupiter.api.Test
     @Override // Overridden because the default storage type doesn't support adding columns
     public void testAddNotNullColumnToEmptyTable()
     {
@@ -230,6 +243,7 @@ public class TestClickHouseConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override // Overridden because (a) the default storage type doesn't support adding columns and (b) ClickHouse has implicit default value for new NON NULL column
     public void testAddNotNullColumn()
     {
@@ -248,7 +262,7 @@ public class TestClickHouseConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testAddColumnWithComment()
     {
@@ -264,21 +278,23 @@ public class TestClickHouseConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableAddLongColumnName()
     {
         // TODO: Find the maximum column name length in ClickHouse and enable this test.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableRenameColumnToLongName()
     {
         // TODO: Find the maximum column name length in ClickHouse and enable this test.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -328,6 +344,7 @@ public class TestClickHouseConnectorTest
                         "col_required2 Int64) ENGINE=Log");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -337,7 +354,7 @@ public class TestClickHouseConnectorTest
                 .hasMessageContaining("Expected rows");
 
         // TODO run the test with clickhouse.map-string-as-varchar
-        throw new SkipException("");
+        abort("");
     }
 
     @Test
@@ -628,7 +645,7 @@ public class TestClickHouseConnectorTest
         return new TestTable(onRemoteDatabase(), name, "(t_double Nullable(Float64), u_double Nullable(Float64), v_real Nullable(Float32), w_real Nullable(Float32)) Engine=Log", rows);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertIntoNotNullColumn()
     {
@@ -668,7 +685,7 @@ public class TestClickHouseConnectorTest
         return "Date must be between 1970-01-01 and 2149-06-06 in ClickHouse: " + date;
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDateYearOfEraPredicate()
     {
@@ -699,6 +716,7 @@ public class TestClickHouseConnectorTest
         return new TestTable(onRemoteDatabase(), "tpch.simple_table", "(col BIGINT) Engine=Log", ImmutableList.of("1", "2"));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableWithLongTableName()
     {
@@ -718,6 +736,7 @@ public class TestClickHouseConnectorTest
         assertTrue(getQueryRunner().tableExists(getSession(), validTableName));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameSchemaToLongName()
     {
@@ -755,6 +774,7 @@ public class TestClickHouseConnectorTest
         assertThat(e).hasMessageContaining("File name too long");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameTableToLongTableName()
     {

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -430,6 +430,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -39,6 +39,8 @@ import io.trino.testing.minio.MinioClient;
 import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
@@ -86,6 +88,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -239,7 +242,8 @@ public class TestDeltaLakeConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Delta Lake does not support columns with a default value");
+        abort("Delta Lake does not support columns with a default value");
+        throw new AssertionError(); // unreachable
     }
 
     @Override
@@ -258,7 +262,7 @@ public class TestDeltaLakeConnectorTest
                 .build();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -362,6 +366,7 @@ public class TestDeltaLakeConnectorTest
                 "Using array, map or row type on partitioned columns is unsupported");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateSchema()
     {
@@ -373,6 +378,7 @@ public class TestDeltaLakeConnectorTest
                         ")", getSession().getCatalog().orElseThrow(), schemaName, bucketName));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropNonEmptySchemaWithTable()
     {
@@ -388,6 +394,7 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("DROP SCHEMA " + schemaName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropColumn()
     {
@@ -397,6 +404,8 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot drop column from table using column mapping mode NONE");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testAddAndDropColumnName(String columnName)
     {
@@ -406,6 +415,7 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot drop column from table using column mapping mode NONE");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropAndAddColumnWithSameName()
     {
@@ -441,6 +451,7 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumn()
     {
@@ -450,6 +461,7 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumnWithComment()
     {
@@ -484,6 +496,7 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableRenameColumnToLongName()
     {
@@ -493,6 +506,8 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
@@ -502,6 +517,7 @@ public class TestDeltaLakeConnectorTest
                 .hasMessageContaining("Cannot rename column in table using column mapping mode NONE");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -242,8 +242,7 @@ public class TestDeltaLakeConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Delta Lake does not support columns with a default value");
-        throw new AssertionError(); // unreachable
+        return abort("Delta Lake does not support columns with a default value");
     }
 
     @Override

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidConnectorTest.java
@@ -56,6 +56,7 @@ import static io.trino.tpch.TpchTable.REGION;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertFalse;
 
 public class TestDruidConnectorTest
@@ -142,7 +143,7 @@ public class TestDruidConnectorTest
         assertThat(metadata.storesUpperCaseIdentifiers()).isTrue();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -161,7 +162,7 @@ public class TestDruidConnectorTest
                         ")");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSelectInformationSchemaColumns()
     {
@@ -200,7 +201,7 @@ public class TestDruidConnectorTest
         assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSelectAll()
     {
@@ -298,18 +299,18 @@ public class TestDruidConnectorTest
                 .isNotFullyPushedDown(joinOverTableScans);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertNegativeDate()
     {
-        throw new SkipException("Druid connector does not map 'orderdate' column to date type and INSERT statement");
+        abort("Druid connector does not map 'orderdate' column to date type and INSERT statement");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDateYearOfEraPredicate()
     {
-        throw new SkipException("Druid connector does not map 'orderdate' column to date type");
+        abort("Druid connector does not map 'orderdate' column to date type");
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -146,7 +146,7 @@ public abstract class BaseElasticsearchConnectorTest
         assertQueryReturnsEmptyResult(format("SELECT 1 FROM jmx.current.\"trino.plugin.elasticsearch.client:*name=%s*\" WHERE \"backpressurestats.alltime.max\" > 0", catalogName));
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSelectAll()
     {
@@ -172,7 +172,7 @@ public abstract class BaseElasticsearchConnectorTest
                 .build();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testPredicateReflectedInExplain()
     {
@@ -184,7 +184,7 @@ public abstract class BaseElasticsearchConnectorTest
                 "nationkey::bigint", "::\\s\\[\\[42\\]\\]");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSortItemsReflectedInExplain()
     {
@@ -195,6 +195,7 @@ public abstract class BaseElasticsearchConnectorTest
                 "TopNPartial\\[count = 5, orderBy = \\[nationkey DESC");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -9154,8 +9154,7 @@ public abstract class BaseHiveConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Hive connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Hive connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -70,7 +70,6 @@ import io.trino.type.TypeDeserializer;
 import org.apache.hadoop.fs.Path;
 import org.assertj.core.api.AbstractLongAssert;
 import org.intellij.lang.annotations.Language;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -194,6 +193,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -264,6 +264,7 @@ public abstract class BaseHiveConnectorTest
         };
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void verifySupportsUpdateDeclaration()
     {
@@ -272,6 +273,7 @@ public abstract class BaseHiveConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void verifySupportsRowLevelUpdateDeclaration()
     {
@@ -293,6 +295,7 @@ public abstract class BaseHiveConnectorTest
                 .containsPattern("io.trino.spi.TrinoException: Cannot read from a table tpch.test_insert_select_\\w+ that was modified within transaction, you need to commit the transaction first");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDelete()
     {
@@ -300,6 +303,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -307,6 +311,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithComplexPredicate()
     {
@@ -314,6 +319,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSemiJoin()
     {
@@ -321,6 +327,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSubquery()
     {
@@ -328,6 +335,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdate()
     {
@@ -335,6 +343,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRowLevelUpdate()
     {
@@ -342,6 +351,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateRowConcurrently()
             throws Exception
@@ -353,6 +363,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateWithPredicates()
     {
@@ -360,6 +371,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateRowType()
     {
@@ -367,6 +379,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateAllValues()
     {
@@ -374,6 +387,7 @@ public abstract class BaseHiveConnectorTest
                 .hasMessage(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
@@ -381,6 +395,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithVarcharPredicate()
     {
@@ -388,6 +403,7 @@ public abstract class BaseHiveConnectorTest
                 .hasStackTraceContaining(MODIFYING_NON_TRANSACTIONAL_TABLE_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRowLevelDelete()
     {
@@ -729,6 +745,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(admin, "DROP ROLE authorized_users IN hive");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateSchemaWithNonLowercaseOwnerName()
     {
@@ -1091,7 +1108,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(admin, "DROP SCHEMA " + schema);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateSchema()
     {
@@ -3134,7 +3151,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsert()
     {
@@ -3419,14 +3436,14 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP TABLE test_null_partition");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertHighestUnicodeCharacter()
     {
-        throw new SkipException("Covered by testInsertUnicode");
+        abort("Covered by testInsertUnicode");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertUnicode()
     {
@@ -4282,7 +4299,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP TABLE IF EXISTS test_comment");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -5068,7 +5085,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP VIEW view_rename.rename_view_new");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumn()
     {
@@ -5092,7 +5109,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP TABLE test_rename_column");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropColumn()
     {
@@ -5119,6 +5136,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate("DROP TABLE test_drop_column");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropAndAddColumnWithSameName()
     {
@@ -9136,7 +9154,8 @@ public abstract class BaseHiveConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Hive connector does not support column default values");
+        abort("Hive connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConnectorTest.java
@@ -62,7 +62,7 @@ public class TestHudiConnectorTest
         };
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -62,7 +62,8 @@ import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.util.JsonUtil;
 import org.intellij.lang.annotations.Language;
-import org.testng.SkipException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -152,6 +153,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -243,6 +245,8 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testAddAndDropColumnName(String columnName)
     {
@@ -289,6 +293,7 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -296,7 +301,7 @@ public abstract class BaseIcebergConnectorTest
                 .hasMessage("Type not supported for Iceberg: char(3)");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateSchema()
     {
@@ -325,7 +330,7 @@ public abstract class BaseIcebergConnectorTest
     }
 
     @Override
-    @Test
+    @org.junit.jupiter.api.Test
     public void testShowCreateTable()
     {
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
@@ -1519,6 +1524,7 @@ public abstract class BaseIcebergConnectorTest
         dropTable("test_schema_evolution_drop_middle");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropRowFieldWhenDuplicates()
     {
@@ -4806,7 +4812,8 @@ public abstract class BaseIcebergConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Iceberg connector does not support column default values");
+        abort("Iceberg connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4812,8 +4812,7 @@ public abstract class BaseIcebergConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Iceberg connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Iceberg connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMinioOrcConnectorTest.java
@@ -156,6 +156,7 @@ public class TestIcebergMinioOrcConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropAmbiguousRowFieldCaseSensitivity()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -86,6 +86,7 @@ public class TestIcebergParquetConnectorTest
         return super.filterSetColumnTypesDataProvider(setup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDropAmbiguousRowFieldCaseSensitivity()
     {

--- a/plugin/trino-ignite/pom.xml
+++ b/plugin/trino-ignite/pom.xml
@@ -215,6 +215,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>jdbc</artifactId>
             <scope>test</scope>

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -24,6 +24,8 @@ import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import io.trino.testng.services.Flaky;
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -38,6 +40,7 @@ import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestIgniteConnectorTest
         extends BaseJdbcConnectorTest
@@ -245,6 +248,7 @@ public class TestIgniteConnectorTest
                         "dummy_id varchar NOT NULL primary key)");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -335,7 +339,7 @@ public class TestIgniteConnectorTest
         assertThat(e).hasMessage("Schema change operation failed: Thread got interrupted while trying to acquire table lock.");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     @Flaky(issue = SCHEMA_CHANGE_OPERATION_FAIL_ISSUE, match = SCHEMA_CHANGE_OPERATION_FAIL_MATCH)
     public void testDropAndAddColumnWithSameName()
@@ -350,7 +354,7 @@ public class TestIgniteConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     @Flaky(issue = SCHEMA_CHANGE_OPERATION_FAIL_ISSUE, match = SCHEMA_CHANGE_OPERATION_FAIL_MATCH)
     public void testAddColumn()
@@ -358,7 +362,7 @@ public class TestIgniteConnectorTest
         super.testAddColumn();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     @Flaky(issue = SCHEMA_CHANGE_OPERATION_FAIL_ISSUE, match = SCHEMA_CHANGE_OPERATION_FAIL_MATCH)
     public void testDropColumn()
@@ -366,7 +370,7 @@ public class TestIgniteConnectorTest
         super.testDropColumn();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     @Flaky(issue = SCHEMA_CHANGE_OPERATION_FAIL_ISSUE, match = SCHEMA_CHANGE_OPERATION_FAIL_MATCH)
     public void testAlterTableAddLongColumnName()
@@ -374,7 +378,8 @@ public class TestIgniteConnectorTest
         super.testAlterTableAddLongColumnName();
     }
 
-    @Test(dataProvider = "testColumnNameDataProvider")
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     @Flaky(issue = SCHEMA_CHANGE_OPERATION_FAIL_ISSUE, match = SCHEMA_CHANGE_OPERATION_FAIL_MATCH)
     public void testAddAndDropColumnName(String columnName)
@@ -388,11 +393,12 @@ public class TestIgniteConnectorTest
         return new TestTable(onRemoteDatabase(), format("%s.simple_table", getSession().getSchema().orElseThrow()), "(col BIGINT, id bigint primary key)", ImmutableList.of("1, 1", "2, 2"));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
         // Ignite will map char to varchar, skip
-        throw new SkipException("Ignite map char to varchar, skip test");
+        abort("Ignite map char to varchar, skip test");
     }
 
     @Override
@@ -430,6 +436,7 @@ public class TestIgniteConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDateYearOfEraPredicate()
     {

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -26,7 +26,6 @@ import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -70,6 +69,7 @@ import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CL
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -199,7 +199,8 @@ public class TestKafkaConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Kafka connector does not support column default values");
+        abort("Kafka connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Test
@@ -378,7 +379,7 @@ public class TestKafkaConnectorTest
                         ")");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsert()
     {
@@ -417,7 +418,7 @@ public class TestKafkaConnectorTest
                 "SELECT 2 * count(*) FROM customer");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertNegativeDate()
     {
@@ -428,17 +429,17 @@ public class TestKafkaConnectorTest
         assertQuery(format("SELECT dt FROM %s WHERE dt = date '-0001-01-01'", TABLE_INSERT_NEGATIVE_DATE), "VALUES date '-0001-01-01'");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertArray()
     {
         // Override because the base test uses CREATE TABLE statement that is unsupported in Kafka connector
         assertThatThrownBy(() -> query("INSERT INTO " + TABLE_INSERT_ARRAY + " (a) VALUES (ARRAY[null])"))
                 .hasMessage("Unsupported column type 'array(double)' for column 'a'");
-        throw new SkipException("not supported");
+        abort("not supported");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertUnicode()
     {
@@ -462,7 +463,7 @@ public class TestKafkaConnectorTest
         assertQueryReturnsEmptyResult("SELECT test FROM " + TABLE_INSERT_UNICODE_3 + " WHERE test = 'b'");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertHighestUnicodeCharacter()
     {
@@ -472,10 +473,11 @@ public class TestKafkaConnectorTest
                 .containsExactlyInAnyOrder("Hello", "hello测试􏿿world编码");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertRowConcurrently()
     {
-        throw new SkipException("TODO Prepare a topic in Kafka and enable this test");
+        abort("TODO Prepare a topic in Kafka and enable this test");
     }
 
     @Test

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaConnectorTest.java
@@ -199,8 +199,7 @@ public class TestKafkaConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Kafka connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Kafka connector does not support column default values");
     }
 
     @Test

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -212,6 +212,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -20,8 +20,11 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.testng.SkipException;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -35,8 +38,10 @@ import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -155,22 +160,26 @@ public class TestKuduConnectorTest
                 .hasMessage("Creating schema in Kudu connector not allowed if schema emulation is disabled.");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testAddAndDropColumnName(String columnName)
     {
         // TODO: Enable this test
         assertThatThrownBy(() -> super.testAddAndDropColumnName(columnName))
                 .hasMessage("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
         // TODO: Enable this test
         assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                 .hasMessage("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Override
@@ -306,13 +315,14 @@ public class TestKuduConnectorTest
         }
     }
 
+    @Test
     @Override
     public void testAddNotNullColumnToEmptyTable()
     {
         // TODO: Enable this test
         assertThatThrownBy(super::testAddNotNullColumnToEmptyTable)
                 .hasMessage("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Test
@@ -420,6 +430,7 @@ public class TestKuduConnectorTest
         //assertFalse(getQueryRunner().tableExists(getSession(), tableNameLike));
     }
 
+    @Test
     @Override
     public void testCreateTableWithLongTableName()
     {
@@ -443,6 +454,7 @@ public class TestKuduConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), validTableName));
     }
 
+    @Test
     @Override
     public void testCreateTableWithLongColumnName()
     {
@@ -469,6 +481,7 @@ public class TestKuduConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
+    @Test
     @Override
     public void testCreateTableWithColumnComment()
     {
@@ -485,6 +498,7 @@ public class TestKuduConnectorTest
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
     }
 
+    @Test
     @Override
     public void testDropTable()
     {
@@ -600,6 +614,7 @@ public class TestKuduConnectorTest
         }
     }
 
+    @Test
     @Override
     public void testInsertNegativeDate()
     {
@@ -690,7 +705,8 @@ public class TestKuduConnectorTest
      * This test fails intermittently because Kudu doesn't have strong enough
      * semantics to support writing from multiple threads.
      */
-    @org.testng.annotations.Test(enabled = false)
+    @Disabled
+    @Test
     @Override
     public void testUpdateWithPredicates()
     {
@@ -712,6 +728,7 @@ public class TestKuduConnectorTest
      * This test fails intermittently because Kudu doesn't have strong enough
      * semantics to support writing from multiple threads.
      */
+    @Test
     @Override
     public void testUpdateAllValues()
     {
@@ -723,12 +740,15 @@ public class TestKuduConnectorTest
         });
     }
 
+    @Test
     @Override
     public void testWrittenStats()
     {
         // TODO Kudu connector supports CTAS and inserts, but the test would fail
     }
 
+    @Test
+    @Timeout(value = 180, unit = SECONDS)
     @Override
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
@@ -740,7 +760,7 @@ public class TestKuduConnectorTest
             // TODO (https://github.com/trinodb/trino/issues/12974): shouldn't fail
             assertThat(expected)
                     .hasMessageMatching(".* table .* was deleted: Table deleted at .* UTC");
-            throw new SkipException("to be fixed");
+            abort("to be fixed");
         }
     }
 
@@ -777,15 +797,17 @@ public class TestKuduConnectorTest
                 .hasStackTraceContaining("Cannot apply operator: varchar = date");
     }
 
+    @Test
     @Override
     public void testVarcharCastToDateInPredicate()
     {
         assertThatThrownBy(super::testVarcharCastToDateInPredicate)
                 .hasStackTraceContaining("Table partitioning must be specified using setRangePartitionColumns or addHashPartitions");
 
-        throw new SkipException("TODO: implement the test for Kudu");
+        abort("TODO: implement the test for Kudu");
     }
 
+    @Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -795,7 +817,7 @@ public class TestKuduConnectorTest
                 .hasMessageContaining("Actual rows")
                 .hasMessageContaining("Expected rows");
 
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Test
@@ -947,7 +969,8 @@ public class TestKuduConnectorTest
      * This test fails intermittently because Kudu doesn't have strong enough
      * semantics to support writing from multiple threads.
      */
-    @org.testng.annotations.Test(enabled = false)
+    @Disabled
+    @Test
     @Override
     public void testUpdate()
     {
@@ -963,7 +986,8 @@ public class TestKuduConnectorTest
      * This test fails intermittently because Kudu doesn't have strong enough
      * semantics to support writing from multiple threads.
      */
-    @org.testng.annotations.Test(enabled = false)
+    @Disabled
+    @Test
     @Override
     public void testRowLevelUpdate()
     {
@@ -984,11 +1008,12 @@ public class TestKuduConnectorTest
         });
     }
 
+    @Test
     @Override
     public void testUpdateRowConcurrently()
             throws Exception
     {
-        throw new SkipException("Kudu doesn't support concurrent update of different columns in a row");
+        abort("Kudu doesn't support concurrent update of different columns in a row");
     }
 
     @Test
@@ -1005,6 +1030,8 @@ public class TestKuduConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @ParameterizedTest
+    @MethodSource("testCommentDataProvider")
     @Override
     public void testCreateTableWithTableCommentSpecialCharacter(String comment)
     {
@@ -1042,7 +1069,8 @@ public class TestKuduConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Kudu connector does not support column default values");
+        abort("Kudu connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -1069,8 +1069,7 @@ public class TestKuduConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Kudu connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Kudu connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -187,6 +187,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
             <scope>test</scope>

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/BaseMariaDbConnectorTest.java
@@ -140,7 +140,7 @@ public abstract class BaseMariaDbConnectorTest
                 .build();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -181,6 +181,7 @@ public abstract class BaseMariaDbConnectorTest
         assertUpdate("DROP TABLE test_column_comment");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAddNotNullColumn()
     {
@@ -254,7 +255,7 @@ public abstract class BaseMariaDbConnectorTest
                 .isFullyPushedDown();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -263,7 +264,7 @@ public abstract class BaseMariaDbConnectorTest
     }
 
     // Overridden because the method from BaseConnectorTest fails on one of the assertions, see TODO below
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertIntoNotNullColumn()
     {

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
@@ -16,6 +16,9 @@ package io.trino.plugin.mariadb;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -37,6 +40,7 @@ public class TestMariaDbConnectorTest
         return server::execute;
     }
 
+    @Test
     @Override
     public void testRenameColumn()
     {
@@ -44,6 +48,8 @@ public class TestMariaDbConnectorTest
                 .hasMessageContaining("Rename column not supported for the MariaDB server version");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
@@ -51,6 +57,7 @@ public class TestMariaDbConnectorTest
                 .hasMessageContaining("Rename column not supported for the MariaDB server version");
     }
 
+    @Test
     @Override
     public void testAlterTableRenameColumnToLongName()
     {

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -174,6 +174,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -106,8 +106,7 @@ public class TestMemoryConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Memory connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Memory connector does not support column default values");
     }
 
     @Test

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -32,7 +32,6 @@ import io.trino.testing.sql.TestTable;
 import io.trino.testng.services.Flaky;
 import io.trino.tpch.TpchTable;
 import org.intellij.lang.annotations.Language;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -44,6 +43,7 @@ import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType;
 import static io.trino.sql.planner.OptimizerConfig.JoinDistributionType.BROADCAST;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -106,7 +106,8 @@ public class TestMemoryConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Memory connector does not support column default values");
+        abort("Memory connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Test

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -220,6 +220,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <!-- Needed while junit 4 is in classpath -->
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -35,6 +35,8 @@ import io.trino.testing.sql.TestTable;
 import org.bson.Document;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -61,6 +63,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -117,10 +120,12 @@ public class TestMongoConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("MongoDB connector does not support column default values");
+        abort("MongoDB connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
-    @Test(dataProvider = "testColumnNameDataProvider")
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testColumnName(String columnName)
     {
@@ -128,13 +133,13 @@ public class TestMongoConnectorTest
             assertThatThrownBy(() -> super.testColumnName(columnName))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessage("Column name must not contain '$' or '.' for INSERT: " + columnName);
-            throw new SkipException("Insert would fail");
+            abort("Insert would fail");
         }
 
         super.testColumnName(columnName);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSortItemsReflectedInExplain()
     {
@@ -276,6 +281,7 @@ public class TestMongoConnectorTest
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithComplexPredicate()
     {
@@ -283,6 +289,7 @@ public class TestMongoConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -290,6 +297,7 @@ public class TestMongoConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSemiJoin()
     {
@@ -297,6 +305,7 @@ public class TestMongoConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithSubquery()
     {
@@ -304,6 +313,7 @@ public class TestMongoConnectorTest
                 .hasStackTraceContaining("TrinoException: " + MODIFYING_ROWS_MESSAGE);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testExplainAnalyzeWithDeleteWithSubquery()
     {
@@ -923,11 +933,12 @@ public class TestMongoConnectorTest
         assertUpdate("DROP TABLE test." + tableName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAddColumnConcurrently()
     {
         // TODO: Enable after supporting multi-document transaction https://www.mongodb.com/docs/manual/core/transactions/
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Test
@@ -1670,20 +1681,20 @@ public class TestMongoConnectorTest
         };
     }
 
+    @org.junit.jupiter.api.Test
     @Override
-    @Test
     public void testProjectionPushdownReadsLessData()
     {
         // TODO https://github.com/trinodb/trino/issues/17713
-        throw new SkipException("MongoDB connector does not calculate physical data input size");
+        abort("MongoDB connector does not calculate physical data input size");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
-    @Test
     public void testProjectionPushdownPhysicalInputSize()
     {
         // TODO https://github.com/trinodb/trino/issues/17713
-        throw new SkipException("MongoDB connector does not calculate physical data input size");
+        abort("MongoDB connector does not calculate physical data input size");
     }
 
     @Override

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoConnectorTest.java
@@ -120,8 +120,7 @@ public class TestMongoConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("MongoDB connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("MongoDB connector does not support column default values");
     }
 
     @ParameterizedTest

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -216,6 +216,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
             <scope>test</scope>

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -165,6 +165,7 @@ public abstract class BaseMySqlConnectorTest
                 .build();
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -182,6 +183,7 @@ public abstract class BaseMySqlConnectorTest
                         ")");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -262,6 +264,7 @@ public abstract class BaseMySqlConnectorTest
         assertUpdate("DROP TABLE test_column_comment");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAddNotNullColumn()
     {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlLegacyConnectorTest.java
@@ -20,6 +20,8 @@ import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.MarkDistinctNode;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -44,7 +46,7 @@ public class TestMySqlLegacyConnectorTest
         return createMySqlQueryRunner(mySqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableAsSelectWithUnicode()
     {
@@ -52,7 +54,7 @@ public class TestMySqlLegacyConnectorTest
                 .hasStackTraceContaining("Failed to insert data: Incorrect string value: '\\xE2\\x98\\x83'");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertUnicode()
     {
@@ -82,7 +84,7 @@ public class TestMySqlLegacyConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertHighestUnicodeCharacter()
     {
@@ -125,7 +127,7 @@ public class TestMySqlLegacyConnectorTest
         }
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumn()
     {
@@ -134,6 +136,8 @@ public class TestMySqlLegacyConnectorTest
                 .hasStackTraceContaining("RENAME COLUMN x TO before_y");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
@@ -142,6 +146,7 @@ public class TestMySqlLegacyConnectorTest
                 .hasStackTraceContaining("RENAME COLUMN");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableRenameColumnToLongName()
     {

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -160,7 +160,7 @@ public abstract class BaseOracleConnectorTest
                 .build();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -191,6 +191,7 @@ public abstract class BaseOracleConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -214,6 +215,7 @@ public abstract class BaseOracleConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testVarcharCharComparison()
     {
@@ -266,6 +268,7 @@ public abstract class BaseOracleConnectorTest
         return new TestTable(onRemoteDatabase(), name, "(short_decimal number(9, 3), long_decimal number(30, 10), a_bigint number(19), t_double binary_double)", rows);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -367,6 +367,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -25,6 +25,8 @@ import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -64,6 +66,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertTrue;
 
 public class TestPhoenixConnectorTest
@@ -204,7 +207,8 @@ public class TestPhoenixConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Phoenix connector does not support column default values");
+        abort("Phoenix connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override
@@ -214,24 +218,28 @@ public class TestPhoenixConnectorTest
         throw new SkipException("Cannot find an unsupported data type");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testRenameColumn()
     {
         assertThatThrownBy(super::testRenameColumn)
                 // TODO (https://github.com/trinodb/trino/issues/7205) support column rename in Phoenix
                 .hasMessageContaining("Syntax error. Encountered \"RENAME\"");
-        throw new SkipException("Rename column is not yet supported by Phoenix connector");
+        abort("Rename column is not yet supported by Phoenix connector");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableRenameColumnToLongName()
     {
         assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
                 // TODO (https://github.com/trinodb/trino/issues/7205) support column rename in Phoenix
                 .hasMessageContaining("Syntax error. Encountered \"RENAME\"");
-        throw new SkipException("Rename column is not yet supported by Phoenix connector");
+        abort("Rename column is not yet supported by Phoenix connector");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testRenameColumnName(String columnName)
     {
@@ -243,9 +251,11 @@ public class TestPhoenixConnectorTest
         assertThatThrownBy(() -> super.testRenameColumnName(columnName))
                 // TODO (https://github.com/trinodb/trino/issues/7205) support column rename in Phoenix
                 .hasMessageContaining("Syntax error. Encountered \"RENAME\"");
-        throw new SkipException("Rename column is not yet supported by Phoenix connector");
+        abort("Rename column is not yet supported by Phoenix connector");
     }
 
+    @ParameterizedTest
+    @MethodSource("testColumnNameDataProvider")
     @Override
     public void testAddAndDropColumnName(String columnName)
     {
@@ -253,16 +263,17 @@ public class TestPhoenixConnectorTest
         if (columnName.equals("an'apostrophe")) {
             assertThatThrownBy(() -> super.testAddAndDropColumnName(columnName))
                     .hasMessageContaining("Syntax error. Mismatched input");
-            throw new SkipException("TODO");
+            abort("TODO");
         }
         if (columnName.equals("a\\backslash`")) {
             assertThatThrownBy(() -> super.testAddAndDropColumnName(columnName))
                     .hasMessageContaining("Undefined column");
-            throw new SkipException("TODO");
+            abort("TODO");
         }
         super.testAddAndDropColumnName(columnName);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertArray()
     {
@@ -271,10 +282,11 @@ public class TestPhoenixConnectorTest
                 .hasMessage("Phoenix JDBC driver replaced 'null' with '0.0' at index 1 in [0.0]");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateSchema()
     {
-        throw new SkipException("test disabled until issue fixed"); // TODO https://github.com/trinodb/trino/issues/2348
+        abort("test disabled until issue fixed"); // TODO https://github.com/trinodb/trino/issues/2348
     }
 
     @Override
@@ -309,6 +321,7 @@ public class TestPhoenixConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -332,6 +345,7 @@ public class TestPhoenixConnectorTest
                         ")");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -355,6 +369,7 @@ public class TestPhoenixConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testVarcharCharComparison()
     {
@@ -523,10 +538,11 @@ public class TestPhoenixConnectorTest
         assertUpdate("DROP TABLE " + targetTable);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testUpdateRowConcurrently()
     {
-        throw new SkipException("Phoenix doesn't support concurrent update of different columns in a row");
+        abort("Phoenix doesn't support concurrent update of different columns in a row");
     }
 
     @Test
@@ -780,34 +796,38 @@ public class TestPhoenixConnectorTest
                 .hasMessageContaining("Concurrent modification to table");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateSchemaWithLongName()
     {
         // TODO: Find the maximum table schema length in Phoenix and enable this test.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableWithLongTableName()
     {
         // TODO: Find the maximum table name length in Phoenix and enable this test.
         // Table name length with 65536 chars throws "startRow's length must be less than or equal to 32767 to meet the criteria for a row key."
         // 32767 chars still causes the same error and shorter names (e.g. 10000) causes timeout.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableWithLongColumnName()
     {
         // TODO: Find the maximum column name length in Phoenix and enable this test.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAlterTableAddLongColumnName()
     {
         // TODO: Find the maximum column name length in Phoenix and enable this test.
-        throw new SkipException("TODO");
+        abort("TODO");
     }
 
     @Test

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -207,8 +207,7 @@ public class TestPhoenixConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Phoenix connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Phoenix connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -285,6 +285,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
             <scope>test</scope>

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -90,8 +90,7 @@ public abstract class BaseRaptorConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        abort("Raptor connector does not support column default values");
-        throw new AssertionError(); // unreachable
+        return abort("Raptor connector does not support column default values");
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -25,7 +25,6 @@ import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.testng.services.Flaky;
 import org.intellij.lang.annotations.Language;
-import org.testng.SkipException;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
@@ -59,6 +58,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -90,7 +90,8 @@ public abstract class BaseRaptorConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Raptor connector does not support column default values");
+        abort("Raptor connector does not support column default values");
+        throw new AssertionError(); // unreachable
     }
 
     @Override
@@ -99,7 +100,7 @@ public abstract class BaseRaptorConnectorTest
         assertThat(e).hasMessageContaining("Table was updated by a different transaction. Please retry the operation.");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testCharVarcharComparison()
     {
@@ -599,7 +600,7 @@ public abstract class BaseRaptorConnectorTest
         assertQuery("SELECT count(DISTINCT \"$bucket_number\") FROM orders_bucketed_mixed", "SELECT 50");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorBucketedConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorBucketedConnectorTest.java
@@ -30,7 +30,7 @@ public class TestRaptorBucketedConnectorTest
         return createRaptorQueryRunner(ImmutableMap.of(), REQUIRED_TPCH_TABLES, true, ImmutableMap.of());
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -47,6 +47,7 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 
 public class TestRedshiftConnectorTest
         extends BaseJdbcConnectorTest
@@ -149,6 +150,7 @@ public class TestRedshiftConnectorTest
     /**
      * Overridden due to Redshift not supporting non-ASCII characters in CHAR.
      */
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableAsSelectWithUnicode()
     {
@@ -225,6 +227,7 @@ public class TestRedshiftConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDelete()
     {
@@ -587,17 +590,18 @@ public class TestRedshiftConnectorTest
         }
     }
 
+    @org.junit.jupiter.api.Test
     @Override
-    @Test
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
-        throw new SkipException("Test fails with a timeout sometimes and is flaky");
+        abort("Test fails with a timeout sometimes and is flaky");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertRowConcurrently()
     {
-        throw new SkipException("Test fails with a timeout sometimes and is flaky");
+        abort("Test fails with a timeout sometimes and is flaky");
     }
 
     @Override
@@ -657,6 +661,7 @@ public class TestRedshiftConnectorTest
         return RedshiftQueryRunner::executeInRedshift;
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {

--- a/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
+++ b/plugin/trino-singlestore/src/test/java/io/trino/plugin/singlestore/TestSingleStoreConnectorTest.java
@@ -23,7 +23,6 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
-import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -40,6 +39,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.abort;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -144,20 +144,23 @@ public class TestSingleStoreConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertUnicode()
     {
         // SingleStore's utf8 encoding is 3 bytes and truncates strings upon encountering a 4 byte sequence
-        throw new SkipException("SingleStore doesn't support utf8mb4");
+        abort("SingleStore doesn't support utf8mb4");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertHighestUnicodeCharacter()
     {
         // SingleStore's utf8 encoding is 3 bytes and truncates strings upon encountering a 4 byte sequence
-        throw new SkipException("SingleStore doesn't support utf8mb4");
+        abort("SingleStore doesn't support utf8mb4");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testDeleteWithLike()
     {
@@ -209,6 +212,7 @@ public class TestSingleStoreConnectorTest
     }
 
     // Overridden because the method from BaseConnectorTest fails on one of the assertions, see TODO below
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertIntoNotNullColumn()
     {
@@ -253,6 +257,7 @@ public class TestSingleStoreConnectorTest
         assertUpdate("DROP TABLE test_column_comment");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testAddNotNullColumn()
     {
@@ -316,6 +321,7 @@ public class TestSingleStoreConnectorTest
                 .isNotFullyPushedDown(AggregationNode.class);
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testCreateTableAsSelectNegativeDate()
     {
@@ -324,7 +330,7 @@ public class TestSingleStoreConnectorTest
                 .hasStackTraceContaining("TrinoException: Driver returned null LocalDate for a non-null value");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testInsertNegativeDate()
     {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -25,6 +25,7 @@ import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
 import io.trino.testng.services.Flaky;
+import org.junit.jupiter.api.Timeout;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -40,6 +41,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.TestingNames.randomNameSuffix;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,14 +132,15 @@ public abstract class BaseSqlServerConnectorTest
 
     // TODO (https://github.com/trinodb/trino/issues/10846): Test is expected to be flaky because tests execute in parallel
     @Flaky(issue = "https://github.com/trinodb/trino/issues/10846", match = "was deadlocked on lock resources with another process and has been chosen as the deadlock victim")
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testSelectInformationSchemaColumns()
     {
         super.testSelectInformationSchemaColumns();
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
+    @Timeout(value = 180, unit = SECONDS)
     @Override
     public void testReadMetadataWithRelationsConcurrentModifications()
     {
@@ -447,7 +450,7 @@ public abstract class BaseSqlServerConnectorTest
         onRemoteDatabase().execute("SELECT count(*) FROM dbo.orders WHERE " + longInClauses);
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -576,7 +579,7 @@ public abstract class BaseSqlServerConnectorTest
         assertUpdate("DROP TABLE test_show_unique_constraint_table");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testDateYearOfEraPredicate()
     {

--- a/pom.xml
+++ b/pom.xml
@@ -2476,6 +2476,10 @@
                 <configuration>
                     <properties>
                         <configurationParameters>junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD
+                            junit.jupiter.execution.parallel.enabled=true
+                            junit.jupiter.execution.parallel.mode.default=concurrent
+                            junit.jupiter.execution.parallel.config.strategy=fixed
+                            junit.jupiter.execution.parallel.config.fixed.parallelism=${air.test.thread-count}
                             junit.jupiter.extensions.autodetection.enabled = true</configurationParameters>
                     </properties>
                     <includes>

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyAnnotationVerifier.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/FlakyAnnotationVerifier.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -115,6 +116,9 @@ public class FlakyAnnotationVerifier
         return Arrays.stream(realClass.getMethods())
                 .filter(method -> findInheritableAnnotation(method, Flaky.class).isPresent())
                 .filter(method -> !method.isAnnotationPresent(Test.class))
+                .filter(method -> Stream.of(method.getAnnotations())
+                        .map(Annotation::getClass)
+                        .noneMatch(ReportBadTestAnnotations::isJUnitAnnotation))
                 .collect(toImmutableList());
     }
 

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportBadTestAnnotations.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/ReportBadTestAnnotations.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -202,9 +203,10 @@ public class ReportBadTestAnnotations
                 });
     }
 
-    private static boolean isJUnitAnnotation(Class<? extends Annotation> clazz)
+    public static boolean isJUnitAnnotation(Class<? extends Annotation> clazz)
     {
-        return clazz.getPackage().getName().startsWith("org.junit.jupiter.");
+        return clazz.getPackage().getName().startsWith("org.junit.jupiter.") ||
+                Stream.of(clazz.getInterfaces()).anyMatch(interfaceClass -> interfaceClass.getPackage().getName().startsWith("org.junit.jupiter."));
     }
 
     @VisibleForTesting

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -180,6 +180,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -2976,7 +2976,7 @@ public abstract class BaseConnectorTest
         catch (Exception e) {
             verifyUnsupportedTypeException(e, setup.sourceColumnType);
             abort("Unsupported column type: " + setup.sourceColumnType);
-            throw new AssertionError(); // unreachable
+            return; // unreachable
         }
         try (table) {
             Runnable setColumnType = () -> assertUpdate("ALTER TABLE " + table.getName() + " ALTER COLUMN col SET DATA TYPE " + setup.newColumnType);
@@ -3186,7 +3186,7 @@ public abstract class BaseConnectorTest
         catch (Exception e) {
             verifyUnsupportedTypeException(e, setup.sourceColumnType);
             abort("Unsupported column type: " + setup.sourceColumnType);
-            throw new AssertionError(); // unreachable
+            return; // unreachable
         }
         try (table) {
             Runnable setFieldType = () -> assertUpdate("ALTER TABLE " + table.getName() + " ALTER COLUMN col.field SET DATA TYPE " + setup.newColumnType);

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
@@ -151,7 +151,7 @@ public class TestTpchConnectorTest
                 "SELECT * FROM lineitem ORDER BY orderkey ASC LIMIT 10");
     }
 
-    @Test
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowTables()
     {
@@ -162,6 +162,7 @@ public class TestTpchConnectorTest
         assertQueryFails("SHOW TABLES FROM sf0", "line 1:1: Schema 'sf0' does not exist");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testShowCreateTable()
     {
@@ -179,6 +180,7 @@ public class TestTpchConnectorTest
                         ")");
     }
 
+    @org.junit.jupiter.api.Test
     @Override
     public void testPredicateReflectedInExplain()
     {


### PR DESCRIPTION
Its parent class, `AbstractTestQueries` already has JUnit annotations, so migrating `BaseConnectorTest` now won't increase number of test setups run during a CI run.
