### PR TITLE
Added docs link for Kerberos authentication with Iceberg connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -275,12 +275,17 @@ No other types are supported.
 
 ## Security
 
-The Iceberg connector allows you to choose one of several means of providing
-authorization at the catalog level.
+### Kerberos authentication
+
+The Iceberg connector supports Kerberos authentication for the Hive metastore
+and HDFS and is configured using the same parameters as the Hive connector. Find
+more information in the [](/connector/hive-security) section.
 
 (iceberg-authorization)=
+### Authorization
 
-### Authorization checks
+The Iceberg connector allows you to choose one of several means of providing
+authorization at the catalog level.
 
 You can enable authorization checks for the connector by setting the
 `iceberg.security` property in the catalog properties file. This property must
@@ -308,7 +313,6 @@ be one of the following values:
 :::
 
 (iceberg-sql-support)=
-
 ## SQL support
 
 This connector provides read access and write access to data and metadata in


### PR DESCRIPTION
## Description
A question came up on the Trino Slack about Kerberos authentication for the Apache Iceberg connector, I've tested it and it works using the same parameters as the Hive connector. I added a short paragraph to the Iceberg connector docs referring to the Hive authentication docs.

## Additional context and related issues
Docs only update


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
