### PR TITLE
Fix ArrayIndexOutOfBoundsException when parquet statistics are ignored

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -237,8 +237,8 @@ public class ParquetPageSourceFactory
             List<TupleDomain<ColumnDescriptor>> parquetTupleDomains;
             List<TupleDomainParquetPredicate> parquetPredicates;
             if (options.isIgnoreStatistics()) {
-                parquetTupleDomains = ImmutableList.of();
-                parquetPredicates = ImmutableList.of();
+                parquetTupleDomains = ImmutableList.of(TupleDomain.all());
+                parquetPredicates = ImmutableList.of(buildPredicate(requestedSchema, TupleDomain.all(), descriptorsByPath, timeZone));
             }
             else {
                 ImmutableList.Builder<TupleDomain<ColumnDescriptor>> parquetTupleDomainsBuilder = ImmutableList.builderWithExpectedSize(disjunctTupleDomains.size());
@@ -258,7 +258,7 @@ public class ParquetPageSourceFactory
             ImmutableList.Builder<Optional<ColumnIndexStore>> columnIndexes = ImmutableList.builder();
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
-                for (int i = 0; i < disjunctTupleDomains.size(); i++) {
+                for (int i = 0; i < parquetTupleDomains.size(); i++) {
                     TupleDomain<ColumnDescriptor> parquetTupleDomain = parquetTupleDomains.get(i);
                     TupleDomainParquetPredicate parquetPredicate = parquetPredicates.get(i);
                     Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -5942,6 +5942,43 @@ public abstract class BaseHiveConnectorTest
     }
 
     @Test
+    public void testParquetIgnoreStatistics()
+    {
+        for (boolean ignoreStatistics : ImmutableList.of(true, false)) {
+            Session session = Session.builder(getSession())
+                    .setCatalogSessionProperty(catalog, "parquet_ignore_statistics", String.valueOf(ignoreStatistics))
+                    .build();
+
+            String tableName = "test_parquet_ignore_statistics";
+
+            assertUpdate(session, format(
+                    "CREATE TABLE %s(" +
+                            "  a varchar, " +
+                            "  b varchar) " +
+                            "WITH (format='PARQUET', partitioned_by=ARRAY['b'])",
+                    tableName));
+            assertUpdate(session, "INSERT INTO " + tableName + " VALUES ('a', 'b')", 1);
+
+            assertQuery(
+                    session,
+                    "SELECT a, b FROM " + tableName,
+                    "VALUES ('a', 'b')");
+
+            assertQuery(
+                    session,
+                    "SELECT a, b FROM " + tableName + " WHERE b = 'b'",
+                    "VALUES ('a', 'b')");
+
+            assertQuery(
+                    session,
+                    "SELECT a, b FROM " + tableName + " WHERE a = 'a'",
+                    "VALUES ('a', 'b')");
+
+            assertUpdate(session, "DROP TABLE " + tableName);
+        }
+    }
+
+    @Test
     public void testNestedColumnWithDuplicateName()
     {
         String tableName = "test_nested_column_with_duplicate_name";


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix ArrayIndexOutOfBoundsException when using parquet ignore statistics. (https://github.com/trinodb/trino/issues/19760)
Add unit tests.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

parquetTupleDomains and parquetPredicates are empty when ignore statistics is used, can cause exception. 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`19760`)
```
