### PR TITLE
Fix docs render for date_parse

### DIFF
--- a/docs/src/main/sphinx/functions/datetime.md
+++ b/docs/src/main/sphinx/functions/datetime.md
@@ -426,10 +426,10 @@ SELECT date_format(TIMESTAMP '2022-10-20 05:10:00', '%m-%d-%Y %H');
 ```
 :::
 
-:::{function} date_parse(string, format) -> timestamp(3)
+:::{js:function} date_parse(string, format) → timestamp(3)
 Parses `string` into a timestamp using `format`:
 
-```
+```sql
 SELECT date_parse('2022/10/20/05', '%Y/%m/%d/%H');
 -- 2022-10-20 05:00:00.000
 ```


### PR DESCRIPTION
## Description

Somehow the output is currently not displayed. 

Changing to js:function fixes the render but makes the output parameter italics.

The upper approach gets rid of using of a Sphinx domain and just hardcodes the output. But then we need to add an anchor and also the indent of the function gets lost.

If we truly want to control this stuff we need to add a new SQL or even Trino SQL domain as extensions or even as contribution to sphinx. Thats quite a lot of work though.. 

https://www.sphinx-doc.org/en/master/usage/domains/index.html
https://github.com/sphinx-doc/sphinx/tree/master/sphinx/domains


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
