### PR TITLE
Delete all objects before deleting s3 bucket used for ci

### DIFF
--- a/.github/bin/s3/delete-s3-bucket.sh
+++ b/.github/bin/s3/delete-s3-bucket.sh
@@ -11,6 +11,11 @@ fi
 
 S3_BUCKET_IDENTIFIER=$(cat "${S3_SCRIPTS_DIR}"/.bucket-identifier)
 
+echo "Deleting all leftover objects from AWS S3 bucket ${S3_BUCKET_IDENTIFIER}"
+aws s3 rm s3://"${S3_BUCKET_IDENTIFIER}" \
+  --region "${AWS_REGION}" \
+  --recursive
+
 echo "Deleting AWS S3 bucket ${S3_BUCKET_IDENTIFIER}"
 aws s3api delete-bucket \
   --bucket "${S3_BUCKET_IDENTIFIER}" \


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The s3api won't allow you to delete a bucket that still has objects in it, so we should delete all objects from the s3 bucket used for the S3FileSystem cloud tests before trying to delete the bucket

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Fixes #19360 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
