### PR TITLE
Projection pushdown with connector expressions in JDBC

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -240,6 +240,12 @@ public class CachingJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate.convertProjection(session, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle)
     {
         return delegate.getSplits(session, tableHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -149,6 +149,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return delegate().convertProjection(session, expression, assignments);
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return delegate().getSplits(session, layoutHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -94,6 +94,11 @@ public interface JdbcClient
         return Optional.empty();
     }
 
+    default Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return Optional.empty();
+    }
+
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle tableHandle);
 
     ConnectorSplitSource getSplits(ConnectorSession session, JdbcProcedureHandle procedureHandle);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/JdbcClientStats.java
@@ -62,6 +62,7 @@ public final class JdbcClientStats
     private final JdbcApiStats toWriteMapping = new JdbcApiStats();
     private final JdbcApiStats implementAggregation = new JdbcApiStats();
     private final JdbcApiStats convertPredicate = new JdbcApiStats();
+    private final JdbcApiStats convertProjection = new JdbcApiStats();
     private final JdbcApiStats getTableScanRedirection = new JdbcApiStats();
     private final JdbcApiStats delete = new JdbcApiStats();
     private final JdbcApiStats update = new JdbcApiStats();
@@ -373,6 +374,13 @@ public final class JdbcClientStats
     public JdbcApiStats getConvertPredicate()
     {
         return convertPredicate;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getConvertProjection()
+    {
+        return convertProjection;
     }
 
     @Managed

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -170,6 +170,12 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public Optional<JdbcExpression> convertProjection(ConnectorSession session, ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    {
+        return stats.getConvertProjection().wrap(() -> delegate().convertProjection(session, expression, assignments));
+    }
+
+    @Override
     public ConnectorSplitSource getSplits(ConnectorSession session, JdbcTableHandle layoutHandle)
     {
         return stats.getGetSplits().wrap(() -> delegate().getSplits(session, layoutHandle));

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -29,6 +29,7 @@ import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.plan.ExchangeNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.testing.QueryRunner;
@@ -74,6 +75,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -1023,6 +1025,39 @@ public class TestPostgreSqlConnectorTest
                     .matches("VALUES 1")
                     .isFullyPushedDown();
         }
+    }
+
+    @Test
+    public void testProjectionPushdownWithConnectorExpressions()
+    {
+        assertThat(query("SELECT nationkey, nationkey + (100 - regionkey ) FROM nation"))
+                .isFullyPushedDown();
+
+        // connector expression - nested rewritten call with casts, $cast call not implemented so the call tree is not pushed down
+        assertThat(query("SELECT nationkey, custkey + (nationkey + (acctbal + 100)) FROM customer"))
+                .isNotFullyPushedDown(ProjectNode.class);
+
+        assertThat(query("SELECT nationkey, CAST(regionkey AS VARCHAR) FROM nation"))
+                .isNotFullyPushedDown(ProjectNode.class);
+
+        assertThat(query("SELECT nationkey, upper(name) FROM nation"))
+                .isNotFullyPushedDown(ProjectNode.class);
+
+        assertThat(query("SELECT shippriority % 4 FROM orders")).isFullyPushedDown();
+
+        assertThat(query("SELECT name, (nationkey - regionkey) % (nationkey + 1) FROM nation"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT name, (nationkey - regionkey) / (nationkey + 1) FROM nation WHERE comment = 'non'"))
+                .isFullyPushedDown();
+
+        // some databases calculate remainder instead of modulus when one of the values is negative
+        assertThat(query("SELECT nationkey, name, regionkey, (nationkey - regionkey) % -nationkey FROM nation WHERE nationkey > 0 AND (nationkey - regionkey) % -nationkey = 2"))
+                .isFullyPushedDown()
+                .matches("VALUES (BIGINT '3', CAST('CANADA' AS varchar(25)), BIGINT '1', BIGINT '2')");
+
+        assertThatThrownBy(() -> query("SELECT nationkey, name, regionkey, (nationkey - regionkey) % 0 FROM nation"))
+                .hasMessageContaining("by zero");
     }
 
     private String getLongInClause(int start, int length)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add ability to push down projection with connector expressions for JDBC connectors.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
-  rules rewriter is implemented for Postgres with this PR (same rules as used for predicate pushdowns)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
- Enable projection pushdown with connector expressions capability in JDBC connectors
```
