### PR TITLE
Fix X-Trino-Authorization-User typo

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -977,7 +977,7 @@ public class TestResourceSecurity
             server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticators(TestResourceSecurity::authenticate);
             HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
 
-            // Authenticated user TEST_USER_LOGIN impersonates impersonated-user by passing request header X-Trino-Authorization-User
+            // Authenticated user TEST_USER_LOGIN impersonates impersonated-user by passing request header X-Trino-User
             Request request = new Request.Builder()
                     .url(getLocation(httpServerInfo.getHttpsUri(), "/protocol/identity"))
                     .addHeader("Authorization", Credentials.basic(TEST_USER_LOGIN, TEST_PASSWORD))

--- a/docs/src/main/sphinx/develop/client-protocol.md
+++ b/docs/src/main/sphinx/develop/client-protocol.md
@@ -218,11 +218,12 @@ subsequent requests to be consistent with the response headers received.
     header in subsequent client requests.
 * - `X-Trino-Set-Authorization-User`
   - Instructs the client to set the session authorization user in the
-    `X-Trino-Authorization-User` request header in subsequent client requests.
+    `X-Trino-User` request header in subsequent client requests.
+    `X-Trino-Original-User` should also be set.
 * - `X-Trino-Reset-Authorization-User`
-  - Instructs the client to remove `X-Trino-Authorization-User` request header
-    in subsequent client requests to reset the authorization user back to the
-    original user.
+  - Instructs the client to reset `X-Trino-User` request header to its original
+    value in subsequent client requests and remove `X-Trino-Original-User`
+    to reset the authorization user back to the original user.
 * - `X-Trino-Set-Session`
   - The value of the `X-Trino-Set-Session` response header is a string of the
     form *property* = *value*. It instructs the client include session property


### PR DESCRIPTION
There is no such header. Only `X-Trino-User` and `X-Trino-Original-User` exist.

Follows https://github.com/trinodb/trino/pull/16067