### PR TITLE
Ignore internal TableAlreadyExistsException in Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -171,8 +171,8 @@ public final class IcebergUtil
 
     public static final String METADATA_FOLDER_NAME = "metadata";
     public static final String METADATA_FILE_EXTENSION = ".metadata.json";
+    public static final String TRINO_QUERY_ID_NAME = "trino_query_id";
     private static final Pattern SIMPLE_NAME = Pattern.compile("[a-z][a-z0-9]*");
-    static final String TRINO_QUERY_ID_NAME = "trino_query_id";
     // Metadata file name examples
     //  - 00001-409702ba-4735-4645-8f14-09537cc0b2c8.metadata.json
     //  - 00001-409702ba-4735-4645-8f14-09537cc0b2c8.gz.metadata.json (https://github.com/apache/iceberg/blob/ab398a0d5ff195f763f8c7a4358ac98fa38a8de7/core/src/main/java/org/apache/iceberg/TableMetadataParser.java#L141)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergCreateTableInternalRetry.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergCreateTableInternalRetry.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.TableAlreadyExistsException;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HiveMetastoreConfig;
+import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.trino.plugin.iceberg.catalog.file.TestingIcebergFileMetastoreCatalogModule;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestIcebergCreateTableInternalRetry
+        extends AbstractTestQueryFramework
+{
+    private static final String SCHEMA_NAME = "iceberg_internal_retry_schema";
+    private File metastoreDir;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(SCHEMA_NAME)
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        metastoreDir = queryRunner.getCoordinator().getBaseDataDir().resolve("test_iceberg_table_smoke_test").toFile();
+        this.metastoreDir.deleteOnExit();
+        HiveMetastore metastore = new FileHiveMetastore(
+                new NodeVersion("testversion"),
+                HDFS_FILE_SYSTEM_FACTORY,
+                new HiveMetastoreConfig().isHideDeltaLakeTables(),
+                new FileHiveMetastoreConfig()
+                        .setCatalogDirectory(metastoreDir.toURI().toString())
+                        .setMetastoreUser("test"))
+        {
+            @Override
+            public synchronized void createTable(Table table, PrincipalPrivileges principalPrivileges)
+            {
+                // Simulate retry mechanism with timeout failure of ThriftHiveMetastore.
+                // 1. createTable correctly create table but timeout is triggered
+                // 2. Retry to createTable throws TableAlreadyExistsException
+                super.createTable(table, principalPrivileges);
+                throw new TableAlreadyExistsException(table.getSchemaTableName());
+            }
+        };
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(Optional.of(new TestingIcebergFileMetastoreCatalogModule(metastore)), Optional.empty(), EMPTY_MODULE));
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", ImmutableMap.of("iceberg.register-table-procedure.enabled", "true"));
+        queryRunner.execute("CREATE SCHEMA " + SCHEMA_NAME);
+        return queryRunner;
+    }
+
+    @AfterAll
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateTableInternalRetry()
+    {
+        assertQuerySucceeds("CREATE TABLE test_ct_internal_retry(a int)");
+        assertQuery("SHOW TABLES LIKE 'test_ct_internal_retry'", "VALUES 'test_ct_internal_retry'");
+    }
+
+    @Test
+    public void testCreateTableAsSelectInternalRetry()
+    {
+        assertQuerySucceeds("CREATE TABLE test_ctas_internal_retry AS SELECT 1 a");
+        assertQuery("SHOW TABLES LIKE 'test_ctas_internal_retry'", "VALUES 'test_ctas_internal_retry'");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Ignore internal TableAlreadyExistsException in CREATE TABLE & register_table on Iceberg connector
Fixes https://github.com/trinodb/trino/issues/18308

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
