### PR TITLE
Deprecate old ConstraintApplicationResult constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -196,7 +196,7 @@ public class InformationSchemaMetadata
         }
 
         table = new InformationSchemaTableHandle(table.getCatalogName(), table.getTable(), prefixes, table.getLimit());
-        return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     public static Set<QualifiedTablePrefix> defaultPrefixes(String catalogName)

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemTablesMetadata.java
@@ -163,7 +163,7 @@ public class SystemTablesMetadata
             // TODO (https://github.com/trinodb/trino/issues/3647) indicate the table scan is empty
         }
         table = new SystemTableHandle(table.getSchemaName(), table.getTableName(), newDomain);
-        return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(table, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     private Constraint effectiveConstraint(TupleDomain<ColumnHandle> oldDomain, Constraint newConstraint, TupleDomain<ColumnHandle> effectiveDomain)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
@@ -442,6 +442,7 @@ public class TestTableScanRedirectionWithPushdown
                             new MockConnectorTableHandle(handle.getTableName(), newDomain, Optional.empty()),
                             constraint.getSummary()
                                     .filter((columnHandle, domain) -> !pushdownColumns.contains(columnHandle)),
+                            constraint.getExpression(),
                             false));
         };
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -412,10 +412,10 @@ public class TestPushPredicateIntoTableScan
         builder
                 .withApplyFilter((session, tableHandle, constraint) -> {
                     if (tableHandle.equals(CONNECTOR_PARTITIONED_TABLE_HANDLE_TO_UNPARTITIONED)) {
-                        return Optional.of(new ConstraintApplicationResult<>(CONNECTOR_UNPARTITIONED_TABLE_HANDLE, TupleDomain.all(), false));
+                        return Optional.of(new ConstraintApplicationResult<>(CONNECTOR_UNPARTITIONED_TABLE_HANDLE, TupleDomain.all(), constraint.getExpression(), false));
                     }
                     if (tableHandle.equals(CONNECTOR_PARTITIONED_TABLE_HANDLE)) {
-                        return Optional.of(new ConstraintApplicationResult<>(CONNECTOR_PARTITIONED_TABLE_HANDLE, TupleDomain.all(), false));
+                        return Optional.of(new ConstraintApplicationResult<>(CONNECTOR_PARTITIONED_TABLE_HANDLE, TupleDomain.all(), constraint.getExpression(), false));
                     }
                     return Optional.empty();
                 })

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveEmptyUnionBranches.java
@@ -148,6 +148,7 @@ public class TestRemoveEmptyUnionBranches
                                         new MockConnectorTableHandle(handle.getTableName(), TupleDomain.none(), Optional.empty()),
                                         constraint.getSummary()
                                                 .filter((ch, domain) -> !shouldPushdown.test(ch)),
+                                        constraint.getExpression(),
                                         false));
                     }
 
@@ -160,6 +161,7 @@ public class TestRemoveEmptyUnionBranches
                                     new MockConnectorTableHandle(handle.getTableName(), newDomain, Optional.empty()),
                                     constraint.getSummary()
                                             .filter((columnHandle, domain) -> !shouldPushdown.test(columnHandle)),
+                                    constraint.getExpression(),
                                     false));
                 }
             }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
@@ -31,7 +31,10 @@ public class ConstraintApplicationResult<T>
     /**
      * @param precalculateStatistics Indicates whether engine should consider calculating statistics based on the plan before pushdown,
      * as the connector may be unable to provide good table statistics for {@code handle}.
+     *
+     * @deprecated Use {@link #ConstraintApplicationResult(Object, TupleDomain, ConnectorExpression, boolean)}.
      */
+    @Deprecated
     public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean precalculateStatistics)
     {
         this(handle, remainingFilter, Optional.empty(), precalculateStatistics);

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloMetadata.java
@@ -387,7 +387,7 @@ public class AccumuloMetadata
                 handle.getSerializerClassName(),
                 handle.getScanAuthorizations());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     private void checkNoRollback()

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopMetadata.java
@@ -176,6 +176,6 @@ public class AtopMetadata
                 newStartTimeDomain,
                 newEndTimeDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -179,11 +179,11 @@ public class DefaultJdbcMetadata
         TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
         List<ParameterizedExpression> newConstraintExpressions;
         TupleDomain<ColumnHandle> remainingFilter;
-        Optional<ConnectorExpression> remainingExpression;
+        ConnectorExpression remainingExpression;
         if (newDomain.isNone()) {
             newConstraintExpressions = ImmutableList.of();
             remainingFilter = TupleDomain.all();
-            remainingExpression = Optional.of(Constant.TRUE);
+            remainingExpression = Constant.TRUE;
         }
         else {
             Map<ColumnHandle, Domain> domains = newDomain.getDomains().orElseThrow();
@@ -225,11 +225,11 @@ public class DefaultJdbcMetadata
                         .addAll(handle.getConstraintExpressions())
                         .addAll(newExpressions)
                         .build().asList();
-                remainingExpression = Optional.of(and(remainingExpressions));
+                remainingExpression = and(remainingExpressions);
             }
             else {
                 newConstraintExpressions = ImmutableList.of();
-                remainingExpression = Optional.empty();
+                remainingExpression = constraint.getExpression();
             }
         }
 
@@ -250,10 +250,7 @@ public class DefaultJdbcMetadata
                 handle.getAuthorization(),
                 handle.getUpdateAssignments());
 
-        return Optional.of(
-                remainingExpression.isPresent()
-                        ? new ConstraintApplicationResult<>(handle, remainingFilter, remainingExpression.get(), precalculateStatisticsForPushdown)
-                        : new ConstraintApplicationResult<>(handle, remainingFilter, precalculateStatisticsForPushdown));
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, remainingExpression, precalculateStatisticsForPushdown));
     }
 
     private JdbcTableHandle flushAttributesAsQuery(ConnectorSession session, JdbcTableHandle handle)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -788,7 +788,7 @@ public class BigQueryMetadata
 
         BigQueryTableHandle updatedHandle = bigQueryTableHandle.withConstraint(newDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(updatedHandle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(updatedHandle, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -273,6 +273,7 @@ public class CassandraMetadata
                         // TODO this should probably be AND-ed with handle.getClusteringKeyPredicates()
                         clusteringKeyPredicates)),
                         unenforcedConstraint,
+                        constraint.getExpression(),
                         false));
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2753,6 +2753,7 @@ public class DeltaLakeMetadata
         return Optional.of(new ConstraintApplicationResult<>(
                 newHandle,
                 newUnenforcedConstraint.transformKeys(ColumnHandle.class::cast),
+                constraint.getExpression(),
                 false));
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2995,7 +2995,7 @@ public class HiveMetadata
             unenforcedConstraint = partitionResult.getEffectivePredicate().filter((column, domain) -> !partitionColumns.contains(column));
         }
 
-        return Optional.of(new ConstraintApplicationResult<>(newHandle, unenforcedConstraint, false));
+        return Optional.of(new ConstraintApplicationResult<>(newHandle, unenforcedConstraint, constraint.getExpression(), false));
     }
 
     @Override

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -174,6 +174,7 @@ public class HudiMetadata
         return Optional.of(new ConstraintApplicationResult<>(
                 newHudiTableHandle,
                 newHudiTableHandle.getRegularPredicates().transformKeys(ColumnHandle.class::cast),
+                constraint.getExpression(),
                 false));
     }
 

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
@@ -287,7 +287,7 @@ public class JmxMetadata
 
         JmxTableHandle newTableHandle = new JmxTableHandle(tableHandle.getTableName(), tableHandle.getObjectNames(), tableHandle.getColumnHandles(), tableHandle.isLiveData(), newDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(newTableHandle, TupleDomain.withColumnDomains(otherDomains), false));
+        return Optional.of(new ConstraintApplicationResult<>(newTableHandle, TupleDomain.withColumnDomains(otherDomains), constraint.getExpression(), false));
     }
 
     private static Type getColumnType(MBeanAttributeInfo attribute)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -252,7 +252,7 @@ public class KafkaMetadata
                 handle.getColumns(),
                 newDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     private KafkaTopicDescription getRequiredTopicDescription(ConnectorSession session, SchemaTableName schemaTableName)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -462,7 +462,7 @@ public class KuduMetadata
                 handle.getBucketCount(),
                 handle.getLimit());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     /**

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileMetadata.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileMetadata.java
@@ -148,6 +148,6 @@ public class LocalFileMetadata
                 handle.getServerAddressColumn(),
                 newDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 }

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoMetadata.java
@@ -631,7 +631,7 @@ public class MongoMetadata
                 handle.getProjectedColumns(),
                 handle.getLimit());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, constraint.getExpression(), false));
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -317,7 +317,7 @@ public class PinotMetadata
                 newDomain,
                 handle.getLimit(),
                 handle.getQuery());
-        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, constraint.getExpression(), false));
     }
 
     // IS NULL and IS NOT NULL are handled differently in Pinot, pushing down would lead to inconsistent results.

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
@@ -158,6 +158,6 @@ public class PrometheusMetadata
     {
         PrometheusTableHandle tableHandle = ((PrometheusTableHandle) handle)
                 .withPredicate(constraint.getSummary());
-        return Optional.of(new ConstraintApplicationResult<>(tableHandle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(tableHandle, constraint.getSummary(), constraint.getExpression(), false));
     }
 }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -327,6 +327,7 @@ public class RaptorMetadata
                         newDomain.intersect(table.getConstraint()),
                         table.getBucketAssignments()),
                 constraint.getSummary(),
+                constraint.getExpression(),
                 false));
     }
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -240,7 +240,7 @@ public class RedisMetadata
                 handle.getKeyName(),
                 newDomain);
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, remainingFilter, constraint.getExpression(), false));
     }
 
     @Override

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftMetadata.java
@@ -179,7 +179,7 @@ public class ThriftMetadata
                 newDomain,
                 handle.getDesiredColumns());
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), false));
+        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
     }
 
     @Override

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -505,6 +505,7 @@ public class TpchMetadata
                         handle.getScaleFactor(),
                         oldDomain.intersect(predicate)),
                 unenforcedConstraint,
+                constraint.getExpression(),
                 false));
     }
 


### PR DESCRIPTION
The new `ConnectorExpression`-based API was introduced long ago and is stable.
