### PR TITLE
Move QueryAssertions initialization to constructor

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestAggregation.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestAggregation
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestAggregationsInRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestAggregationsInRowPatternMatching.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestAggregationsInRowPatternMatching
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestArraySortAfterArrayDistinct.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestArraySortAfterArrayDistinct
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCheckConstraint.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCheckConstraint.java
@@ -22,7 +22,6 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.Identity;
 import io.trino.testing.LocalQueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -50,10 +49,9 @@ public class TestCheckConstraint
             .setIdentity(Identity.forUser(USER).build())
             .build();
 
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestCheckConstraint()
     {
         LocalQueryRunner runner = LocalQueryRunner.builder(SESSION).build();
 
@@ -152,7 +150,6 @@ public class TestCheckConstraint
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     /**

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -31,7 +31,6 @@ import io.trino.spi.type.VarcharType;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingAccessControlManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -68,11 +67,10 @@ public class TestColumnMask
             .setIdentity(Identity.forUser(USER).build())
             .build();
 
-    private QueryAssertions assertions;
-    private TestingAccessControlManager accessControl;
+    private final QueryAssertions assertions;
+    private final TestingAccessControlManager accessControl;
 
-    @BeforeAll
-    public void init()
+    public TestColumnMask()
     {
         LocalQueryRunner runner = LocalQueryRunner.builder(SESSION).build();
 
@@ -190,9 +188,7 @@ public class TestColumnMask
     @AfterAll
     public void teardown()
     {
-        accessControl = null;
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestComplexTypesWithNull.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestComplexTypesWithNull.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -27,19 +26,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestComplexTypesWithNull
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCopyAggregationStateInRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCopyAggregationStateInRowPatternMatching.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -40,19 +39,12 @@ public class TestCopyAggregationStateInRowPatternMatching
               ) AS m
             """;
 
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedAggregation.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestCorrelatedAggregation
 {
-    protected QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    protected final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestCorrelatedJoin.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestCorrelatedJoin
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestDistinctWithOrderBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestDistinctWithOrderBy.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestDistinctWithOrderBy
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExecute.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExecute.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestExecute
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExecuteImmediate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExecuteImmediate.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.sql.parser.ParsingException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -27,19 +26,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestExecuteImmediate
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExpressionRewriteInRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExpressionRewriteInRowPatternMatching.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestExpressionRewriteInRowPatternMatching
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestExpressions.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestExpressions
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -23,7 +23,6 @@ import io.trino.spi.security.ViewExpression;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingAccessControlManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -49,11 +48,10 @@ public class TestFilterInaccessibleColumns
             .setIdentity(Identity.forUser(USER).build())
             .build();
 
-    private QueryAssertions assertions;
-    private TestingAccessControlManager accessControl;
+    private final QueryAssertions assertions;
+    private final TestingAccessControlManager accessControl;
 
-    @BeforeAll
-    public void init()
+    public TestFilterInaccessibleColumns()
     {
         LocalQueryRunner runner = LocalQueryRunner.builder(SESSION)
                 .withFeaturesConfig(new FeaturesConfig().setHideInaccessibleColumns(true))
@@ -68,7 +66,6 @@ public class TestFilterInaccessibleColumns
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilteredAggregations.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilteredAggregations.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.plan.FilterNode;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
@@ -31,19 +30,12 @@ import static org.testng.Assert.assertFalse;
 public class TestFilteredAggregations
         extends BasePlanTest
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFormat.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFormat.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestFormat
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFullJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFullJoin.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestFullJoin
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestGroupBy
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestGrouping.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestGrouping.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestGrouping
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestGroupingSets.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestGroupingSets.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestGroupingSets
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoin.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.plan.JoinNode;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -39,19 +38,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestJoin
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJoinUsing.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJoinUsing.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestJoinUsing
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonArrayFunction.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -33,19 +32,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestJsonArrayFunction
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonExistsFunction.java
@@ -17,7 +17,6 @@ import io.trino.json.PathEvaluationError;
 import io.trino.operator.scalar.json.JsonInputConversionError;
 import io.trino.sql.parser.ParsingException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -35,19 +34,12 @@ public class TestJsonExistsFunction
 {
     private static final String INPUT = "[\"a\", \"b\", \"c\"]";
     private static final String INCORRECT_INPUT = "[...";
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonObjectFunction.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -34,19 +33,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestJsonObjectFunction
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonQueryFunction.java
@@ -18,7 +18,6 @@ import io.trino.operator.scalar.json.JsonInputConversionError;
 import io.trino.operator.scalar.json.JsonOutputConversionError;
 import io.trino.sql.parser.ParsingException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -37,19 +36,12 @@ public class TestJsonQueryFunction
     private static final String INPUT = "[\"a\", \"b\", \"c\"]";
     private static final String OBJECT_INPUT = "{\"key\" : 1}";
     private static final String INCORRECT_INPUT = "[...";
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestJsonValueFunction.java
@@ -18,7 +18,6 @@ import io.trino.operator.scalar.json.JsonInputConversionError;
 import io.trino.operator.scalar.json.JsonValueFunction.JsonValueResultError;
 import io.trino.sql.parser.ParsingException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -36,19 +35,12 @@ public class TestJsonValueFunction
 {
     private static final String INPUT = "[\"a\", \"b\", \"c\"]";
     private static final String INCORRECT_INPUT = "[...";
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestLambdaExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestLambdaExpressions.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestLambdaExpressions
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestLateral.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestLateral.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestLateral
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
@@ -16,7 +16,6 @@ package io.trino.sql.query;
 import io.trino.spi.TrinoException;
 import io.trino.sql.parser.ParsingException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -29,19 +28,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestListagg
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestMergeProjectWithValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestMergeProjectWithValues.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestMergeProjectWithValues
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestMinMaxNWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestMinMaxNWindow.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestMinMaxNWindow
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestNestedLogicalBinaryExpression.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestNestedLogicalBinaryExpression.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.testing.LocalQueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -34,10 +33,9 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestNestedLogicalBinaryExpression
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestNestedLogicalBinaryExpression()
     {
         Session session = testSessionBuilder()
                 .setCatalog(TEST_CATALOG_NAME)
@@ -56,7 +54,6 @@ public class TestNestedLogicalBinaryExpression
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestNumericalStability.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestNumericalStability.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestNumericalStability
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestOrderedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestOrderedAggregation.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestOrderedAggregation
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestPrecomputedHashes.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestPrecomputedHashes.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -27,10 +26,9 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestPrecomputedHashes
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestPrecomputedHashes()
     {
         Session session = testSessionBuilder()
                 .setSystemProperty(OPTIMIZE_HASH_GENERATION, "true")
@@ -43,7 +41,6 @@ public class TestPrecomputedHashes
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestPredicatePushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestPredicatePushdown.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestPredicatePushdown
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRecursiveCte.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRecursiveCte.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.Session;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -28,19 +27,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestRecursiveCte
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestReduceAgg.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestReduceAgg.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestReduceAgg
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -29,7 +29,6 @@ import io.trino.spi.type.VarcharType;
 import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingAccessControlManager;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
@@ -65,11 +64,10 @@ public class TestRowFilter
             .setIdentity(Identity.forUser(USER).build())
             .build();
 
-    private QueryAssertions assertions;
-    private TestingAccessControlManager accessControl;
+    private final QueryAssertions assertions;
+    private final TestingAccessControlManager accessControl;
 
-    @BeforeAll
-    public void init()
+    public TestRowFilter()
     {
         LocalQueryRunner runner = LocalQueryRunner.builder(SESSION).build();
 
@@ -145,9 +143,7 @@ public class TestRowFilter
     @AfterAll
     public void teardown()
     {
-        accessControl = null;
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -26,19 +25,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestRowPatternMatching
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatchingInWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatchingInWindow.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -26,19 +25,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestRowPatternMatchingInWindow
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.testing.MaterializedResult;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -28,21 +27,14 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestSelectAll
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions = new QueryAssertions();
 
     private static final String UNSUPPORTED_DECORRELATION_MESSAGE = ".*: Given correlated subquery is not supported";
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestSetDigestFunctions
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSetOperations.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSetOperations.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -24,19 +23,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestSetOperations
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -19,7 +19,6 @@ import io.trino.connector.MockConnectorFactory;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.testing.LocalQueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -33,10 +32,9 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestShowQueries
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestShowQueries()
     {
         LocalQueryRunner queryRunner = LocalQueryRunner.create(testSessionBuilder()
                 .setCatalog("local")
@@ -71,7 +69,6 @@ public class TestShowQueries
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -20,7 +20,6 @@ import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.testing.LocalQueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -59,10 +58,9 @@ public class TestSubqueries
 {
     private static final String UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG = "line .*: Given correlated subquery is not supported";
 
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestSubqueries()
     {
         Session session = testSessionBuilder()
                 .setCatalog(TEST_CATALOG_NAME)
@@ -81,7 +79,6 @@ public class TestSubqueries
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestTDigestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestTDigestFunctions.java
@@ -15,7 +15,6 @@ package io.trino.sql.query;
 
 import io.trino.testing.MaterializedResult;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -31,19 +30,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestTDigestFunctions
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestTrim.java
@@ -18,7 +18,6 @@ import io.trino.operator.scalar.TestStringFunctions;
 import io.trino.spi.TrinoException;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -30,10 +29,9 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestTrim
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestTrim()
     {
         assertions = new QueryAssertions();
         assertions.addFunctions(InternalFunctionBundle.builder()
@@ -45,7 +43,6 @@ public class TestTrim
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnnest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnnest.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestUnnest
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestUnwrapCastInComparison.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.spi.type.TimeZoneKey;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -39,19 +38,12 @@ public class TestUnwrapCastInComparison
     private static final List<String> COMPARISON_OPERATORS = asList("=", "<>", ">=", ">", "<=", "<", "IS DISTINCT FROM");
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss[.SSS]");
 
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestValues.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -26,19 +25,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestValues
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestWindow
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -29,19 +28,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestWindowFrameGroups
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRange.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRange.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -25,19 +24,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestWindowFrameRange
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRows.java
@@ -14,7 +14,6 @@
 package io.trino.sql.query;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -28,19 +27,12 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestWindowFrameRows
 {
-    private QueryAssertions assertions;
-
-    @BeforeAll
-    public void init()
-    {
-        assertions = new QueryAssertions();
-    }
+    private final QueryAssertions assertions = new QueryAssertions();
 
     @AfterAll
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWith.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWith.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.testing.LocalQueryRunner;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -33,10 +32,9 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 @TestInstance(PER_CLASS)
 public class TestWith
 {
-    private QueryAssertions assertions;
+    private final QueryAssertions assertions;
 
-    @BeforeAll
-    public void init()
+    public TestWith()
     {
         Session session = testSessionBuilder()
                 .setCatalog(TEST_CATALOG_NAME)
@@ -55,7 +53,6 @@ public class TestWith
     public void teardown()
     {
         assertions.close();
-        assertions = null;
     }
 
     @Test


### PR DESCRIPTION
There's not benefit from initializing it in a @BeforeAll method. By moving it to the constructor, the field can be marked as final and follow best practices for Java objects that don't need to have mutable state.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
