### PR TITLE
Upgrade Error Prone to 2.23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dep.swagger.version>1.6.12</dep.swagger.version>
         <dep.kotlin.version>1.9.10</dep.kotlin.version>
         <dep.google.http.client.version>1.43.3</dep.google.http.client.version>
-        <dep.errorprone.version>2.22.0</dep.errorprone.version>
+        <dep.errorprone.version>2.23.0</dep.errorprone.version>
         <dep.testcontainers.version>1.19.1</dep.testcontainers.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.confluent.version>7.4.1</dep.confluent.version>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Released on Oct 18.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/google/error-prone/releases/tag/v2.23.0

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
