### PR TITLE
Run testReplaceTableWithSchemaChangeOnCheckpoint only with OSS Delta

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateTableAsSelectCompatibility.java
@@ -32,7 +32,6 @@ import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_104;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_113;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_DATABRICKS_122;
-import static io.trino.tests.product.TestGroups.DELTA_LAKE_EXCLUDE_133;
 import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertLastEntryIsCheckpointed;
@@ -172,9 +171,7 @@ public class TestDeltaLakeCreateTableAsSelectCompatibility
         }
     }
 
-    // Databricks 11.3, 12.2 and 13.3 don't create a checkpoint file at 'CREATE OR REPLACE TABLE' statement
-    @Test(groups = {DELTA_LAKE_DATABRICKS, DELTA_LAKE_OSS, DELTA_LAKE_EXCLUDE_133, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
     public void testReplaceTableWithSchemaChangeOnCheckpoint()
     {
         String tableName = "test_replace_table_with_schema_change_" + randomNameSuffix();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TransactionLogAssertions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TransactionLogAssertions.java
@@ -15,19 +15,15 @@ package io.trino.tests.product.deltalake;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
-import com.google.common.base.Throwables;
-import org.testng.Assert.ThrowingRunnable;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.Long.parseLong;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 public class TransactionLogAssertions
 {
@@ -48,43 +44,6 @@ public class TransactionLogAssertions
         Optional<String> lastJsonEntry = listJsonLogEntries(s3Client, bucketName, tableName).stream().max(String::compareTo);
         assertThat(lastJsonEntry).isPresent();
         assertEquals(lastJsonEntry.get(), format("%020d.json", versionNumber));
-    }
-
-    public static void assertNewVersion(AmazonS3 s3Client, String bucketName, String tableName, ThrowingRunnable runnable)
-    {
-        long initialVersion = getTransactionLogVersion(s3Client, bucketName, tableName);
-        try {
-            runnable.run();
-        }
-        catch (Throwable e) {
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
-        }
-        assertThat(getTransactionLogVersion(s3Client, bucketName, tableName))
-                .isGreaterThan(initialVersion);
-    }
-
-    public static void assertNoNewVersion(AmazonS3 s3Client, String bucketName, String tableName, ThrowingRunnable runnable)
-    {
-        long initialVersion = getTransactionLogVersion(s3Client, bucketName, tableName);
-        try {
-            runnable.run();
-        }
-        catch (Throwable e) {
-            Throwables.throwIfUnchecked(e);
-            throw new RuntimeException(e);
-        }
-        assertThat(getTransactionLogVersion(s3Client, bucketName, tableName))
-                .isEqualTo(initialVersion);
-    }
-
-    private static long getTransactionLogVersion(AmazonS3 s3Client, String bucketName, String tableName)
-    {
-        Optional<String> lastJsonEntry = listJsonLogEntries(s3Client, bucketName, tableName).stream().max(String::compareTo);
-        if (lastJsonEntry.isEmpty()) {
-            fail("Cannot determine version for table " + tableName);
-        }
-        return parseLong(lastJsonEntry.get().split("\\.")[0]);
     }
 
     private static List<String> listJsonLogEntries(AmazonS3 s3Client, String bucketName, String tableName)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TransactionLogAssertions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TransactionLogAssertions.java
@@ -25,7 +25,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
-public class TransactionLogAssertions
+public final class TransactionLogAssertions
 {
     private TransactionLogAssertions() {}
 


### PR DESCRIPTION
## Description

Probably, OPTIMIZE procedure ran in the background on Databricks side. 
Fixes #19580

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
