### PR TITLE
Fix broken link in doc

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -182,7 +182,7 @@ queries/tasks are no longer retried in the event of repeated failures:
   - `10s`
   - `QUERY` and `TASK`
 * - `retry-max-delay`
-  - Maximum :ref:`time <prop-type-duration>` that a failed query or task must
+  - Maximum [time](prop-type-duration) that a failed query or task must
     wait before it is retried. Wait time is increased on each subsequent
     failure. May be overridden with the ``retry_max_delay`` [session
     property](session-properties-definition).

--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -1055,13 +1055,13 @@ keep a backup of the original values if you change them.
     starts issuing reads of the `max-split-size` size.
   - `200`
 * - `delta.max-initial-split-size`
-  - Sets the initial :ref:`prop-type-data-size` for a single read section
+  - Sets the initial [](prop-type-data-size) for a single read section
     assigned to a worker until `max-initial-splits` have been processed. You can
     also use the corresponding catalog session property
     `<catalog-name>.max_initial_split_size`.
   - `32MB`
 * - `delta.max-split-size`
-  - Sets the largest :ref:`prop-type-data-size` for a single read section
+  - Sets the largest [](prop-type-data-size) for a single read section
     assigned to a worker after `max-initial-splits` have been processed. You can
     also use the corresponding catalog session property
     `<catalog-name>.max_split_size`.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix broken link in doc.

https://trino.io/docs/433/admin/fault-tolerant-execution.html
https://trino.io/docs/433/connector/delta-lake.html
<img width="671" alt="image" src="https://github.com/trinodb/trino/assets/2330687/503f8190-27bd-40bb-96e3-04647cdf8f68">



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
```
$ grep --include=\*.md -rn docs/src/main/sphinx -e ':ref:'
docs/src/main/sphinx/admin/fault-tolerant-execution.md:185:  - Maximum :ref:`time <prop-type-duration>` that a failed query or task must
docs/src/main/sphinx/connector/delta-lake.md:1058:  - Sets the initial :ref:`prop-type-data-size` for a single read section
docs/src/main/sphinx/connector/delta-lake.md:1064:  - Sets the largest :ref:`prop-type-data-size` for a single read section
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

