### PR TITLE
Do not require all sinks to be finished in FileSystemExchange

### DIFF
--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
@@ -183,7 +183,6 @@ public class FileSystemExchange
                 return;
             }
             verify(noMoreSinks, "noMoreSinks is expected to be set");
-            verify(finishedSinks.keySet().containsAll(allSinks), "all sinks are expected to be finished");
             // input is ready, create exchange source handles
             exchangeSourceHandlesCreationStarted = true;
             exchangeSourceHandlesCreationFuture = stats.getCreateExchangeSourceHandles().record(this::createExchangeSourceHandles);


### PR DESCRIPTION
It is not enforced by engine that each created sink will be finished. Some tasks may be abandoned as not required for computing query result and siks for those tasks will not be finished.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.



