### PR TITLE
Ensure "nessie.commit.id table" property is set when updating the table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
@@ -19,9 +19,11 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.nessie.NessieIcebergClient;
+import org.apache.iceberg.nessie.NessieUtil;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ContentKey;
@@ -78,6 +80,16 @@ public class IcebergNessieTableOperations
     {
         refreshNessieClient();
         return super.refresh(invalidateCaches);
+    }
+
+    @Override
+    protected void refreshFromMetadataLocation(String newLocation)
+    {
+        super.refreshFromMetadataLocation(
+                newLocation,
+                location -> NessieUtil.updateTableMetadataWithNessieSpecificProperties(
+                    TableMetadataParser.read(fileIo, location),
+                    location, table, getSchemaTableName().toString(), nessieClient.getReference()));
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Spark sets the table property `NESSIE_COMMIT_ID_PROPERTY` in `NessieTableOperations#loadTableMetadata`. Then `NessieIcebergClient.commitTable` uses this property.

In Trino, this property is never set but used in `NessieIcebergClient.commitTable` as it is a common code. Hence, the commit id is old and doesn't allow new commits.

Use the common code (available From Iceberg 1.4.0) `NessieUtil.updateTableMetadataWithNessieSpecificProperties` in Trino, which handles setting the property like `"nessie.commit.id"`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes https://github.com/trinodb/trino/issues/17813   


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
