### PR TITLE
Refactor RunLengthEncodedBlock hash combination logic

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
@@ -13,9 +13,12 @@
  */
 package io.trino.operator.scalar;
 
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.type.StandardTypes;
+
+import static java.util.Objects.checkFromToIndex;
 
 public final class CombineHashFunction
 {
@@ -26,5 +29,15 @@ public final class CombineHashFunction
     public static long getHash(@SqlType(StandardTypes.BIGINT) long previousHashValue, @SqlType(StandardTypes.BIGINT) long value)
     {
         return (31 * previousHashValue + value);
+    }
+
+    @UsedByGeneratedCode
+    public static void combineAllHashesWithConstant(long[] hashes, int fromIndex, int toIndex, long value)
+    {
+        checkFromToIndex(fromIndex, toIndex, hashes.length);
+
+        for (int i = 0; i < toIndex; i++) {
+            hashes[i] = (31 * hashes[i]) + value;
+        }
     }
 }


### PR DESCRIPTION
## Description
Refactors `RunLengthEncodedBlock` column-wise hash calculations to call a common implementation of the hash combination loop instead of directly embedding the same loop logic in each method of generated code. This reduces overall code size and JIT warm-up time for RLE hash handling.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Follows up from https://github.com/trinodb/trino/pull/19723


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
