### PR TITLE
Ensure cleanupQuery gets called for procedures

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/UncheckedCloseable.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/util/UncheckedCloseable.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.util;
+
+public interface UncheckedCloseable
+        extends AutoCloseable
+{
+    @Override
+    void close();
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/DropExtendedStatsProcedure.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake.procedure;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.deltalake.DeltaLakeMetadata;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.LocatedTableHandle;
@@ -79,11 +80,14 @@ public class DropExtendedStatsProcedure
 
         SchemaTableName name = new SchemaTableName(schema, table);
         DeltaLakeMetadata metadata = metadataFactory.create(session.getIdentity());
-        LocatedTableHandle tableHandle = metadata.getTableHandle(session, name);
-        if (tableHandle == null) {
-            throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", name));
+        metadata.beginQuery(session);
+        try (UncheckedCloseable ignore = () -> metadata.cleanupQuery(session)) {
+            LocatedTableHandle tableHandle = metadata.getTableHandle(session, name);
+            if (tableHandle == null) {
+                throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Table '%s' does not exist", name));
+            }
+            accessControl.checkCanInsertIntoTable(null, name);
+            statsAccess.deleteExtendedStatistics(session, name, tableHandle.location());
         }
-        accessControl.checkCanInsertIntoTable(null, name);
-        statsAccess.deleteExtendedStatistics(session, name, tableHandle.location());
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/procedure/RegisterTableProcedure.java
@@ -19,7 +19,9 @@ import com.google.inject.Provider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
+import io.trino.plugin.deltalake.DeltaLakeMetadata;
 import io.trino.plugin.deltalake.DeltaLakeMetadataFactory;
 import io.trino.plugin.deltalake.metastore.DeltaLakeMetastore;
 import io.trino.plugin.deltalake.statistics.CachingExtendedStatisticsAccess;
@@ -140,59 +142,63 @@ public class RegisterTableProcedure
         checkProcedureArgument(!isNullOrEmpty(tableLocation), "table_location cannot be null or empty");
 
         SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
-        DeltaLakeMetastore metastore = metadataFactory.create(session.getIdentity()).getMetastore();
+        DeltaLakeMetadata metadata = metadataFactory.create(session.getIdentity());
+        metadata.beginQuery(session);
+        try (UncheckedCloseable ignore = () -> metadata.cleanupQuery(session)) {
+            DeltaLakeMetastore metastore = metadata.getMetastore();
 
-        if (metastore.getDatabase(schemaName).isEmpty()) {
-            throw new SchemaNotFoundException(schemaTableName.getSchemaName());
-        }
-
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        try {
-            Location transactionLogDir = Location.of(getTransactionLogDir(tableLocation));
-            if (!fileSystem.listFiles(transactionLogDir).hasNext()) {
-                throw new TrinoException(GENERIC_USER_ERROR, format("No transaction log found in location %s", transactionLogDir));
+            if (metastore.getDatabase(schemaName).isEmpty()) {
+                throw new SchemaNotFoundException(schemaTableName.getSchemaName());
             }
-        }
-        catch (IOException e) {
-            throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed checking table location %s", tableLocation), e);
-        }
 
-        Table table = buildTable(session, schemaTableName, tableLocation, true);
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            try {
+                Location transactionLogDir = Location.of(getTransactionLogDir(tableLocation));
+                if (!fileSystem.listFiles(transactionLogDir).hasNext()) {
+                    throw new TrinoException(GENERIC_USER_ERROR, format("No transaction log found in location %s", transactionLogDir));
+                }
+            }
+            catch (IOException e) {
+                throw new TrinoException(DELTA_LAKE_FILESYSTEM_ERROR, format("Failed checking table location %s", tableLocation), e);
+            }
 
-        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
-        statisticsAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
-        transactionLogAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
-        // Verify we're registering a location with a valid table
-        try {
-            TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(session, table.getSchemaTableName(), tableLocation);
-            transactionLogAccess.getMetadataEntry(tableSnapshot, session); // verify metadata exists
-        }
-        catch (TrinoException e) {
-            throw e;
-        }
-        catch (IOException | RuntimeException e) {
-            throw new TrinoException(DELTA_LAKE_INVALID_TABLE, "Failed to access table location: " + tableLocation, e);
-        }
+            Table table = buildTable(session, schemaTableName, tableLocation, true);
 
-        // Ensure the table has queryId set. This is relied on for exception handling
-        String queryId = session.getQueryId();
-        verify(
-                getQueryId(table).orElseThrow(() -> new IllegalArgumentException("Query id is not present")).equals(queryId),
-                "Table '%s' does not have correct query id set",
-                table);
-        try {
-            metastore.createTable(
-                    session,
-                    table,
-                    principalPrivileges);
-        }
-        catch (TableAlreadyExistsException e) {
-            // Ignore TableAlreadyExistsException when table looks like created by us.
-            // This may happen when an actually successful metastore create call is retried
-            // e.g. because of a timeout on our side.
-            Optional<Table> existingTable = metastore.getRawMetastoreTable(schemaName, tableName);
-            if (existingTable.isEmpty() || !isCreatedBy(existingTable.get(), queryId)) {
+            PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner().orElseThrow());
+            statisticsAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
+            transactionLogAccess.invalidateCache(schemaTableName, Optional.of(tableLocation));
+            // Verify we're registering a location with a valid table
+            try {
+                TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(session, table.getSchemaTableName(), tableLocation);
+                transactionLogAccess.getMetadataEntry(tableSnapshot, session); // verify metadata exists
+            }
+            catch (TrinoException e) {
                 throw e;
+            }
+            catch (IOException | RuntimeException e) {
+                throw new TrinoException(DELTA_LAKE_INVALID_TABLE, "Failed to access table location: " + tableLocation, e);
+            }
+
+            // Ensure the table has queryId set. This is relied on for exception handling
+            String queryId = session.getQueryId();
+            verify(
+                    getQueryId(table).orElseThrow(() -> new IllegalArgumentException("Query id is not present")).equals(queryId),
+                    "Table '%s' does not have correct query id set",
+                    table);
+            try {
+                metastore.createTable(
+                        session,
+                        table,
+                        principalPrivileges);
+            }
+            catch (TableAlreadyExistsException e) {
+                // Ignore TableAlreadyExistsException when table looks like created by us.
+                // This may happen when an actually successful metastore create call is retried
+                // e.g. because of a timeout on our side.
+                Optional<Table> existingTable = metastore.getRawMetastoreTable(schemaName, tableName);
+                if (existingTable.isEmpty() || !isCreatedBy(existingTable.get(), queryId)) {
+                    throw e;
+                }
             }
         }
     }

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -116,10 +116,6 @@ public class TestDeltaLakeMetadata
     private static final RowType NESTED_ROW_FIELD = RowType.from(ImmutableList.of(
             new RowType.Field(Optional.of("child1"), INTEGER),
             new RowType.Field(Optional.of("child2"), INTEGER)));
-    private static final RowType HIGHLY_NESTED_ROW_FIELD = RowType.from(ImmutableList.of(
-            new RowType.Field(Optional.of("grandparent"), RowType.from(ImmutableList.of(
-                    new RowType.Field(Optional.of("parent"), RowType.from(ImmutableList.of(
-                            new RowType.Field(Optional.of("child"), INTEGER)))))))));
 
     private static final DeltaLakeColumnHandle BOOLEAN_COLUMN_HANDLE =
             new DeltaLakeColumnHandle("boolean_column_name", BooleanType.BOOLEAN, OptionalInt.empty(), "boolean_column_name", BooleanType.BOOLEAN, REGULAR, Optional.empty());
@@ -142,32 +138,12 @@ public class TestDeltaLakeMetadata
                     NESTED_ROW_FIELD,
                     REGULAR,
                     Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(1), ImmutableList.of("child2"))));
-    private static final DeltaLakeColumnHandle NESTED_COLUMN_HANDLE_WITH_PROJECTION =
-            new DeltaLakeColumnHandle(
-                    "highly_nested_column_name",
-                    HIGHLY_NESTED_ROW_FIELD,
-                    OptionalInt.empty(),
-                    "highly_nested_column_name",
-                    HIGHLY_NESTED_ROW_FIELD,
-                    REGULAR,
-                    Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0, 0), ImmutableList.of("grandparent", "parent"))));
-    private static final DeltaLakeColumnHandle EXPECTED_NESTED_COLUMN_HANDLE_WITH_PROJECTION =
-            new DeltaLakeColumnHandle(
-                    "highly_nested_column_name",
-                    HIGHLY_NESTED_ROW_FIELD,
-                    OptionalInt.empty(),
-                    "highly_nested_column_name",
-                    HIGHLY_NESTED_ROW_FIELD,
-                    REGULAR,
-                    Optional.of(new DeltaLakeColumnProjectionInfo(INTEGER, ImmutableList.of(0, 0, 0), ImmutableList.of("grandparent", "parent", "child"))));
 
     private static final Map<String, ColumnHandle> SYNTHETIC_COLUMN_ASSIGNMENTS = ImmutableMap.of(
             "test_synthetic_column_name_1", BOGUS_COLUMN_HANDLE,
             "test_synthetic_column_name_2", VARCHAR_COLUMN_HANDLE);
     private static final Map<String, ColumnHandle> NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("nested_column_name", NESTED_COLUMN_HANDLE);
     private static final Map<String, ColumnHandle> EXPECTED_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("nested_column_name#child2", EXPECTED_NESTED_COLUMN_HANDLE);
-    private static final Map<String, ColumnHandle> HIGHLY_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("highly_nested_column_name#grandparent#parent", NESTED_COLUMN_HANDLE_WITH_PROJECTION);
-    private static final Map<String, ColumnHandle> EXPECTED_HIGHLY_NESTED_COLUMN_ASSIGNMENTS = ImmutableMap.of("highly_nested_column_name#grandparent#parent#child", EXPECTED_NESTED_COLUMN_HANDLE_WITH_PROJECTION);
 
     private static final ConnectorExpression DOUBLE_PROJECTION = new Variable("double_projection", DoubleType.DOUBLE);
     private static final ConnectorExpression BOOLEAN_PROJECTION = new Variable("boolean_projection", BooleanType.BOOLEAN);
@@ -182,13 +158,6 @@ public class TestDeltaLakeMetadata
     private static final ConnectorExpression EXPECTED_NESTED_DEREFERENCE_PROJECTION = new Variable(
             "nested_column_name#child2",
             INTEGER);
-    private static final ConnectorExpression HIGHLY_NESTED_DEREFERENCE_PROJECTION = new FieldDereference(
-            INTEGER,
-            new Variable("highly_nested_column_name#grandparent#parent", HIGHLY_NESTED_ROW_FIELD),
-            0);
-    private static final ConnectorExpression EXPECTED_HIGHLY_NESTED_DEREFERENCE_PROJECTION = new Variable(
-            "highly_nested_column_name#grandparent#parent#child",
-            INTEGER);
 
     private static final List<ConnectorExpression> SIMPLE_COLUMN_PROJECTIONS =
             ImmutableList.of(DOUBLE_PROJECTION, BOOLEAN_PROJECTION);
@@ -198,10 +167,6 @@ public class TestDeltaLakeMetadata
             ImmutableList.of(NESTED_DEREFERENCE_PROJECTION);
     private static final List<ConnectorExpression> EXPECTED_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
             ImmutableList.of(EXPECTED_NESTED_DEREFERENCE_PROJECTION);
-    private static final List<ConnectorExpression> HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
-            ImmutableList.of(HIGHLY_NESTED_DEREFERENCE_PROJECTION);
-    private static final List<ConnectorExpression> EXPECTED_HIGHLY_NESTED_DEREFERENCE_COLUMN_PROJECTIONS =
-            ImmutableList.of(EXPECTED_HIGHLY_NESTED_DEREFERENCE_PROJECTION);
 
     private static final Set<DeltaLakeColumnHandle> PREDICATE_COLUMNS =
             ImmutableSet.of(BOOLEAN_COLUMN_HANDLE, DOUBLE_COLUMN_HANDLE);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/glue/TestDeltaLakeGlueMetastore.java
@@ -243,6 +243,8 @@ public class TestDeltaLakeGlueMetastore
                 .isEmpty();
         assertThat(listTableColumns(metadata, new SchemaTablePrefix(databaseName, nonDeltaLakeView1.getTableName())))
                 .isEmpty();
+
+        metadata.cleanupQuery(session);
     }
 
     private Set<SchemaTableName> listTableColumns(DeltaLakeMetadata metadata, SchemaTablePrefix tablePrefix)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
@@ -20,8 +20,10 @@ import com.google.inject.Provider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.HiveConfig;
 import io.trino.plugin.hive.PartitionStatistics;
+import io.trino.plugin.hive.TransactionalMetadata;
 import io.trino.plugin.hive.TransactionalMetadataFactory;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
@@ -113,49 +115,53 @@ public class RegisterPartitionProcedure
             throw new TrinoException(PERMISSION_DENIED, "register_partition procedure is disabled");
         }
 
-        SemiTransactionalHiveMetastore metastore = hiveMetadataFactory.create(session.getIdentity(), true).getMetastore();
+        TransactionalMetadata hiveMetadata = hiveMetadataFactory.create(session.getIdentity(), true);
+        hiveMetadata.beginQuery(session);
+        try (UncheckedCloseable ignore = () -> hiveMetadata.cleanupQuery(session)) {
+            SemiTransactionalHiveMetastore metastore = hiveMetadata.getMetastore();
 
-        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+            SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
 
-        Table table = metastore.getTable(schemaName, tableName)
-                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+            Table table = metastore.getTable(schemaName, tableName)
+                    .orElseThrow(() -> new TableNotFoundException(schemaTableName));
 
-        accessControl.checkCanInsertIntoTable(null, schemaTableName);
+            accessControl.checkCanInsertIntoTable(null, schemaTableName);
 
-        checkIsPartitionedTable(table);
-        checkPartitionColumns(table, partitionColumns);
+            checkIsPartitionedTable(table);
+            checkPartitionColumns(table, partitionColumns);
 
-        Optional<Partition> partition = metastore.unsafeGetRawHiveMetastoreClosure().getPartition(schemaName, tableName, partitionValues);
-        if (partition.isPresent()) {
-            String partitionName = makePartName(partitionColumns, partitionValues);
-            throw new TrinoException(ALREADY_EXISTS, format("Partition [%s] is already registered with location %s", partitionName, partition.get().getStorage().getLocation()));
-        }
-
-        Location partitionLocation = Optional.ofNullable(location)
-                .map(Location::of)
-                .orElseGet(() -> Location.of(table.getStorage().getLocation()).appendPath(makePartName(partitionColumns, partitionValues)));
-
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        try {
-            if (!fileSystem.directoryExists(partitionLocation).orElse(true)) {
-                throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Partition location does not exist: " + partitionLocation);
+            Optional<Partition> partition = metastore.unsafeGetRawHiveMetastoreClosure().getPartition(schemaName, tableName, partitionValues);
+            if (partition.isPresent()) {
+                String partitionName = makePartName(partitionColumns, partitionValues);
+                throw new TrinoException(ALREADY_EXISTS, format("Partition [%s] is already registered with location %s", partitionName, partition.get().getStorage().getLocation()));
             }
-        }
-        catch (IOException e) {
-            throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Failed checking partition location: " + partitionLocation, e);
-        }
 
-        metastore.addPartition(
-                session,
-                table.getDatabaseName(),
-                table.getTableName(),
-                buildPartitionObject(session, table, partitionValues, partitionLocation),
-                partitionLocation,
-                Optional.empty(), // no need for failed attempts cleanup
-                PartitionStatistics.empty(),
-                false);
+            Location partitionLocation = Optional.ofNullable(location)
+                    .map(Location::of)
+                    .orElseGet(() -> Location.of(table.getStorage().getLocation()).appendPath(makePartName(partitionColumns, partitionValues)));
 
-        metastore.commit();
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            try {
+                if (!fileSystem.directoryExists(partitionLocation).orElse(true)) {
+                    throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Partition location does not exist: " + partitionLocation);
+                }
+            }
+            catch (IOException e) {
+                throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Failed checking partition location: " + partitionLocation, e);
+            }
+
+            metastore.addPartition(
+                    session,
+                    table.getDatabaseName(),
+                    table.getTableName(),
+                    buildPartitionObject(session, table, partitionValues, partitionLocation),
+                    partitionLocation,
+                    Optional.empty(), // no need for failed attempts cleanup
+                    PartitionStatistics.empty(),
+                    false);
+
+            metastore.commit();
+        }
     }
 
     private static Partition buildPartitionObject(ConnectorSession session, Table table, List<String> partitionValues, Location location)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -21,7 +21,9 @@ import com.google.inject.Provider;
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.PartitionStatistics;
+import io.trino.plugin.hive.TransactionalMetadata;
 import io.trino.plugin.hive.TransactionalMetadataFactory;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.Partition;
@@ -116,36 +118,40 @@ public class SyncPartitionMetadataProcedure
         checkProcedureArgument(mode != null, "mode cannot be null");
 
         SyncMode syncMode = toSyncMode(mode);
-        SemiTransactionalHiveMetastore metastore = hiveMetadataFactory.create(session.getIdentity(), true).getMetastore();
-        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+        TransactionalMetadata hiveMetadata = hiveMetadataFactory.create(session.getIdentity(), true);
+        hiveMetadata.beginQuery(session);
+        try (UncheckedCloseable ignore = () -> hiveMetadata.cleanupQuery(session)) {
+            SemiTransactionalHiveMetastore metastore = hiveMetadata.getMetastore();
+            SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
 
-        Table table = metastore.getTable(schemaName, tableName)
-                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
-        if (table.getPartitionColumns().isEmpty()) {
-            throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Table is not partitioned: " + schemaTableName);
+            Table table = metastore.getTable(schemaName, tableName)
+                    .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+            if (table.getPartitionColumns().isEmpty()) {
+                throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, "Table is not partitioned: " + schemaTableName);
+            }
+
+            if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
+                accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName));
+            }
+            if (syncMode == SyncMode.DROP || syncMode == SyncMode.FULL) {
+                accessControl.checkCanDeleteFromTable(null, new SchemaTableName(schemaName, tableName));
+            }
+
+            Location tableLocation = Location.of(table.getStorage().getLocation());
+
+            Set<String> partitionsInMetastore = metastore.getPartitionNames(schemaName, tableName)
+                    .map(ImmutableSet::copyOf)
+                    .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+            Set<String> partitionsInFileSystem = listPartitions(fileSystemFactory.create(session), tableLocation, table.getPartitionColumns(), caseSensitive);
+
+            // partitions in file system but not in metastore
+            Set<String> partitionsToAdd = difference(partitionsInFileSystem, partitionsInMetastore);
+
+            // partitions in metastore but not in file system
+            Set<String> partitionsToDrop = difference(partitionsInMetastore, partitionsInFileSystem);
+
+            syncPartitions(partitionsToAdd, partitionsToDrop, syncMode, metastore, session, table);
         }
-
-        if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
-            accessControl.checkCanInsertIntoTable(null, new SchemaTableName(schemaName, tableName));
-        }
-        if (syncMode == SyncMode.DROP || syncMode == SyncMode.FULL) {
-            accessControl.checkCanDeleteFromTable(null, new SchemaTableName(schemaName, tableName));
-        }
-
-        Location tableLocation = Location.of(table.getStorage().getLocation());
-
-        Set<String> partitionsInMetastore = metastore.getPartitionNames(schemaName, tableName)
-                .map(ImmutableSet::copyOf)
-                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
-        Set<String> partitionsInFileSystem = listPartitions(fileSystemFactory.create(session), tableLocation, table.getPartitionColumns(), caseSensitive);
-
-        // partitions in file system but not in metastore
-        Set<String> partitionsToAdd = difference(partitionsInFileSystem, partitionsInMetastore);
-
-        // partitions in metastore but not in file system
-        Set<String> partitionsToDrop = difference(partitionsInMetastore, partitionsInFileSystem);
-
-        syncPartitions(partitionsToAdd, partitionsToDrop, syncMode, metastore, session, table);
     }
 
     private static Set<String> listPartitions(TrinoFileSystem fileSystem, Location directory, List<Column> partitionColumns, boolean caseSensitive)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseS3AndGlueMetastoreTest.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.trino.Session;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -345,12 +346,5 @@ public abstract class BaseS3AndGlueMetastoreTest
         {
             return locationPattern.formatted(bucketName, schemaName, tableName);
         }
-    }
-
-    protected interface UncheckedCloseable
-            extends AutoCloseable
-    {
-        @Override
-        void close();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveS3AndGlueMetastoreTest.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.SelectedRole;
 import io.trino.testing.DistributedQueryRunner;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergS3AndGlueMetastoreTest.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.catalog.glue;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.util.UncheckedCloseable;
 import io.trino.plugin.hive.BaseS3AndGlueMetastoreTest;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.testing.DistributedQueryRunner;


### PR DESCRIPTION
Ensure `cleanupQuery` is called for cases when `ConnectorMetadata` is constructed outside of typical query processing
(`Connector.getMetadata`).
