### PR TITLE
Add junit-extensions to test classpaths

### DIFF
--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -100,6 +100,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <scope>test</scope>

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -25,6 +25,14 @@
         <process-name>${project.artifactId}</process-name>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -137,6 +137,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -113,6 +113,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>

--- a/testing/trino-benchmark-queries/pom.xml
+++ b/testing/trino-benchmark-queries/pom.xml
@@ -16,6 +16,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
`junit-extensions` is necessary safety extensions to JUnit, preventing JUnit "UX trap" which makes overridden tests silently skipped. It should be on every module's classpath.

For the record, the modules were identified using

    find -name pom.xml | grep -vFxf <(find -name pom.xml -exec grep -l junit-extensions {} +)

