### PR TITLE
Flush PagePartitioner dictionaries before release

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -69,6 +69,9 @@ public class PagePartitioner
     private final int nullChannel; // when >= 0, send the position to every partition if this channel is null
 
     private boolean hasAnyRowBeenReplicated;
+    // outputSizeInBytes that has already been reported to the operator stats during release and should be subtracted
+    // from future stats reporting to avoid double counting
+    private long outputSizeReportedBeforeRelease;
 
     public PagePartitioner(
             PartitionFunction partitionFunction,
@@ -135,7 +138,6 @@ public class PagePartitioner
         }
 
         int outputPositionCount = replicatesAnyRow && !hasAnyRowBeenReplicated ? page.getPositionCount() + positionsAppenders.length - 1 : page.getPositionCount();
-        long positionsAppendersSizeBefore = getPositionsAppendersSizeInBytes();
         if (page.getPositionCount() < partitionFunction.partitionCount() * COLUMNAR_STRATEGY_COEFFICIENT) {
             // Partition will have on average less than COLUMNAR_STRATEGY_COEFFICIENT rows.
             // Doing it column-wise would degrade performance, so we fall back to row-wise approach.
@@ -146,11 +148,68 @@ public class PagePartitioner
         else {
             partitionPageByColumn(page);
         }
-        long positionsAppendersSizeAfter = getPositionsAppendersSizeInBytes();
-        flushPositionsAppenders(false);
+        long outputSizeInBytes = flushPositionsAppenders(false);
         updateMemoryUsage();
+        operatorContext.recordOutput(outputSizeInBytes, outputPositionCount);
+    }
 
-        operatorContext.recordOutput(positionsAppendersSizeAfter - positionsAppendersSizeBefore, outputPositionCount);
+    private long adjustFlushedOutputSizeWithEagerlyReportedBytes(long flushedOutputSize)
+    {
+        // Reduce the flushed output size by the previously eagerly reported amount to avoid double counting
+        if (outputSizeReportedBeforeRelease > 0) {
+            long adjustmentAmount = min(flushedOutputSize, outputSizeReportedBeforeRelease);
+            outputSizeReportedBeforeRelease -= adjustmentAmount;
+            flushedOutputSize -= adjustmentAmount;
+        }
+        return flushedOutputSize;
+    }
+
+    private long adjustEagerlyReportedBytesWithBufferedBytesOnRelease(long bufferedBytesOnRelease)
+    {
+        // adjust the amount to eagerly report as output by the amount already eagerly reported if the new value
+        // is larger, since this indicates that no data was flushed and only the delta between the two values should
+        // be reported eagerly
+        if (outputSizeReportedBeforeRelease > 0 && bufferedBytesOnRelease >= outputSizeReportedBeforeRelease) {
+            bufferedBytesOnRelease -= outputSizeReportedBeforeRelease;
+            outputSizeReportedBeforeRelease += bufferedBytesOnRelease;
+        }
+        return bufferedBytesOnRelease;
+    }
+
+    /**
+     * Prepares this {@link PagePartitioner} for release to the pool by checking for dictionary mode appenders and either flattening
+     * them into direct appenders or forcing their current pages to flush to preserve a valuable dictionary encoded representation. This
+     * is done before release because we know that after reuse, the appenders will not observe any more inputs using the same dictionary.
+     * <p>
+     * When a {@link PagePartitioner} is released back to the {@link PagePartitionerPool} we don't know if it will ever be reused. If it is not
+     * reused, then we have no {@link OperatorContext} we can use to report the output size of the final flushed page, so instead we report the
+     * buffered bytes still in the partitioner after {@link PagePartitioner#prepareForRelease(OperatorContext)} as output bytes eagerly and record
+     * that amount in {@link #outputSizeReportedBeforeRelease}. If the {@link PagePartitioner} is reused after having reported buffered bytes eagerly,
+     * we then have to subtract that same amount from the subsequent output bytes to avoid double counting them.
+     */
+    public void prepareForRelease(OperatorContext operatorContext)
+    {
+        long bufferedSizeInBytes = 0;
+        long outputSizeInBytes = 0;
+        for (int partition = 0; partition < positionsAppenders.length; partition++) {
+            PositionsAppenderPageBuilder positionsAppender = positionsAppenders[partition];
+            Optional<Page> flushedPage = positionsAppender.flushOrFlattenBeforeRelease();
+            if (flushedPage.isPresent()) {
+                Page page = flushedPage.get();
+                outputSizeInBytes += page.getSizeInBytes();
+                enqueuePage(page, partition);
+            }
+            else {
+                // Dictionaries have now been flattened, so the new reported size is trustworthy to report
+                // eagerly
+                bufferedSizeInBytes += positionsAppender.getSizeInBytes();
+            }
+        }
+        updateMemoryUsage();
+        // Adjust flushed and buffered values against the previously eagerly reported sizes
+        outputSizeInBytes = adjustFlushedOutputSizeWithEagerlyReportedBytes(outputSizeInBytes);
+        bufferedSizeInBytes = adjustEagerlyReportedBytesWithBufferedBytesOnRelease(bufferedSizeInBytes);
+        operatorContext.recordOutput(outputSizeInBytes + bufferedSizeInBytes, 0 /* no new positions */);
     }
 
     public void partitionPageByRow(Page page)
@@ -208,15 +267,6 @@ public class PagePartitioner
                 partitionPositions.clear();
             }
         }
-    }
-
-    private long getPositionsAppendersSizeInBytes()
-    {
-        long sizeInBytes = 0;
-        for (PositionsAppenderPageBuilder pageBuilder : positionsAppenders) {
-            sizeInBytes += pageBuilder.getSizeInBytes();
-        }
-        return sizeInBytes;
     }
 
     private IntArrayList[] partitionPositions(Page page)
@@ -424,6 +474,7 @@ public class PagePartitioner
     {
         try {
             flushPositionsAppenders(true);
+            outputSizeReportedBeforeRelease = 0;
         }
         finally {
             // clear buffers before memory release
@@ -432,16 +483,19 @@ public class PagePartitioner
         }
     }
 
-    private void flushPositionsAppenders(boolean force)
+    private long flushPositionsAppenders(boolean force)
     {
+        long outputSizeInBytes = 0;
         // add all full pages to output buffer
         for (int partition = 0; partition < positionsAppenders.length; partition++) {
             PositionsAppenderPageBuilder partitionPageBuilder = positionsAppenders[partition];
             if (!partitionPageBuilder.isEmpty() && (force || partitionPageBuilder.isFull())) {
                 Page pagePartition = partitionPageBuilder.build();
+                outputSizeInBytes += pagePartition.getSizeInBytes();
                 enqueuePage(pagePartition, partition);
             }
         }
+        return adjustFlushedOutputSizeWithEagerlyReportedBytes(outputSizeInBytes);
     }
 
     private void enqueuePage(Page pagePartition, int partition)

--- a/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PartitionedOutputOperator.java
@@ -284,6 +284,7 @@ public class PartitionedOutputOperator
     public void finish()
     {
         if (!finished) {
+            pagePartitioner.prepareForRelease(operatorContext);
             pagePartitionerPool.release(pagePartitioner);
             finished = true;
         }

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPartitionedOutputOperator.java
@@ -68,7 +68,10 @@ public class TestPartitionedOutputOperator
         partitionedOutputOperator.addInput(page);
 
         OperatorContext operatorContext = partitionedOutputOperator.getOperatorContext();
-        assertThat(operatorContext.getOutputDataSize().getTotalCount()).isEqualTo(page.getSizeInBytes());
+        assertThat(operatorContext.getOutputDataSize().getTotalCount()).isEqualTo(0);
         assertThat(operatorContext.getOutputPositions().getTotalCount()).isEqualTo(page.getPositionCount());
+
+        partitionedOutputOperator.finish();
+        assertThat(operatorContext.getOutputDataSize().getTotalCount()).isEqualTo(page.getSizeInBytes());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/output/TestPositionsAppenderPageBuilder.java
@@ -16,14 +16,20 @@ package io.trino.operator.output;
 import io.airlift.slice.Slices;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.block.ValueBlock;
+import io.trino.spi.predicate.Utils;
 import io.trino.type.BlockTypeOperators;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
+import static io.trino.block.BlockAssertions.createRandomBlockForType;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.lang.Math.toIntExact;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,5 +107,60 @@ public class TestPositionsAppenderPageBuilder
         Page result = pageBuilder.build();
         assertEquals(120, result.getPositionCount(), "result positions should be below the 8192 maximum");
         assertTrue(result.getBlock(0) instanceof RunLengthEncodedBlock, "result block is RLE encoded");
+    }
+
+    @Test
+    public void testFlushUsefulDictionariesOnRelease()
+    {
+        int maxPageBytes = 100;
+        int maxDirectSize = 1000;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        Block valueBlock = Utils.nativeValueToBlock(VARCHAR, Slices.utf8Slice("test"));
+        Block dictionaryBlock = DictionaryBlock.create(10, valueBlock, new int[10]);
+        Page inputPage = new Page(dictionaryBlock);
+
+        pageBuilder.appendToOutputPartition(inputPage, IntArrayList.wrap(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        // Dictionary mode appender should report the size of the ID's, but doesn't currently track
+        // the per-position size at all because it would be inefficient
+        assertEquals(Integer.BYTES * 10, pageBuilder.getSizeInBytes());
+        assertFalse(pageBuilder.isFull());
+
+        Optional<Page> flushedPage = pageBuilder.flushOrFlattenBeforeRelease();
+        assertTrue(flushedPage.isPresent(), "pageBuilder should force flush the dictionary");
+        assertTrue(flushedPage.get().getBlock(0) instanceof DictionaryBlock, "result should be dictionary encoded");
+    }
+
+    @Test
+    public void testFlattenUnhelpfulDictionariesOnRelease()
+    {
+        // Create unhelpful dictionary wrapping
+        Block valueBlock = createRandomBlockForType(VARCHAR, 10, 0.25f);
+        Block dictionaryBlock = DictionaryBlock.create(10, valueBlock, new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        Page inputPage = new Page(dictionaryBlock);
+
+        // Ensure the builder allows the entire value block to be inserted without being full
+        int maxPageBytes = toIntExact(valueBlock.getSizeInBytes() * 10);
+        int maxDirectSize = maxPageBytes * 10;
+        PositionsAppenderPageBuilder pageBuilder = PositionsAppenderPageBuilder.withMaxPageSize(
+                maxPageBytes,
+                maxDirectSize,
+                List.of(VARCHAR),
+                new PositionsAppenderFactory(new BlockTypeOperators()));
+
+        pageBuilder.appendToOutputPartition(inputPage, IntArrayList.wrap(new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        assertEquals(Integer.BYTES * 10, pageBuilder.getSizeInBytes());
+        assertFalse(pageBuilder.isFull());
+
+        assertEquals(Optional.empty(), pageBuilder.flushOrFlattenBeforeRelease(), "pageBuilder should not force a flush");
+        assertFalse(pageBuilder.isFull());
+        assertEquals(valueBlock.getSizeInBytes(), pageBuilder.getSizeInBytes(), "pageBuilder should have transitioned to direct mode");
+
+        Page result = pageBuilder.build();
+        assertTrue(result.getBlock(0) instanceof ValueBlock, "result should not be a dictionary block");
     }
 }


### PR DESCRIPTION
## Description
`PagePartitioner` instances should either flatten their dictionary-mode appenders and transition to direct mode, or force their current page to preserve the dictionary encoding and force the current page to be flushed being released to the pool for reuse since it is not possible for the appender to observe the same dictionary input when reused by a different driver.

Also fixes an issue where dictionary encoded output pages significantly under-report their output size for `PartitionedOutputOperator`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Follows up from https://github.com/trinodb/trino/pull/19762 which mitigates similar issues for RLE blocks, but using a different strategy that's more appropriate for dictionary block handling.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
