### PR TITLE
Mark PageSorter.sort supported method 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/InternalNode.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalNode.java
@@ -60,13 +60,6 @@ public class InternalNode
         return internalUri.getHost();
     }
 
-    @Override
-    @Deprecated
-    public URI getHttpUri()
-    {
-        return getInternalUri();
-    }
-
     public URI getInternalUri()
     {
         return internalUri;

--- a/core/trino-spi/src/main/java/io/trino/spi/Node.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Node.java
@@ -13,19 +13,11 @@
  */
 package io.trino.spi;
 
-import java.net.URI;
-
 public interface Node
 {
     String getHost();
 
     HostAddress getHostAndPort();
-
-    /**
-     * @deprecated Connectors should not access the HTTP endpoints of other nodes.
-     */
-    @Deprecated
-    URI getHttpUri();
 
     String getNodeIdentifier();
 

--- a/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageSorter.java
@@ -24,7 +24,6 @@ public interface PageSorter
      * @return Sorted synthetic addresses for pages. A synthetic address is encoded as a long with
      * the high 32 bits containing the page index and the low 32 bits containing position index
      */
-    @Deprecated
     long[] sort(List<Type> types, List<Page> pages, List<Integer> sortChannels, List<SortOrder> sortOrders, int expectedPositions);
 
     int decodePageIndex(long address);

--- a/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/CharType.java
@@ -34,7 +34,6 @@ import static io.trino.spi.type.Chars.padSpaces;
 import static io.trino.spi.type.Slices.sliceRepresentation;
 import static java.lang.Character.MAX_CODE_POINT;
 import static java.lang.Character.MIN_CODE_POINT;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Collections.singletonList;
@@ -59,18 +58,6 @@ public final class CharType
 
     private final int length;
     private volatile Optional<Range> range;
-
-    /**
-     * @deprecated Use {@link #createCharType(int)} instead.
-     */
-    @Deprecated
-    public static CharType createCharType(long length)
-    {
-        if (length < 0 || length > MAX_LENGTH) {
-            throw new IllegalArgumentException(format("CHAR length must be in range [0, %s], got %s", MAX_LENGTH, length));
-        }
-        return createCharType(toIntExact(length));
-    }
 
     public static CharType createCharType(int length)
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
@@ -43,13 +43,6 @@ public abstract sealed class TimeWithTimeZoneType
     public static final TimeWithTimeZoneType TIME_TZ_NANOS = createTimeWithTimeZoneType(9);
     public static final TimeWithTimeZoneType TIME_TZ_PICOS = createTimeWithTimeZoneType(12);
 
-    /**
-     * @deprecated Use {@link #createTimeWithTimeZoneType} instead.
-     */
-    @Deprecated
-    // Use singleton for backwards compatibility with code checking `type == TIME_WITH_TIME_ZONE`
-    public static final TimeWithTimeZoneType TIME_WITH_TIME_ZONE = TIME_TZ_MILLIS;
-
     private final int precision;
 
     public static TimeWithTimeZoneType createTimeWithTimeZoneType(int precision)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/VarbinaryType.java
@@ -36,15 +36,6 @@ public final class VarbinaryType
         super(new TypeSignature(StandardTypes.VARBINARY), Slice.class);
     }
 
-    /**
-     * @deprecated Use {@code type instanceof VarbinaryType} instead.
-     */
-    @Deprecated
-    public static boolean isVarbinaryType(Type type)
-    {
-        return type instanceof VarbinaryType;
-    }
-
     @Override
     public boolean isComparable()
     {


### PR DESCRIPTION
Commit https://github.com/trinodb/trino/commit/d2289252054151d634e10311301c831d269c98d4 un-deprecated
`PageSorter` and it looks like an omission not to un-deprecate it's only
sorting method.