### PR TITLE
Check go-offline for protoc

### DIFF
--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -405,6 +405,7 @@
                         </goals>
                         <phase>generate-test-sources</phase>
                         <configuration>
+                            <protocArtifact>com.google.protobuf:protoc:${dep.protobuf.version}</protocArtifact>
                             <protocVersion>${dep.protobuf.version}</protocVersion>
                             <addSources>none</addSources>
                             <inputDirectories>

--- a/pom.xml
+++ b/pom.xml
@@ -2450,6 +2450,22 @@
                                 <type>jar</type>
                                 <repositoryType>MAIN</repositoryType>
                             </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>com.google.protobuf</groupId>
+                                <artifactId>protoc</artifactId>
+                                <type>exe</type>
+                                <classifier>linux-x86_64</classifier>
+                                <version>${dep.protobuf.version}</version>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
+                            <DynamicDependency>
+                                <groupId>com.google.protobuf</groupId>
+                                <artifactId>protoc</artifactId>
+                                <type>exe</type>
+                                <classifier>linux-aarch_64</classifier>
+                                <version>${dep.protobuf.version}</version>
+                                <repositoryType>MAIN</repositoryType>
+                            </DynamicDependency>
                         </dynamicDependencies>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Tested locally with:

```
rm -Rf ~/.m2/repository/com/google/protobuf/
./.github/bin/download-maven-dependencies.sh
ls -laR ~/.m2/repository/com/google/protobuf/protoc/
-rw-r--r--  1 mateuszgajewski  staff  8541384 Oct  4 19:00 protoc-3.24.4-linux-aarch_64.exe
-rw-r--r--  1 mateuszgajewski  staff       40 Oct 31 14:20 protoc-3.24.4-linux-aarch_64.exe.sha1
-rw-r--r--  1 mateuszgajewski  staff  8532336 Oct  4 19:01 protoc-3.24.4-linux-x86_64.exe
-rw-r--r--  1 mateuszgajewski  staff       40 Oct 31 14:20 protoc-3.24.4-linux-x86_64.exe.sha1
```