### PR TITLE
Fix partitioned output page flushing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderPageBuilder.java
@@ -13,6 +13,8 @@
  */
 package io.trino.operator.output;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.operator.project.PageProcessor;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
@@ -26,6 +28,9 @@ import static java.util.Objects.requireNonNull;
 public class PositionsAppenderPageBuilder
 {
     private static final int DEFAULT_INITIAL_EXPECTED_ENTRIES = 8;
+    @VisibleForTesting
+    static final int MAX_POSITION_COUNT = PageProcessor.MAX_BATCH_SIZE * 4;
+
     private final UnnestingPositionsAppender[] channelAppenders;
     private final int maxPageSizeInBytes;
     private int declaredPositions;
@@ -98,7 +103,7 @@ public class PositionsAppenderPageBuilder
 
     public boolean isFull()
     {
-        return declaredPositions == Integer.MAX_VALUE || getSizeInBytes() >= maxPageSizeInBytes;
+        return declaredPositions >= MAX_POSITION_COUNT || getSizeInBytes() >= maxPageSizeInBytes;
     }
 
     public boolean isEmpty()

--- a/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderSizeAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PositionsAppenderSizeAccumulator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.output;
+
+final class PositionsAppenderSizeAccumulator
+{
+    private long sizeInBytes;
+    private long directSizeInBytes;
+
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
+    }
+
+    public long getDirectSizeInBytes()
+    {
+        return directSizeInBytes;
+    }
+
+    public void accumulate(long sizeInBytes, long directSizeInBytes)
+    {
+        this.sizeInBytes += sizeInBytes;
+        this.directSizeInBytes += directSizeInBytes;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "PositionsAppenderSizeAccumulator{sizeInBytes=" + sizeInBytes + " directSizeInBytes=" + directSizeInBytes + "}";
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -206,7 +206,8 @@ public class UnnestingPositionsAppender
     public long getSizeInBytes()
     {
         return delegate.getSizeInBytes() +
-                // dictionary size is not included due to the expense of the calculation
+                // dictionary size is not included due to the expense of the calculation, but we can account for the ids size
+                (dictionaryIdsBuilder.size() * (long) Integer.BYTES) +
                 (rleValue != null ? rleValue.getSizeInBytes() : 0);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/UnnestingPositionsAppender.java
@@ -211,6 +211,14 @@ public class UnnestingPositionsAppender
                 (rleValue != null ? rleValue.getSizeInBytes() : 0);
     }
 
+    void addSizesToAccumulator(PositionsAppenderSizeAccumulator accumulator)
+    {
+        long sizeInBytes = getSizeInBytes();
+        // dictionary size is not included due to the expense of the calculation, so this will under-report for dictionaries
+        long directSizeInBytes = (rleValue == null) ? sizeInBytes : (rleValue.getSizeInBytes() * rlePositionCount);
+        accumulator.accumulate(sizeInBytes, directSizeInBytes);
+    }
+
     private static class DictionaryIdsBuilder
     {
         private static final int INSTANCE_SIZE = instanceSize(DictionaryIdsBuilder.class);

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.output;
+
+import io.airlift.slice.Slices;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.type.BlockTypeOperators;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestPositionsAppenderPageBuilder
+{
+    @Test
+    public void testFullOnPositionCountLimit()
+    {
+        int maxPageBytes = 1024 * 1024;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        Block rleBlock = RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
+        Page inputPage = new Page(rleBlock);
+
+        IntArrayList positions = IntArrayList.wrap(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        // Append 32760 positions, just less than MAX_POSITION_COUNT
+        assertEquals(32768, PositionsAppenderPageBuilder.MAX_POSITION_COUNT, "expected MAX_POSITION_COUNT to be 32768");
+        for (int i = 0; i < 3276; i++) {
+            pageBuilder.appendToOutputPartition(inputPage, positions);
+        }
+        assertFalse(pageBuilder.isFull(), "pageBuilder should still not be full");
+        // Append 10 more positions, crossing the threshold on position count
+        pageBuilder.appendToOutputPartition(inputPage, positions);
+        assertTrue(pageBuilder.isFull(), "pageBuilder should be full");
+        assertEquals(rleBlock.getSizeInBytes(), pageBuilder.getSizeInBytes());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -34,8 +34,10 @@ public class TestPositionsAppenderPageBuilder
     public void testFullOnPositionCountLimit()
     {
         int maxPageBytes = 1024 * 1024;
+        int maxDirectSize = maxPageBytes * 10;
         PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
                 maxPageBytes,
+                maxDirectSize,
                 List.of(VARCHAR),
                 new PositionsAppenderFactory(new BlockTypeOperators()));
 
@@ -52,6 +54,52 @@ public class TestPositionsAppenderPageBuilder
         // Append 10 more positions, crossing the threshold on position count
         pageBuilder.appendToOutputPartition(inputPage, positions);
         assertTrue(pageBuilder.isFull(), "pageBuilder should be full");
-        assertEquals(rleBlock.getSizeInBytes(), pageBuilder.getSizeInBytes());
+        PositionsAppenderSizeAccumulator sizeAccumulator = pageBuilder.computeAppenderSizes();
+        assertEquals(rleBlock.getSizeInBytes(), sizeAccumulator.getSizeInBytes());
+        assertTrue(sizeAccumulator.getDirectSizeInBytes() < maxDirectSize, "direct size should still be below threshold");
+        assertEquals(sizeAccumulator.getSizeInBytes(), pageBuilder.getSizeInBytes(), "pageBuilder sizeInBytes must match sizeAccumulator value");
+    }
+
+    @Test
+    public void testFullOnDirectSizeInBytes()
+    {
+        int maxPageBytes = 100;
+        int maxDirectSize = 1000;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        PositionsAppenderSizeAccumulator sizeAccumulator = pageBuilder.computeAppenderSizes();
+        assertEquals(0L, sizeAccumulator.getSizeInBytes());
+        assertEquals(0L, sizeAccumulator.getDirectSizeInBytes());
+        assertFalse(pageBuilder.isFull());
+
+        Block rleBlock = RunLengthEncodedBlock.create(VARCHAR, Slices.utf8Slice("test"), 10);
+        Page inputPage = new Page(rleBlock);
+
+        IntArrayList positions = IntArrayList.wrap(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        pageBuilder.appendToOutputPartition(inputPage, positions);
+        // 10 positions inserted, size in bytes is still the same since we're in RLE mode but direct size is 10x
+        sizeAccumulator = pageBuilder.computeAppenderSizes();
+        assertEquals(rleBlock.getSizeInBytes(), sizeAccumulator.getSizeInBytes());
+        assertEquals(sizeAccumulator.getSizeInBytes(), pageBuilder.getSizeInBytes(), "pageBuilder sizeInBytes must match sizeAccumulator value");
+        assertEquals(rleBlock.getSizeInBytes() * 10, sizeAccumulator.getDirectSizeInBytes());
+        assertFalse(pageBuilder.isFull());
+
+        // Keep inserting until the direct size limit is reached
+        while (pageBuilder.computeAppenderSizes().getDirectSizeInBytes() < maxDirectSize) {
+            pageBuilder.appendToOutputPartition(inputPage, positions);
+        }
+        // size in bytes is unchanged
+        sizeAccumulator = pageBuilder.computeAppenderSizes();
+        assertEquals(rleBlock.getSizeInBytes(), sizeAccumulator.getSizeInBytes(), "sizeInBytes must still report the RLE block size only");
+        assertEquals(sizeAccumulator.getSizeInBytes(), pageBuilder.getSizeInBytes(), "pageBuilder sizeInBytes must match sizeAccumulator value");
+        // builder reports full due to maximum size in bytes reached
+        assertTrue(pageBuilder.isFull());
+        Page result = pageBuilder.build();
+        assertEquals(120, result.getPositionCount(), "result positions should be below the 8192 maximum");
+        assertTrue(result.getBlock(0) instanceof RunLengthEncodedBlock, "result block is RLE encoded");
     }
 }


### PR DESCRIPTION
## Description
Fixes a number of issues with the flushing behavior of `PositionsAppenderPageBuilder` and related classes. The fixes are:

1. To consider `PositionsAppenderPageBuilder` to be full after at least 4x `PageProcessor.MAX_BATCH_SIZE` (4 * 8192 = 32,768) positions have been inserted, regardless of the current size in bytes. The previous behavior of only considering the builder full when `declaredPositions == Integer.MAX_VALUE` was unsafe since `PositionsAppenderPageBuilder#isFull()` is only checked after inserting an entire page not after each row, so integer overflows could occur.
2. Accounting for the size of at least the current dictionary ids in `UnnestingPositionsAppender` when in dictionary mode, even though the size of the actually referenced entries is still not tracked. Previously, repeated insertions that used the same underlying dictionary would report _no increase_ in the size of the builder and never flush. If at some later point a page were inserted with a different dictionary, the builder's transition to direct mode could then create very large memory allocations due to how many positions were buffered.
3. Setting an upper bound on the resulting size of an `UnnestingPositionsAppender` in RLE mode if it were to be transitioned to direct mode. Before this change, RLE mode appenders could accumulate an unbounded number of positions and report no size changes so long as the same value kept being inserted. At the point at which a different value was inserted, the transition to direct mode could cause huge spikes in memory usage and cause query failures and/or worker node heap OOMs.

In particular, issues 2 and 3 are exceedingly common when performing `CROSS JOIN UNNEST` queries since the `UnnestOperator` will emit RLE and dictionary blocks that repeat the same value or use the same dictionary for extended periods before suddenly transitioning to new values or dictionaries.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix an issue that could cause sudden increases in PagePartitioner memory consumption in some scenarios
```
