### PR TITLE
Support predicate pushdown on floating point types in mongodb

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -102,6 +102,7 @@ import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
@@ -114,6 +115,7 @@ import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
@@ -685,6 +687,14 @@ public class MongoSession
         }
 
         if (type == BIGINT) {
+            return Optional.of(trinoNativeValue);
+        }
+
+        if (type == REAL) {
+            return Optional.of(intBitsToFloat(toIntExact((long) trinoNativeValue)));
+        }
+
+        if (type == DOUBLE) {
             return Optional.of(trinoNativeValue);
         }
 

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/TypeUtils.java
@@ -24,7 +24,9 @@ import java.util.Set;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.StandardTypes.JSON;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
@@ -40,6 +42,8 @@ public final class TypeUtils
             SMALLINT,
             INTEGER,
             BIGINT,
+            REAL,
+            DOUBLE,
             DATE,
             TIME_MILLIS,
             TIMESTAMP_MILLIS,


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Support predicate pushdown on floating point types in mongodb

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# MongoDB
* Add support for predicate pushdown on `real` and `double` types. ({issue}`19575`)
```
