### PR TITLE
Rename legacyPreparedStatements to explicitPrepare

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -99,7 +99,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, String> DNS_RESOLVER_CONTEXT = new ResolverContext();
     public static final ConnectionProperty<String, String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
     public static final ConnectionProperty<String, ZoneId> TIMEZONE = new TimeZone();
-    public static final ConnectionProperty<String, Boolean> LEGACY_PREPARED_STATEMENTS = new LegacyPreparedStatements();
+    public static final ConnectionProperty<String, Boolean> EXPLICIT_PREPARE = new ExplicitPrepare();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             .add(USER)
@@ -145,7 +145,7 @@ final class ConnectionProperties
             .add(DNS_RESOLVER_CONTEXT)
             .add(HOSTNAME_IN_CERTIFICATE)
             .add(TIMEZONE)
-            .add(LEGACY_PREPARED_STATEMENTS)
+            .add(EXPLICIT_PREPARE)
             .build();
 
     private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -718,12 +718,12 @@ final class ConnectionProperties
         }
     }
 
-    private static class LegacyPreparedStatements
+    private static class ExplicitPrepare
             extends AbstractConnectionProperty<String, Boolean>
     {
-        public LegacyPreparedStatements()
+        public ExplicitPrepare()
         {
-            super(PropertyName.LEGACY_PREPARED_STATEMENTS, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+            super(PropertyName.EXPLICIT_PREPARE, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -61,7 +61,7 @@ public enum PropertyName
     TRACE_TOKEN("traceToken"),
     SESSION_PROPERTIES("sessionProperties"),
     SOURCE("source"),
-    LEGACY_PREPARED_STATEMENTS("legacyPreparedStatements"),
+    EXPLICIT_PREPARE("explicitPrepare"),
     DNS_RESOLVER("dnsResolver"),
     DNS_RESOLVER_CONTEXT("dnsResolverContext"),
     HOSTNAME_IN_CERTIFICATE("hostnameInCertificate"),

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -70,6 +70,7 @@ import static io.trino.client.uri.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.client.uri.ConnectionProperties.DISABLE_COMPRESSION;
 import static io.trino.client.uri.ConnectionProperties.DNS_RESOLVER;
 import static io.trino.client.uri.ConnectionProperties.DNS_RESOLVER_CONTEXT;
+import static io.trino.client.uri.ConnectionProperties.EXPLICIT_PREPARE;
 import static io.trino.client.uri.ConnectionProperties.EXTERNAL_AUTHENTICATION;
 import static io.trino.client.uri.ConnectionProperties.EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS;
 import static io.trino.client.uri.ConnectionProperties.EXTERNAL_AUTHENTICATION_TIMEOUT;
@@ -86,7 +87,6 @@ import static io.trino.client.uri.ConnectionProperties.KERBEROS_PRINCIPAL;
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.client.uri.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
-import static io.trino.client.uri.ConnectionProperties.LEGACY_PREPARED_STATEMENTS;
 import static io.trino.client.uri.ConnectionProperties.PASSWORD;
 import static io.trino.client.uri.ConnectionProperties.ROLES;
 import static io.trino.client.uri.ConnectionProperties.SESSION_PROPERTIES;
@@ -168,7 +168,7 @@ public class TrinoUri
     private Optional<String> traceToken;
     private Optional<Map<String, String>> sessionProperties;
     private Optional<String> source;
-    private Optional<Boolean> legacyPreparedStatements;
+    private Optional<Boolean> explicitPrepare;
 
     private Optional<String> catalog = Optional.empty();
     private Optional<String> schema = Optional.empty();
@@ -222,7 +222,7 @@ public class TrinoUri
             Optional<String> traceToken,
             Optional<Map<String, String>> sessionProperties,
             Optional<String> source,
-            Optional<Boolean> legacyPreparedStatements)
+            Optional<Boolean> explicitPrepare)
             throws SQLException
     {
         this.uri = requireNonNull(uri, "uri is null");
@@ -275,7 +275,7 @@ public class TrinoUri
         this.traceToken = TRACE_TOKEN.getValueOrDefault(urlProperties, traceToken);
         this.sessionProperties = SESSION_PROPERTIES.getValueOrDefault(urlProperties, sessionProperties);
         this.source = SOURCE.getValueOrDefault(urlProperties, source);
-        this.legacyPreparedStatements = LEGACY_PREPARED_STATEMENTS.getValueOrDefault(urlProperties, legacyPreparedStatements);
+        this.explicitPrepare = EXPLICIT_PREPARE.getValueOrDefault(urlProperties, explicitPrepare);
 
         properties = buildProperties();
 
@@ -361,7 +361,7 @@ public class TrinoUri
         clientTags.ifPresent(value -> properties.setProperty(PropertyName.CLIENT_TAGS.toString(), value));
         traceToken.ifPresent(value -> properties.setProperty(PropertyName.TRACE_TOKEN.toString(), value));
         source.ifPresent(value -> properties.setProperty(PropertyName.SOURCE.toString(), value));
-        legacyPreparedStatements.ifPresent(value -> properties.setProperty(PropertyName.LEGACY_PREPARED_STATEMENTS.toString(), value.toString()));
+        explicitPrepare.ifPresent(value -> properties.setProperty(PropertyName.EXPLICIT_PREPARE.toString(), value.toString()));
         return properties;
     }
 
@@ -421,7 +421,7 @@ public class TrinoUri
         this.traceToken = TRACE_TOKEN.getValue(properties);
         this.sessionProperties = SESSION_PROPERTIES.getValue(properties);
         this.source = SOURCE.getValue(properties);
-        this.legacyPreparedStatements = LEGACY_PREPARED_STATEMENTS.getValue(properties);
+        this.explicitPrepare = EXPLICIT_PREPARE.getValue(properties);
 
         // enable SSL by default for the trino schema and the standard port
         useSecureConnection = ssl.orElse(uri.getScheme().equals("https") || (uri.getScheme().equals("trino") && uri.getPort() == 443));
@@ -529,9 +529,9 @@ public class TrinoUri
         return source;
     }
 
-    public Optional<Boolean> getLegacyPreparedStatements()
+    public Optional<Boolean> getExplicitPrepare()
     {
-        return legacyPreparedStatements;
+        return explicitPrepare;
     }
 
     public boolean isCompressionDisabled()
@@ -938,7 +938,7 @@ public class TrinoUri
         private String traceToken;
         private Map<String, String> sessionProperties;
         private String source;
-        private Boolean legacyPreparedStatements;
+        private Boolean explicitPrepare;
 
         private Builder() {}
 
@@ -1227,9 +1227,9 @@ public class TrinoUri
             return this;
         }
 
-        public Builder setLegacyPreparedStatements(Boolean legacyPreparedStatements)
+        public Builder setExplicitPrepare(Boolean explicitPrepare)
         {
-            this.legacyPreparedStatements = requireNonNull(legacyPreparedStatements, "legacyPreparedStatements is null");
+            this.explicitPrepare = requireNonNull(explicitPrepare, "explicitPrepare is null");
             return this;
         }
 
@@ -1282,7 +1282,7 @@ public class TrinoUri
                     Optional.ofNullable(traceToken),
                     Optional.ofNullable(sessionProperties),
                     Optional.ofNullable(source),
-                    Optional.ofNullable(legacyPreparedStatements));
+                    Optional.ofNullable(explicitPrepare));
         }
     }
 }

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -134,6 +134,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
             <scope>test</scope>
         </dependency>
@@ -255,6 +261,12 @@
         <dependency>
             <groupId>org.eclipse.jetty.toolchain</groupId>
             <artifactId>jetty-jakarta-servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -112,7 +112,7 @@ public class TrinoConnection
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final Call.Factory httpCallFactory;
     private final Set<TrinoStatement> statements = newSetFromMap(new ConcurrentHashMap<>());
-    private boolean useLegacyPreparedStatements = true;
+    private boolean useExplicitPrepare = true;
 
     TrinoConnection(TrinoDriverUri uri, Call.Factory httpCallFactory)
     {
@@ -146,7 +146,7 @@ public class TrinoConnection
         locale.set(Locale.getDefault());
         sessionProperties.putAll(uri.getSessionProperties());
 
-        uri.getLegacyPreparedStatements().ifPresent(value -> this.useLegacyPreparedStatements = value);
+        uri.getExplicitPrepare().ifPresent(value -> this.useExplicitPrepare = value);
     }
 
     @Override
@@ -915,8 +915,8 @@ public class TrinoConnection
         }
     }
 
-    public Boolean isUseLegacyPreparedStatements()
+    public boolean useExplicitPrepare()
     {
-        return this.useLegacyPreparedStatements;
+        return this.useExplicitPrepare;
     }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
@@ -117,7 +117,7 @@ public class TrinoPreparedStatement
         super(connection, onClose);
         this.statementName = requireNonNull(statementName, "statementName is null");
         this.originalSql = requireNonNull(sql, "sql is null");
-        if (connection().isUseLegacyPreparedStatements()) {
+        if (connection().useExplicitPrepare()) {
             super.execute(format("PREPARE %s FROM %s", statementName, sql));
             prepareStatementExecuted = true;
         }
@@ -1020,7 +1020,7 @@ public class TrinoPreparedStatement
     private String getExecuteSql(String statementName, List<String> values)
             throws SQLException
     {
-        return connection().isUseLegacyPreparedStatements()
+        return connection().useExplicitPrepare()
                 ? getLegacySql(statementName, values)
                 : getExecuteImmediateSql(values);
     }
@@ -1147,7 +1147,7 @@ public class TrinoPreparedStatement
     }
 
     /*
-    When isUseLegacyPreparedStatements is disabled, the PREPARE statement won't be executed unless needed
+    When explicitPrepare is disabled, the PREPARE statement won't be executed unless needed
     e.g. when getMetadata() or getParameterMetadata() are called.
     When needed, just make sure it is executed only once, even if the metadata methods are called many times
      */

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -121,10 +121,10 @@ public class TestJdbcPreparedStatement
         testExecuteQuery(true);
     }
 
-    private void testExecuteQuery(boolean useLegacyPreparedStatements)
+    private void testExecuteQuery(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection(useLegacyPreparedStatements);
+        try (Connection connection = createConnection(explicitPrepare);
                 PreparedStatement statement = connection.prepareStatement("SELECT ?, ?")) {
             statement.setInt(1, 123);
             statement.setString(2, "hello");
@@ -154,10 +154,10 @@ public class TestJdbcPreparedStatement
         testGetMetadata(false);
     }
 
-    private void testGetMetadata(boolean useLegacyPreparedStatements)
+    private void testGetMetadata(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection("blackhole", "blackhole", explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE test_get_metadata (" +
                         "c_boolean boolean, " +
@@ -219,10 +219,10 @@ public class TestJdbcPreparedStatement
         testGetParameterMetaData(false);
     }
 
-    private void testGetParameterMetaData(boolean useLegacyPreparedStatements)
+    private void testGetParameterMetaData(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection("blackhole", "blackhole", explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE test_get_parameterMetaData (" +
                         "c_boolean boolean, " +
@@ -414,10 +414,10 @@ public class TestJdbcPreparedStatement
         testDeallocate(false);
     }
 
-    private void testDeallocate(boolean useLegacyPreparedStatements)
+    private void testDeallocate(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection(useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection(explicitPrepare)) {
             for (int i = 0; i < 200; i++) {
                 try {
                     connection.prepareStatement("SELECT '" + repeat("a", 300) + "'").close();
@@ -437,10 +437,10 @@ public class TestJdbcPreparedStatement
         testCloseIdempotency(false);
     }
 
-    private void testCloseIdempotency(boolean useLegacyPreparedStatements)
+    private void testCloseIdempotency(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection(useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection(explicitPrepare)) {
             PreparedStatement statement = connection.prepareStatement("SELECT 123");
             statement.close();
             statement.close();
@@ -455,11 +455,11 @@ public class TestJdbcPreparedStatement
         testLargePreparedStatement(false);
     }
 
-    private void testLargePreparedStatement(boolean useLegacyPreparedStatements)
+    private void testLargePreparedStatement(boolean explicitPrepare)
             throws Exception
     {
         int elements = HEADER_SIZE_LIMIT + 1;
-        try (Connection connection = createConnection(useLegacyPreparedStatements);
+        try (Connection connection = createConnection(explicitPrepare);
                 PreparedStatement statement = connection.prepareStatement("VALUES ?" + repeat(", ?", elements - 1))) {
             for (int i = 0; i < elements; i++) {
                 statement.setLong(i + 1, i);
@@ -479,10 +479,10 @@ public class TestJdbcPreparedStatement
         testExecuteUpdate(false);
     }
 
-    public void testExecuteUpdate(boolean useLegacyPreparedStatements)
+    public void testExecuteUpdate(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection("blackhole", "blackhole", explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE test_execute_update (" +
                         "c_boolean boolean, " +
@@ -525,10 +525,10 @@ public class TestJdbcPreparedStatement
         testExecuteBatch(false);
     }
 
-    private void testExecuteBatch(boolean useLegacyPreparedStatements)
+    private void testExecuteBatch(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection("memory", "default", useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection("memory", "default", explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE test_execute_batch(c_int integer)");
             }
@@ -579,10 +579,10 @@ public class TestJdbcPreparedStatement
         testInvalidExecuteBatch(false);
     }
 
-    private void testInvalidExecuteBatch(boolean useLegacyPreparedStatements)
+    private void testInvalidExecuteBatch(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
+        try (Connection connection = createConnection("blackhole", "blackhole", explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute("CREATE TABLE test_invalid_execute_batch(c_int integer)");
             }
@@ -621,10 +621,10 @@ public class TestJdbcPreparedStatement
         testPrepareMultiple(false);
     }
 
-    private void testPrepareMultiple(boolean useLegacyPreparedStatements)
+    private void testPrepareMultiple(boolean explicitPrepare)
             throws Exception
     {
-        try (Connection connection = createConnection(useLegacyPreparedStatements);
+        try (Connection connection = createConnection(explicitPrepare);
                 PreparedStatement statement1 = connection.prepareStatement("SELECT 123");
                 PreparedStatement statement2 = connection.prepareStatement("SELECT 456")) {
             try (ResultSet rs = statement1.executeQuery()) {
@@ -649,11 +649,11 @@ public class TestJdbcPreparedStatement
         testPrepareLarge(false);
     }
 
-    private void testPrepareLarge(boolean useLegacyPreparedStatements)
+    private void testPrepareLarge(boolean explicitPrepare)
             throws Exception
     {
         String sql = format("SELECT '%s' = '%s'", repeat("x", 100_000), repeat("y", 100_000));
-        try (Connection connection = createConnection(useLegacyPreparedStatements);
+        try (Connection connection = createConnection(explicitPrepare);
                 PreparedStatement statement = connection.prepareStatement(sql);
                 ResultSet rs = statement.executeQuery()) {
             assertTrue(rs.next());
@@ -670,46 +670,46 @@ public class TestJdbcPreparedStatement
         testSetNull(false);
     }
 
-    private void testSetNull(boolean useLegacyPreparedStatements)
+    private void testSetNull(boolean explicitPrepare)
             throws Exception
     {
-        assertSetNull(Types.BOOLEAN, useLegacyPreparedStatements);
-        assertSetNull(Types.BIT, Types.BOOLEAN, useLegacyPreparedStatements);
-        assertSetNull(Types.TINYINT, useLegacyPreparedStatements);
-        assertSetNull(Types.SMALLINT, useLegacyPreparedStatements);
-        assertSetNull(Types.INTEGER, useLegacyPreparedStatements);
-        assertSetNull(Types.BIGINT, useLegacyPreparedStatements);
-        assertSetNull(Types.REAL, useLegacyPreparedStatements);
-        assertSetNull(Types.FLOAT, Types.REAL, useLegacyPreparedStatements);
-        assertSetNull(Types.DECIMAL, useLegacyPreparedStatements);
-        assertSetNull(Types.NUMERIC, Types.DECIMAL, useLegacyPreparedStatements);
-        assertSetNull(Types.CHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.NCHAR, Types.CHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.VARCHAR, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.NVARCHAR, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.LONGVARCHAR, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.VARCHAR, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.CLOB, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.NCLOB, Types.VARCHAR, useLegacyPreparedStatements);
-        assertSetNull(Types.VARBINARY, Types.VARBINARY, useLegacyPreparedStatements);
-        assertSetNull(Types.VARBINARY, useLegacyPreparedStatements);
-        assertSetNull(Types.BLOB, Types.VARBINARY, useLegacyPreparedStatements);
-        assertSetNull(Types.DATE, useLegacyPreparedStatements);
-        assertSetNull(Types.TIME, useLegacyPreparedStatements);
-        assertSetNull(Types.TIMESTAMP, useLegacyPreparedStatements);
-        assertSetNull(Types.NULL, useLegacyPreparedStatements);
+        assertSetNull(Types.BOOLEAN, explicitPrepare);
+        assertSetNull(Types.BIT, Types.BOOLEAN, explicitPrepare);
+        assertSetNull(Types.TINYINT, explicitPrepare);
+        assertSetNull(Types.SMALLINT, explicitPrepare);
+        assertSetNull(Types.INTEGER, explicitPrepare);
+        assertSetNull(Types.BIGINT, explicitPrepare);
+        assertSetNull(Types.REAL, explicitPrepare);
+        assertSetNull(Types.FLOAT, Types.REAL, explicitPrepare);
+        assertSetNull(Types.DECIMAL, explicitPrepare);
+        assertSetNull(Types.NUMERIC, Types.DECIMAL, explicitPrepare);
+        assertSetNull(Types.CHAR, explicitPrepare);
+        assertSetNull(Types.NCHAR, Types.CHAR, explicitPrepare);
+        assertSetNull(Types.VARCHAR, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.NVARCHAR, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.LONGVARCHAR, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.VARCHAR, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.CLOB, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.NCLOB, Types.VARCHAR, explicitPrepare);
+        assertSetNull(Types.VARBINARY, Types.VARBINARY, explicitPrepare);
+        assertSetNull(Types.VARBINARY, explicitPrepare);
+        assertSetNull(Types.BLOB, Types.VARBINARY, explicitPrepare);
+        assertSetNull(Types.DATE, explicitPrepare);
+        assertSetNull(Types.TIME, explicitPrepare);
+        assertSetNull(Types.TIMESTAMP, explicitPrepare);
+        assertSetNull(Types.NULL, explicitPrepare);
     }
 
-    private void assertSetNull(int sqlType, boolean useLegacyPreparedStatements)
+    private void assertSetNull(int sqlType, boolean explicitPrepare)
             throws SQLException
     {
-        assertSetNull(sqlType, sqlType, useLegacyPreparedStatements);
+        assertSetNull(sqlType, sqlType, explicitPrepare);
     }
 
-    private void assertSetNull(int sqlType, int expectedSqlType, boolean useLegacyPreparedStatements)
+    private void assertSetNull(int sqlType, int expectedSqlType, boolean explicitPrepare)
             throws SQLException
     {
-        try (Connection connection = createConnection(useLegacyPreparedStatements);
+        try (Connection connection = createConnection(explicitPrepare);
                 PreparedStatement statement = connection.prepareStatement("SELECT ?")) {
             statement.setNull(1, sqlType);
 
@@ -732,23 +732,23 @@ public class TestJdbcPreparedStatement
         testConvertBoolean(false);
     }
 
-    private void testConvertBoolean(boolean useLegacyPreparedStatements)
+    private void testConvertBoolean(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setBoolean(i, true), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-        assertBind((ps, i) -> ps.setBoolean(i, false), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
-        assertBind((ps, i) -> ps.setObject(i, true), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-        assertBind((ps, i) -> ps.setObject(i, false), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
+        assertBind((ps, i) -> ps.setBoolean(i, true), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+        assertBind((ps, i) -> ps.setBoolean(i, false), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
+        assertBind((ps, i) -> ps.setObject(i, true), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+        assertBind((ps, i) -> ps.setObject(i, false), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
 
         for (int type : asList(Types.BOOLEAN, Types.BIT)) {
-            assertBind((ps, i) -> ps.setObject(i, true, type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-            assertBind((ps, i) -> ps.setObject(i, false, type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
-            assertBind((ps, i) -> ps.setObject(i, 13, type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-            assertBind((ps, i) -> ps.setObject(i, 0, type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
-            assertBind((ps, i) -> ps.setObject(i, "1", type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-            assertBind((ps, i) -> ps.setObject(i, "true", type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
-            assertBind((ps, i) -> ps.setObject(i, "0", type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
-            assertBind((ps, i) -> ps.setObject(i, "false", type), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, false);
+            assertBind((ps, i) -> ps.setObject(i, true, type), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+            assertBind((ps, i) -> ps.setObject(i, false, type), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
+            assertBind((ps, i) -> ps.setObject(i, 13, type), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+            assertBind((ps, i) -> ps.setObject(i, 0, type), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
+            assertBind((ps, i) -> ps.setObject(i, "1", type), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+            assertBind((ps, i) -> ps.setObject(i, "true", type), explicitPrepare).roundTripsAs(Types.BOOLEAN, true);
+            assertBind((ps, i) -> ps.setObject(i, "0", type), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
+            assertBind((ps, i) -> ps.setObject(i, "false", type), explicitPrepare).roundTripsAs(Types.BOOLEAN, false);
         }
     }
 
@@ -760,23 +760,23 @@ public class TestJdbcPreparedStatement
         testConvertTinyint(false);
     }
 
-    private void testConvertTinyint(boolean useLegacyPreparedStatements)
+    private void testConvertTinyint(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setByte(i, (byte) 123), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123L, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, "123", Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
-        assertBind((ps, i) -> ps.setObject(i, true, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 1);
-        assertBind((ps, i) -> ps.setObject(i, false, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 0);
+        assertBind((ps, i) -> ps.setByte(i, (byte) 123), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123L, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, "123", Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 123);
+        assertBind((ps, i) -> ps.setObject(i, true, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 1);
+        assertBind((ps, i) -> ps.setObject(i, false, Types.TINYINT), explicitPrepare).roundTripsAs(Types.TINYINT, (byte) 0);
     }
 
     @Test
@@ -787,23 +787,23 @@ public class TestJdbcPreparedStatement
         testConvertSmallint(false);
     }
 
-    private void testConvertSmallint(boolean useLegacyPreparedStatements)
+    private void testConvertSmallint(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setShort(i, (short) 123), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123L, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, "123", Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
-        assertBind((ps, i) -> ps.setObject(i, true, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 1);
-        assertBind((ps, i) -> ps.setObject(i, false, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 0);
+        assertBind((ps, i) -> ps.setShort(i, (short) 123), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123L, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, "123", Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 123);
+        assertBind((ps, i) -> ps.setObject(i, true, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 1);
+        assertBind((ps, i) -> ps.setObject(i, false, Types.SMALLINT), explicitPrepare).roundTripsAs(Types.SMALLINT, (short) 0);
     }
 
     @Test
@@ -814,24 +814,24 @@ public class TestJdbcPreparedStatement
         testConvertInteger(false);
     }
 
-    private void testConvertInteger(boolean useLegacyPreparedStatements)
+    private void testConvertInteger(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setInt(i, 123), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, 123), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, 123, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, 123L, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, "123", Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
-        assertBind((ps, i) -> ps.setObject(i, true, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 1);
-        assertBind((ps, i) -> ps.setObject(i, false, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 0);
+        assertBind((ps, i) -> ps.setInt(i, 123), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, 123), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, 123, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, 123L, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, "123", Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 123);
+        assertBind((ps, i) -> ps.setObject(i, true, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 1);
+        assertBind((ps, i) -> ps.setObject(i, false, Types.INTEGER), explicitPrepare).roundTripsAs(Types.INTEGER, 0);
     }
 
     @Test
@@ -842,23 +842,23 @@ public class TestJdbcPreparedStatement
         testConvertBigint(false);
     }
 
-    private void testConvertBigint(boolean useLegacyPreparedStatements)
+    private void testConvertBigint(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setLong(i, 123L), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, 123L), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, 123, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, 123L, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, "123", Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
-        assertBind((ps, i) -> ps.setObject(i, true, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 1L);
-        assertBind((ps, i) -> ps.setObject(i, false, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 0L);
+        assertBind((ps, i) -> ps.setLong(i, 123L), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, 123L), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, 123, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, 123L, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, "123", Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 123L);
+        assertBind((ps, i) -> ps.setObject(i, true, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 1L);
+        assertBind((ps, i) -> ps.setObject(i, false, Types.BIGINT), explicitPrepare).roundTripsAs(Types.BIGINT, 0L);
     }
 
     @Test
@@ -869,25 +869,25 @@ public class TestJdbcPreparedStatement
         testConvertReal(false);
     }
 
-    private void testConvertReal(boolean useLegacyPreparedStatements)
+    private void testConvertReal(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setFloat(i, 4.2f), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 4.2f);
-        assertBind((ps, i) -> ps.setObject(i, 4.2f), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 4.2f);
+        assertBind((ps, i) -> ps.setFloat(i, 4.2f), explicitPrepare).roundTripsAs(Types.REAL, 4.2f);
+        assertBind((ps, i) -> ps.setObject(i, 4.2f), explicitPrepare).roundTripsAs(Types.REAL, 4.2f);
 
         for (int type : asList(Types.REAL, Types.FLOAT)) {
-            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, 123, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, 123L, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.9f);
-            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.9f);
-            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.0f);
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 123.9f);
-            assertBind((ps, i) -> ps.setObject(i, "4.2", type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 4.2f);
-            assertBind((ps, i) -> ps.setObject(i, true, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 1.0f);
-            assertBind((ps, i) -> ps.setObject(i, false, type), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 0.0f);
+            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, 123, type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, 123L, type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), explicitPrepare).roundTripsAs(Types.REAL, 123.9f);
+            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), explicitPrepare).roundTripsAs(Types.REAL, 123.9f);
+            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), explicitPrepare).roundTripsAs(Types.REAL, 123.0f);
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), type), explicitPrepare).roundTripsAs(Types.REAL, 123.9f);
+            assertBind((ps, i) -> ps.setObject(i, "4.2", type), explicitPrepare).roundTripsAs(Types.REAL, 4.2f);
+            assertBind((ps, i) -> ps.setObject(i, true, type), explicitPrepare).roundTripsAs(Types.REAL, 1.0f);
+            assertBind((ps, i) -> ps.setObject(i, false, type), explicitPrepare).roundTripsAs(Types.REAL, 0.0f);
         }
     }
 
@@ -899,23 +899,23 @@ public class TestJdbcPreparedStatement
         testConvertDouble(false);
     }
 
-    private void testConvertDouble(boolean useLegacyPreparedStatements)
+    private void testConvertDouble(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setDouble(i, 4.2d), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 4.2d);
-        assertBind((ps, i) -> ps.setObject(i, 4.2d), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 4.2d);
-        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, 123, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, 123L, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, (double) 123.9f);
-        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.9d);
-        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.0d);
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 123.9d);
-        assertBind((ps, i) -> ps.setObject(i, "4.2", Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 4.2d);
-        assertBind((ps, i) -> ps.setObject(i, true, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 1.0d);
-        assertBind((ps, i) -> ps.setObject(i, false, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 0.0d);
+        assertBind((ps, i) -> ps.setDouble(i, 4.2d), explicitPrepare).roundTripsAs(Types.DOUBLE, 4.2d);
+        assertBind((ps, i) -> ps.setObject(i, 4.2d), explicitPrepare).roundTripsAs(Types.DOUBLE, 4.2d);
+        assertBind((ps, i) -> ps.setObject(i, (byte) 123, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, (short) 123, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, 123, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, 123L, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, 123.9f, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, (double) 123.9f);
+        assertBind((ps, i) -> ps.setObject(i, 123.9d, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.9d);
+        assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.0d);
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 123.9d);
+        assertBind((ps, i) -> ps.setObject(i, "4.2", Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 4.2d);
+        assertBind((ps, i) -> ps.setObject(i, true, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 1.0d);
+        assertBind((ps, i) -> ps.setObject(i, false, Types.DOUBLE), explicitPrepare).roundTripsAs(Types.DOUBLE, 0.0d);
     }
 
     @Test
@@ -926,25 +926,25 @@ public class TestJdbcPreparedStatement
         testConvertDecimal(false);
     }
 
-    private void testConvertDecimal(boolean useLegacyPreparedStatements)
+    private void testConvertDecimal(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setBigDecimal(i, BigDecimal.valueOf(123)), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123)), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+        assertBind((ps, i) -> ps.setBigDecimal(i, BigDecimal.valueOf(123)), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+        assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123)), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
 
         for (int type : asList(Types.DECIMAL, Types.NUMERIC)) {
-            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, 123, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, 123L, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9f));
-            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9d));
-            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9d), type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9d));
-            assertBind((ps, i) -> ps.setObject(i, "123", type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
-            assertBind((ps, i) -> ps.setObject(i, true, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(1));
-            assertBind((ps, i) -> ps.setObject(i, false, type), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(0));
+            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, 123, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, 123L, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9f));
+            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9d));
+            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9d), type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123.9d));
+            assertBind((ps, i) -> ps.setObject(i, "123", type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
+            assertBind((ps, i) -> ps.setObject(i, true, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(1));
+            assertBind((ps, i) -> ps.setObject(i, false, type), explicitPrepare).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(0));
         }
     }
 
@@ -956,29 +956,29 @@ public class TestJdbcPreparedStatement
         testConvertVarchar(false);
     }
 
-    private void testConvertVarchar(boolean useLegacyPreparedStatements)
+    private void testConvertVarchar(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setString(i, "hello"), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "hello");
-        assertBind((ps, i) -> ps.setObject(i, "hello"), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "hello");
+        assertBind((ps, i) -> ps.setString(i, "hello"), explicitPrepare).roundTripsAs(Types.VARCHAR, "hello");
+        assertBind((ps, i) -> ps.setObject(i, "hello"), explicitPrepare).roundTripsAs(Types.VARCHAR, "hello");
 
         String unicodeAndNull = "abc'xyz\0\u2603\uD835\uDCABtest";
-        assertBind((ps, i) -> ps.setString(i, unicodeAndNull), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, unicodeAndNull);
+        assertBind((ps, i) -> ps.setString(i, unicodeAndNull), explicitPrepare).roundTripsAs(Types.VARCHAR, unicodeAndNull);
 
         for (int type : asList(Types.CHAR, Types.NCHAR, Types.VARCHAR, Types.NVARCHAR, Types.LONGVARCHAR, Types.LONGNVARCHAR)) {
-            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, 123, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, 123L, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123.9");
-            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123.9");
-            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123");
-            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "123.9");
-            assertBind((ps, i) -> ps.setObject(i, "hello", type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "hello");
-            assertBind((ps, i) -> ps.setObject(i, true, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "true");
-            assertBind((ps, i) -> ps.setObject(i, false, type), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "false");
+            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, (byte) 123, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, (short) 123, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, 123, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, 123L, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, 123.9f, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123.9");
+            assertBind((ps, i) -> ps.setObject(i, 123.9d, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123.9");
+            assertBind((ps, i) -> ps.setObject(i, BigInteger.valueOf(123), type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123), type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123");
+            assertBind((ps, i) -> ps.setObject(i, BigDecimal.valueOf(123.9), type), explicitPrepare).roundTripsAs(Types.VARCHAR, "123.9");
+            assertBind((ps, i) -> ps.setObject(i, "hello", type), explicitPrepare).roundTripsAs(Types.VARCHAR, "hello");
+            assertBind((ps, i) -> ps.setObject(i, true, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "true");
+            assertBind((ps, i) -> ps.setObject(i, false, type), explicitPrepare).roundTripsAs(Types.VARCHAR, "false");
         }
     }
 
@@ -990,18 +990,18 @@ public class TestJdbcPreparedStatement
         testConvertVarbinary(false);
     }
 
-    private void testConvertVarbinary(boolean useLegacyPreparedStatements)
+    private void testConvertVarbinary(boolean explicitPrepare)
             throws SQLException
     {
         String value = "abc\0xyz";
         byte[] bytes = value.getBytes(UTF_8);
 
-        assertBind((ps, i) -> ps.setBytes(i, bytes), useLegacyPreparedStatements).roundTripsAs(Types.VARBINARY, bytes);
-        assertBind((ps, i) -> ps.setObject(i, bytes), useLegacyPreparedStatements).roundTripsAs(Types.VARBINARY, bytes);
+        assertBind((ps, i) -> ps.setBytes(i, bytes), explicitPrepare).roundTripsAs(Types.VARBINARY, bytes);
+        assertBind((ps, i) -> ps.setObject(i, bytes), explicitPrepare).roundTripsAs(Types.VARBINARY, bytes);
 
         for (int type : asList(Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY)) {
-            assertBind((ps, i) -> ps.setObject(i, bytes, type), useLegacyPreparedStatements).roundTripsAs(Types.VARBINARY, bytes);
-            assertBind((ps, i) -> ps.setObject(i, value, type), useLegacyPreparedStatements).roundTripsAs(Types.VARBINARY, bytes);
+            assertBind((ps, i) -> ps.setObject(i, bytes, type), explicitPrepare).roundTripsAs(Types.VARBINARY, bytes);
+            assertBind((ps, i) -> ps.setObject(i, value, type), explicitPrepare).roundTripsAs(Types.VARBINARY, bytes);
         }
     }
 
@@ -1013,7 +1013,7 @@ public class TestJdbcPreparedStatement
         testConvertDate(false);
     }
 
-    private void testConvertDate(boolean useLegacyPreparedStatements)
+    private void testConvertDate(boolean explicitPrepare)
             throws SQLException
     {
         LocalDate date = LocalDate.of(2001, 5, 6);
@@ -1022,35 +1022,35 @@ public class TestJdbcPreparedStatement
         LocalDateTime dateTime = LocalDateTime.of(date, LocalTime.of(12, 34, 56));
         Timestamp sqlTimestamp = Timestamp.valueOf(dateTime);
 
-        assertBind((ps, i) -> ps.setDate(i, sqlDate), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setDate(i, sqlDate), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlDate), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlDate), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlDate, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlDate, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06", Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06", Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, sqlDate);
     }
@@ -1063,39 +1063,39 @@ public class TestJdbcPreparedStatement
         testConvertLocalDate(false);
     }
 
-    private void testConvertLocalDate(boolean useLegacyPreparedStatements)
+    private void testConvertLocalDate(boolean explicitPrepare)
             throws SQLException
     {
         LocalDate date = LocalDate.of(2001, 5, 6);
 
-        assertBind((ps, i) -> ps.setObject(i, date), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, Date.valueOf(date));
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.DATE), explicitPrepare)
                 .resultsIn("date", "DATE '2001-05-06'")
                 .roundTripsAs(Types.DATE, Date.valueOf(date));
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.TIME), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.time.LocalDate to time");
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.time.LocalDate to time with time zone");
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.TIMESTAMP), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.time.LocalDate to timestamp");
 
-        assertBind((ps, i) -> ps.setObject(i, date, Types.TIMESTAMP_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, date, Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.time.LocalDate to timestamp with time zone");
 
         LocalDate jvmGapDate = LocalDate.of(1970, 1, 1);
         checkIsGap(ZoneId.systemDefault(), jvmGapDate.atTime(LocalTime.MIDNIGHT));
 
-        assertBind((ps, i) -> ps.setObject(i, jvmGapDate), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, jvmGapDate), explicitPrepare)
                 .resultsIn("date", "DATE '1970-01-01'")
                 .roundTripsAs(Types.DATE, Date.valueOf(jvmGapDate));
 
-        assertBind((ps, i) -> ps.setObject(i, jvmGapDate, Types.DATE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, jvmGapDate, Types.DATE), explicitPrepare)
                 .roundTripsAs(Types.DATE, Date.valueOf(jvmGapDate));
     }
 
@@ -1107,7 +1107,7 @@ public class TestJdbcPreparedStatement
         testConvertTime(false);
     }
 
-    private void testConvertTime(boolean useLegacyPreparedStatements)
+    private void testConvertTime(boolean explicitPrepare)
             throws SQLException
     {
         LocalTime time = LocalTime.of(12, 34, 56);
@@ -1116,58 +1116,58 @@ public class TestJdbcPreparedStatement
         LocalDateTime dateTime = LocalDateTime.of(LocalDate.of(2001, 5, 6), time);
         Timestamp sqlTimestamp = Timestamp.valueOf(dateTime);
 
-        assertBind((ps, i) -> ps.setTime(i, sqlTime), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTime(i, sqlTime), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.000'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTime), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTime), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.000'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTime, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTime, Types.TIME), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.000'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.TIME), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.000'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.TIME), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.000'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.TIME), explicitPrepare)
                 .resultsIn("time(0)", "TIME '12:34:56'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56", Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56", Types.TIME), explicitPrepare)
                 .resultsIn("time(0)", "TIME '12:34:56'")
                 .roundTripsAs(Types.TIME, sqlTime);
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123", Types.TIME), useLegacyPreparedStatements).resultsIn("time(3)", "TIME '12:34:56.123'");
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456", Types.TIME), useLegacyPreparedStatements).resultsIn("time(6)", "TIME '12:34:56.123456'");
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123", Types.TIME), explicitPrepare).resultsIn("time(3)", "TIME '12:34:56.123'");
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456", Types.TIME), explicitPrepare).resultsIn("time(6)", "TIME '12:34:56.123456'");
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789", Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789", Types.TIME), explicitPrepare)
                 .resultsIn("time(9)", "TIME '12:34:56.123456789'");
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789012", Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789012", Types.TIME), explicitPrepare)
                 .resultsIn("time(12)", "TIME '12:34:56.123456789012'");
 
         Time timeWithDecisecond = new Time(sqlTime.getTime() + 100);
-        assertBind((ps, i) -> ps.setObject(i, timeWithDecisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timeWithDecisecond), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.100'")
                 .roundTripsAs(Types.TIME, timeWithDecisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timeWithDecisecond, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timeWithDecisecond, Types.TIME), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.100'")
                 .roundTripsAs(Types.TIME, timeWithDecisecond);
 
         Time timeWithMillisecond = new Time(sqlTime.getTime() + 123);
-        assertBind((ps, i) -> ps.setObject(i, timeWithMillisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timeWithMillisecond), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.123'")
                 .roundTripsAs(Types.TIME, timeWithMillisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timeWithMillisecond, Types.TIME), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timeWithMillisecond, Types.TIME), explicitPrepare)
                 .resultsIn("time(3)", "TIME '12:34:56.123'")
                 .roundTripsAs(Types.TIME, timeWithMillisecond);
     }
@@ -1180,59 +1180,59 @@ public class TestJdbcPreparedStatement
         testConvertTimeWithTimeZone(false);
     }
 
-    private void testConvertTimeWithTimeZone(boolean useLegacyPreparedStatements)
+    private void testConvertTimeWithTimeZone(boolean explicitPrepare)
             throws SQLException
     {
         // zero fraction
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(0) with time zone", "TIME '12:34:56+00:00'")
                 .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(5, 34, 56)));
 
         // setObject with implicit type
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC)), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC)), explicitPrepare)
                 .resultsIn("time(0) with time zone", "TIME '12:34:56+00:00'");
 
         // setObject with JDBCType
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC), JDBCType.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 0, UTC), JDBCType.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(0) with time zone", "TIME '12:34:56+00:00'");
 
         // millisecond precision
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_000_000, UTC), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_000_000, UTC), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(3) with time zone", "TIME '12:34:56.555+00:00'")
                 .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(5, 34, 56, 555_000_000)));
 
         // microsecond precision
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_555_000, UTC), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_555_000, UTC), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(6) with time zone", "TIME '12:34:56.555555+00:00'")
                 .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(5, 34, 56, 556_000_000)));
 
         // nanosecond precision
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_555_555, UTC), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 555_555_555, UTC), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(9) with time zone", "TIME '12:34:56.555555555+00:00'")
                 .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(5, 34, 56, 556_000_000)));
 
         // positive offset
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 123_456_789, ZoneOffset.ofHoursMinutes(7, 35)), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 123_456_789, ZoneOffset.ofHoursMinutes(7, 35)), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(9) with time zone", "TIME '12:34:56.123456789+07:35'");
         // TODO (https://github.com/trinodb/trino/issues/6351) the result is not as expected here:
         //      .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(20, 59, 56, 123_000_000)));
 
         // negative offset
-        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 123_456_789, ZoneOffset.ofHoursMinutes(-7, -35)), Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, OffsetTime.of(12, 34, 56, 123_456_789, ZoneOffset.ofHoursMinutes(-7, -35)), Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(9) with time zone", "TIME '12:34:56.123456789-07:35'")
                 .roundTripsAs(Types.TIME_WITH_TIMEZONE, toSqlTime(LocalTime.of(13, 9, 56, 123_000_000)));
 
         // String as TIME WITH TIME ZONE
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123 +05:45", Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123 +05:45", Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(3) with time zone", "TIME '12:34:56.123 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456 +05:45", Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456 +05:45", Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(6) with time zone", "TIME '12:34:56.123456 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789 +05:45", Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789 +05:45", Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(9) with time zone", "TIME '12:34:56.123456789 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789012 +05:45", Types.TIME_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "12:34:56.123456789012 +05:45", Types.TIME_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("time(12) with time zone", "TIME '12:34:56.123456789012 +05:45'");
     }
 
@@ -1244,7 +1244,7 @@ public class TestJdbcPreparedStatement
         testConvertTimestamp(false);
     }
 
-    private void testConvertTimestamp(boolean useLegacyPreparedStatements)
+    private void testConvertTimestamp(boolean explicitPrepare)
             throws SQLException
     {
         LocalDateTime dateTime = LocalDateTime.of(2001, 5, 6, 12, 34, 56);
@@ -1254,85 +1254,85 @@ public class TestJdbcPreparedStatement
         Timestamp sameInstantInWarsawZone = Timestamp.valueOf(dateTime.atZone(ZoneId.systemDefault()).withZoneSameInstant(ZoneId.of("Europe/Warsaw")).toLocalDateTime());
         java.util.Date javaDate = java.util.Date.from(dateTime.atZone(ZoneId.systemDefault()).toInstant());
 
-        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, null), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, null), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance()), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance()), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("Europe/Warsaw")))), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, sqlTimestamp, Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("Europe/Warsaw")))), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 20:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sameInstantInWarsawZone);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setObject(i, sqlDate, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlDate, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 00:00:00.000'")
                 .roundTripsAs(Types.TIMESTAMP, new Timestamp(sqlDate.getTime()));
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTime, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTime, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '1970-01-01 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, new Timestamp(sqlTime.getTime()));
 
-        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, sqlTimestamp, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, javaDate, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.000'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, dateTime, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(0)", "TIMESTAMP '2001-05-06 12:34:56'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56", Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56", Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(0)", "TIMESTAMP '2001-05-06 12:34:56'")
                 .roundTripsAs(Types.TIMESTAMP, sqlTimestamp);
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123", Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123", Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.123'");
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456", Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456", Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(6)", "TIMESTAMP '2001-05-06 12:34:56.123456'");
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456789", Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456789", Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(9)", "TIMESTAMP '2001-05-06 12:34:56.123456789'");
 
-        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456789012", Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "2001-05-06 12:34:56.123456789012", Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(12)", "TIMESTAMP '2001-05-06 12:34:56.123456789012'");
 
         Timestamp timestampWithWithDecisecond = new Timestamp(sqlTimestamp.getTime() + 100);
-        assertBind((ps, i) -> ps.setTimestamp(i, timestampWithWithDecisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, timestampWithWithDecisecond), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.100'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithWithDecisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timestampWithWithDecisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timestampWithWithDecisecond), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.100'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithWithDecisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timestampWithWithDecisecond, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timestampWithWithDecisecond, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.100'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithWithDecisecond);
 
         Timestamp timestampWithMillisecond = new Timestamp(sqlTimestamp.getTime() + 123);
-        assertBind((ps, i) -> ps.setTimestamp(i, timestampWithMillisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setTimestamp(i, timestampWithMillisecond), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.123'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithMillisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timestampWithMillisecond), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timestampWithMillisecond), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.123'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithMillisecond);
 
-        assertBind((ps, i) -> ps.setObject(i, timestampWithMillisecond, Types.TIMESTAMP), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, timestampWithMillisecond, Types.TIMESTAMP), explicitPrepare)
                 .resultsIn("timestamp(3)", "TIMESTAMP '2001-05-06 12:34:56.123'")
                 .roundTripsAs(Types.TIMESTAMP, timestampWithMillisecond);
     }
@@ -1345,22 +1345,22 @@ public class TestJdbcPreparedStatement
         testConvertTimestampWithTimeZone(false);
     }
 
-    private void testConvertTimestampWithTimeZone(boolean useLegacyPreparedStatements)
+    private void testConvertTimestampWithTimeZone(boolean explicitPrepare)
             throws SQLException
     {
         // TODO (https://github.com/trinodb/trino/issues/6299) support ZonedDateTime
 
         // String as TIMESTAMP WITH TIME ZONE
-        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("timestamp(3) with time zone", "TIMESTAMP '1970-01-01 12:34:56.123 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("timestamp(6) with time zone", "TIMESTAMP '1970-01-01 12:34:56.123456 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456789 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456789 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("timestamp(9) with time zone", "TIMESTAMP '1970-01-01 12:34:56.123456789 +05:45'");
 
-        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456789012 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "1970-01-01 12:34:56.123456789012 +05:45", Types.TIMESTAMP_WITH_TIMEZONE), explicitPrepare)
                 .resultsIn("timestamp(12) with time zone", "TIMESTAMP '1970-01-01 12:34:56.123456789012 +05:45'");
     }
 
@@ -1372,58 +1372,58 @@ public class TestJdbcPreparedStatement
         testInvalidConversions(false);
     }
 
-    private void testInvalidConversions(boolean useLegacyPreparedStatements)
+    private void testInvalidConversions(boolean explicitPrepare)
             throws SQLException
     {
-        assertBind((ps, i) -> ps.setObject(i, String.class), useLegacyPreparedStatements).isInvalid("Unsupported object type: java.lang.Class");
-        assertBind((ps, i) -> ps.setObject(i, String.class, Types.BIGINT), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, String.class), explicitPrepare).isInvalid("Unsupported object type: java.lang.Class");
+        assertBind((ps, i) -> ps.setObject(i, String.class, Types.BIGINT), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.lang.Class to SQL type " + Types.BIGINT);
-        assertBind((ps, i) -> ps.setObject(i, "abc", Types.SMALLINT), useLegacyPreparedStatements)
+        assertBind((ps, i) -> ps.setObject(i, "abc", Types.SMALLINT), explicitPrepare)
                 .isInvalid("Cannot convert instance of java.lang.String to SQL type " + Types.SMALLINT);
     }
 
     @Test
-    public void testLegacyPreparedStatementsTrue()
+    public void testExplicitPrepare()
             throws Exception
     {
-        testLegacyPreparedStatementsSetting(true,
+        testExplicitPrepareSetting(true,
                 "EXECUTE %statement% USING %values%");
     }
 
     @Test
-    public void testLegacyPreparedStatementsFalse()
+    public void testExecuteImmediate()
             throws Exception
     {
-        testLegacyPreparedStatementsSetting(false,
+        testExplicitPrepareSetting(false,
                 "EXECUTE IMMEDIATE '%query%' USING %values%");
     }
 
-    private BindAssertion assertBind(Binder binder, boolean useLegacyPreparedStatements)
+    private BindAssertion assertBind(Binder binder, boolean explicitPrepare)
     {
-        return new BindAssertion(() -> this.createConnection(useLegacyPreparedStatements), binder);
+        return new BindAssertion(() -> this.createConnection(explicitPrepare), binder);
     }
 
-    private Connection createConnection(boolean useLegacyPreparedStatements)
+    private Connection createConnection(boolean explicitPrepare)
             throws SQLException
     {
-        String url = format("jdbc:trino://%s?legacyPreparedStatements=" + useLegacyPreparedStatements, server.getAddress());
+        String url = format("jdbc:trino://%s?explicitPrepare=" + explicitPrepare, server.getAddress());
         return DriverManager.getConnection(url, "test", null);
     }
 
-    private Connection createConnection(String catalog, String schema, boolean useLegacyPreparedStatements)
+    private Connection createConnection(String catalog, String schema, boolean explicitPrepare)
             throws SQLException
     {
-        String url = format("jdbc:trino://%s/%s/%s?legacyPreparedStatements=" + useLegacyPreparedStatements, server.getAddress(), catalog, schema);
+        String url = format("jdbc:trino://%s/%s/%s?explicitPrepare=" + explicitPrepare, server.getAddress(), catalog, schema);
         return DriverManager.getConnection(url, "test", null);
     }
 
-    private void testLegacyPreparedStatementsSetting(boolean legacyPreparedStatements, String expectedSql)
+    private void testExplicitPrepareSetting(boolean explicitPrepare, String expectedSql)
             throws Exception
     {
         String selectSql = "SELECT * FROM blackhole.blackhole.test_table WHERE x = ? AND y = ? AND y <> 'Test'";
         String insertSql = "INSERT INTO blackhole.blackhole.test_table (x, y) VALUES (?, ?)";
 
-        try (Connection connection = createConnection(legacyPreparedStatements)) {
+        try (Connection connection = createConnection(explicitPrepare)) {
             try (Statement statement = connection.createStatement()) {
                 assertEquals(statement.executeUpdate("CREATE TABLE blackhole.blackhole.test_table (x bigint, y varchar)"), 0);
             }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -24,7 +24,6 @@ import io.trino.plugin.memory.MemoryPlugin;
 import io.trino.server.testing.TestingTrinoServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
@@ -76,12 +75,6 @@ import static org.testng.Assert.assertTrue;
 
 public class TestJdbcPreparedStatement
 {
-    @DataProvider
-    public Object[][] legacyPreparedStatementProvider()
-    {
-        return new Object[][] {{true}, {false}};
-    }
-
     private static final int HEADER_SIZE_LIMIT = 16 * 1024;
 
     private TestingTrinoServer server;
@@ -117,8 +110,15 @@ public class TestJdbcPreparedStatement
         server = null;
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testExecuteQuery(boolean useLegacyPreparedStatements)
+    @Test
+    public void testExecuteQuery()
+            throws Exception
+    {
+        testExecuteQuery(false);
+        testExecuteQuery(true);
+    }
+
+    private void testExecuteQuery(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection(useLegacyPreparedStatements);
@@ -143,8 +143,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testGetMetadata(boolean useLegacyPreparedStatements)
+    @Test
+    public void testGetMetadata()
+            throws Exception
+    {
+        testGetMetadata(true);
+        testGetMetadata(false);
+    }
+
+    private void testGetMetadata(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
@@ -201,8 +208,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testGetParameterMetaData(boolean useLegacyPreparedStatements)
+    @Test
+    public void testGetParameterMetaData()
+            throws Exception
+    {
+        testGetParameterMetaData(true);
+        testGetParameterMetaData(false);
+    }
+
+    private void testGetParameterMetaData(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
@@ -389,8 +403,15 @@ public class TestJdbcPreparedStatement
         assertEquals(actualClientTypeSignature, expectedClientTypeSignature);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testDeallocate(boolean useLegacyPreparedStatements)
+    @Test
+    public void testDeallocate()
+            throws Exception
+    {
+        testDeallocate(true);
+        testDeallocate(false);
+    }
+
+    private void testDeallocate(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection(useLegacyPreparedStatements)) {
@@ -405,8 +426,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testCloseIdempotency(boolean useLegacyPreparedStatements)
+    @Test
+    public void testCloseIdempotency()
+            throws Exception
+    {
+        testCloseIdempotency(true);
+        testCloseIdempotency(false);
+    }
+
+    private void testCloseIdempotency(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection(useLegacyPreparedStatements)) {
@@ -416,8 +444,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testLargePreparedStatement(boolean useLegacyPreparedStatements)
+    @Test
+    public void testLargePreparedStatement()
+            throws Exception
+    {
+        testLargePreparedStatement(true);
+        testLargePreparedStatement(false);
+    }
+
+    private void testLargePreparedStatement(boolean useLegacyPreparedStatements)
             throws Exception
     {
         int elements = HEADER_SIZE_LIMIT + 1;
@@ -433,7 +468,14 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
+    @Test
+    public void testExecuteUpdate()
+            throws Exception
+    {
+        testExecuteUpdate(true);
+        testExecuteUpdate(false);
+    }
+
     public void testExecuteUpdate(boolean useLegacyPreparedStatements)
             throws Exception
     {
@@ -472,8 +514,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testExecuteBatch(boolean useLegacyPreparedStatements)
+    @Test
+    public void testExecuteBatch()
+            throws Exception
+    {
+        testExecuteBatch(true);
+        testExecuteBatch(false);
+    }
+
+    private void testExecuteBatch(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection("memory", "default", useLegacyPreparedStatements)) {
@@ -519,8 +568,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testInvalidExecuteBatch(boolean useLegacyPreparedStatements)
+    @Test
+    public void testInvalidExecuteBatch()
+            throws Exception
+    {
+        testInvalidExecuteBatch(true);
+        testInvalidExecuteBatch(false);
+    }
+
+    private void testInvalidExecuteBatch(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection("blackhole", "blackhole", useLegacyPreparedStatements)) {
@@ -554,8 +610,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testPrepareMultiple(boolean useLegacyPreparedStatements)
+    @Test
+    public void testPrepareMultiple()
+            throws Exception
+    {
+        testPrepareMultiple(true);
+        testPrepareMultiple(false);
+    }
+
+    private void testPrepareMultiple(boolean useLegacyPreparedStatements)
             throws Exception
     {
         try (Connection connection = createConnection(useLegacyPreparedStatements);
@@ -575,8 +638,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testPrepareLarge(boolean useLegacyPreparedStatements)
+    @Test
+    public void testPrepareLarge()
+            throws Exception
+    {
+        testPrepareLarge(true);
+        testPrepareLarge(false);
+    }
+
+    private void testPrepareLarge(boolean useLegacyPreparedStatements)
             throws Exception
     {
         String sql = format("SELECT '%s' = '%s'", repeat("x", 100_000), repeat("y", 100_000));
@@ -589,8 +659,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testSetNull(boolean useLegacyPreparedStatements)
+    @Test
+    public void testSetNull()
+            throws Exception
+    {
+        testSetNull(true);
+        testSetNull(false);
+    }
+
+    private void testSetNull(boolean useLegacyPreparedStatements)
             throws Exception
     {
         assertSetNull(Types.BOOLEAN, useLegacyPreparedStatements);
@@ -644,8 +721,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertBoolean(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertBoolean()
+            throws SQLException
+    {
+        testConvertBoolean(true);
+        testConvertBoolean(false);
+    }
+
+    private void testConvertBoolean(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setBoolean(i, true), useLegacyPreparedStatements).roundTripsAs(Types.BOOLEAN, true);
@@ -665,8 +749,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertTinyint(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertTinyint()
+            throws SQLException
+    {
+        testConvertTinyint(true);
+        testConvertTinyint(false);
+    }
+
+    private void testConvertTinyint(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setByte(i, (byte) 123), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 123);
@@ -685,8 +776,15 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, false, Types.TINYINT), useLegacyPreparedStatements).roundTripsAs(Types.TINYINT, (byte) 0);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertSmallint(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertSmallint()
+            throws SQLException
+    {
+        testConvertSmallint(true);
+        testConvertSmallint(false);
+    }
+
+    private void testConvertSmallint(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setShort(i, (short) 123), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 123);
@@ -705,8 +803,15 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, false, Types.SMALLINT), useLegacyPreparedStatements).roundTripsAs(Types.SMALLINT, (short) 0);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertInteger(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertInteger()
+            throws SQLException
+    {
+        testConvertInteger(true);
+        testConvertInteger(false);
+    }
+
+    private void testConvertInteger(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setInt(i, 123), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 123);
@@ -726,8 +831,15 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, false, Types.INTEGER), useLegacyPreparedStatements).roundTripsAs(Types.INTEGER, 0);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertBigint(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertBigint()
+            throws SQLException
+    {
+        testConvertBigint(true);
+        testConvertBigint(false);
+    }
+
+    private void testConvertBigint(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setLong(i, 123L), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 123L);
@@ -746,8 +858,15 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, false, Types.BIGINT), useLegacyPreparedStatements).roundTripsAs(Types.BIGINT, 0L);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertReal(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertReal()
+            throws SQLException
+    {
+        testConvertReal(true);
+        testConvertReal(false);
+    }
+
+    private void testConvertReal(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setFloat(i, 4.2f), useLegacyPreparedStatements).roundTripsAs(Types.REAL, 4.2f);
@@ -769,8 +888,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertDouble(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertDouble()
+            throws SQLException
+    {
+        testConvertDouble(true);
+        testConvertDouble(false);
+    }
+
+    private void testConvertDouble(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setDouble(i, 4.2d), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 4.2d);
@@ -789,8 +915,15 @@ public class TestJdbcPreparedStatement
         assertBind((ps, i) -> ps.setObject(i, false, Types.DOUBLE), useLegacyPreparedStatements).roundTripsAs(Types.DOUBLE, 0.0d);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertDecimal(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertDecimal()
+            throws SQLException
+    {
+        testConvertDecimal(true);
+        testConvertDecimal(false);
+    }
+
+    private void testConvertDecimal(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setBigDecimal(i, BigDecimal.valueOf(123)), useLegacyPreparedStatements).roundTripsAs(Types.DECIMAL, BigDecimal.valueOf(123));
@@ -812,8 +945,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertVarchar(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertVarchar()
+            throws SQLException
+    {
+        testConvertVarchar(true);
+        testConvertVarchar(false);
+    }
+
+    private void testConvertVarchar(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setString(i, "hello"), useLegacyPreparedStatements).roundTripsAs(Types.VARCHAR, "hello");
@@ -839,8 +979,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertVarbinary(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertVarbinary()
+            throws SQLException
+    {
+        testConvertVarbinary(true);
+        testConvertVarbinary(false);
+    }
+
+    private void testConvertVarbinary(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         String value = "abc\0xyz";
@@ -855,8 +1002,15 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertDate(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertDate()
+            throws SQLException
+    {
+        testConvertDate(true);
+        testConvertDate(false);
+    }
+
+    private void testConvertDate(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         LocalDate date = LocalDate.of(2001, 5, 6);
@@ -898,8 +1052,15 @@ public class TestJdbcPreparedStatement
                 .roundTripsAs(Types.DATE, sqlDate);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertLocalDate(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertLocalDate()
+            throws SQLException
+    {
+        testConvertLocalDate(true);
+        testConvertLocalDate(false);
+    }
+
+    private void testConvertLocalDate(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         LocalDate date = LocalDate.of(2001, 5, 6);
@@ -935,8 +1096,15 @@ public class TestJdbcPreparedStatement
                 .roundTripsAs(Types.DATE, Date.valueOf(jvmGapDate));
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertTime(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertTime()
+            throws SQLException
+    {
+        testConvertTime(true);
+        testConvertTime(false);
+    }
+
+    private void testConvertTime(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         LocalTime time = LocalTime.of(12, 34, 56);
@@ -1001,8 +1169,15 @@ public class TestJdbcPreparedStatement
                 .roundTripsAs(Types.TIME, timeWithMillisecond);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertTimeWithTimeZone(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertTimeWithTimeZone()
+            throws SQLException
+    {
+        testConvertTimeWithTimeZone(true);
+        testConvertTimeWithTimeZone(false);
+    }
+
+    private void testConvertTimeWithTimeZone(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         // zero fraction
@@ -1058,8 +1233,15 @@ public class TestJdbcPreparedStatement
                 .resultsIn("time(12) with time zone", "TIME '12:34:56.123456789012 +05:45'");
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertTimestamp(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertTimestamp()
+            throws SQLException
+    {
+        testConvertTimestamp(true);
+        testConvertTimestamp(false);
+    }
+
+    private void testConvertTimestamp(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         LocalDateTime dateTime = LocalDateTime.of(2001, 5, 6, 12, 34, 56);
@@ -1152,8 +1334,15 @@ public class TestJdbcPreparedStatement
                 .roundTripsAs(Types.TIMESTAMP, timestampWithMillisecond);
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testConvertTimestampWithTimeZone(boolean useLegacyPreparedStatements)
+    @Test
+    public void testConvertTimestampWithTimeZone()
+            throws SQLException
+    {
+        testConvertTimestampWithTimeZone(true);
+        testConvertTimestampWithTimeZone(false);
+    }
+
+    private void testConvertTimestampWithTimeZone(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         // TODO (https://github.com/trinodb/trino/issues/6299) support ZonedDateTime
@@ -1172,8 +1361,15 @@ public class TestJdbcPreparedStatement
                 .resultsIn("timestamp(12) with time zone", "TIMESTAMP '1970-01-01 12:34:56.123456789012 +05:45'");
     }
 
-    @Test(dataProvider = "legacyPreparedStatementProvider")
-    public void testInvalidConversions(boolean useLegacyPreparedStatements)
+    @Test
+    public void testInvalidConversions()
+            throws SQLException
+    {
+        testInvalidConversions(true);
+        testInvalidConversions(false);
+    }
+
+    private void testInvalidConversions(boolean useLegacyPreparedStatements)
             throws SQLException
     {
         assertBind((ps, i) -> ps.setObject(i, String.class), useLegacyPreparedStatements).isInvalid("Unsupported object type: java.lang.Class");

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcPreparedStatement.java
@@ -22,9 +22,10 @@ import io.trino.client.ClientTypeSignatureParameter;
 import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.plugin.memory.MemoryPlugin;
 import io.trino.server.testing.TestingTrinoServer;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -68,18 +69,20 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+@TestInstance(PER_CLASS)
 public class TestJdbcPreparedStatement
 {
     private static final int HEADER_SIZE_LIMIT = 16 * 1024;
 
     private TestingTrinoServer server;
 
-    @BeforeClass
+    @BeforeAll
     public void setup()
             throws Exception
     {
@@ -102,7 +105,7 @@ public class TestJdbcPreparedStatement
         }
     }
 
-    @AfterClass(alwaysRun = true)
+    @AfterAll
     public void tearDown()
             throws Exception
     {

--- a/docs/src/main/sphinx/client/jdbc.md
+++ b/docs/src/main/sphinx/client/jdbc.md
@@ -246,7 +246,7 @@ may not be specified using both methods.
   - Sets the time zone for the session using the [time zone
     passed](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/ZoneId.html#of(java.lang.String)).
     Defaults to the timezone of the JVM running the JDBC driver.
-* - `legacyPreparedStatements`
+* - `explicitPrepare`
   - Defaults to `true`. When set to `false`, prepared statements are executed
     calling a single `EXECUTE IMMEDIATE` query instead of the standard
     `PREPARE <statement>` followed by `EXECUTE <statement>`. This reduces


### PR DESCRIPTION

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
