### PR TITLE
Skip archiving in Glue an old table version during a table update operation

### DIFF
--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -295,7 +295,7 @@ described with the following additional property:
   - Skip archiving an old table version when creating a new version in a commit.
     See [AWS Glue Skip
     Archive](https://iceberg.apache.org/docs/latest/aws/#skip-archive).
-  - `false`
+  - `true`
 :::
 
 ## Iceberg-specific metastores

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/IcebergGlueCatalogConfig.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.ConfigDescription;
 public class IcebergGlueCatalogConfig
 {
     private boolean cacheTableMetadata = true;
-    private boolean skipArchive;
+    private boolean skipArchive = true;
 
     public boolean isCacheTableMetadata()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogConfig.java
@@ -29,7 +29,7 @@ public class TestIcebergGlueCatalogConfig
     {
         assertRecordedDefaults(recordDefaults(IcebergGlueCatalogConfig.class)
                 .setCacheTableMetadata(true)
-                .setSkipArchive(false));
+                .setSkipArchive(true));
     }
 
     @Test
@@ -37,12 +37,12 @@ public class TestIcebergGlueCatalogConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("iceberg.glue.cache-table-metadata", "false")
-                .put("iceberg.glue.skip-archive", "true")
+                .put("iceberg.glue.skip-archive", "false")
                 .buildOrThrow();
 
         IcebergGlueCatalogConfig expected = new IcebergGlueCatalogConfig()
                 .setCacheTableMetadata(false)
-                .setSkipArchive(true);
+                .setSkipArchive(false);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogSkipArchive.java
@@ -82,7 +82,6 @@ public class TestIcebergGlueCatalogSkipArchive
                 .setIcebergProperties(
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.catalog.type", "glue")
-                                .put("iceberg.glue.skip-archive", "true")
                                 .put("hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath())
                                 .buildOrThrow())
                 .setSchemaInitializer(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Slack discussion: https://trinodb.slack.com/archives/CJ6UC075E/p1699927658771409

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/14336


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
