### PR TITLE
Improve CBO estimates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -208,6 +208,8 @@ public final class SystemSessionProperties
     public static final String USE_COST_BASED_PARTITIONING = "use_cost_based_partitioning";
     public static final String FORCE_SPILLING_JOIN = "force_spilling_join";
     public static final String PAGE_PARTITIONING_BUFFER_POOL_SIZE = "page_partitioning_buffer_pool_size";
+    public static final String ENHANCE_UNKNOWN_STATS_CALCULATION = "enhance_unknown_stats_calculation";
+    public static final String ENHANCE_UNKNOWN_COST_CALCULATION = "enhance_unknown_cost_calculation";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1064,7 +1066,17 @@ public final class SystemSessionProperties
                 integerProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE,
                         "Maximum number of free buffers in the per task partitioned page buffer pool. Setting this to zero effectively disables the pool",
                         taskManagerConfig.getPagePartitioningBufferPoolSize(),
-                        true));
+                        true),
+                booleanProperty(
+                        ENHANCE_UNKNOWN_STATS_CALCULATION,
+                        "Enhance unknown stats calculation",
+                        optimizerConfig.isEnhanceUnknownStatsCalculation(),
+                        false),
+                booleanProperty(
+                        ENHANCE_UNKNOWN_COST_CALCULATION,
+                        "Enhance unknown cost calculation",
+                        optimizerConfig.isEnhanceUnknownCostCalculation(),
+                        false));
     }
 
     @Override
@@ -1906,5 +1918,15 @@ public final class SystemSessionProperties
     public static int getPagePartitioningBufferPoolSize(Session session)
     {
         return session.getSystemProperty(PAGE_PARTITIONING_BUFFER_POOL_SIZE, Integer.class);
+    }
+
+    public static boolean isEnhanceUnknownStatsCalculation(Session session)
+    {
+        return session.getSystemProperty(ENHANCE_UNKNOWN_STATS_CALCULATION, Boolean.class);
+    }
+
+    public static boolean isEnhanceUnknownCostCalculation(Session session)
+    {
+        return session.getSystemProperty(ENHANCE_UNKNOWN_COST_CALCULATION, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComposableStatsCalculator.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Multimaps.toMultimap;
+import static io.trino.SystemSessionProperties.isEnhanceUnknownStatsCalculation;
 
 public class ComposableStatsCalculator
         implements StatsCalculator
@@ -73,6 +74,10 @@ public class ComposableStatsCalculator
             if (calculatedStats.isPresent()) {
                 return calculatedStats.get();
             }
+        }
+
+        if (isEnhanceUnknownStatsCalculation(session) && node.getSources().size() == 1) {
+            return sourceStats.getStats(node.getSources().get(0));
         }
         return PlanNodeStatsEstimate.unknown();
     }

--- a/core/trino-main/src/main/java/io/trino/cost/DistinctLimitStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/DistinctLimitStatsRule.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 
 import java.util.Optional;
@@ -50,8 +51,10 @@ public class DistinctLimitStatsRule
 
         PlanNodeStatsEstimate distinctStats = AggregationStatsRule.groupBy(
                 statsProvider.getStats(node.getSource()),
+                AggregationNode.Step.SINGLE,
                 node.getDistinctSymbols(),
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                session);
         PlanNodeStatsEstimate distinctLimitStats = distinctStats.mapOutputRowCount(rowCount -> min(rowCount, node.getLimit()));
         return Optional.of(distinctLimitStats);
     }

--- a/core/trino-main/src/main/java/io/trino/cost/StatsCalculatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/StatsCalculatorModule.java
@@ -72,6 +72,7 @@ public class StatsCalculatorModule
             rules.add(new LimitStatsRule(normalizer));
             rules.add(new DistinctLimitStatsRule(normalizer));
             rules.add(new TopNStatsRule(normalizer));
+            rules.add(new TopNRankingStatsRule(normalizer));
             rules.add(new EnforceSingleRowStatsRule(normalizer));
             rules.add(new ProjectStatsRule(scalarStatsCalculator, normalizer));
             rules.add(new ExchangeStatsRule(normalizer));

--- a/core/trino-main/src/main/java/io/trino/cost/TopNRankingStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TopNRankingStatsRule.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.cost;
+
+import io.airlift.log.Logger;
+import io.trino.Session;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.iterative.Lookup;
+import io.trino.sql.planner.plan.TopNRankingNode;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.isEnhanceUnknownStatsCalculation;
+import static io.trino.sql.planner.plan.Patterns.topNRanking;
+
+public class TopNRankingStatsRule
+        extends SimpleStatsRule<TopNRankingNode>
+{
+    private static final Logger log = Logger.get(TopNRankingNode.class);
+
+    private static final Pattern<TopNRankingNode> PATTERN = topNRanking();
+
+    public TopNRankingStatsRule(StatsNormalizer normalizer)
+    {
+        super(normalizer);
+    }
+
+    @Override
+    public Pattern<TopNRankingNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    protected Optional<PlanNodeStatsEstimate> doCalculate(TopNRankingNode node, StatsProvider statsProvider, Lookup lookup, Session session, TypeProvider types, TableStatsProvider tableStatsProvider)
+    {
+        if (isEnhanceUnknownStatsCalculation(session)) {
+            return Optional.of(statsProvider.getStats(node.getSource()));
+        }
+
+        return Optional.of(PlanNodeStatsEstimate.unknown());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerConfig.java
@@ -93,6 +93,8 @@ public class OptimizerConfig
     private long joinPartitionedBuildMinRowCount = 1_000_000L;
     private DataSize minInputSizePerTask = DataSize.of(5, GIGABYTE);
     private long minInputRowsPerTask = 10_000_000L;
+    private boolean enhanceUnknownStatsCalculation;
+    private boolean enhanceUnknownCostCalculation;
 
     public enum JoinReorderingStrategy
     {
@@ -785,6 +787,30 @@ public class OptimizerConfig
     public OptimizerConfig setUseCostBasedPartitioning(boolean useCostBasedPartitioning)
     {
         this.useCostBasedPartitioning = useCostBasedPartitioning;
+        return this;
+    }
+
+    public boolean isEnhanceUnknownStatsCalculation()
+    {
+        return enhanceUnknownStatsCalculation;
+    }
+
+    @Config("optimizer.enhance-unknown-stats-calculation")
+    public OptimizerConfig setEnhanceUnknownStatsCalculation(boolean enhanceUnknownStatsCalculation)
+    {
+        this.enhanceUnknownStatsCalculation = enhanceUnknownStatsCalculation;
+        return this;
+    }
+
+    public boolean isEnhanceUnknownCostCalculation()
+    {
+        return enhanceUnknownCostCalculation;
+    }
+
+    @Config("optimizer.enhance-unknown-cost-calculation")
+    public OptimizerConfig setEnhanceUnknownCostCalculation(boolean enhanceUnknownCostCalculation)
+    {
+        this.enhanceUnknownCostCalculation = enhanceUnknownCostCalculation;
         return this;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestOptimizerConfig.java
@@ -91,7 +91,9 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(5, GIGABYTE))
                 .setMinInputRowsPerTask(10_000_000L)
                 .setUseExactPartitioning(false)
-                .setUseCostBasedPartitioning(true));
+                .setUseCostBasedPartitioning(true)
+                .setEnhanceUnknownStatsCalculation(false)
+                .setEnhanceUnknownCostCalculation(false));
     }
 
     @Test
@@ -150,6 +152,8 @@ public class TestOptimizerConfig
                 .put("optimizer.min-input-rows-per-task", "1000000")
                 .put("optimizer.use-exact-partitioning", "true")
                 .put("optimizer.use-cost-based-partitioning", "false")
+                .put("optimizer.enhance-unknown-stats-calculation", "true")
+                .put("optimizer.enhance-unknown-cost-calculation", "true")
                 .buildOrThrow();
 
         OptimizerConfig expected = new OptimizerConfig()
@@ -204,7 +208,9 @@ public class TestOptimizerConfig
                 .setMinInputSizePerTask(DataSize.of(1, MEGABYTE))
                 .setMinInputRowsPerTask(1_000_000L)
                 .setUseExactPartitioning(true)
-                .setUseCostBasedPartitioning(false);
+                .setUseCostBasedPartitioning(false)
+                .setEnhanceUnknownStatsCalculation(true)
+                .setEnhanceUnknownCostCalculation(true);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR adds missing cardinality / cost estimation logic to allow more TPC-DS queries to enforce the CBO rules. 
Adds estimation logic for LikePredicate, Case Expression, simple aggregation functions like count(*), sum, min, max. This also adds basic cost model for TopNRankingNode.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
