### PR TITLE
Specialize batched column-wise hashing for RunLengthEncodedBlock

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
@@ -44,6 +44,7 @@ import static io.trino.spi.type.UuidType.UUID;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.type.IpAddressType.IPADDRESS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -51,6 +52,17 @@ public class TestFlatHashStrategy
 {
     private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
     private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(TYPE_OPERATORS);
+
+    @Test
+    public void testBatchedRawHashesZeroLength()
+    {
+        List<Type> types = createTestingTypes();
+        FlatHashStrategy flatHashStrategy = JOIN_COMPILER.getFlatHashStrategy(types);
+
+        int positionCount = 10;
+        // Attempting to touch any of the blocks would result in a NullPointerException
+        assertDoesNotThrow(() -> flatHashStrategy.hashBlocksBatched(new Block[types.size()], new long[positionCount], 0, 0));
+    }
 
     @Test
     public void testBatchedRawHashesMatchSinglePositionHashes()

--- a/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestFlatHashStrategy.java
@@ -51,14 +51,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestFlatHashStrategy
 {
-    private static final TypeOperators TYPE_OPERATORS = new TypeOperators();
-    private static final JoinCompiler JOIN_COMPILER = new JoinCompiler(TYPE_OPERATORS);
+    private final TypeOperators typeOperators = new TypeOperators();
+    private final JoinCompiler joinCompiler = new JoinCompiler(typeOperators);
 
     @Test
     public void testBatchedRawHashesZeroLength()
     {
-        List<Type> types = createTestingTypes();
-        FlatHashStrategy flatHashStrategy = JOIN_COMPILER.getFlatHashStrategy(types);
+        List<Type> types = createTestingTypes(typeOperators);
+        FlatHashStrategy flatHashStrategy = joinCompiler.getFlatHashStrategy(types);
 
         int positionCount = 10;
         // Attempting to touch any of the blocks would result in a NullPointerException
@@ -68,8 +68,8 @@ public class TestFlatHashStrategy
     @Test
     public void testBatchedRawHashesMatchSinglePositionHashes()
     {
-        List<Type> types = createTestingTypes();
-        FlatHashStrategy flatHashStrategy = JOIN_COMPILER.getFlatHashStrategy(types);
+        List<Type> types = createTestingTypes(typeOperators);
+        FlatHashStrategy flatHashStrategy = joinCompiler.getFlatHashStrategy(types);
 
         int positionCount = 1024;
         Block[] blocks = new Block[types.size()];
@@ -102,7 +102,7 @@ public class TestFlatHashStrategy
         }
     }
 
-    private static List<Type> createTestingTypes()
+    private static List<Type> createTestingTypes(TypeOperators typeOperators)
     {
         List<Type> baseTypes = List.of(
                 BIGINT,
@@ -128,7 +128,7 @@ public class TestFlatHashStrategy
         builder.add(RowType.anonymous(baseTypes));
         for (Type baseType : baseTypes) {
             builder.add(new ArrayType(baseType));
-            builder.add(new MapType(baseType, baseType, TYPE_OPERATORS));
+            builder.add(new MapType(baseType, baseType, typeOperators));
         }
         return builder.build();
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adds special case handling of `RunLengthEncodedBlock` in generated `FlatHashStrategy` implementations that hoists the hash calculation outside of the loop. This has the added benefit of making the normal compute loop at most bi-morphic between `DictionaryBlock` and the type-corresponding `ValueBock` subclass.

`FlatGroupByHash` already specializes hash calculations for `RunLengthEncodedBlock` at a higher level when _all_ group by input blocks are run-length encoded, so this change will only affect performance for mutli-column grouping operations with a mix of run length and dictionary/plain block inputs.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
