### PR TITLE
Document missing extended-statistics properties in Iceberg connector

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -131,11 +131,21 @@ implementation is used:
     aggregations or joins.
   - 0.05
 * - `iceberg.table-statistics-enabled`
-  - Enables [](/optimizer/statistics). The equivalent [catalog session
+  - Enable [](/optimizer/statistics). The equivalent [catalog session
     property](/sql/set-session) is `statistics_enabled` for session specific
     use. Set to `false` to disable statistics. Disabling statistics means that
     [](/optimizer/cost-based-optimizations) cannot make better decisions about
     the query plan.
+  - `true`
+* - `iceberg.extended-statistics.enabled`
+  - Enable statistics collection with [](/sql/analyze) and use of extended
+    statistics. The equivalent catalog session property is
+    `extended_statistics_enabled`.
+  - `true`
+* - `iceberg.extended-statistics.collect-on-write`
+  - Enable collection of extended statistics for write operations. The
+    equivalent catalog session property is
+    `collect_extended_statistics_on_write`.
   - `true`
 * - `iceberg.projection-pushdown-enabled`
   - Enable [projection pushdown](/optimizer/pushdown)


### PR DESCRIPTION
## Description

Unlike in the Delta Lake connector, `iceberg.extended-statistics.enabled` and `iceberg.extended-statistics.collect-on-write` and their respective session properties `extended_statistics_enabled` and `collect_extended_statistics_on_write` have not been documented yet.


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
