### PR TITLE
Update JLine to 3.24.0

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -15,7 +15,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <main-class>io.trino.cli.Trino</main-class>
-        <dep.jline.version>3.21.0</dep.jline.version>
+        <dep.jline.version>3.24.0</dep.jline.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This version solves a bug that prevented us from upgrading to 3.23.0. This version is tested against JDK 21