### PR TITLE
Remove unused fields from BigQueryColumnHandle

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
 import static io.airlift.slice.SizeOf.instanceSize;
-import static io.airlift.slice.SizeOf.sizeOf;
 import static java.util.Objects.requireNonNull;
 
 public class BigQueryColumnHandle
@@ -42,8 +41,6 @@ public class BigQueryColumnHandle
     private final StandardSQLTypeName bigqueryType;
     private final boolean isPushdownSupported;
     private final Field.Mode mode;
-    private final Long precision;
-    private final Long scale;
     private final List<BigQueryColumnHandle> subColumns;
     private final String description;
     private final boolean hidden;
@@ -55,8 +52,6 @@ public class BigQueryColumnHandle
             @JsonProperty("bigqueryType") StandardSQLTypeName bigqueryType,
             @JsonProperty("isPushdownSupported") boolean isPushdownSupported,
             @JsonProperty("mode") Field.Mode mode,
-            @JsonProperty("precision") Long precision,
-            @JsonProperty("scale") Long scale,
             @JsonProperty("subColumns") List<BigQueryColumnHandle> subColumns,
             @JsonProperty("description") String description,
             @JsonProperty("hidden") boolean hidden)
@@ -66,8 +61,6 @@ public class BigQueryColumnHandle
         this.bigqueryType = requireNonNull(bigqueryType, "bigqueryType is null");
         this.isPushdownSupported = isPushdownSupported;
         this.mode = requireNonNull(mode, "Field mode cannot be null");
-        this.precision = precision;
-        this.scale = scale;
         this.subColumns = ImmutableList.copyOf(requireNonNull(subColumns, "subColumns is null"));
         this.description = description;
         this.hidden = hidden;
@@ -101,18 +94,6 @@ public class BigQueryColumnHandle
     public Field.Mode getMode()
     {
         return mode;
-    }
-
-    @JsonProperty
-    public Long getPrecision()
-    {
-        return precision;
-    }
-
-    @JsonProperty
-    public Long getScale()
-    {
-        return scale;
     }
 
     @JsonProperty
@@ -159,8 +140,6 @@ public class BigQueryColumnHandle
                 Objects.equals(bigqueryType, that.bigqueryType) &&
                 Objects.equals(isPushdownSupported, that.isPushdownSupported) &&
                 Objects.equals(mode, that.mode) &&
-                Objects.equals(precision, that.precision) &&
-                Objects.equals(scale, that.scale) &&
                 Objects.equals(subColumns, that.subColumns) &&
                 Objects.equals(description, that.description);
     }
@@ -168,7 +147,7 @@ public class BigQueryColumnHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, trinoType, bigqueryType, isPushdownSupported, mode, precision, scale, subColumns, description);
+        return Objects.hash(name, trinoType, bigqueryType, isPushdownSupported, mode, subColumns, description);
     }
 
     @Override
@@ -180,8 +159,6 @@ public class BigQueryColumnHandle
                 .add("bigqueryType", bigqueryType)
                 .add("isPushdownSupported", isPushdownSupported)
                 .add("mode", mode)
-                .add("precision", precision)
-                .add("scale", scale)
                 .add("subColumns", subColumns)
                 .add("description", description)
                 .toString();
@@ -191,8 +168,6 @@ public class BigQueryColumnHandle
     {
         return INSTANCE_SIZE
                 + estimatedSizeOf(name)
-                + sizeOf(precision)
-                + sizeOf(scale)
                 + estimatedSizeOf(subColumns, BigQueryColumnHandle::getRetainedSizeInBytes)
                 + estimatedSizeOf(description);
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPseudoColumn.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPseudoColumn.java
@@ -58,8 +58,6 @@ public enum BigQueryPseudoColumn
                 bigqueryType,
                 true,
                 Field.Mode.REQUIRED,
-                null,
-                null,
                 ImmutableList.of(),
                 null,
                 true);

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/Conversions.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/Conversions.java
@@ -45,8 +45,6 @@ public final class Conversions
                 field.getType().getStandardType(),
                 columnMapping.isPushdownSupported(),
                 getMode(field),
-                field.getPrecision(),
-                field.getScale(),
                 subColumns,
                 field.getDescription(),
                 false);


### PR DESCRIPTION
## Description

Remove unused fields from BigQueryColumnHandle

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
