### PR TITLE
Construct AddFileEntry instance only if necessary while reading the Delta Lake checkpoint

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
@@ -62,9 +62,34 @@ public class AddFileEntry
             @JsonProperty("tags") @Nullable Map<String, String> tags,
             @JsonProperty("deletionVector") Optional<DeletionVectorEntry> deletionVector)
     {
+        this(
+                path,
+                partitionValues,
+                canonicalizePartitionValues(partitionValues),
+                size,
+                modificationTime,
+                dataChange,
+                stats,
+                parsedStats,
+                tags,
+                deletionVector);
+    }
+
+    public AddFileEntry(
+            String path,
+            Map<String, String> partitionValues,
+            Map<String, Optional<String>> canonicalPartitionValues,
+            long size,
+            long modificationTime,
+            boolean dataChange,
+            Optional<String> stats,
+            Optional<DeltaLakeParquetFileStatistics> parsedStats,
+            @Nullable Map<String, String> tags,
+            Optional<DeletionVectorEntry> deletionVector)
+    {
         this.path = path;
-        this.partitionValues = partitionValues;
-        this.canonicalPartitionValues = canonicalizePartitionValues(partitionValues);
+        this.partitionValues = requireNonNull(partitionValues, "partitionValues is null");
+        this.canonicalPartitionValues = requireNonNull(canonicalPartitionValues, "canonicalPartitionValues is null");
         this.size = size;
         this.modificationTime = modificationTime;
         this.dataChange = dataChange;

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -141,6 +141,7 @@ public class CheckpointEntryIterator
     private final TupleDomain<DeltaLakeColumnHandle> partitionConstraint;
     private MetadataEntry metadataEntry;
     private ProtocolEntry protocolEntry;
+    private boolean deletionVectorsEnabled;
     private List<DeltaLakeColumnMetadata> schema;
     private List<DeltaLakeColumnMetadata> columnsWithMinMaxStats;
     private Page page;
@@ -185,6 +186,7 @@ public class CheckpointEntryIterator
             this.metadataEntry = metadataEntry.get();
             checkArgument(protocolEntry.isPresent(), "Protocol entry must be provided when reading ADD entries from Checkpoint files");
             this.protocolEntry = protocolEntry.get();
+            deletionVectorsEnabled = isDeletionVectorEnabled(this.metadataEntry, this.protocolEntry);
             checkArgument(addStatsMinMaxColumnFilter.isPresent(), "addStatsMinMaxColumnFilter must be provided when reading ADD entries from Checkpoint files");
             this.schema = extractSchema(this.metadataEntry, this.protocolEntry, typeManager);
             this.columnsWithMinMaxStats = columnsWithStats(schema, this.metadataEntry.getOriginalPartitionColumns());
@@ -466,7 +468,6 @@ public class CheckpointEntryIterator
             return null;
         }
         RowType type = (RowType) parquetFields.get("add");
-        boolean deletionVectorsEnabled = isDeletionVectorEnabled(metadataEntry, protocolEntry);
         SqlRow addEntryRow = block.getObject(pagePosition, SqlRow.class);
         log.debug("Block %s has %s fields", block, addEntryRow.getFieldCount());
         CheckpointFieldReader add = new CheckpointFieldReader(session, addEntryRow, type);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -136,7 +136,7 @@ public class CheckpointEntryIterator
     private final MapType stringMap;
     private final ArrayType stringList;
     private final Queue<DeltaLakeTransactionLogEntry> nextEntries;
-    private final List<CheckPointFieldExtractor> extractors;
+    private final List<CheckpointFieldExtractor> extractors;
     private final boolean checkpointRowStatisticsWritingEnabled;
     private final TupleDomain<DeltaLakeColumnHandle> partitionConstraint;
     private MetadataEntry metadataEntry;
@@ -171,7 +171,7 @@ public class CheckpointEntryIterator
         this.partitionConstraint = requireNonNull(partitionConstraint, "partitionConstraint is null");
         requireNonNull(addStatsMinMaxColumnFilter, "addStatsMinMaxColumnFilter is null");
         checkArgument(!fields.isEmpty(), "fields is empty");
-        Map<EntryType, CheckPointFieldExtractor> extractors = ImmutableMap.<EntryType, CheckPointFieldExtractor>builder()
+        Map<EntryType, CheckpointFieldExtractor> extractors = ImmutableMap.<EntryType, CheckpointFieldExtractor>builder()
                 .put(TRANSACTION, this::buildTxnEntry)
                 .put(ADD, this::buildAddEntry)
                 .put(REMOVE, this::buildRemoveEntry)
@@ -716,7 +716,7 @@ public class CheckpointEntryIterator
     }
 
     @FunctionalInterface
-    public interface CheckPointFieldExtractor
+    private interface CheckpointFieldExtractor
     {
         @Nullable
         DeltaLakeTransactionLogEntry getEntry(ConnectorSession session, Block block, int pagePosition);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -121,7 +121,8 @@ public class CheckpointSchemaManager
             ProtocolEntry protocolEntry,
             Predicate<String> addStatsMinMaxColumnFilter,
             boolean requireWriteStatsAsJson,
-            boolean requireWriteStatsAsStruct)
+            boolean requireWriteStatsAsStruct,
+            boolean usePartitionValues)
     {
         List<DeltaLakeColumnMetadata> allColumns = extractSchema(metadataEntry, protocolEntry, typeManager);
         List<DeltaLakeColumnMetadata> minMaxColumns = columnsWithStats(metadataEntry, protocolEntry, typeManager);
@@ -158,7 +159,9 @@ public class CheckpointSchemaManager
         MapType stringMap = (MapType) typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
         ImmutableList.Builder<RowType.Field> addFields = ImmutableList.builder();
         addFields.add(RowType.field("path", VARCHAR));
-        addFields.add(RowType.field("partitionValues", stringMap));
+        if (usePartitionValues) {
+            addFields.add(RowType.field("partitionValues", stringMap));
+        }
         addFields.add(RowType.field("size", BIGINT));
         addFields.add(RowType.field("modificationTime", BIGINT));
         addFields.add(RowType.field("dataChange", BOOLEAN));
@@ -179,6 +182,15 @@ public class CheckpointSchemaManager
             addFields.add(RowType.field("stats_parsed", RowType.from(statsColumns.build())));
         }
         addFields.add(RowType.field("tags", stringMap));
+
+        return RowType.from(addFields.build());
+    }
+
+    public RowType getAddEntryPartitionValuesType()
+    {
+        ImmutableList.Builder<RowType.Field> addFields = ImmutableList.builder();
+        MapType stringMap = (MapType) typeManager.getType(TypeSignature.mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
+        addFields.add(RowType.field("partitionValues", stringMap));
 
         return RowType.from(addFields.build());
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -120,7 +120,8 @@ public class CheckpointWriter
                 entries.getProtocolEntry(),
                 alwaysTrue(),
                 writeStatsAsJson,
-                writeStatsAsStruct);
+                writeStatsAsStruct,
+                true);
         RowType removeEntryType = checkpointSchemaManager.getRemoveEntryType();
 
         List<String> columnNames = ImmutableList.of(


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case that there is checkpoint filtering applied and there are partition constraints which do not
match the partition values of the entry, avoid early to create the `AddFileEntry` instance.

Split the loading for the `add` entries from the Parquet checkpoint in two channels:
- one channels contains the `partitionValues` information
- the other channel contains everything else related to `add`

When building the `add` entry, check first the partition constraint to match against the partition values and only then load the `add` block to avoid unecessary resources spent on deserialization.

Used for testing a multi-part checkpoint file (25 parts , each around 12MB ~ 300MB in total) for testing this feature while storing the checkpoint in local MinIO and came up with the following results:

```
ADD retrieval of all entries
number of add entries: Optional[1235155]
checkpoint iterator completed positions: Optional[1235157]
checkpoint iterator completed bytes: Optional[323227977]
Elapsed Time in milliseconds: 17866

ADD partition pruning without current changes
number of add entries: Optional[18578]
checkpoint iterator completed positions: Optional[49290]
checkpoint iterator completed bytes: Optional[14099674]
Elapsed Time in milliseconds: 1056

ADD partition pruning with current changes (
number of add entries: Optional[18578]
checkpoint iterator completed positions: Optional[49290]
checkpoint iterator completed bytes: Optional[14099674]
Elapsed Time in milliseconds: 701
```

As can be seen from the analysis above, there can't be spotted any relevant improvement in terms of IO with this change. 
That's because the Parquet page is already loaded because it contains at least one entry matching the partition predicate.
This is why the checkpoint iterator still does read the same amount of bytes as the baseline in case of applying the partition pruning.

However, it can be seen that the elapsed number of milliseconds decreases in case of using this change because there is less deserialization performed.


Tested as well with a more permissive filter and haven't actually spotted bigger improvements than ~ 0.5s in terms of elapsed time between the base line and the current changes.

```
ADD partition pruning without current changes
number of add entries: Optional[210575]
checkpoint iterator completed positions: Optional[248524]
checkpoint iterator completed bytes: Optional[66021553]
Elapsed Time in milliseconds: 3992

ADD partition pruning with current changes
number of add entries: Optional[210575]
checkpoint iterator completed positions: Optional[248524]
checkpoint iterator completed bytes: Optional[66021553]
Elapsed Time in milliseconds: 3532
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This change builds on top of https://github.com/trinodb/trino/pull/19588

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
