### PR TITLE
Provide default implementations in ConnectorSplit 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/table/Sequence.java
+++ b/core/trino-main/src/main/java/io/trino/operator/table/Sequence.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Provider;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorTableFunction;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -43,7 +42,6 @@ import io.trino.spi.function.table.TableFunctionProcessorState;
 import io.trino.spi.function.table.TableFunctionSplitProcessor;
 
 import java.math.BigInteger;
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -206,18 +204,6 @@ public class Sequence
         public long getStop()
         {
             return stop;
-        }
-
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return true;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/split/EmptySplit.java
+++ b/core/trino-main/src/main/java/io/trino/split/EmptySplit.java
@@ -15,12 +15,8 @@ package io.trino.split;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
-
-import java.util.List;
 
 import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
@@ -37,18 +33,6 @@ public class EmptySplit
             @JsonProperty("catalogHandle") CatalogHandle catalogHandle)
     {
         this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/split/RemoteSplit.java
+++ b/core/trino-main/src/main/java/io/trino/split/RemoteSplit.java
@@ -15,12 +15,8 @@ package io.trino.split;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import io.trino.exchange.ExchangeInput;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-
-import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -49,18 +45,6 @@ public class RemoteSplit
     public Object getInfo()
     {
         return this;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -26,7 +26,6 @@ import io.trino.connector.MockConnectorFactory.ApplyTableFunction;
 import io.trino.connector.MockConnectorFactory.ApplyTableScanRedirect;
 import io.trino.connector.MockConnectorFactory.ApplyTopN;
 import io.trino.connector.MockConnectorFactory.ListRoleGrants;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
@@ -1046,18 +1045,6 @@ public class MockConnector
             implements ConnectorSplit
     {
         MOCK_CONNECTOR_SPLIT;
-
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return true;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
-        }
 
         @Override
         public Object getInfo()

--- a/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestingTableFunctions.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -1367,18 +1366,6 @@ public class TestingTableFunctions
             public long getCount()
             {
                 return count;
-            }
-
-            @Override
-            public boolean isRemotelyAccessible()
-            {
-                return true;
-            }
-
-            @Override
-            public List<HostAddress> getAddresses()
-            {
-                return ImmutableList.of();
             }
 
             @Override

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -258,12 +258,6 @@ public class BenchmarkNodeScheduler
         }
 
         @Override
-        public boolean isRemotelyAccessible()
-        {
-            return true;
-        }
-
-        @Override
         public List<HostAddress> getAddresses()
         {
             return hosts;

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -994,12 +994,6 @@ public class TestNodeScheduler
         }
 
         @Override
-        public boolean isRemotelyAccessible()
-        {
-            return true;
-        }
-
-        @Override
         public List<HostAddress> getAddresses()
         {
             return hosts;

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -46,7 +46,6 @@ import io.trino.operator.SourceOperator;
 import io.trino.operator.SourceOperatorFactory;
 import io.trino.operator.TaskContext;
 import io.trino.operator.output.TaskOutputOperator.TaskOutputOperatorFactory;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
 import io.trino.spi.QueryId;
 import io.trino.spi.block.TestingBlockEncodingSerde;
@@ -56,7 +55,6 @@ import io.trino.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -506,18 +504,6 @@ public class TestSqlTaskExecution
         {
             this.begin = begin;
             this.end = end;
-        }
-
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return true;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryBlocking.java
@@ -27,7 +27,6 @@ import io.trino.operator.Driver;
 import io.trino.operator.DriverContext;
 import io.trino.operator.TableScanOperator;
 import io.trino.operator.TaskContext;
-import io.trino.spi.HostAddress;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.DynamicFilter;
@@ -155,18 +154,6 @@ public class TestMemoryBlocking
     private static class TestSplit
             implements ConnectorSplit
     {
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return false;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
-        }
-
         @Override
         public Object getInfo()
         {

--- a/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
@@ -24,7 +24,6 @@ import io.trino.execution.SplitAssignment;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.metadata.Split;
 import io.trino.metadata.TableHandle;
-import io.trino.spi.HostAddress;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
@@ -548,18 +547,6 @@ public class TestDriver
     private static class MockSplit
             implements ConnectorSplit
     {
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return false;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
-        }
-
         @Override
         public Object getInfo()
         {

--- a/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
@@ -19,7 +19,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.trino.annotation.NotThreadSafe;
 import io.trino.metadata.Split;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorSplit;
 
@@ -148,18 +147,6 @@ public class MockSplitSource
     public static class MockConnectorSplit
             implements ConnectorSplit
     {
-        @Override
-        public boolean isRemotelyAccessible()
-        {
-            return false;
-        }
-
-        @Override
-        public List<HostAddress> getAddresses()
-        {
-            return ImmutableList.of();
-        }
-
         @Override
         public Object getInfo()
         {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplit.java
@@ -27,9 +27,18 @@ public interface ConnectorSplit
      * during splits assignment.
      * When false, the split will always be scheduled on one of the addresses returned by {@link #getAddresses()}.
      */
-    boolean isRemotelyAccessible();
+    default boolean isRemotelyAccessible()
+    {
+        return true;
+    }
 
-    List<HostAddress> getAddresses();
+    default List<HostAddress> getAddresses()
+    {
+        if (!isRemotelyAccessible()) {
+            throw new IllegalStateException("getAddresses must be implemented when for splits with isRemotelyAccessible=false");
+        }
+        return List.of();
+    }
 
     Object getInfo();
 

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/AccumuloSplit.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/model/AccumuloSplit.java
@@ -77,12 +77,6 @@ public class AccumuloSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public List<HostAddress> getAddresses()
     {
         return addresses;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplit.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplit.java
@@ -15,13 +15,10 @@ package io.trino.plugin.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
-import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.slice.SizeOf.instanceSize;
@@ -65,18 +62,6 @@ public class JdbcSplit
     public TupleDomain<JdbcColumnHandle> getDynamicFilter()
     {
         return dynamicFilter;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplit.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplit.java
@@ -16,7 +16,6 @@ package io.trino.plugin.bigquery;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
@@ -121,18 +120,6 @@ public class BigQuerySplit
     public OptionalInt getDataSize()
     {
         return dataSize;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleSplit.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleSplit.java
@@ -13,28 +13,12 @@
  */
 package io.trino.plugin.blackhole;
 
-import com.google.common.collect.ImmutableList;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-
-import java.util.List;
 
 public enum BlackHoleSplit
         implements ConnectorSplit
 {
     INSTANCE;
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
-    }
 
     @Override
     public Object getInfo()

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
@@ -70,12 +70,6 @@ public class CassandraSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public Object getInfo()
     {
         return ImmutableMap.builder()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplit.java
@@ -14,18 +14,14 @@
 package io.trino.plugin.deltalake;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import io.trino.plugin.deltalake.transactionlog.DeletionVectorEntry;
-import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -76,19 +72,6 @@ public class DeltaLakeSplit
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
         this.statisticsPredicate = requireNonNull(statisticsPredicate, "statisticsPredicate is null");
         this.partitionKeys = requireNonNull(partitionKeys, "partitionKeys is null");
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @JsonIgnore
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @JsonProperty

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplit.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesSplit.java
@@ -14,14 +14,11 @@
 package io.trino.plugin.deltalake.functions.tablechanges;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
-import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,20 +36,6 @@ public record TableChangesSplit(
         implements ConnectorSplit
 {
     private static final int INSTANCE_SIZE = instanceSize(TableChangesSplit.class);
-
-    @JsonIgnore
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @JsonIgnore
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
-    }
 
     @JsonIgnore
     @Override

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplit.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchSplit.java
@@ -68,12 +68,6 @@ public class ElasticsearchSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public List<HostAddress> getAddresses()
     {
         return address.map(host -> ImmutableList.of(HostAddress.fromString(host)))

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
@@ -15,10 +15,8 @@ package io.trino.plugin.google.sheets;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
@@ -45,18 +43,6 @@ public class SheetsSplit
     public List<List<String>> getValues()
     {
         return values;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplit.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplit.java
@@ -14,13 +14,11 @@
 package io.trino.plugin.hudi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.HivePartitionKey;
-import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.predicate.TupleDomain;
@@ -71,19 +69,6 @@ public class HudiSplit
         this.predicate = requireNonNull(predicate, "predicate is null");
         this.partitionKeys = ImmutableList.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @JsonIgnore
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -14,13 +14,11 @@
 package io.trino.plugin.iceberg;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.iceberg.delete.DeleteFile;
-import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 
@@ -70,19 +68,6 @@ public class IcebergSplit
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
         this.deletes = ImmutableList.copyOf(requireNonNull(deletes, "deletes is null"));
         this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @JsonIgnore
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @JsonProperty

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
@@ -38,7 +38,6 @@ public record TableChangesSplit(
         long fileSize,
         long fileRecordCount,
         IcebergFileFormat fileFormat,
-        List<HostAddress> addresses,
         String partitionSpecJson,
         String partitionDataJson,
         SplitWeight splitWeight) implements ConnectorSplit
@@ -50,7 +49,6 @@ public record TableChangesSplit(
         requireNonNull(changeType, "changeType is null");
         requireNonNull(path, "path is null");
         requireNonNull(fileFormat, "fileFormat is null");
-        addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         requireNonNull(partitionDataJson, "partitionDataJson is null");
         requireNonNull(splitWeight, "splitWeight is null");
@@ -65,7 +63,7 @@ public record TableChangesSplit(
     @Override
     public List<HostAddress> getAddresses()
     {
-        return addresses;
+        return ImmutableList.of();
     }
 
     @Override
@@ -89,7 +87,6 @@ public record TableChangesSplit(
     {
         return INSTANCE_SIZE
                 + estimatedSizeOf(path)
-                + estimatedSizeOf(addresses, HostAddress::getRetainedSizeInBytes)
                 + estimatedSizeOf(partitionSpecJson)
                 + estimatedSizeOf(partitionDataJson)
                 + splitWeight.getRetainedSizeInBytes();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplit.java
@@ -13,15 +13,11 @@
  */
 package io.trino.plugin.iceberg.functions.tablechanges;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.SizeOf;
 import io.trino.plugin.iceberg.IcebergFileFormat;
-import io.trino.spi.HostAddress;
 import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
-
-import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
@@ -52,18 +48,6 @@ public record TableChangesSplit(
         requireNonNull(partitionSpecJson, "partitionSpecJson is null");
         requireNonNull(partitionDataJson, "partitionDataJson is null");
         requireNonNull(splitWeight, "splitWeight is null");
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesSplitSource.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg.functions.tablechanges;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import io.trino.plugin.iceberg.IcebergFileFormat;
 import io.trino.plugin.iceberg.PartitionData;
@@ -152,7 +151,6 @@ public class TableChangesSplitSource
                 task.file().fileSizeInBytes(),
                 task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
-                ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),
                 PartitionData.toJson(task.file().partition()),
                 SplitWeight.standard());
@@ -171,7 +169,6 @@ public class TableChangesSplitSource
                 task.file().fileSizeInBytes(),
                 task.file().recordCount(),
                 IcebergFileFormat.fromIceberg(task.file().format()),
-                ImmutableList.of(),
                 PartitionSpecParser.toJson(task.spec()),
                 PartitionData.toJson(task.file().partition()),
                 SplitWeight.standard());

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
@@ -113,12 +113,6 @@ public class KafkaSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public List<HostAddress> getAddresses()
     {
         return ImmutableList.of(leader);

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
@@ -15,11 +15,7 @@ package io.trino.plugin.kinesis;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
-
-import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
@@ -93,18 +89,6 @@ public class KinesisSplit
     public String getShardId()
     {
         return shardId;
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplit.java
@@ -78,12 +78,6 @@ public class KuduSplit
         return bucketNumber;
     }
 
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
     @JsonProperty
     @Override
     public List<HostAddress> getAddresses()

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplit.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSplit.java
@@ -39,12 +39,6 @@ public class MongoSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     @JsonProperty
     public List<HostAddress> getAddresses()
     {

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
-import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
@@ -121,18 +120,6 @@ public class PinotSplit
                 .add("segments", segments)
                 .add("segmentHost", segmentHost)
                 .toString();
-    }
-
-    @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
-    public List<HostAddress> getAddresses()
-    {
-        return ImmutableList.of();
     }
 
     @Override

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplit.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplit.java
@@ -49,12 +49,6 @@ public class PrometheusSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public List<HostAddress> getAddresses()
     {
         return addresses;

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplit.java
@@ -142,12 +142,6 @@ public final class RedisSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public List<HostAddress> getAddresses()
     {
         return nodes;

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorSplit.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftConnectorSplit.java
@@ -73,12 +73,6 @@ public class ThriftConnectorSplit
     }
 
     @Override
-    public boolean isRemotelyAccessible()
-    {
-        return true;
-    }
-
-    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {


### PR DESCRIPTION
Provide default implementations for
`ConnectorSplit.isRemotelyAccessible` and `ConnectorSplit.getAddresses`
methods. Makes it easier to implement a new split class. Scheduling
preferences are opt-in.

This is a follow-up to recent questions from slack.