### PR TITLE
Update docker-images version to 89

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <dep.aws-sdk.version>1.12.657</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>87</dep.docker.images.version>
+        <dep.docker.images.version>89</dep.docker.images.version>
         <dep.drift.version>1.21</dep.drift.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.errorprone.version>2.24.1</dep.errorprone.version>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkHive.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkHive.java
@@ -24,10 +24,14 @@ import io.trino.tests.product.launcher.env.common.Hadoop;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
 import io.trino.tests.product.launcher.testcontainers.PortBinder;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+
+import java.io.File;
 
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentDefaults.HADOOP_BASE_IMAGE;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP_INIT_D;
 import static java.util.Objects.requireNonNull;
@@ -37,6 +41,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class EnvSinglenodeSparkHive
         extends EnvironmentProvider
 {
+    private static final File HIVE_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/hive-jdbc.jar");
+
     private static final int SPARK_THRIFT_PORT = 10213;
 
     private final DockerFiles dockerFiles;
@@ -66,6 +72,10 @@ public class EnvSinglenodeSparkHive
 
         builder.addContainer(createSpark())
                 .containerDependsOn("spark", HADOOP);
+
+        builder.configureContainer(TESTS, dockerContainer -> dockerContainer
+                // Binding instead of copying for avoiding OutOfMemoryError https://github.com/testcontainers/testcontainers-java/issues/2863
+                .withFileSystemBind(HIVE_JDBC_PROVIDER.getParent(), "/docker/jdbc", BindMode.READ_ONLY));
     }
 
     @SuppressWarnings("resource")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergJdbcCatalog.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergJdbcCatalog.java
@@ -24,10 +24,14 @@ import io.trino.tests.product.launcher.env.common.Hadoop;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
 import io.trino.tests.product.launcher.testcontainers.PortBinder;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+
+import java.io.File;
 
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentDefaults.HADOOP_BASE_IMAGE;
 import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP_INIT_D;
 import static java.util.Objects.requireNonNull;
@@ -37,6 +41,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class EnvSinglenodeSparkIcebergJdbcCatalog
         extends EnvironmentProvider
 {
+    private static final File HIVE_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/hive-jdbc.jar");
+
     private static final int SPARK_THRIFT_PORT = 10213;
     // Use non-default PostgreSQL port to avoid conflicts with locally installed PostgreSQL if any.
     public static final int POSTGRESQL_PORT = 25432;
@@ -70,6 +76,10 @@ public class EnvSinglenodeSparkIcebergJdbcCatalog
 
         builder.addContainer(createSpark())
                 .containerDependsOn("spark", HADOOP);
+
+        builder.configureContainer(TESTS, dockerContainer -> dockerContainer
+                // Binding instead of copying for avoiding OutOfMemoryError https://github.com/testcontainers/testcontainers-java/issues/2863
+                .withFileSystemBind(HIVE_JDBC_PROVIDER.getParent(), "/docker/jdbc", BindMode.READ_ONLY));
     }
 
     @SuppressWarnings("resource")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
@@ -24,10 +24,14 @@ import io.trino.tests.product.launcher.env.common.Hadoop;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
 import io.trino.tests.product.launcher.testcontainers.PortBinder;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+
+import java.io.File;
 
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
@@ -35,6 +39,8 @@ import static org.testcontainers.utility.MountableFile.forHostPath;
 public class EnvSinglenodeSparkIcebergNessie
         extends EnvironmentProvider
 {
+    private static final File HIVE_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/hive-jdbc.jar");
+
     private static final int SPARK_THRIFT_PORT = 10213;
     private static final int NESSIE_PORT = 19120;
     private static final String NESSIE_VERSION = "0.71.0";
@@ -60,6 +66,10 @@ public class EnvSinglenodeSparkIcebergNessie
         builder.addConnector("iceberg", forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-spark-iceberg-nessie/iceberg.properties")));
 
         builder.addContainer(createSparkContainer()).containerDependsOn(SPARK, HADOOP);
+
+        builder.configureContainer(TESTS, dockerContainer -> dockerContainer
+                // Binding instead of copying for avoiding OutOfMemoryError https://github.com/testcontainers/testcontainers-java/issues/2863
+                .withFileSystemBind(HIVE_JDBC_PROVIDER.getParent(), "/docker/jdbc", BindMode.READ_ONLY));
     }
 
     @SuppressWarnings("resource")

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -36,7 +36,6 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.sql.Date;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -238,10 +237,11 @@ public class TestIcebergSparkCompatibility
                 ", DECIMAL '123456.78' _short_decimal " +
                 ", DECIMAL '1234567890123456789.0123456789012345678' _long_decimal " +
                 ", true _boolean " +
-                //", TIMESTAMP '2020-06-28 14:16:00.456' _timestamp " +
+                ", TIMESTAMP '2020-06-28 14:16:00.123456' _timestamp " +
                 ", TIMESTAMP '2021-08-03 08:32:21.123456 Europe/Warsaw' _timestamptz " +
                 ", DATE '1950-06-28' _date " +
                 ", X'000102f0feff' _binary " +
+                ", UUID '406caec7-68b9-4778-81b2-a12ece70c8b1' _uuid " +
                 //", TIME '01:23:45.123456' _time " +
                 "";
 
@@ -257,10 +257,11 @@ public class TestIcebergSparkCompatibility
                                 ", _short_decimal decimal(8,2)" +
                                 ", _long_decimal decimal(38,19)" +
                                 ", _boolean BOOLEAN" +
-                                //", _timestamp TIMESTAMP" -- per https://iceberg.apache.org/spark-writes/ Iceberg's timestamp is currently not supported with Spark
+                                ", _timestamp TIMESTAMP" +
                                 ", _timestamptz timestamp(6) with time zone" +
                                 ", _date DATE" +
                                 ", _binary VARBINARY" +
+                                ", _uuid UUID" +
                                 //", _time time(6)" + -- per https://iceberg.apache.org/spark-writes/ Iceberg's time is currently not supported with Spark
                                 ") WITH (format = '%s')",
                         trinoTableName,
@@ -291,10 +292,11 @@ public class TestIcebergSparkCompatibility
                 new BigDecimal("123456.78"),
                 new BigDecimal("1234567890123456789.0123456789012345678"),
                 true,
-                //"2020-06-28 14:16:00.456",
+                "2020-06-28 14:16:00.123456",
                 "2021-08-03 06:32:21.123456 UTC", // Iceberg's timestamptz stores point in time, without zone
                 "1950-06-28",
-                new byte[] {00, 01, 02, -16, -2, -1}
+                new byte[] {00, 01, 02, -16, -2, -1},
+                "406caec7-68b9-4778-81b2-a12ece70c8b1"
                 // "01:23:45.123456"
                 /**/);
         assertThat(onTrino().executeQuery(
@@ -307,10 +309,11 @@ public class TestIcebergSparkCompatibility
                         ", _short_decimal" +
                         ", _long_decimal" +
                         ", _boolean" +
-                        // _timestamp OR CAST(_timestamp AS varchar)
+                        ", CAST(_timestamp AS varchar)" +
                         ", CAST(_timestamptz AS varchar)" +
                         ", CAST(_date AS varchar)" +
                         ", _binary" +
+                        ", _uuid" +
                         //", CAST(_time AS varchar)" +
                         " FROM " + trinoTableName))
                 .containsOnly(row);
@@ -325,10 +328,11 @@ public class TestIcebergSparkCompatibility
                         ", _short_decimal" +
                         ", _long_decimal" +
                         ", _boolean" +
-                        // _timestamp OR CAST(_timestamp AS string)
+                        ", CAST(_timestamp AS string)" +
                         ", CAST(_timestamptz AS string) || ' UTC'" + // Iceberg timestamptz is mapped to Spark timestamp and gets represented without time zone
                         ", CAST(_date AS string)" +
                         ", _binary" +
+                        ", _uuid" +
                         // ", CAST(_time AS string)" +
                         " FROM " + sparkTableName))
                 .containsOnly(row);
@@ -346,28 +350,6 @@ public class TestIcebergSparkCompatibility
                         new Object[] {storageFormat, CREATE_TABLE_AS_SELECT},
                         new Object[] {storageFormat, CREATE_TABLE_WITH_NO_DATA_AND_INSERT}))
                 .toArray(Object[][]::new);
-    }
-
-    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE}, dataProvider = "storageFormats")
-    public void testSparkReadTrinoUuid(StorageFormat storageFormat)
-    {
-        String tableName = toLowerCase("test_spark_read_trino_uuid_" + storageFormat);
-        String trinoTableName = trinoTableName(tableName);
-        String sparkTableName = sparkTableName(tableName);
-
-        onTrino().executeQuery("DROP TABLE IF EXISTS " + trinoTableName);
-
-        onTrino().executeQuery(format(
-                "CREATE TABLE %s AS SELECT UUID '406caec7-68b9-4778-81b2-a12ece70c8b1' u",
-                trinoTableName));
-
-        assertQueryFailure(() -> onSpark().executeQuery("SELECT * FROM " + sparkTableName))
-                // TODO Iceberg Spark integration needs yet to gain support
-                //  once this is supported, merge this test with testSparkReadingTrinoData()
-                .isInstanceOf(SQLException.class)
-                .hasMessageMatching("org.apache.hive.service.cli.HiveSQLException: Error running query:.*\\Q java.lang.UnsupportedOperationException\\E(?s:.*)");
-
-        onTrino().executeQuery("DROP TABLE " + trinoTableName);
     }
 
     @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE}, dataProvider = "specVersions")
@@ -611,7 +593,8 @@ public class TestIcebergSparkCompatibility
                 specVersion));
 
         assertThat(onTrino().executeQuery("SELECT key, value FROM " + trinoPropertiesTableName))
-                .containsOnly(
+                // Use contains method because the result may contain format-specific properties
+                .contains(
                         row("custom.table-property", "my_custom_value"),
                         row("write.format.default", storageFormat.name()),
                         row("owner", "hive"));
@@ -1677,7 +1660,7 @@ public class TestIcebergSparkCompatibility
                 .containsOnly(row(1, null));
     }
 
-    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC})
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}) // Run only with ICEBERG because Spark returns the different stats based on the catalog
     public void testPartialStats()
     {
         String tableName = "test_partial_stats_" + randomNameSuffix();
@@ -1690,8 +1673,8 @@ public class TestIcebergSparkCompatibility
                 .containsOnly(
                         row("col0", null, null, 0.0, null, "1", "1"),
                         row("col1", null, null, 0.0, null, "2", "2"),
-                        row("col2", 151.0, null, 0.0, null, null, null),
-                        row("col3", 72.0, null, 0.0, null, null, null),
+                        row("col2", 124.0, null, 0.0, null, null, null),
+                        row("col3", 58.0, null, 0.0, null, null, null),
                         row(null, null, null, null, 1.0, null, null));
 
         onSpark().executeQuery("ALTER TABLE " + sparkTableName + " SET TBLPROPERTIES (write.metadata.metrics.column.col1='none')");
@@ -1700,8 +1683,8 @@ public class TestIcebergSparkCompatibility
                 .containsOnly(
                         row("col0", null, null, 0.0, null, "1", "3"),
                         row("col1", null, null, null, null, null, null),
-                        row("col2", 305.0, null, 0.0, null, null, null),
-                        row("col3", 145.0, null, 0.0, null, null, null),
+                        row("col2", 248.0, null, 0.0, null, null, null),
+                        row("col3", 117.0, null, 0.0, null, null, null),
                         row(null, null, null, null, 2.0, null, null));
 
         onSpark().executeQuery("DROP TABLE " + sparkTableName);

--- a/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
@@ -149,6 +149,7 @@ databases:
   spark:
     host: spark
     jdbc_driver_class: org.apache.hive.jdbc.HiveDriver
+    jdbc_jar: /docker/jdbc/hive-jdbc.jar
     jdbc_url: jdbc:hive2://${databases.spark.host}:10213
     jdbc_user: hive
     jdbc_password: na


### PR DESCRIPTION
## Description

Relates to https://github.com/trinodb/docker-images/pull/184
Fixes #17562

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
