### PR TITLE
Fix resource group keep setting incorrect softMemoryLimit

### DIFF
--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -191,7 +191,10 @@ public abstract class AbstractResourceConfigurationManager
     protected void configureGroup(ResourceGroup group, ResourceGroupSpec match)
     {
         if (match.getSoftMemoryLimit().isPresent()) {
-            group.setSoftMemoryLimitBytes(match.getSoftMemoryLimit().get().toBytes());
+            synchronized (memoryPoolFraction) {
+                memoryPoolFraction.remove(group);
+                group.setSoftMemoryLimitBytes(match.getSoftMemoryLimit().get().toBytes());
+            }
         }
         else {
             synchronized (memoryPoolFraction) {


### PR DESCRIPTION
## Description
When using database resource group manager, if softMemoryLimit was setup to 80% and then modified to 100MB. The softMemoryLimit in resource group is always 80% instead of 100MB.
The root cause is after using fraction(i.e. percentage) in softMemoryLimit in resource group, SqlQueryManager start updating softMemoryLimit to resource group per second. And the background update will not stop even if a static value is set in softMemoryLimit.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
