### PR TITLE
Restore release preparation goals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,7 @@
            - had forward change at midnight (1970-01-01 00:00:00 clocks turned forward 1 hour)
           -->
         <air.modernizer.java-version>8</air.modernizer.java-version>
+        <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
         <air.test.timezone>America/Bahia_Banderas</air.test.timezone>
         <air.test.parallel>methods</air.test.parallel>
         <air.test.thread-count>2</air.test.thread-count>


### PR DESCRIPTION
This property was lost in ab1e89b4aa07077f2c8e7ca61719a1034457fb20 and is causing the release process to attempt to run all the tests.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
