### PR TITLE
Fix syntax in `PredicatePushDown#createDynamicFilters` arguments list

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -610,7 +610,8 @@ public class PredicatePushDown
                 JoinNode node,
                 List<JoinNode.EquiJoinClause> equiJoinClauses,
                 List<Expression> joinFilterClauses,
-                Session session, PlanNodeIdAllocator idAllocator)
+                Session session,
+                PlanNodeIdAllocator idAllocator)
         {
             if ((node.getType() != INNER && node.getType() != RIGHT) || !isEnableDynamicFiltering(session) || !dynamicFiltering) {
                 return new DynamicFiltersResult(ImmutableMap.of(), ImmutableList.of());


### PR DESCRIPTION
## Description

Fix syntax in `PredicatePushDown#createDynamicFilters` arguments list

## Release notes

(* ) This is not user-visible or is docs only, and no release notes are required.

