### PR TITLE
Add cause of failures in ThriftHiveMetastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SchemaAlreadyExistsException.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SchemaAlreadyExistsException.java
@@ -25,12 +25,17 @@ public class SchemaAlreadyExistsException
 
     public SchemaAlreadyExistsException(String schemaName)
     {
-        this(schemaName, format("Schema already exists: '%s'", schemaName));
+        this(schemaName, null);
     }
 
-    public SchemaAlreadyExistsException(String schemaName, String message)
+    public SchemaAlreadyExistsException(String schemaName, Throwable cause)
     {
-        super(ALREADY_EXISTS, message);
+        this(schemaName, format("Schema already exists: '%s'", schemaName), cause);
+    }
+
+    public SchemaAlreadyExistsException(String schemaName, String message, Throwable cause)
+    {
+        super(ALREADY_EXISTS, message, cause);
         this.schemaName = schemaName;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableAlreadyExistsException.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableAlreadyExistsException.java
@@ -26,12 +26,12 @@ public class TableAlreadyExistsException
 
     public TableAlreadyExistsException(SchemaTableName tableName)
     {
-        this(tableName, format("Table already exists: '%s'", tableName));
+        this(tableName, null);
     }
 
-    public TableAlreadyExistsException(SchemaTableName tableName, String message)
+    public TableAlreadyExistsException(SchemaTableName tableName, Throwable cause)
     {
-        this(tableName, message, null);
+        this(tableName, format("Table already exists: '%s'", tableName), cause);
     }
 
     public TableAlreadyExistsException(SchemaTableName tableName, String message, Throwable cause)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -354,7 +354,7 @@ public class GlueHiveMetastore
             columnStatisticsProvider.updateTableColumnStatistics(table, updatedStatistics.getColumnStatistics());
         }
         catch (EntityNotFoundException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -486,7 +486,7 @@ public class GlueHiveMetastore
                     glueClient.createDatabase(new CreateDatabaseRequest().withDatabaseInput(databaseInput)));
         }
         catch (AlreadyExistsException e) {
-            throw new SchemaAlreadyExistsException(database.getDatabaseName());
+            throw new SchemaAlreadyExistsException(database.getDatabaseName(), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -518,7 +518,7 @@ public class GlueHiveMetastore
                     glueClient.deleteDatabase(new DeleteDatabaseRequest().withName(databaseName)));
         }
         catch (EntityNotFoundException e) {
-            throw new SchemaNotFoundException(databaseName);
+            throw new SchemaNotFoundException(databaseName, e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -562,10 +562,10 @@ public class GlueHiveMetastore
                             .withTableInput(input)));
         }
         catch (AlreadyExistsException e) {
-            throw new TableAlreadyExistsException(new SchemaTableName(table.getDatabaseName(), table.getTableName()));
+            throw new TableAlreadyExistsException(new SchemaTableName(table.getDatabaseName(), table.getTableName()), e);
         }
         catch (EntityNotFoundException e) {
-            throw new SchemaNotFoundException(table.getDatabaseName());
+            throw new SchemaNotFoundException(table.getDatabaseName(), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -625,7 +625,7 @@ public class GlueHiveMetastore
                             .withTableInput(newTableInput)));
         }
         catch (EntityNotFoundException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -706,7 +706,7 @@ public class GlueHiveMetastore
                             .withTableInput(newTableInput)));
         }
         catch (EntityNotFoundException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -1121,7 +1121,7 @@ public class GlueHiveMetastore
                     partition.getStatistics().getColumnStatistics());
         }
         catch (EntityNotFoundException e) {
-            throw new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), partition.getPartition().getValues());
+            throw new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), partition.getPartition().getValues(), e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -1265,10 +1265,10 @@ public class GlueHiveMetastore
                             .withFunctionInput(functionInput)));
         }
         catch (AlreadyExistsException e) {
-            throw new TrinoException(ALREADY_EXISTS, "Function already exists");
+            throw new TrinoException(ALREADY_EXISTS, "Function already exists", e);
         }
         catch (EntityNotFoundException e) {
-            throw new SchemaNotFoundException(databaseName);
+            throw new SchemaNotFoundException(databaseName, e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -1301,7 +1301,7 @@ public class GlueHiveMetastore
                             .withFunctionName(metastoreFunctionName(functionName, signatureToken))));
         }
         catch (EntityNotFoundException e) {
-            throw new TrinoException(FUNCTION_NOT_FOUND, "Function not found");
+            throw new TrinoException(FUNCTION_NOT_FOUND, "Function not found", e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -366,7 +366,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -480,7 +480,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -561,7 +561,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -585,7 +585,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -655,7 +655,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -679,7 +679,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -974,7 +974,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (AlreadyExistsException e) {
-            throw new SchemaAlreadyExistsException(database.getName());
+            throw new SchemaAlreadyExistsException(database.getName(), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -999,7 +999,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new SchemaNotFoundException(databaseName);
+            throw new SchemaNotFoundException(databaseName, e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -1027,7 +1027,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new SchemaNotFoundException(databaseName);
+            throw new SchemaNotFoundException(databaseName, e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
@@ -1053,10 +1053,10 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (AlreadyExistsException e) {
-            throw new TableAlreadyExistsException(new SchemaTableName(table.getDbName(), table.getTableName()));
+            throw new TableAlreadyExistsException(new SchemaTableName(table.getDbName(), table.getTableName()), e);
         }
         catch (NoSuchObjectException e) {
-            throw new SchemaNotFoundException(table.getDbName());
+            throw new SchemaNotFoundException(table.getDbName(), e);
         }
         catch (InvalidObjectException e) {
             boolean databaseMissing;
@@ -1068,7 +1068,7 @@ public class ThriftHiveMetastore
                 databaseMissing = false; // we don't know, assume it exists for the purpose of error reporting
             }
             if (databaseMissing) {
-                throw new SchemaNotFoundException(table.getDbName());
+                throw new SchemaNotFoundException(table.getDbName(), e);
             }
             throw new TrinoException(HIVE_METASTORE_ERROR, e);
         }
@@ -1100,7 +1100,7 @@ public class ThriftHiveMetastore
                     }));
         }
         catch (NoSuchObjectException e) {
-            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
+            throw new TableNotFoundException(new SchemaTableName(databaseName, tableName), e);
         }
         catch (TException e) {
             throw new TrinoException(HIVE_METASTORE_ERROR, e);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -256,7 +256,7 @@ public class TrinoGlueCatalog
                     glueClient.deleteDatabase(new DeleteDatabaseRequest().withName(namespace)));
         }
         catch (EntityNotFoundException e) {
-            throw new SchemaNotFoundException(namespace);
+            throw new SchemaNotFoundException(namespace, e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, e);
@@ -280,7 +280,7 @@ public class TrinoGlueCatalog
             return metadata.buildOrThrow();
         }
         catch (EntityNotFoundException e) {
-            throw new SchemaNotFoundException(namespace);
+            throw new SchemaNotFoundException(namespace, e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, e);
@@ -305,7 +305,7 @@ public class TrinoGlueCatalog
                             .withDatabaseInput(createDatabaseInput(namespace, properties))));
         }
         catch (AlreadyExistsException e) {
-            throw new SchemaAlreadyExistsException(namespace);
+            throw new SchemaAlreadyExistsException(namespace, e);
         }
         catch (AmazonServiceException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, e);


### PR DESCRIPTION
This will be beneficial in case of detecting retry issues.
Currently in case of failure after retry (e.g createTable, dropTable) we have no information that it was consecutive attempt. After this  change exceptions from previous attempts will be visible in stack trace.

Example in case 2 attemps:
1. `ClientException`
2. `NoSuchObjectException`

Before:
```
io.trino.spi.connector.TableNotFoundException: Table 'test.test' not found

	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.dropTable(ThriftHiveMetastore.java:1103)
	at io.trino.plugin.hive.TestTriftHiveMetastore.testDropTable(TestTriftHiveMetastore.java:194)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
After:
```
io.trino.spi.connector.TableNotFoundException: Table 'test.test' not found

	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.dropTable(ThriftHiveMetastore.java:1103)
	at io.trino.plugin.hive.TestTriftHiveMetastore.testDropTable(TestTriftHiveMetastore.java:194)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: NoSuchObjectException(message:null)
	at io.trino.plugin.hive.TestTriftHiveMetastore$2.getTable(TestTriftHiveMetastore.java:178)
	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.lambda$dropTable$41(ThriftHiveMetastore.java:1092)
	at io.trino.plugin.hive.metastore.thrift.ThriftMetastoreApiStats.lambda$wrap$0(ThriftMetastoreApiStats.java:41)
	at io.trino.plugin.hive.util.RetryDriver.run(RetryDriver.java:116)
	at io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore.dropTable(ThriftHiveMetastore.java:1090)
	... 4 more
	Suppressed: io.trino.client.ClientException: Timout
		at io.trino.plugin.hive.TestTriftHiveMetastore$2.getTable(TestTriftHiveMetastore.java:176)
		... 8 more
```
'''
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
