### PR TITLE
Test accessing ORC columns by name

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -9007,6 +9007,26 @@ public abstract class BaseHiveConnectorTest
         }
     }
 
+    @Test
+    public void testOrcUseColumnNames()
+    {
+        Session useOrcColumnNamesSession = Session.builder(getSession())
+                .setCatalogSessionProperty("hive", "orc_use_column_names", "true")
+                .build();
+
+        try (TestTable testTable = new TestTable(
+                getQueryRunner()::execute,
+                "test_orc_use_column_names_",
+                "(id INT, name VARCHAR) WITH (format = 'ORC')")) {
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (1, 'Mary')", 1);
+            assertUpdate("INSERT INTO " + testTable.getName() + " VALUES (2, 'John')", 1);
+
+            assertQuery("SELECT * FROM " + testTable.getName(), "VALUES (1, 'Mary'), (2, 'John')");
+            assertQuery(useOrcColumnNamesSession, "SELECT * FROM " + testTable.getName(), "VALUES (1, 'Mary'), (2, 'John')");
+            assertQuery(useOrcColumnNamesSession, "SELECT id, name FROM " + testTable.getName(), "VALUES (1, 'Mary'), (2, 'John')");
+        }
+    }
+
     private static final Set<HiveStorageFormat> NAMED_COLUMN_ONLY_FORMATS = ImmutableSet.of(HiveStorageFormat.AVRO, HiveStorageFormat.JSON);
 
     private Session getParallelWriteSession(Session baseSession)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add an integration tests for the functionality `hive.orc.use-column-names` besides the existing test

https://github.com/trinodb/trino/blob/67f04aae4a018721ae14d4ebf94864a5e5dd38ef/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java#L479-L495



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
