### PR TITLE
Remove sortpom-maven-plugin from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2490,11 +2490,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>com.github.ekryd.sortpom</groupId>
-                <artifactId>sortpom-maven-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This PR remove `sortpom-maven-plugin` from pom.xml because this plugin already exists in airbase.
Having this plugin in pom.xml causes `air.check.skip-all` fail to work.
Ref:
https://github.com/airlift/airbase/blob/859b24e2a3daf450de5bf74614b646af635aad7f/airbase/pom.xml#L1499-L1500


`sortpom-maven-plugin` was introduced by:
https://github.com/trinodb/trino/pull/17994/commits/8a95a9cb295ae4415d85b8288300ff3cead100eb

Being added to airbase 147:
https://github.com/airlift/airbase/pull/370/commits/dbd07e08d65ec27ee84efa897c98522079dc7615

Didn't finished the cleanup when update to airbase 147:
https://github.com/trinodb/trino/commit/d2b9fb8581928508399a658c5598ae0f4eecd5b3


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
