### PR TITLE
Fix non-deterministic construction of Kafka plugin

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPlugin.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPlugin.java
@@ -14,43 +14,30 @@
 package io.trino.plugin.kafka;
 
 import com.google.common.collect.ImmutableList;
-import com.google.inject.Binder;
 import com.google.inject.Module;
-import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.plugin.kafka.security.KafkaSecurityModule;
 import io.trino.spi.Plugin;
 import io.trino.spi.connector.ConnectorFactory;
 
-import static java.util.Objects.requireNonNull;
+import java.util.List;
 
 public class KafkaPlugin
         implements Plugin
 {
-    public static final Module DEFAULT_EXTENSION = new AbstractConfigurationAwareModule()
-    {
-        @Override
-        protected void setup(Binder binder)
-        {
-            install(new KafkaClientsModule());
-            install(new KafkaSecurityModule());
-        }
-    };
-
-    private final Module extension;
+    private final List<Module> extensions;
 
     public KafkaPlugin()
     {
-        this(DEFAULT_EXTENSION);
+        this(ImmutableList.of());
     }
 
-    public KafkaPlugin(Module extension)
+    public KafkaPlugin(List<Module> extensions)
     {
-        this.extension = requireNonNull(extension, "extension is null");
+        this.extensions = ImmutableList.copyOf(extensions);
     }
 
     @Override
     public synchronized Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new KafkaConnectorFactory(extension));
+        return ImmutableList.of(new KafkaConnectorFactory(extensions));
     }
 }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -15,7 +15,6 @@ package io.trino.plugin.kafka;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -43,7 +42,6 @@ import java.util.Optional;
 
 import static com.google.common.io.ByteStreams.toByteArray;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
-import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.kafka.util.TestUtils.loadTpchTopicDescription;
 import static java.lang.String.format;
@@ -92,13 +90,6 @@ public final class KafkaQueryRunner
         }
 
         @Override
-        public Builder setExtension(Module extension)
-        {
-            this.extension = requireNonNull(extension, "extension is null");
-            return this;
-        }
-
-        @Override
         public void preInit(DistributedQueryRunner queryRunner)
                 throws Exception
         {
@@ -125,16 +116,14 @@ public final class KafkaQueryRunner
                     .putAll(tpchTopicDescriptions)
                     .putAll(testTopicDescriptions.buildOrThrow())
                     .buildOrThrow();
-            setExtension(combine(
-                    extension,
-                    conditionalModule(
-                            KafkaConfig.class,
-                            kafkaConfig -> kafkaConfig.getTableDescriptionSupplier().equalsIgnoreCase(TEST),
-                            binder -> binder.bind(TableDescriptionSupplier.class)
-                                    .toInstance(new MapBasedTableDescriptionSupplier(topicDescriptions))),
-                    binder -> binder.bind(ContentSchemaProvider.class).to(FileReadContentSchemaProvider.class).in(Scopes.SINGLETON),
-                    new DecoderModule(),
-                    new EncoderModule()));
+            addExtension(conditionalModule(
+                    KafkaConfig.class,
+                    kafkaConfig -> kafkaConfig.getTableDescriptionSupplier().equalsIgnoreCase(TEST),
+                    binder -> binder.bind(TableDescriptionSupplier.class)
+                            .toInstance(new MapBasedTableDescriptionSupplier(topicDescriptions))));
+            addExtension(binder -> binder.bind(ContentSchemaProvider.class).to(FileReadContentSchemaProvider.class).in(Scopes.SINGLETON));
+            addExtension(new DecoderModule());
+            addExtension(new EncoderModule());
             Map<String, String> properties = new HashMap<>(extraKafkaProperties);
             properties.putIfAbsent("kafka.table-description-supplier", TEST);
             setExtraKafkaProperties(properties);


### PR DESCRIPTION
There's an order-dependent initialization of Guice modules happening within the Kafka plugin when they are added indirectly via "install()" that causes ConfigurationAwareModule to not consume the expected configuration properties.

Fixes #19702

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
