### PR TITLE
Limit session state during metadata queries in Iceberg

### DIFF
--- a/lib/trino-cache/src/main/java/io/trino/cache/CacheUtils.java
+++ b/lib/trino-cache/src/main/java/io/trino/cache/CacheUtils.java
@@ -14,6 +14,8 @@
 package io.trino.cache;
 
 import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.ExecutionError;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -26,6 +28,11 @@ public final class CacheUtils
 {
     private CacheUtils() {}
 
+    /**
+     * @throws UncheckedExecutionException when {@code loader} throws an unchecked exception
+     * @throws ExecutionError when {@code loader} throws an {@link Error}
+     * @throws RuntimeException when{@code loader} throws a checked exception (which should not happen)
+     */
     public static <K, V> V uncheckedCacheGet(Cache<K, V> cache, K key, Supplier<V> loader)
     {
         try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -149,6 +149,7 @@ public abstract class AbstractTrinoCatalog
         else {
             icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
         }
+        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -156,6 +157,7 @@ public abstract class AbstractTrinoCatalog
     {
         Table icebergTable = loadTable(session, schemaTableName);
         icebergTable.updateSchema().updateColumnDoc(columnIdentity.getName(), comment.orElse(null)).commit();
+        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -470,6 +472,8 @@ public abstract class AbstractTrinoCatalog
                 .put(TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT)
                 .buildOrThrow();
     }
+
+    protected abstract void invalidateTableCache(SchemaTableName schemaTableName);
 
     protected static class MaterializedViewMayBeBeingRemovedException
             extends RuntimeException

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -86,7 +86,6 @@ import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.TableType.VIRTUAL_VIEW;
 import static io.trino.plugin.hive.ViewReaderUtil.ICEBERG_MATERIALIZED_VIEW_COMMENT;
-import static io.trino.plugin.hive.ViewReaderUtil.encodeViewData;
 import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static io.trino.plugin.hive.ViewReaderUtil.isTrinoMaterializedView;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
@@ -478,16 +477,6 @@ public class TrinoHiveCatalog
     public void updateViewColumnComment(ConnectorSession session, SchemaTableName viewName, String columnName, Optional<String> comment)
     {
         trinoViewHiveMetastore.updateViewColumnComment(session, viewName, columnName, comment);
-    }
-
-    private void replaceView(ConnectorSession session, SchemaTableName viewName, io.trino.plugin.hive.metastore.Table view, ConnectorViewDefinition newDefinition)
-    {
-        io.trino.plugin.hive.metastore.Table.Builder viewBuilder = io.trino.plugin.hive.metastore.Table.builder(view)
-                .setViewOriginalText(Optional.of(encodeViewData(newDefinition)));
-
-        PrincipalPrivileges principalPrivileges = isUsingSystemSecurity ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
-
-        metastore.replaceTable(viewName.getSchemaName(), viewName.getTableName(), viewBuilder.build(), principalPrivileges);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -273,6 +273,7 @@ public class TrinoJdbcCatalog
             LOG.warn(e, "Failed to delete table data referenced by metadata");
         }
         deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, table.location());
+        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -287,6 +288,7 @@ public class TrinoJdbcCatalog
         }
         String tableLocation = metadataLocation.get().replaceFirst("/metadata/[^/]*$", "");
         deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, tableLocation);
+        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -298,6 +300,7 @@ public class TrinoJdbcCatalog
         catch (RuntimeException e) {
             throw new TrinoException(ICEBERG_CATALOG_ERROR, "Failed to rename table from %s to %s".formatted(from, to), e);
         }
+        invalidateTableCache(from);
     }
 
     @Override
@@ -445,6 +448,12 @@ public class TrinoJdbcCatalog
     public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName, String hiveCatalogName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    {
+        tableMetadataCache.remove(schemaTableName);
     }
 
     private static TableIdentifier toIdentifier(SchemaTableName table)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -218,6 +218,7 @@ public class TrinoNessieCatalog
         validateTableCanBeDropped(table);
         nessieClient.dropTable(toIdentifier(schemaTableName), true);
         deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, table.location());
+        invalidateTableCache(schemaTableName);
     }
 
     @Override
@@ -230,6 +231,7 @@ public class TrinoNessieCatalog
     public void renameTable(ConnectorSession session, SchemaTableName from, SchemaTableName to)
     {
         nessieClient.renameTable(toIdentifier(from), toIdentifier(to));
+        invalidateTableCache(from);
     }
 
     @Override
@@ -418,5 +420,11 @@ public class TrinoNessieCatalog
     public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName, String hiveCatalogName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    protected void invalidateTableCache(SchemaTableName schemaTableName)
+    {
+        tableMetadataCache.remove(schemaTableName);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -82,7 +82,7 @@ public class TrinoRestCatalog
     private final String trinoVersion;
     private final boolean useUniqueTableLocation;
 
-    private final Map<String, Table> tableCache = new ConcurrentHashMap<>();
+    private final Map<SchemaTableName, Table> tableCache = new ConcurrentHashMap<>();
 
     public TrinoRestCatalog(
             RESTSessionCatalog restSessionCatalog,
@@ -300,7 +300,7 @@ public class TrinoRestCatalog
     {
         try {
             return tableCache.computeIfAbsent(
-                    schemaTableName.toString(),
+                    schemaTableName,
                     key -> {
                         BaseTable baseTable = (BaseTable) restSessionCatalog.loadTable(convert(session), toIdentifier(schemaTableName));
                         // Creating a new base table is necessary to adhere to Trino's expectations for quoted table names


### PR DESCRIPTION
Metadata queries such as `information_schema.columns`,
`system.jdbc.columns` or `system.metadata.table_comments` may end up
loading arbitrary number of relations within single query (transaction).
It is important to bound memory usage for such queries.

In case of Iceberg Hive metastore based catalog, this is already done in
`TrinoHiveCatalogFactory` bu means of configuring per-query
`CachingHiveMetastore`. However, catalogs with explicit caching need
something similar.