### PR TITLE
Increase timeout when scaling cluster in test

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -300,7 +300,8 @@ public class DistributedQueryRunner
     {
         long start = System.nanoTime();
         while (!allNodesGloballyVisible()) {
-            Assertions.assertLessThan(nanosSince(start), new Duration(10, SECONDS));
+            // TODO node announcement should be propagated faster when new node starts
+            Assertions.assertLessThan(nanosSince(start), new Duration(30, SECONDS));
             MILLISECONDS.sleep(10);
         }
         log.info("Announced servers in %s", nanosSince(start).convertToMostSuccinctTimeUnit());


### PR DESCRIPTION
Increase
`TestMinWorkerRequirement.testMultipleRequiredWorkerNodesSessionOverride` timeout, hopefully fixing its flakiness.  Before the changes, running the test with `@Test(invocationCount = 20, threadPoolSize = 4)` would pretty deterministically reproduce the failure locally (with first 4 runs failing, other succeeding). It is up to future investigation to understand why it sometimes takes more time to register new worker node.

Hopefully maybe this fixes https://github.com/trinodb/trino/issues/19446