### PR TITLE
Fix PartitionedOutputOperator metrics

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertNull;
 public class TestOperatorStats
 {
     private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo(TEST_CATALOG_HANDLE, "some_info");
-    private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1, 2, 1024);
+    private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1024);
 
     public static final OperatorStats EXPECTED = new OperatorStats(
             0,
@@ -287,6 +287,6 @@ public class TestOperatorStats
         assertEquals(actual.getPeakTotalMemoryReservation(), DataSize.ofBytes(25));
         assertEquals(actual.getSpilledDataSize(), DataSize.ofBytes(3 * 26));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);
-        assertEquals(((PartitionedOutputInfo) actual.getInfo()).getPagesAdded(), 3 * MERGEABLE_INFO.getPagesAdded());
+        assertEquals(((PartitionedOutputInfo) actual.getInfo()).getOutputBufferPeakMemoryUsage(), MERGEABLE_INFO.getOutputBufferPeakMemoryUsage());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -63,7 +63,6 @@ public class TestPartitionedOutputOperator
         Page page = new Page(createLongSequenceBlock(0, 8));
 
         partitionedOutputOperator.addInput(page);
-        partitionedOutputOperator.finish();
 
         OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
         assertEquals(operatorContext.getOutputDataSize().getTotalCount(), page.getSizeInBytes());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`PartitionedOutputOperator` partition's input pages into
`PagePartitioner` shared between operators.
Since `PagePartitioner` can be flushed to output buffers
on `noMoreOperators`, and by that time all operators can
be finished, we need to update the operator metrics on
`addInput` to get them propagated to the `OperatorSummary`
inside the `PipelineStats`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
