### PR TITLE
Fix loop index range in CombineHashFunction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/CombineHashFunction.java
@@ -36,7 +36,7 @@ public final class CombineHashFunction
     {
         checkFromToIndex(fromIndex, toIndex, hashes.length);
 
-        for (int i = 0; i < toIndex; i++) {
+        for (int i = fromIndex; i < toIndex; i++) {
             hashes[i] = (31 * hashes[i]) + value;
         }
     }


### PR DESCRIPTION
## Description
Fixes a bug introduced in https://github.com/trinodb/trino/pull/19759 that would accidentally loop from `0` instead of `fromIndex`. This has no correctness implications because currently `fromIndex` is always `0`, but might cause issues in the future if other usages are added.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: