### PR TITLE
Support register_table and unregister_table procedure in Iceberg REST catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -257,13 +257,15 @@ public class TrinoRestCatalog
     @Override
     public void registerTable(ConnectorSession session, SchemaTableName tableName, TableMetadata tableMetadata)
     {
-        throw new TrinoException(NOT_SUPPORTED, "registerTable is not supported for Iceberg REST catalog");
+        restSessionCatalog.registerTable(convert(session), toIdentifier(tableName), tableMetadata.metadataFileLocation());
     }
 
     @Override
     public void unregisterTable(ConnectorSession session, SchemaTableName tableName)
     {
-        throw new TrinoException(NOT_SUPPORTED, "unregisterTable is not supported for Iceberg REST catalogs");
+        if (!restSessionCatalog.dropTable(convert(session), toIdentifier(tableName))) {
+            throw new TableNotFoundException(tableName);
+        }
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -138,7 +140,7 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     @Override
     protected void dropTableFromMetastore(String tableName)
     {
-        // used when registering a table, which is not supported by the REST catalog
+        backend.dropTable(toIdentifier(tableName), false);
     }
 
     @Override
@@ -158,94 +160,6 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     protected boolean locationExists(String location)
     {
         return java.nio.file.Files.exists(Path.of(location));
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithTableLocation()
-    {
-        assertThatThrownBy(super::testRegisterTableWithTableLocation)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithComments()
-    {
-        assertThatThrownBy(super::testRegisterTableWithComments)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithShowCreateTable()
-    {
-        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithReInsert()
-    {
-        assertThatThrownBy(super::testRegisterTableWithReInsert)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithDifferentTableName()
-    {
-        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithMetadataFile()
-    {
-        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testRegisterTableWithTrailingSpaceInLocation()
-    {
-        assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
-                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
-    }
-
-    @Test
-    @Override
-    public void testUnregisterTable()
-    {
-        assertThatThrownBy(super::testUnregisterTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
-    }
-
-    @Test
-    @Override
-    public void testUnregisterBrokenTable()
-    {
-        assertThatThrownBy(super::testUnregisterBrokenTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
-    }
-
-    @Test
-    @Override
-    public void testUnregisterTableNotExistingTable()
-    {
-        assertThatThrownBy(super::testUnregisterTableNotExistingTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
-    }
-
-    @Test
-    @Override
-    public void testRepeatUnregisterTable()
-    {
-        assertThatThrownBy(super::testRepeatUnregisterTable)
-                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
     }
 
     @Test
@@ -300,7 +214,12 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     @Override
     protected void deleteDirectory(String location)
     {
-        // used when unregistering a table, which is not supported by the REST catalog
+        try {
+            deleteRecursively(Path.of(location), ALLOW_INSECURE);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private TableIdentifier toIdentifier(String tableName)


### PR DESCRIPTION
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Add support for `register_table` and `unregister_table` procedures in REST catalog. ({issue}`15512`)
```

Fixes #15512