### PR TITLE
Format table names in error messages less ambiguously

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -102,6 +102,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -2057,6 +2058,15 @@ public class Analysis
             SourceColumn entry = (SourceColumn) obj;
             return Objects.equals(tableName, entry.tableName) &&
                     Objects.equals(columnName, entry.columnName);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("tableName", tableName)
+                    .add("columnName", columnName)
+                    .toString();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Output.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -100,5 +101,17 @@ public final class Output
     public int hashCode()
     {
         return Objects.hash(catalogName, catalogVersion, schema, table, columns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalogName", catalogName)
+                .add("catalogVersion", catalogVersion)
+                .add("schema", schema)
+                .add("table", table)
+                .add("columns", columns)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/OutputColumn.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/OutputColumn.java
@@ -23,6 +23,7 @@ import io.trino.sql.analyzer.Analysis.SourceColumn;
 import java.util.Objects;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -68,5 +69,14 @@ public final class OutputColumn
         OutputColumn entry = (OutputColumn) obj;
         return Objects.equals(column, entry.column) &&
                 Objects.equals(sourceColumns, entry.sourceColumns);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("column", column)
+                .add("sourceColumns", sourceColumns)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingHandles.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingHandles.java
@@ -25,7 +25,7 @@ public final class TestingHandles
     private TestingHandles() {}
 
     private static final CatalogVersion TEST_CATALOG_VERSION = new CatalogVersion("test");
-    public static final String TEST_CATALOG_NAME = "test-catalog";
+    public static final String TEST_CATALOG_NAME = "test_catalog";
     public static final CatalogHandle TEST_CATALOG_HANDLE = createTestCatalogHandle(TEST_CATALOG_NAME);
     public static final TableHandle TEST_TABLE_HANDLE = new TableHandle(
             TEST_CATALOG_HANDLE,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -104,7 +104,7 @@ public class TestCallTask
         assertThatThrownBy(
                 () -> executeCallTask(PROCEDURE_METHOD_HANDLE.bindTo(target), transactionManager -> new DenyAllAccessControl()))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("Access Denied: Cannot execute procedure test-catalog.test.testing_procedure");
+                .hasMessage("Access Denied: Cannot execute procedure test_catalog.test.testing_procedure");
         assertThat(target.invoked).isFalse();
     }
 
@@ -121,7 +121,7 @@ public class TestCallTask
                             return accessControl;
                         }))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("Access Denied: Cannot insert into table test-catalog.test.testing_table");
+                .hasMessage("Access Denied: Cannot insert into table test_catalog.test.testing_table");
     }
 
     private void executeCallTask(MethodHandle methodHandle, Function<TransactionManager, AccessControl> accessControlProvider)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -227,7 +227,7 @@ public class TestCreateMaterializedViewTask
         assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(plannerContext, new AllowAllAccessControl(), parser, analyzerFactory, materializedViewPropertyManager)
                 .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .hasErrorCode(INVALID_MATERIALIZED_VIEW_PROPERTY)
-                .hasMessage("Catalog 'test-catalog' materialized view property 'baz' does not exist");
+                .hasMessage("Catalog 'test_catalog' materialized view property 'baz' does not exist");
 
         assertEquals(metadata.getCreateMaterializedViewCallCount(), 0);
     }
@@ -283,7 +283,7 @@ public class TestCreateMaterializedViewTask
         assertThatThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(plannerContext, accessControl, parser, analyzerFactory, materializedViewPropertyManager)
                 .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessageContaining("Cannot create materialized view test-catalog.schema.test_mv");
+                .hasMessageContaining("Cannot create materialized view test_catalog.schema.test_mv");
     }
 
     private QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateSchemaTask.java
@@ -46,7 +46,7 @@ public class TestCreateSchemaTask
         assertTrue(metadata.schemaExists(testSession, CATALOG_SCHEMA_NAME));
         assertThatExceptionOfType(TrinoException.class)
                 .isThrownBy(() -> getFutureValue(task.execute(statement, queryStateMachine, emptyList(), WarningCollector.NOOP)))
-                .withMessage("Schema 'test-catalog.test_db' already exists");
+                .withMessage("Schema 'test_catalog.test_db' already exists");
     }
 
     @Test
@@ -71,14 +71,14 @@ public class TestCreateSchemaTask
                         queryStateMachine,
                         emptyList(),
                         WarningCollector.NOOP)))
-                .withMessage("TEST create schema fail: test-catalog.test_db");
+                .withMessage("TEST create schema fail: test_catalog.test_db");
         assertThatExceptionOfType(TrinoException.class)
                 .isThrownBy(() -> getFutureValue(task.execute(
                         new CreateSchema(QualifiedName.of(CATALOG_SCHEMA_NAME.getSchemaName()), true, ImmutableList.of()),
                         queryStateMachine,
                         emptyList(),
                         WarningCollector.NOOP)))
-                .withMessage("TEST create schema fail: test-catalog.test_db");
+                .withMessage("TEST create schema fail: test_catalog.test_db");
     }
 
     private CreateSchemaTask getCreateSchemaTask()

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -224,7 +224,7 @@ public class TestCreateTableTask
         CreateTableTask createTableTask = new CreateTableTask(plannerContext, new AllowAllAccessControl(), columnPropertyManager, tablePropertyManager);
         assertTrinoExceptionThrownBy(() -> getFutureValue(createTableTask.internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(INVALID_TABLE_PROPERTY)
-                .hasMessage("Catalog 'test-catalog' table property 'foo' does not exist");
+                .hasMessage("Catalog 'test_catalog' table property 'foo' does not exist");
 
         assertEquals(metadata.getCreateTableCallCount(), 0);
     }
@@ -276,7 +276,7 @@ public class TestCreateTableTask
         assertTrinoExceptionThrownBy(() ->
                 getFutureValue(createTableTask.internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(NOT_SUPPORTED)
-                .hasMessage("Catalog 'test-catalog' does not support non-null column for column name 'b'");
+                .hasMessage("Catalog 'test_catalog' does not support non-null column for column name 'b'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropSchemaTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropSchemaTask.java
@@ -56,7 +56,7 @@ public class TestDropSchemaTask
 
         assertThatExceptionOfType(TrinoException.class)
                 .isThrownBy(() -> getFutureValue(dropSchemaTask.execute(dropSchema, queryStateMachine, emptyList(), NOOP)))
-                .withMessage("Schema 'test-catalog.test_db' does not exist");
+                .withMessage("Schema 'test_catalog.test_db' does not exist");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -107,7 +107,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(viewName, qualifiedName("existing_view_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW test-catalog.schema.existing_view RENAME TO ...?", viewName);
+                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW test_catalog.schema.existing_view RENAME TO ...?", viewName);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class TestRenameMaterializedViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameMaterializedView(viewName, qualifiedName("existing_view_new"), true)))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW test-catalog.schema.existing_view RENAME TO ...?", viewName);
+                .hasMessage("Materialized View '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW test_catalog.schema.existing_view RENAME TO ...?", viewName);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -94,7 +94,7 @@ public class TestRenameTableTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test-catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test_catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class TestRenameTableTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), true)))
                 .hasErrorCode(GENERIC_USER_ERROR)
-                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test-catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test_catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -75,7 +75,7 @@ public class TestRenameViewTask
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, qualifiedName("existing_materialized_view_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test-catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
+                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW test_catalog.schema.existing_materialized_view RENAME TO ...?", viewName);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/metadata/TestQualifiedObjectName.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestQualifiedObjectName.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.airlift.json.JsonCodec;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestQualifiedObjectName
+{
+    private final JsonCodec<QualifiedObjectName> codec = JsonCodec.jsonCodec(QualifiedObjectName.class);
+
+    @Test
+    public void testJsonSerializationRoundTrip()
+    {
+        // simple
+        testRoundTrip(new QualifiedObjectName("catalog", "schema", "table_name"));
+
+        // names with dots
+        testRoundTrip(new QualifiedObjectName("catalog.twój", "schema.ściema", "tabel.tabelkówna"));
+
+        // names with apostrophes
+        testRoundTrip(new QualifiedObjectName("cata\"l.o.g\"", "s\"ch.e.ma\"", "\"t.a.b.e.l\""));
+
+        // non-lowercase (currently illegal but TODO coming in https://github.com/trinodb/trino/issues/17)
+        assertThatThrownBy(() -> new QualifiedObjectName("CataLOG", "SchemA", "TabEl"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("catalogName is not lowercase: CataLOG");
+
+        // empty
+        testRoundTrip(new QualifiedObjectName("", "", ""));
+    }
+
+    private void testRoundTrip(QualifiedObjectName value)
+    {
+        String json = codec.toJson(value);
+        QualifiedObjectName parsed = codec.fromJson(json);
+        assertEquals(parsed, value);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestAccessControlManager.java
@@ -136,7 +136,7 @@ public class TestAccessControlManager
                     accessControlManager.checkCanInsertIntoTable(new SecurityContext(transactionId, identity, queryId, queryStart), tableName);
                 }))
                 .isInstanceOf(AccessDeniedException.class)
-                .hasMessage("Access Denied: Cannot insert into table test-catalog.schema.table");
+                .hasMessage("Access Denied: Cannot insert into table test_catalog.schema.table");
     }
 
     @Test
@@ -311,7 +311,7 @@ public class TestAccessControlManager
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
         accessControlManager.loadSystemAccessControl("deny-all", ImmutableMap.of());
 
-        assertDenyExecuteProcedure(transactionManager, metadata, accessControlManager, "Access Denied: Cannot execute procedure test-catalog.schema.procedure");
+        assertDenyExecuteProcedure(transactionManager, metadata, accessControlManager, "Access Denied: Cannot execute procedure test_catalog.schema.procedure");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -941,6 +941,14 @@ public class TestAnalyzer
         assertFails("SELECT * FROM foo FOR VERSION AS OF 'version1'")
                 .hasErrorCode(TABLE_NOT_FOUND)
                 .hasMessage("line 1:15: Table 'tpch.s1.foo' does not exist");
+        // table name containing dots
+        assertFails("SELECT * FROM \"table.not.existing\"")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:15: Table 'tpch.s1.table.not.existing' does not exist");
+        // table name containing whitespace
+        assertFails("SELECT * FROM \"table' does not exist, or maybe 'view\"")
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("line 1:15: Table 'tpch.s1.table' does not exist, or maybe 'view' does not exist");
     }
 
     @Test
@@ -952,6 +960,10 @@ public class TestAnalyzer
         assertFails("SHOW TABLES IN NONEXISTENT_SCHEMA LIKE '%'")
                 .hasErrorCode(SCHEMA_NOT_FOUND)
                 .hasMessage("line 1:1: Schema 'nonexistent_schema' does not exist");
+        assertFails("SELECT * FROM \"a.b.c.d.e.\".\"f.g.h\" ")
+                .hasErrorCode(SCHEMA_NOT_FOUND)
+                // TODO like in TABLE_NOT_FOUND, the error message should include current catalog
+                .hasMessage("line 1:15: Schema 'a.b.c.d.e.' does not exist");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -944,11 +944,11 @@ public class TestAnalyzer
         // table name containing dots
         assertFails("SELECT * FROM \"table.not.existing\"")
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("line 1:15: Table 'tpch.s1.table.not.existing' does not exist");
+                .hasMessage("line 1:15: Table 'tpch.s1.\"table.not.existing\"' does not exist");
         // table name containing whitespace
         assertFails("SELECT * FROM \"table' does not exist, or maybe 'view\"")
                 .hasErrorCode(TABLE_NOT_FOUND)
-                .hasMessage("line 1:15: Table 'tpch.s1.table' does not exist, or maybe 'view' does not exist");
+                .hasMessage("line 1:15: Table 'tpch.s1.\"table' does not exist, or maybe 'view\"' does not exist");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestOutput.java
@@ -50,4 +50,25 @@ public class TestOutput
 
         assertEquals(actual, expected);
     }
+
+    @Test
+    public void testRoundWithComplexIdentifiers()
+    {
+        Output expected = new Output(
+                "catalog.Mój",
+                new CatalogVersion("default"),
+                "ści.e-Ma",
+                "ta.b-Elką go",
+                Optional.of(
+                        ImmutableList.of(
+                                new OutputColumn(
+                                        new Column("ko.LU-mieńka", "type"),
+                                        ImmutableSet.of(
+                                                new SourceColumn(new QualifiedObjectName("catalog.twój", "schema.ściema", "tabel.tabelkówna"), "co-lumn.słodziak\""))))));
+
+        String json = codec.toJson(expected);
+        Output actual = codec.fromJson(json);
+
+        assertEquals(actual, expected);
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -2028,7 +2028,7 @@ public class TestLogicalPlanner
     public void testSizeBasedJoin()
     {
         // both local.sf100000.nation and local.sf100000.orders don't provide stats, therefore no reordering happens
-        assertDistributedPlan("SELECT custkey FROM \"test-catalog\".\"sf42.5\".nation, \"test-catalog\".\"sf42.5\".orders WHERE nation.nationkey = orders.custkey",
+        assertDistributedPlan("SELECT custkey FROM \"test_catalog\".\"sf42.5\".nation, \"test_catalog\".\"sf42.5\".orders WHERE nation.nationkey = orders.custkey",
                 automaticJoinDistribution(),
                 output(
                         join(INNER, builder -> builder
@@ -2040,7 +2040,7 @@ public class TestLogicalPlanner
                                         anyTree(
                                                 tableScan("orders", ImmutableMap.of("CUSTKEY", "custkey")))))));
 
-        assertDistributedPlan("SELECT custkey FROM (VALUES CAST(1 AS BIGINT), CAST(2 AS BIGINT)) t(a), \"test-catalog\".\"sf42.5\".orders WHERE t.a = orders.custkey",
+        assertDistributedPlan("SELECT custkey FROM (VALUES CAST(1 AS BIGINT), CAST(2 AS BIGINT)) t(a), \"test_catalog\".\"sf42.5\".orders WHERE t.a = orders.custkey",
                 automaticJoinDistribution(),
                 output(
                         join(INNER, builder -> builder
@@ -2058,7 +2058,7 @@ public class TestLogicalPlanner
     public void testSizeBasedSemiJoin()
     {
         // both local.sf100000.nation and local.sf100000.orders don't provide stats, therefore no reordering happens
-        assertDistributedPlan("SELECT custkey FROM \"test-catalog\".\"sf42.5\".orders WHERE orders.custkey NOT IN (SELECT nationkey FROM \"test-catalog\".\"sf42.5\".nation)",
+        assertDistributedPlan("SELECT custkey FROM \"test_catalog\".\"sf42.5\".orders WHERE orders.custkey NOT IN (SELECT nationkey FROM \"test_catalog\".\"sf42.5\".nation)",
                 automaticJoinDistribution(),
                 output(
                         anyTree(
@@ -2069,7 +2069,7 @@ public class TestLogicalPlanner
                                                 tableScan("nation", ImmutableMap.of("NATIONKEY", "nationkey")))))));
 
         // values node provides stats
-        assertDistributedPlan("SELECT custkey FROM \"test-catalog\".\"sf42.5\".orders WHERE orders.custkey NOT IN (SELECT t.a FROM (VALUES CAST(1 AS BIGINT), CAST(2 AS BIGINT)) t(a))",
+        assertDistributedPlan("SELECT custkey FROM \"test_catalog\".\"sf42.5\".orders WHERE orders.custkey NOT IN (SELECT t.a FROM (VALUES CAST(1 AS BIGINT), CAST(2 AS BIGINT)) t(a))",
                 automaticJoinDistribution(),
                 output(
                         anyTree(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
@@ -184,7 +184,7 @@ public class TestApplyTableScanRedirection
                                 WarningCollector.NOOP,
                                 createPlanOptimizersStatsCollector()))
                         .isInstanceOf(TrinoException.class)
-                        .hasMessageMatching("Cast not possible from redirected column test-catalog.target_schema.target_table.destination_col_d with type Bogus to source column .*test-catalog.test_schema.test_table.*source_col_a.* with type: varchar");
+                        .hasMessageMatching("Cast not possible from redirected column test_catalog.target_schema.target_table.destination_col_d with type Bogus to source column .*test_catalog.test_schema.test_table.*source_col_a.* with type: varchar");
                 return null;
             });
         }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -149,7 +149,7 @@ public class TestFilterInaccessibleColumns
 
         // Select all columns explicitly
         assertThatThrownBy(() -> assertions.query("SELECT nationkey, name, regionkey, comment FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -185,7 +185,7 @@ public class TestFilterInaccessibleColumns
                         .build());
         accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
         assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -204,7 +204,7 @@ public class TestFilterInaccessibleColumns
         accessControl.rowFilter(table, USER, filter);
 
         assertThatThrownBy(() -> assertions.query(user(USER), "SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
         assertThat(assertions.query(user(ADMIN), "SELECT * FROM nation WHERE name = 'FRANCE'"))
                 .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
     }
@@ -244,7 +244,7 @@ public class TestFilterInaccessibleColumns
                         .build());
 
         assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -286,7 +286,7 @@ public class TestFilterInaccessibleColumns
         accessControl.columnMask(table, "comment", USER, mask);
 
         assertThatThrownBy(() -> assertions.query(user(USER), "SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
         assertThat(assertions.query(user(ADMIN), "SELECT * FROM nation WHERE name = 'CANADA'"))
                 .matches("VALUES (BIGINT '3', CAST('CANADA' AS VARCHAR(25)), BIGINT '1', CAST('masked-comment' AS VARCHAR(152)))");
     }
@@ -299,7 +299,7 @@ public class TestFilterInaccessibleColumns
         // Hide name but use it in the query predicate
         accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
         assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
-                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view test_catalog.tiny.nation");
     }
 
     @Test
@@ -348,7 +348,7 @@ public class TestFilterInaccessibleColumns
 
         accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
         assertThatThrownBy(() -> assertions.query("SELECT * FROM (SELECT concat(name,'-test') FROM nation WHERE name = 'FRANCE')"))
-                .hasMessage("Access Denied: Cannot select from columns [name] in table or view test-catalog.tiny.nation");
+                .hasMessage("Access Denied: Cannot select from columns [name] in table or view test_catalog.tiny.nation");
     }
 
     private Session user(String user)

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -218,7 +218,7 @@ public final class SqlFormatter
         return ExpressionFormatter.formatExpression(identifier);
     }
 
-    static String formatName(QualifiedName name)
+    public static String formatName(QualifiedName name)
     {
         return name.getOriginalParts().stream()
                 .map(SqlFormatter::formatName)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -290,7 +290,7 @@ public abstract class BaseBigQueryConnectorTest
                         "Expecting message:\n" +
                         "  \"Cannot read partition information from a table that is not partitioned: \\E\\S+\\Q:tpch.nation$data\"\n" +
                         "to match regex:\n" +
-                        "  \"line 1:1: Table '\\w+.\\w+.nation\\$data' does not exist\"\n" +
+                        "  \"line 1:1: Table '\\w+.\\w+.\"nation\\$data\"' does not exist\"\n" +
                         "but did not.");
         throw new SkipException("TODO");
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
@@ -144,7 +144,7 @@ public class TestDeltaLakePartitioning
     {
         assertQueryFails(
                 "SELECT * FROM \"partitions$partitions\"",
-                ".*'delta\\.tpch\\.partitions\\$partitions' does not exist");
+                ".*'delta\\.tpch\\.\"partitions\\$partitions\"' does not exist");
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -3629,17 +3629,17 @@ public abstract class BaseHiveConnectorTest
         assertQueryFails(
                 getSession(),
                 "SHOW COLUMNS FROM \"$partitions\"",
-                ".*Table '.*\\.tpch\\.\\$partitions' does not exist");
+                ".*Table '.*\\.tpch\\.\"\\$partitions\"' does not exist");
 
         assertQueryFails(
                 getSession(),
                 "SHOW COLUMNS FROM \"orders$partitions\"",
-                ".*Table '.*\\.tpch\\.orders\\$partitions' does not exist");
+                ".*Table '.*\\.tpch\\.\"orders\\$partitions\"' does not exist");
 
         assertQueryFails(
                 getSession(),
                 "SHOW COLUMNS FROM \"blah$partitions\"",
-                ".*Table '.*\\.tpch\\.blah\\$partitions' does not exist");
+                ".*Table '.*\\.tpch\\.\"blah\\$partitions\"' does not exist");
     }
 
     @Test
@@ -3661,12 +3661,12 @@ public abstract class BaseHiveConnectorTest
         assertQueryFails(
                 getSession(),
                 "SELECT * FROM \"test_partitions_invalid$partitions$partitions\"",
-                ".*Table '.*\\.tpch\\.test_partitions_invalid\\$partitions\\$partitions' does not exist");
+                ".*Table '.*\\.tpch\\.\"test_partitions_invalid\\$partitions\\$partitions\"' does not exist");
 
         assertQueryFails(
                 getSession(),
                 "SELECT * FROM \"non_existent$partitions\"",
-                ".*Table '.*\\.tpch\\.non_existent\\$partitions' does not exist");
+                ".*Table '.*\\.tpch\\.\"non_existent\\$partitions\"' does not exist");
     }
 
     @Test

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSystemTables.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiSystemTables.java
@@ -43,6 +43,6 @@ public class TestHudiSystemTables
                 "VALUES ('20220906063435640', 'commit', 'COMPLETED'), ('20220906063456550', 'commit', 'COMPLETED')");
 
         assertQueryFails("SELECT timestamp, action, state FROM tests.\"non_existing$timeline\"",
-                ".*Table 'hudi.tests.non_existing\\$timeline' does not exist");
+                ".*Table 'hudi.tests.\"non_existing\\$timeline\"' does not exist");
     }
 }

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteConnectorTest.java
@@ -148,8 +148,8 @@ public class TestIgniteConnectorTest
             assertThat((String) computeScalar("SHOW CREATE TABLE " + normalTableName)).contains("primary_key = ARRAY['a']");
             assertThat((String) computeScalar("SHOW CREATE TABLE " + underscoreTableName)).contains("primary_key = ARRAY['b']");
             assertThat((String) computeScalar("SHOW CREATE TABLE " + percentTableName)).contains("primary_key = ARRAY['c']");
-            assertQueryFails("SHOW CREATE TABLE " + "\"test%\"", ".*Table 'ignite.public.test%' does not exist");
-            assertQueryFails("SHOW COLUMNS FROM " + "\"test%\"", ".*Table 'ignite.public.test%' does not exist");
+            assertQueryFails("SHOW CREATE TABLE " + "\"test%\"", ".*Table 'ignite.public.\"test%\"' does not exist");
+            assertQueryFails("SHOW COLUMNS FROM " + "\"test%\"", ".*Table 'ignite.public.\"test%\"' does not exist");
         }
         finally {
             assertUpdate("DROP TABLE IF EXISTS " + normalTableName);

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/BaseRaptorConnectorTest.java
@@ -496,7 +496,7 @@ public abstract class BaseRaptorConnectorTest
                 "SELECT min(orderkey), max(orderkey) FROM orders");
 
         // No such table test
-        assertQueryFails("SELECT * FROM \"no_table$column_ranges\"", ".*'raptor\\.tpch\\.no_table\\$column_ranges' does not exist.*");
+        assertQueryFails("SELECT * FROM \"no_table$column_ranges\"", ".*'raptor\\.tpch\\.\"no_table\\$column_ranges\"' does not exist.*");
 
         // No range column for DOUBLE, INTEGER or VARCHAR
         assertQueryFails("SELECT totalprice_min FROM \"orders$column_ranges\"", ".*Column 'totalprice_min' cannot be resolved.*");
@@ -521,7 +521,7 @@ public abstract class BaseRaptorConnectorTest
         // Drop table
         assertUpdate("DROP TABLE column_ranges_test");
         assertQueryFails("SELECT a_min, a_max, b_min, b_max FROM \"column_ranges_test$column_ranges\"",
-                ".*'raptor\\.tpch\\.column_ranges_test\\$column_ranges' does not exist.*");
+                ".*'raptor\\.tpch\\.\"column_ranges_test\\$column_ranges\"' does not exist.*");
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestHiveAndDeltaLakeRedirect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestHiveAndDeltaLakeRedirect.java
@@ -135,8 +135,8 @@ public class TestHiveAndDeltaLakeRedirect
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM hive.default.\"%s$partitions\"", tableName)))
-                    .hasMessageMatching(".*Table 'hive.default.test_delta_lake_unpartitioned_table_.*\\$partitions' redirected to 'delta.default.test_delta_lake_unpartitioned_table_.*\\$partitions', " +
-                            "but the target table 'delta.default.test_delta_lake_unpartitioned_table_.*\\$partitions' does not exist");
+                    .hasMessageMatching(".*Table 'hive.default.\"test_delta_lake_unpartitioned_table_.*\\$partitions\"' redirected to 'delta.default.\"test_delta_lake_unpartitioned_table_.*\\$partitions\"', " +
+                            "but the target table 'delta.default.\"test_delta_lake_unpartitioned_table_.*\\$partitions\"' does not exist");
         }
         finally {
             dropDeltaTableWithRetry(tableName);
@@ -152,8 +152,8 @@ public class TestHiveAndDeltaLakeRedirect
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM hive.default.\"%s$partitions\"", tableName)))
-                    .hasMessageMatching(".*Table 'hive.default.test_delta_lake_partitioned_table_.*\\$partitions' redirected to 'delta.default.test_delta_lake_partitioned_table_.*\\$partitions', " +
-                            "but the target table 'delta.default.test_delta_lake_partitioned_table_.*\\$partitions' does not exist");
+                    .hasMessageMatching(".*Table 'hive.default.\"test_delta_lake_partitioned_table_.*\\$partitions\"' redirected to 'delta.default.\"test_delta_lake_partitioned_table_.*\\$partitions\"', " +
+                            "but the target table 'delta.default.\"test_delta_lake_partitioned_table_.*\\$partitions\"' does not exist");
         }
         finally {
             dropDeltaTableWithRetry(tableName);
@@ -291,7 +291,7 @@ public class TestHiveAndDeltaLakeRedirect
 
         try {
             assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM delta.default.\"%s$partitions\"", tableName)))
-                    .hasMessageMatching(".*Table 'delta.default.test_hive_unpartitioned_table.*partitions' does not exist");
+                    .hasMessageMatching(".*Table 'delta.default.\"test_hive_unpartitioned_table.*partitions\"' does not exist");
         }
         finally {
             onTrino().executeQuery("DROP TABLE hive.default." + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
@@ -129,7 +129,7 @@ public class TestHivePartitionsTable
     public void testShowPartitionsFromUnpartitionedTable()
     {
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM \"nation$partitions\""))
-                .hasMessageMatching(".*Table 'hive.default.nation\\$partitions' does not exist");
+                .hasMessageMatching(".*Table 'hive.default.\"nation\\$partitions\"' does not exist");
     }
 
     @Test(groups = HIVE_PARTITIONING)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hudi/TestHudiHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hudi/TestHudiHiveTablesCompatibility.java
@@ -45,10 +45,10 @@ public class TestHudiHiveTablesCompatibility
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not a Hudi table: default." + tableName);
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hudi.default.\"" + tableName + "$data\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hudi.default." + tableName + "$data' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hudi.default.\"" + tableName + "$data\"' does not exist");
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hudi.default.\"" + tableName + "$timeline\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hudi.default." + tableName + "$timeline' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hudi.default.\"" + tableName + "$timeline\"' does not exist");
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hudi.default.\"" + tableName + "$files\""))
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Invalid Hudi table name (unknown type 'files'): " + tableName + "$files");
@@ -68,7 +68,7 @@ public class TestHudiHiveTablesCompatibility
                 .hasMessageMatching(format("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default.%s' does not exist", tableName));
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.default.\"" + tableName + "$partitions\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default." + tableName + "$partitions' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default.\"" + tableName + "$partitions\"' does not exist");
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.default.\"" + tableName + "$properties\""))
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Table 'default." + tableName + "$properties' not found");

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hudi/TestHudiSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hudi/TestHudiSparkCompatibility.java
@@ -313,7 +313,7 @@ public class TestHudiSparkCompatibility
             assertThat(onTrino().executeQuery(format("SELECT action, state FROM hive.default.\"%s$timeline\"", tableName)))
                     .containsOnly(row("commit", "COMPLETED"));
             assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM hive.default.\"%s$timeline\"", nonExistingTableName)))
-                    .hasMessageMatching(".*Table 'hive.default.test_hudi_timeline_system_table_redirect_.*_non_existing\\$timeline' does not exist");
+                    .hasMessageMatching(".*Table 'hive.default.\"test_hudi_timeline_system_table_redirect_.*_non_existing\\$timeline\"' does not exist");
         }
         finally {
             onHudi().executeQuery("DROP TABLE " + tableName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveTablesCompatibility.java
@@ -47,10 +47,10 @@ public class TestIcebergHiveTablesCompatibility
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Not an Iceberg table: default." + tableName);
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$data\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default." + tableName + "$data' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default.\"" + tableName + "$data\"' does not exist");
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.\"" + tableName + "$files\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default." + tableName + "$files' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'iceberg.default.\"" + tableName + "$files\"' does not exist");
 
         onTrino().executeQuery("DROP TABLE hive.default." + tableName);
     }
@@ -65,10 +65,10 @@ public class TestIcebergHiveTablesCompatibility
                 .hasMessageMatching(format("Query failed \\(#\\w+\\):\\Q Cannot query Iceberg table 'default.%s'", tableName));
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.default.\"" + tableName + "$partitions\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default." + tableName + "$partitions' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default.\"" + tableName + "$partitions\"' does not exist");
 
         assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.default.\"" + tableName + "$properties\""))
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default." + tableName + "$properties' does not exist");
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q line 1:15: Table 'hive.default.\"" + tableName + "$properties\"' does not exist");
 
         onTrino().executeQuery("DROP TABLE iceberg.default." + tableName);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergRedirectionToHive.java
@@ -131,12 +131,12 @@ public class TestIcebergRedirectionToHive
     {
         String tableName = "hive_unpartitioned_table_" + randomNameSuffix();
         String hiveTableName = "hive.default." + tableName;
-        String icebergTableName = "iceberg.default." + tableName;
 
         createHiveTable(hiveTableName, false);
 
         assertQueryFailure(() -> onTrino().executeQuery("TABLE iceberg.default.\"" + tableName + "$partitions\""))
-                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Table '" + icebergTableName + "$partitions' redirected to '" + hiveTableName + "$partitions', but the target table '" + hiveTableName + "$partitions' does not exist");
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Table 'iceberg.default.\"" + tableName + "$partitions\"' redirected to 'hive.default.\"" + tableName + "$partitions\"', " +
+                        "but the target table 'hive.default.\"" + tableName + "$partitions\"' does not exist");
 
         onTrino().executeQuery("DROP TABLE " + hiveTableName);
     }
@@ -146,12 +146,12 @@ public class TestIcebergRedirectionToHive
     {
         String tableName = "hive_invalid_table_" + randomNameSuffix();
         String hiveTableName = "hive.default." + tableName;
-        String icebergTableName = "iceberg.default." + tableName;
 
         createHiveTable(hiveTableName, false);
 
         assertQueryFailure(() -> onTrino().executeQuery("TABLE iceberg.default.\"" + tableName + "$invalid\""))
-                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Table '" + icebergTableName + "$invalid' redirected to '" + hiveTableName + "$invalid', but the target table '" + hiveTableName + "$invalid' does not exist");
+                .hasMessageMatching("\\QQuery failed (#\\E\\S+\\Q): Table 'iceberg.default.\"" + tableName + "$invalid\"' redirected to 'hive.default.\"" + tableName + "$invalid\"', " +
+                        "but the target table 'hive.default.\"" + tableName + "$invalid\"' does not exist");
 
         onTrino().executeQuery("DROP TABLE " + hiveTableName);
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -5365,7 +5365,7 @@ public abstract class BaseConnectorTest
     public void testNoDataSystemTable()
     {
         assertQuerySucceeds("TABLE nation");
-        assertQueryFails("TABLE \"nation$data\"", "line 1:1: Table '\\w+.\\w+.nation\\$data' does not exist");
+        assertQueryFails("TABLE \"nation$data\"", "line 1:1: Table '\\w+.\\w+.\"nation\\$data\"' does not exist");
     }
 
     @Test(dataProvider = "testColumnNameDataProvider")


### PR DESCRIPTION
Previously, when table `"a.b.c"."d.e"."f.e.g"` was not found, the message
would indicate a `a.b.c.d.e.f.e.g` table without a hint how to parse
that.

