### PR TITLE
Remove testCreateTableIfNotExists in BigQuery

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -182,14 +182,6 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
-    public void testCreateTableIfNotExists()
-    {
-        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_table_if_not_exists", "(col1 int)")) {
-            assertUpdate("CREATE TABLE IF NOT EXISTS " + table.getName() + "(col1 int)");
-        }
-    }
-
-    @Test
     public void testEmptyProjectionTable()
     {
         testEmptyProjection(


### PR DESCRIPTION
## Description

It's covered by BaseConnectorTest#testCreateTable.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.