### PR TITLE
Fix incorrect result of query table function with projection in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryQueryPageSource.java
@@ -74,6 +74,7 @@ public class BigQueryQueryPageSource
             .optionalEnd()
             .toFormatter();
 
+    private final List<String> columnNames;
     private final List<Type> columnTypes;
     private final PageBuilder pageBuilder;
     private final TableResult tableResult;
@@ -94,6 +95,7 @@ public class BigQueryQueryPageSource
         requireNonNull(columnTypes, "columnTypes is null");
         requireNonNull(filter, "filter is null");
         checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes sizes don't match");
+        this.columnNames = ImmutableList.copyOf(columnNames);
         this.columnTypes = ImmutableList.copyOf(columnTypes);
         this.pageBuilder = new PageBuilder(columnTypes);
         String sql = buildSql(table, client.getProjectId(), ImmutableList.copyOf(columnNames), filter);
@@ -144,7 +146,7 @@ public class BigQueryQueryPageSource
             pageBuilder.declarePosition();
             for (int column = 0; column < columnTypes.size(); column++) {
                 BlockBuilder output = pageBuilder.getBlockBuilder(column);
-                appendTo(columnTypes.get(column), record.get(column), output);
+                appendTo(columnTypes.get(column), record.get(columnNames.get(column)), output);
             }
         }
         finished = true;

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -804,6 +804,18 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
+    public void testNativeQuerySimpleWithProjectedColumns()
+    {
+        assertQuery(
+                "SELECT z, y, x FROM (SELECT y, z, x FROM TABLE(bigquery.system.query(query => 'SELECT 1 x, 2 y, 3 z')))",
+                "VALUES (3, 2, 1)");
+
+        assertQuery(
+                "SELECT z FROM (SELECT x, y, z FROM TABLE(bigquery.system.query(query => 'SELECT 1 x, 2 y, 3 z')))",
+                "VALUES 3");
+    }
+
+    @Test
     public void testNativeQuerySelectForCaseSensitiveColumnNames()
     {
         assertThat(computeActual("SELECT * FROM TABLE(bigquery.system.query(query => 'SELECT 1 AS lower, 2 AS UPPER, 3 AS miXED'))").getColumnNames())


### PR DESCRIPTION
## Description

Fixes https://github.com/trinodb/trino/issues/19570

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Fix incorrect results when query involving projections and `query` table function. ({issue}`19570`)
```
