### PR TITLE
Change latest connector test to smoke test in MariaDB

### DIFF
--- a/docs/src/main/sphinx/connector/mariadb.md
+++ b/docs/src/main/sphinx/connector/mariadb.md
@@ -17,7 +17,7 @@ database.
 
 To connect to MariaDB, you need:
 
-- MariaDB version 10.2 or higher.
+- MariaDB version 10.10 or higher.
 - Network access from the Trino coordinator and workers to MariaDB. Port
   3306 is the default port.
 

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbConnectorTest.java
@@ -16,10 +16,8 @@ package io.trino.plugin.mariadb;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
-import org.junit.jupiter.api.Test;
 
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestMariaDbConnectorTest
         extends BaseMariaDbConnectorTest
@@ -36,31 +34,5 @@ public class TestMariaDbConnectorTest
     protected SqlExecutor onRemoteDatabase()
     {
         return server::execute;
-    }
-
-    @Test
-    @Override
-    public void testRenameColumn()
-    {
-        assertThatThrownBy(super::testRenameColumn)
-                .hasMessageContaining("Rename column not supported for the MariaDB server version");
-    }
-
-    @Test
-    @Override
-    public void testRenameColumnName()
-    {
-        for (String columnName : testColumnNameDataProvider()) {
-            assertThatThrownBy(() -> testRenameColumnName(columnName, requiresDelimiting(columnName)))
-                    .hasMessageContaining("Rename column not supported for the MariaDB server version");
-        }
-    }
-
-    @Test
-    @Override
-    public void testAlterTableRenameColumnToLongName()
-    {
-        assertThatThrownBy(super::testAlterTableRenameColumnToLongName)
-                .hasMessageContaining("Rename column not supported for the MariaDB server version");
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorSmokeTest.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbLatestConnectorSmokeTest.java
@@ -14,26 +14,30 @@
 package io.trino.plugin.mariadb;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.SqlExecutor;
+import io.trino.testing.TestingConnectorBehavior;
 
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
 import static io.trino.plugin.mariadb.TestingMariaDbServer.LATEST_VERSION;
 
-public class TestMariaDbLatestConnectorTest
-        extends BaseMariaDbConnectorTest
+public class TestMariaDbLatestConnectorSmokeTest
+        extends BaseJdbcConnectorSmokeTest
 {
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return switch (connectorBehavior) {
+            case SUPPORTS_RENAME_SCHEMA -> false;
+            default -> super.hasBehavior(connectorBehavior);
+        };
+    }
+
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        server = closeAfterClass(new TestingMariaDbServer(LATEST_VERSION));
+        TestingMariaDbServer server = closeAfterClass(new TestingMariaDbServer(LATEST_VERSION));
         return createMariaDbQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
-    }
-
-    @Override
-    protected SqlExecutor onRemoteDatabase()
-    {
-        return server::execute;
     }
 }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestingMariaDbServer.java
@@ -27,8 +27,8 @@ import static java.lang.String.format;
 public class TestingMariaDbServer
         implements AutoCloseable
 {
-    public static final String LATEST_VERSION = "10.7.1";
-    public static final String DEFAULT_VERSION = "10.2";
+    public static final String LATEST_VERSION = "11.1.3";
+    public static final String DEFAULT_VERSION = "10.10";
     private static final int MARIADB_PORT = 3306;
 
     private final MariaDBContainer<?> container;


### PR DESCRIPTION
## Description

Update the docker image version to remove support for old versions https://endoflife.date/mariadb

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
