### PR TITLE
Fix reads of 0 length on parquet decoders

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaByteArrayDecoders.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/DeltaByteArrayDecoders.java
@@ -181,6 +181,9 @@ public class DeltaByteArrayDecoders
         protected void readBounded(BinaryBuffer values, int offset, int length, int totalInputLength)
         {
             checkPositionIndexes(inputLengthsOffset, inputLengthsOffset + length, prefixLengths.length);
+            if (length == 0) {
+                return;
+            }
             int[] outputOffsets = values.getOffsets();
             byte[] dataBuffer = readUnbounded(outputOffsets, offset, length, totalInputLength);
             Slice inputSlice = Slices.wrappedBuffer(dataBuffer);
@@ -224,6 +227,9 @@ public class DeltaByteArrayDecoders
         protected void readUnbounded(BinaryBuffer values, int offset, int length, int totalInputLength)
         {
             checkPositionIndexes(inputLengthsOffset, inputLengthsOffset + length, prefixLengths.length);
+            if (length == 0) {
+                return;
+            }
             int[] outputOffsets = values.getOffsets();
             Slice outputBuffer = Slices.wrappedBuffer(readUnbounded(outputOffsets, offset, length, totalInputLength));
             values.addChunk(outputBuffer);

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortDecimalFixedWidthByteArrayBatchDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/decoders/ShortDecimalFixedWidthByteArrayBatchDecoder.java
@@ -78,6 +78,9 @@ public class ShortDecimalFixedWidthByteArrayBatchDecoder
         @Override
         public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
         {
+            if (length == 0) {
+                return;
+            }
             int bytesOffSet = 0;
             int endOffset = offset + length;
             for (int i = offset; i < endOffset - 1; i++) {
@@ -106,6 +109,9 @@ public class ShortDecimalFixedWidthByteArrayBatchDecoder
         @Override
         public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
         {
+            if (length == 0) {
+                return;
+            }
             int bytesOffSet = 0;
             int endOffset = offset + length;
             for (int i = offset; i < endOffset - 1; i++) {
@@ -133,6 +139,9 @@ public class ShortDecimalFixedWidthByteArrayBatchDecoder
         @Override
         public void decode(SimpleSliceInputStream input, long[] values, int offset, int length)
         {
+            if (length == 0) {
+                return;
+            }
             int bytesOffSet = 0;
             int endOffset = offset + length;
             for (int i = offset; i < endOffset - 1; i++) {

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/decoders/AbstractValueDecodersTest.java
@@ -75,6 +75,7 @@ import static io.trino.testing.DataProviders.cartesianProduct;
 import static io.trino.testing.DataProviders.concat;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -304,7 +305,7 @@ public abstract class AbstractValueDecodersTest
                 int i = 0;
                 while (i < size) {
                     if (random.nextBoolean()) {
-                        int readBatch = random.nextInt(1, batchSize + 2);
+                        int readBatch = random.nextInt(0, max(batchSize, 1) + 1);
                         decoder.read(data, i, min(readBatch, size - i));
                         i += readBatch;
                     }


### PR DESCRIPTION
## Description
Some files may contain empty dictionaries which when read can cause plain value decoders to be read with 0 length

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Fix JVM crash when reading short decimal columns in parquet files containing empty dictionaries. ({issue}`19697`)
```
