### PR TITLE
Throw IndexOutOfBoundsException in MemoryInputStream

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryInputStream.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryInputStream.java
@@ -20,6 +20,7 @@ import io.trino.filesystem.TrinoInputStream;
 
 import java.io.IOException;
 
+import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 class MemoryInputStream
@@ -78,6 +79,7 @@ class MemoryInputStream
             throws IOException
     {
         ensureOpen();
+        checkFromIndexSize(destinationIndex, length, destination.length);
         return input.read(destination, destinationIndex, length);
     }
 

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/AbstractTestTrinoFileSystem.java
@@ -391,6 +391,13 @@ public abstract class AbstractTestTrinoFileSystem
                     assertThat(inputStream.getPosition()).isEqualTo(fileSize + 100);
                 }
 
+                assertThatThrownBy(() -> inputStream.read(new byte[1], -1, 0))
+                        .isInstanceOf(IndexOutOfBoundsException.class);
+                assertThatThrownBy(() -> inputStream.read(new byte[1], 0, -1))
+                        .isInstanceOf(IndexOutOfBoundsException.class);
+                assertThatThrownBy(() -> inputStream.read(new byte[1], 1, 3))
+                        .isInstanceOf(IndexOutOfBoundsException.class);
+
                 // verify all the methods throw after close
                 inputStream.close();
                 assertThatThrownBy(inputStream::available)

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsTrinoInputStream.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsTrinoInputStream.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import static io.trino.filesystem.hdfs.HdfsFileSystem.withCause;
+import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
 
 class HdfsTrinoInputStream
@@ -96,6 +97,7 @@ class HdfsTrinoInputStream
             throws IOException
     {
         ensureOpen();
+        checkFromIndexSize(off, len, b.length);
         try {
             return stream.read(b, off, len);
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
[InputStream.read is expected to throw IndexOutOfBoundException when](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#read(byte%5B%5D,int,int))
>  off is negative, len is negative, or len is greater than b.length - off

We currently don't test this, and allow using `MemoryInputStream.read` with a negative offset.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
