### PR TITLE
Remove redundant analyzeColumns from IcebergTableHandle

### DIFF
--- a/core/trino-main/src/main/java/io/trino/json/ir/IrLiteral.java
+++ b/core/trino-main/src/main/java/io/trino/json/ir/IrLiteral.java
@@ -15,6 +15,7 @@ package io.trino.json.ir;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 
@@ -35,8 +36,8 @@ public record IrLiteral(Optional<Type> type, Object value)
         requireNonNull(value, "value is null"); // (boxed) native representation. No null values allowed.
     }
 
-    @Deprecated // For JSON deserialization only
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static IrLiteral fromJson(@JsonProperty("type") Type type, @JsonProperty("valueAsBlock") Block value)
     {
         checkArgument(value.getPositionCount() == 1);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/Partitioning.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.annotations.Immutable;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
@@ -59,8 +60,8 @@ public final class Partitioning
                 .collect(toImmutableList()));
     }
 
-    // Factory method for JSON serde only!
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static Partitioning jsonCreate(
             @JsonProperty("handle") PartitioningHandle handle,
             @JsonProperty("arguments") List<ArgumentBinding> arguments)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/StatisticAggregationsDescriptor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/StatisticAggregationsDescriptor.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.statistics.ColumnStatisticMetadata;
 import io.trino.spi.statistics.TableStatisticType;
 
@@ -52,7 +53,7 @@ public class StatisticAggregationsDescriptor<T>
     }
 
     @JsonCreator
-    @Deprecated // for JSON serialization only
+    @DoNotCall // for JSON serialization only
     public static <T> StatisticAggregationsDescriptor<T> fromJson(
             @JsonProperty("grouping") Map<String, T> grouping,
             @JsonProperty("tableStatistics") Map<TableStatisticType, T> tableStatistics,
@@ -84,8 +85,8 @@ public class StatisticAggregationsDescriptor<T>
     }
 
     @JsonProperty
-    @Deprecated // for JSON serialization only
-    public List<ColumnStatisticAggregationsDescriptor<T>> getColumnStatisticsList()
+    @DoNotCall // for JSON serialization only
+    public final List<ColumnStatisticAggregationsDescriptor<T>> getColumnStatisticsList()
     {
         return columnStatistics.entrySet().stream()
                 .map(entry -> new ColumnStatisticAggregationsDescriptor<T>(entry.getKey(), entry.getValue()))

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
@@ -79,7 +79,7 @@ public class TableScanNode
      * This constructor is for JSON deserialization only. Do not use.
      * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
      */
-    @Deprecated
+    /* TODO @DoNotCall once it's applicable to constructors */
     @JsonCreator
     public TableScanNode(
             @JsonProperty("id") PlanNodeId id,

--- a/core/trino-main/src/main/java/io/trino/sql/relational/ConstantExpression.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/ConstantExpression.java
@@ -15,6 +15,7 @@ package io.trino.sql.relational;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.slice.Slice;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -33,6 +34,7 @@ public final class ConstantExpression
         extends RowExpression
 {
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static ConstantExpression fromJson(
             @JsonProperty Block value,
             @JsonProperty Type type)

--- a/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
@@ -82,6 +82,7 @@ public final class SplitWeight
      * to avoid breakages that could arise if {@link SplitWeight#UNIT_VALUE} changes in the future.
      */
     @JsonCreator
+    // TODO Mark with @DoNotCall
     public static SplitWeight fromRawValue(long value)
     {
         return value == UNIT_VALUE ? STANDARD_WEIGHT : new SplitWeight(value);

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionDependencyDeclaration.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionDependencyDeclaration.java
@@ -15,6 +15,7 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
@@ -80,6 +81,7 @@ public class FunctionDependencyDeclaration
     }
 
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static FunctionDependencyDeclaration fromJson(
             @JsonProperty Set<TypeSignature> typeDependencies,
             @JsonProperty Set<FunctionDependency> functionDependencies,

--- a/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/FunctionMetadata.java
@@ -15,6 +15,7 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 
 import java.util.ArrayList;
@@ -149,6 +150,7 @@ public class FunctionMetadata
     }
 
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static FunctionMetadata fromJson(
             @JsonProperty FunctionId functionId,
             @JsonProperty Signature signature,

--- a/core/trino-spi/src/main/java/io/trino/spi/function/LongVariableConstraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/LongVariableConstraint.java
@@ -15,6 +15,7 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 
 import java.util.Objects;
@@ -71,13 +72,9 @@ public class LongVariableConstraint
         return Objects.hash(name, expression);
     }
 
-    /**
-     * This method is only visible for JSON deserialization.
-     *
-     * @deprecated use builder
-     */
-    @Deprecated
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
+    @Deprecated // Discourage usages in SPI consumers
     public static LongVariableConstraint fromJson(
             @JsonProperty("name") String name,
             @JsonProperty("expression") String expression)

--- a/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/Signature.java
@@ -15,6 +15,7 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
@@ -239,13 +240,9 @@ public class Signature
         }
     }
 
-    /**
-     * This method is only visible for JSON deserialization.
-     *
-     * @deprecated use builder
-     */
-    @Deprecated
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
+    @Deprecated // Discourage usages in SPI consumers
     public static Signature fromJson(
             @JsonProperty("typeVariableConstraints") List<TypeVariableConstraint> typeVariableConstraints,
             @JsonProperty("longVariableConstraints") List<LongVariableConstraint> longVariableConstraints,

--- a/core/trino-spi/src/main/java/io/trino/spi/function/TypeVariableConstraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/TypeVariableConstraint.java
@@ -15,6 +15,7 @@ package io.trino.spi.function;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
@@ -208,13 +209,9 @@ public class TypeVariableConstraint
         }
     }
 
-    /**
-     * This method is only visible for JSON deserialization.
-     *
-     * @deprecated use builder
-     */
-    @Deprecated
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
+    @Deprecated // Discourage usages in SPI consumers
     public static TypeVariableConstraint fromJson(
             @JsonProperty("name") String name,
             @JsonProperty("comparableRequired") boolean comparableRequired,

--- a/core/trino-spi/src/main/java/io/trino/spi/function/table/ScalarArgument.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/table/ScalarArgument.java
@@ -15,6 +15,7 @@ package io.trino.spi.function.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.predicate.NullableValue;
@@ -60,6 +61,7 @@ public class ScalarArgument
 
     // deserialization
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static ScalarArgument fromNullableValue(@JsonProperty("nullableValue") NullableValue nullableValue)
     {
         return new ScalarArgument(nullableValue.getType(), nullableValue.getValue());

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/NullableValue.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/NullableValue.java
@@ -15,6 +15,7 @@ package io.trino.spi.predicate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 
@@ -73,8 +74,8 @@ public final class NullableValue
         return new NullableValue(type, null);
     }
 
-    // Jackson deserialization only
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static NullableValue fromSerializable(@JsonProperty("serializable") Serializable serializable)
     {
         Type type = serializable.getType();

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -15,6 +15,7 @@ package io.trino.spi.predicate;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.DictionaryBlock;
@@ -136,8 +137,9 @@ public final class SortedRangeSet
                         .build());
     }
 
-    @Deprecated // For JSON deserialization only
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
+    @Deprecated // Discourage usages in SPI consumers
     public static SortedRangeSet fromJson(
             @JsonProperty("type") Type type,
             @JsonProperty("inclusive") boolean[] inclusive,

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -16,6 +16,7 @@ package io.trino.spi.predicate;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 
@@ -167,12 +168,9 @@ public final class TupleDomain<T>
                         })));
     }
 
-    /*
-     * This method is for JSON serialization only. Do not use.
-     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
-     */
-    @Deprecated
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
+    @Deprecated // Discourage usages in SPI consumers
     public static <T> TupleDomain<T> fromColumnDomains(@JsonProperty("columnDomains") Optional<List<ColumnDomain<T>>> columnDomains)
     {
         if (columnDomains.isEmpty()) {
@@ -182,12 +180,9 @@ public final class TupleDomain<T>
                 .collect(toLinkedMap(ColumnDomain::getColumn, ColumnDomain::getDomain)));
     }
 
-    /*
-     * This method is for JSON serialization only. Do not use.
-     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
-     */
-    @Deprecated
     @JsonProperty
+    @DoNotCall // For JSON serialization only
+    @Deprecated // Discourage usages in SPI consumers
     public Optional<List<ColumnDomain<T>>> getColumnDomains()
     {
         return domains.map(map -> map.entrySet().stream()

--- a/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnStatisticMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/statistics/ColumnStatisticMetadata.java
@@ -16,6 +16,7 @@ package io.trino.spi.statistics;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.Experimental;
 import io.trino.spi.expression.FunctionName;
 
@@ -71,8 +72,8 @@ public class ColumnStatisticMetadata
         }
     }
 
-    @Deprecated // For JSON deserialization only
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static ColumnStatisticMetadata fromJson(
             @JsonProperty("columnName") String columnName,
             @JsonProperty("connectorAggregationId") String connectorAggregationId,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryParameter.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryParameter.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 
@@ -51,6 +52,7 @@ public final class QueryParameter
     }
 
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static QueryParameter fromValueAsBlock(Optional<JdbcTypeHandle> jdbcType, Type type, Block valueBlock)
     {
         requireNonNull(type, "type is null");

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/DeltaLakeColumnStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/DeltaLakeColumnStatistics.java
@@ -15,6 +15,7 @@ package io.trino.plugin.deltalake.statistics;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.slice.Slices;
 import io.airlift.stats.cardinality.HyperLogLog;
 
@@ -29,7 +30,8 @@ public class DeltaLakeColumnStatistics
     private final HyperLogLog ndvSummary;
 
     @JsonCreator
-    public static DeltaLakeColumnStatistics create(
+    @DoNotCall // For JSON deserialization only
+    public static DeltaLakeColumnStatistics fromJson(
             @JsonProperty("totalSizeInBytes") OptionalLong totalSizeInBytes,
             @JsonProperty("ndvSummary") String ndvSummaryBase64)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePageSinkMetadata.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.metastore;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.DoNotCall;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.util.List;
@@ -43,6 +44,7 @@ public class HivePageSinkMetadata
     }
 
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static HivePageSinkMetadata deserialize(
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
             @JsonProperty("table") Optional<Table> table,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2709,10 +2709,10 @@ public class IcebergMetadata
                         originalHandle.getNameMappingJson(),
                         originalHandle.getTableLocation(),
                         originalHandle.getStorageProperties(),
-                        originalHandle.isRecordScannedFiles(),
+                        false, // recordScannedFiles does not affect stats
                         originalHandle.getMaxScannedFileSize(),
-                        originalHandle.getConstraintColumns(),
-                        originalHandle.getForAnalyze()),
+                        ImmutableSet.of(), // constraintColumns do not affect stats
+                        Optional.empty()), // forAnalyze does not affect stats
                 handle -> {
                     Table icebergTable = catalog.loadTable(session, handle.getSchemaTableName());
                     return TableStatisticsReader.getTableStatistics(typeManager, session, handle, icebergTable);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.units.DataSize;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
@@ -72,6 +73,7 @@ public class IcebergTableHandle
     private final Optional<Boolean> forAnalyze;
 
     @JsonCreator
+    @DoNotCall // For JSON deserialization only
     public static IcebergTableHandle fromJsonForDeserializationOnly(
             @JsonProperty("catalog") CatalogHandle catalog,
             @JsonProperty("schemaName") String schemaName,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableHandle.java
@@ -68,8 +68,8 @@ public class IcebergTableHandle
     private final boolean recordScannedFiles;
     private final Optional<DataSize> maxScannedFileSize;
 
-    // ANALYZE only
-    private final Optional<Set<String>> analyzeColumns;
+    // ANALYZE only. Coordinator-only
+    private final Optional<Boolean> forAnalyze;
 
     @JsonCreator
     public static IcebergTableHandle fromJsonForDeserializationOnly(
@@ -130,7 +130,7 @@ public class IcebergTableHandle
             boolean recordScannedFiles,
             Optional<DataSize> maxScannedFileSize,
             Set<IcebergColumnHandle> constraintColumns,
-            Optional<Set<String>> analyzeColumns)
+            Optional<Boolean> forAnalyze)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
@@ -150,7 +150,7 @@ public class IcebergTableHandle
         this.recordScannedFiles = recordScannedFiles;
         this.maxScannedFileSize = requireNonNull(maxScannedFileSize, "maxScannedFileSize is null");
         this.constraintColumns = ImmutableSet.copyOf(requireNonNull(constraintColumns, "constraintColumns is null"));
-        this.analyzeColumns = requireNonNull(analyzeColumns, "analyzeColumns is null");
+        this.forAnalyze = requireNonNull(forAnalyze, "forAnalyze is null");
     }
 
     @JsonProperty
@@ -263,9 +263,9 @@ public class IcebergTableHandle
     }
 
     @JsonIgnore
-    public Optional<Set<String>> getAnalyzeColumns()
+    public Optional<Boolean> getForAnalyze()
     {
-        return analyzeColumns;
+        return forAnalyze;
     }
 
     public SchemaTableName getSchemaTableName()
@@ -299,10 +299,10 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                analyzeColumns);
+                forAnalyze);
     }
 
-    public IcebergTableHandle withAnalyzeColumns(Optional<Set<String>> analyzeColumns)
+    public IcebergTableHandle forAnalyze()
     {
         return new IcebergTableHandle(
                 catalog,
@@ -323,7 +323,7 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                analyzeColumns);
+                Optional.of(true));
     }
 
     public IcebergTableHandle forOptimize(boolean recordScannedFiles, DataSize maxScannedFileSize)
@@ -347,7 +347,7 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 Optional.of(maxScannedFileSize),
                 constraintColumns,
-                analyzeColumns);
+                forAnalyze);
     }
 
     @Override
@@ -379,7 +379,7 @@ public class IcebergTableHandle
                 Objects.equals(storageProperties, that.storageProperties) &&
                 Objects.equals(maxScannedFileSize, that.maxScannedFileSize) &&
                 Objects.equals(constraintColumns, that.constraintColumns) &&
-                Objects.equals(analyzeColumns, that.analyzeColumns);
+                Objects.equals(forAnalyze, that.forAnalyze);
     }
 
     @Override
@@ -404,7 +404,7 @@ public class IcebergTableHandle
                 recordScannedFiles,
                 maxScannedFileSize,
                 constraintColumns,
-                analyzeColumns);
+                forAnalyze);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -188,7 +188,7 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                         false,
                         Optional.empty(),
                         ImmutableSet.of(),
-                        Optional.empty()),
+                        Optional.of(false)),
                 transaction);
 
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -160,7 +160,7 @@ public class TestIcebergSplitSource
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.of(false));
 
         try (IcebergSplitSource splitSource = new IcebergSplitSource(
                 fileSystemFactory,

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/optimizer/TestConnectorPushdownRulesWithIceberg.java
@@ -172,7 +172,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.of(false));
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle fullColumn = partialColumn.getBaseColumn();
@@ -256,7 +256,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.of(false));
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle column = new IcebergColumnHandle(primitiveColumnIdentity(1, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -307,7 +307,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.of(false));
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle columnA = new IcebergColumnHandle(primitiveColumnIdentity(0, "a"), INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
@@ -369,7 +369,7 @@ public class TestConnectorPushdownRulesWithIceberg
                 false,
                 Optional.empty(),
                 ImmutableSet.of(),
-                Optional.empty());
+                Optional.of(false));
         TableHandle table = new TableHandle(catalogHandle, icebergTable, new HiveTransactionHandle(false));
 
         IcebergColumnHandle bigintColumn = new IcebergColumnHandle(primitiveColumnIdentity(1, "just_bigint"), BIGINT, ImmutableList.of(), BIGINT, Optional.empty());

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -32,7 +32,6 @@ import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.DiscreteValues;
-import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.EquatableValueSet;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.Ranges;
@@ -503,10 +502,9 @@ public class KuduClientSession
         }
 
         Schema schema = table.getSchema();
-        for (TupleDomain.ColumnDomain<ColumnHandle> columnDomain : constraintSummary.getColumnDomains().get()) {
-            int position = ((KuduColumnHandle) columnDomain.getColumn()).getOrdinalPosition();
+        constraintSummary.getDomains().orElseThrow().forEach((columnHandle, domain) -> {
+            int position = ((KuduColumnHandle) columnHandle).getOrdinalPosition();
             ColumnSchema columnSchema = schema.getColumnByIndex(position);
-            Domain domain = columnDomain.getDomain();
             verify(!domain.isNone(), "Domain is none");
             if (domain.isAll()) {
                 // no restriction
@@ -560,7 +558,7 @@ public class KuduClientSession
                     throw new IllegalStateException("Unexpected domain: " + domain);
                 }
             }
-        }
+        });
     }
 
     private KuduPredicate createInListPredicate(ColumnSchema columnSchema, DiscreteValues discreteValues)


### PR DESCRIPTION


The information was not correct when ANALYZE was invoked without
`columns` parameter -- instead of all columns, an empty set was there.

The information can be replaced with a single boolean.