### PR TITLE
Fix typo in config

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -265,7 +265,8 @@ public class QueryManagerConfig
         return maxWriterTasksCount;
     }
 
-    @Config("query.max-writer-task-count")
+    @Config("query.max-writer-tasks-count")
+    @LegacyConfig("query.max-writer-task-count")
     @ConfigDescription("Maximum number of tasks that will participate in writing data")
     public QueryManagerConfig setMaxWriterTasksCount(int maxWritersNodesCount)
     {

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -180,7 +180,7 @@ public class TestQueryManagerConfig
                 .put("fault-tolerant-execution-runtime-adaptive-partitioning-partition-count", "888")
                 .put("fault-tolerant-execution-runtime-adaptive-partitioning-max-task-size", "18GB")
                 .put("fault-tolerant-execution-min-source-stage-progress", "0.3")
-                .put("query.max-writer-task-count", "101")
+                .put("query.max-writer-tasks-count", "101")
                 .put("fault-tolerant-execution-small-stage-estimation-enabled", "false")
                 .put("fault-tolerant-execution-small-stage-estimation-threshold", "6GB")
                 .put("fault-tolerant-execution-small-stage-source-size-multiplier", "1.6")


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix https://github.com/trinodb/trino/issues/19783


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
In the previous [release note](https://trino.io/docs/428/release/release-411.html) and [documentation](https://trino.io/docs/428/admin/properties-query-management.html?highlight=max_writer_tasks_count#query-max-writer-tasks-count) the config is correctly written as `query.max-writer-tasks-count`.
I'm not sure if we need another release note for this typo fix.