### PR TITLE
Rename `gcs.projectId` to `gcs.project-id` config property

### DIFF
--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystemConfig.java
@@ -100,7 +100,7 @@ public class GcsFileSystemConfig
         return projectId;
     }
 
-    @Config("gcs.projectId")
+    @Config("gcs.project-id")
     public GcsFileSystemConfig setProjectId(String projectId)
     {
         this.projectId = projectId;

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemConfig.java
@@ -54,7 +54,7 @@ public class TestGcsFileSystemConfig
                 .put("gcs.write-block-size", "52MB")
                 .put("gcs.page-size", "10")
                 .put("gcs.batch-size", "11")
-                .put("gcs.projectId", "project")
+                .put("gcs.project-id", "project")
                 .put("gcs.use-access-token", "true")
                 .put("gcs.json-key", "{}")
                 .put("gcs.json-key-file-path", jsonKeyFile.toString())


### PR DESCRIPTION
## Description

I didn't add `@LegacyConfig` annotation as the module isn't yet released. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
