### PR TITLE
Fix routine example for case

### DIFF
--- a/docs/src/main/sphinx/routines/case.md
+++ b/docs/src/main/sphinx/routines/case.md
@@ -49,6 +49,7 @@ FUNCTION simple_case(a bigint)
       WHEN 1 THEN RETURN 'one';
       ELSE RETURN 'more than one or negative';
     END CASE;
+    RETURN NULL;
   END
 ```
 

--- a/docs/src/main/sphinx/routines/function.md
+++ b/docs/src/main/sphinx/routines/function.md
@@ -60,7 +60,9 @@ function to other users as `description`. The information is accessible with
 [](/sql/show-functions).
 
 The body of the routine can either be a simple single `RETURN` statement with an
-expression, or compound list of `statements` in a `BEGIN` block.
+expression, or compound list of `statements` in a `BEGIN` block. Routines must
+contain a `RETURN` statement at the end of the top-level block, even if it's
+unreachable.
 
 ## Examples
 

--- a/docs/src/main/sphinx/routines/return.md
+++ b/docs/src/main/sphinx/routines/return.md
@@ -27,6 +27,10 @@ Further examples of varying complexity that cover usage of the `RETURN`
 statement in combination with other statements are available in the [SQL
 routines examples documentation](/routines/examples).
 
+All routines must contain a `RETURN` statement at the end of the top-level
+block in the `FUNCTION` declaration, even if it's unreachable.
+
 ## See also
 
 * [](/routines/introduction)
+* [](/routines/function)


### PR DESCRIPTION
## Description

Return null is required. Not sure if we should state that somehow .
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
