### PR TITLE
Remove redundant synchronization around cleanupQuery

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2572,7 +2572,7 @@ public final class MetadataManager
             }
         }
 
-        private synchronized void finish()
+        private void finish()
         {
             List<CatalogMetadata> catalogs;
             synchronized (this) {


### PR DESCRIPTION
`QueryCatalogs.finish` synchronizes within method body, so method-level synchronization looks redundant.
