### PR TITLE
Add BigQuery case insensitive name matching cache

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -205,7 +205,7 @@ public class BigQueryMetadata
             Iterable<Table> tables = client.listTables(DatasetId.of(projectId, remoteSchemaName));
             for (Table table : tables) {
                 // filter ambiguous tables
-                client.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH), tables)
+                client.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH))
                         .filter(RemoteDatabaseObject::isAmbiguous)
                         .ifPresentOrElse(
                                 remoteTable -> log.debug("Filtered out [%s.%s] from list of tables due to ambiguous name", remoteSchemaName, table.getTableId().getTable()),


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hello!

I've stumbled upon a situation where I have a project with hundreds of datasets and for a set of datasets thousands of tables. Enabling case-sensitive name mapping caused a lot of perf degregation and looking at things it's somewhat related to `toRemoteDataset`/`toRemoteTable`.

I'm also seeing a lot of BigQuery rate limits being reached but I'll tackle that on a separate PR (adding a bit more caching for other ops)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#10740

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
