### PR TITLE
Respect air.test.thread-count with JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2484,6 +2484,10 @@
                 <configuration>
                     <properties>
                         <configurationParameters>junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD
+                            junit.jupiter.execution.parallel.enabled=true
+                            junit.jupiter.execution.parallel.mode.default=concurrent
+                            junit.jupiter.execution.parallel.config.strategy=fixed
+                            junit.jupiter.execution.parallel.config.fixed.parallelism=${air.test.thread-count}
                             junit.jupiter.extensions.autodetection.enabled = true</configurationParameters>
                     </properties>
                     <includes>


### PR DESCRIPTION
This change is aimed at reducing tests' wall time on the CI and thus improve throughput. The impact of this change is not yet huge today, as many integration tests were not ported off TestNG yet.
