### PR TITLE
Fix reading ORC long decimal column containing only nulls 

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/DecimalColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/DecimalColumnReader.java
@@ -49,7 +49,6 @@ import static io.trino.orc.reader.ReaderUtils.unpackInt128Nulls;
 import static io.trino.orc.reader.ReaderUtils.unpackLongNulls;
 import static io.trino.orc.reader.ReaderUtils.verifyStreamType;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
-import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.util.Objects.requireNonNull;
 
 public class DecimalColumnReader
@@ -132,7 +131,7 @@ public class DecimalColumnReader
                 block = readNullBlock(isNull, nextBatchSize - nullCount);
             }
             else {
-                block = RunLengthEncodedBlock.create(DOUBLE, null, nextBatchSize);
+                block = RunLengthEncodedBlock.create(type, null, nextBatchSize);
             }
         }
 

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/UuidColumnReader.java
@@ -42,6 +42,7 @@ import static io.trino.orc.metadata.Stream.StreamKind.DATA;
 import static io.trino.orc.metadata.Stream.StreamKind.PRESENT;
 import static io.trino.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.UuidType.UUID;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -256,7 +257,7 @@ public class UuidColumnReader
 
     private Block createAllNullsBlock()
     {
-        return RunLengthEncodedBlock.create(new Int128ArrayBlock(1, Optional.of(new boolean[] {true}), new long[2]), nextBatchSize);
+        return RunLengthEncodedBlock.create(UUID, null, nextBatchSize);
     }
 
     private void openRowGroup()


### PR DESCRIPTION
Fixes #19636

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix reading ORC long DECIMAL column containing only nulls. ({issue}`19636`)
```
