### PR TITLE
Move inline function test to dedicated class

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestInlineFunctions.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.testing.LocalQueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingHandles.TEST_CATALOG_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+
+@TestInstance(PER_CLASS)
+@Execution(CONCURRENT)
+public class TestInlineFunctions
+{
+    private final QueryAssertions assertions;
+
+    public TestInlineFunctions()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(TEST_CATALOG_NAME)
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner runner = LocalQueryRunner.builder(session)
+                .build();
+
+        runner.createCatalog(TEST_CATALOG_NAME, new TpchConnectorFactory(1), ImmutableMap.of());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+    }
+
+    @Test
+    public void testInlineFunction()
+    {
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION my_func(x bigint) 
+                    RETURNS bigint 
+                    RETURN x * 2
+                SELECT my_func(nationkey) 
+                FROM nation 
+                WHERE nationkey = 1
+                """))
+                .matches("VALUES BIGINT '2'");
+
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION my_func(x bigint) 
+                    RETURNS bigint 
+                    RETURN x * 2
+                SELECT my_func(nationkey) 
+                FROM nation 
+                WHERE nationkey >= 1
+                """))
+                .matches("SELECT nationkey * 2 FROM nation WHERE nationkey >= 1");
+
+        assertThat(assertions.query(
+                """
+                WITH FUNCTION my_func(x bigint) 
+                    RETURNS bigint 
+                    RETURN x * 2
+                SELECT my_func(nationkey) 
+                FROM nation
+                """))
+                .matches("SELECT nationkey * 2 FROM nation");
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -6587,27 +6587,6 @@ public abstract class BaseConnectorTest
     }
 
     @Test
-    public void testInlineFunction() {
-        assertQuery("""
-                        WITH FUNCTION my_func(x bigint) RETURNS bigint RETURN x * 2
-                        SELECT my_func(nationkey) FROM tpch.tiny.nation WHERE nationkey = 1
-                        """,
-                "SELECT 2");
-
-        assertQuery("""
-                        WITH FUNCTION my_func(x bigint) RETURNS bigint RETURN x * 2
-                        SELECT my_func(nationkey) FROM tpch.tiny.nation WHERE nationkey >= 1
-                        """,
-                "SELECT nationkey * 2 FROM nation WHERE nationkey >= 1");
-
-        assertQuery("""
-                        WITH FUNCTION my_func(x bigint) RETURNS bigint RETURN x * 2
-                        SELECT my_func(nationkey) FROM tpch.tiny.nation
-                        """,
-                "SELECT nationkey * 2 FROM nation");
-    }
-
-    @Test
     public void testProjectionPushdown()
     {
         skipTestUnless(hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA) && hasBehavior(SUPPORTS_ROW_TYPE));


### PR DESCRIPTION
It's unnecessary to test a core engine feature against every connector. It makes the tests suite take longer unnecessarily and doesn't provide additional value.

Relates to https://github.com/trinodb/trino/pull/19562

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
