### PR TITLE
fix compiler failure with regexp_replace function when working with Hive tables containing row(map<varchar, varchar>) data type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -62,7 +62,6 @@ import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
-import io.trino.type.JoniRegexp;
 import io.trino.type.LikePattern;
 import io.trino.type.Re2JRegexp;
 import io.trino.type.Re2JRegexpType;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ConnectorExpressionTranslator.java
@@ -807,8 +807,7 @@ public final class ConnectorExpressionTranslator
                     ImmutableMap.of());
 
             if (type == JONI_REGEXP) {
-                Slice pattern = ((JoniRegexp) value).pattern();
-                return new Constant(pattern, createVarcharType(countCodePoints(pattern)));
+                return new Constant(value, type);
             }
             if (type instanceof Re2JRegexpType) {
                 Slice pattern = Slices.utf8Slice(((Re2JRegexp) value).pattern());


### PR DESCRIPTION
<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
fix #19689 

