### PR TITLE
Expose EventListenerManager benchmarks through JMX

### DIFF
--- a/core/trino-main/src/main/java/io/trino/eventlistener/EventListenerModule.java
+++ b/core/trino-main/src/main/java/io/trino/eventlistener/EventListenerModule.java
@@ -18,6 +18,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class EventListenerModule
         implements Module
@@ -27,5 +28,7 @@ public class EventListenerModule
     {
         configBinder(binder).bindConfig(EventListenerConfig.class);
         binder.bind(EventListenerManager.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(EventListenerManager.class)
+                .as(generator -> generator.generatedNameOf(EventListenerManager.class));
     }
 }


### PR DESCRIPTION
## Description

JMX bean EventListenerManager contains execution times of queryCompleted, queryCreated and splitCompleted methods.

```
trino:tiny> use jmx.current;
USE
trino:current> select node, object_name, "querycompletedtime.alltime.count" from  "trino.eventlistener:name=eventlistenermanager";
     node      |                  object_name                  | querycompletedtime.alltime.count
---------------+-----------------------------------------------+----------------------------------
 presto-master | trino.eventlistener:name=EventListenerManager |                             37.0
 presto-worker | trino.eventlistener:name=EventListenerManager |                              0.0
(2 rows)

Query 20231108_141144_00037_6i9c6, FINISHED, 2 nodes
Splits: 2 total, 2 done (100.00%)
0.14 [2 rows, 132B] [13 rows/s, 923B/s]
```

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X ) Release notes are required, with the following suggested text:
JMX context exposes EventListener benchmarks.
