### PR TITLE
Allow fetching relation names with their types

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1116,8 +1116,7 @@ public class TestTrinoDatabaseMetaData
                             databaseMetaData -> databaseMetaData.getTables(null, null, null, null),
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on catalog name
@@ -1127,8 +1126,7 @@ public class TestTrinoDatabaseMetaData
                             databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, null, null),
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on schema name
@@ -1142,8 +1140,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                             .build());
 
             // LIKE predicate on schema name
@@ -1157,8 +1154,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on table name
@@ -1171,8 +1167,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE"),
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // LIKE predicate on table name
@@ -1185,8 +1180,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE"),
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on schema name and table name
@@ -1197,8 +1191,8 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                            .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
+                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                            .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
@@ -1212,8 +1206,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listRelations")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // catalog does not exist
@@ -1530,8 +1523,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                             .build());
 
             // getTables's schema and table name patterns treated as literals
@@ -1542,8 +1534,8 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                            .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
+                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                            .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
@@ -1557,8 +1549,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema_)")
-                            .add("ConnectorMetadata.listRelations(schema=test_schema_)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema_)")
                             .build());
 
             // getColumns's schema and table name patterns treated as literals

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1117,7 +1117,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // Equality predicate on catalog name
@@ -1128,7 +1128,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // Equality predicate on schema name
@@ -1143,7 +1143,7 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .build());
 
             // LIKE predicate on schema name
@@ -1158,7 +1158,7 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // Equality predicate on table name
@@ -1172,7 +1172,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // LIKE predicate on table name
@@ -1186,7 +1186,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // Equality predicate on schema name and table name
@@ -1213,7 +1213,7 @@ public class TestTrinoDatabaseMetaData
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.listRelations")
                             .build());
 
             // catalog does not exist
@@ -1337,7 +1337,7 @@ public class TestTrinoDatabaseMetaData
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listSchemaNames")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
@@ -1357,7 +1357,7 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listSchemaNames")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
@@ -1395,10 +1395,10 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .addCopies("ConnectorMetadata.listSchemaNames", 5)
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema2)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema3_empty)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema4_empty)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema2)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema3_empty)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema4_empty)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 20)
                             .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 5)
                             .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 5)
@@ -1531,7 +1531,7 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .build());
 
             // getTables's schema and table name patterns treated as literals
@@ -1558,7 +1558,7 @@ public class TestTrinoDatabaseMetaData
                     list(),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listViews(schema=test_schema_)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema_)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema_)")
                             .build());
 
             // getColumns's schema and table name patterns treated as literals

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -299,7 +299,7 @@ public class InformationSchemaMetadata
         }
 
         Set<QualifiedTablePrefix> tablePrefixes = prefixes.stream()
-                .flatMap(prefix -> metadata.listTables(session, prefix).stream())
+                .flatMap(prefix -> metadata.listRelations(session, prefix).stream())
                 .filter(objectName -> predicate.get().test(asFixedValues(objectName)))
                 .map(QualifiedObjectName::asQualifiedTablePrefix)
                 .distinct()

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -53,10 +53,10 @@ import static io.trino.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
 import static io.trino.metadata.MetadataListing.getViews;
+import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
 import static io.trino.metadata.MetadataListing.listTablePrivileges;
-import static io.trino.metadata.MetadataListing.listTables;
 import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
@@ -275,7 +275,7 @@ public class InformationSchemaPageSource
 
     private void addTablesRecords(QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
+        Set<SchemaTableName> relations = listRelations(session, metadata, accessControl, prefix);
         boolean needsTableType = requiredColumns.contains("table_type");
         Set<SchemaTableName> views = Set.of();
         if (needsTableType) {
@@ -284,7 +284,7 @@ public class InformationSchemaPageSource
         }
         // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views
 
-        for (SchemaTableName name : tables) {
+        for (SchemaTableName name : relations) {
             String type = null;
             if (needsTableType) {
                 // if table and view names overlap, the view wins

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -26,6 +26,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GrantInfo;
@@ -37,6 +38,7 @@ import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
@@ -52,12 +54,12 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
+import static io.trino.metadata.MetadataListing.getRelationTypes;
 import static io.trino.metadata.MetadataListing.getViews;
 import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
 import static io.trino.metadata.MetadataListing.listTablePrivileges;
-import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.type.TypeUtils.getDisplayLabel;
@@ -245,7 +247,7 @@ public class InformationSchemaPageSource
 
     private void addColumnsRecords(QualifiedTablePrefix prefix)
     {
-        for (Map.Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+        for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
             SchemaTableName tableName = entry.getKey();
             long ordinalPosition = 1;
 
@@ -275,12 +277,20 @@ public class InformationSchemaPageSource
 
     private void addTablesRecords(QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> relations = listRelations(session, metadata, accessControl, prefix);
         boolean needsTableType = requiredColumns.contains("table_type");
-        Set<SchemaTableName> views = Set.of();
+        Set<SchemaTableName> relations;
+        Set<SchemaTableName> views;
         if (needsTableType) {
-            // TODO introduce a dedicated method for getting relations with their type from the connector, instead of calling (potentially much more expensive) getViews
-            views = listViews(session, metadata, accessControl, prefix);
+            Map<SchemaTableName, RelationType> relationTypes = getRelationTypes(session, metadata, accessControl, prefix);
+            relations = relationTypes.keySet();
+            views = relationTypes.entrySet().stream()
+                    .filter(entry -> entry.getValue() == RelationType.VIEW)
+                    .map(Entry::getKey)
+                    .collect(toImmutableSet());
+        }
+        else {
+            relations = listRelations(session, metadata, accessControl, prefix);
+            views = Set.of();
         }
         // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views
 
@@ -304,7 +314,7 @@ public class InformationSchemaPageSource
 
     private void addViewsRecords(QualifiedTablePrefix prefix)
     {
-        for (Map.Entry<SchemaTableName, ViewInfo> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
+        for (Entry<SchemaTableName, ViewInfo> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
             addRecord(
                     prefix.getCatalogName(),
                     entry.getKey().getSchemaName(),

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -69,9 +69,9 @@ import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
 import static io.trino.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
+import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
-import static io.trino.metadata.MetadataListing.listTables;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -211,7 +211,7 @@ public class ColumnJdbcTable
                     QualifiedTablePrefix tablePrefix = tableFilter.isPresent()
                             ? new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName(), tableFilter.get())
                             : new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName());
-                    return listTables(session, metadata, accessControl, tablePrefix).stream()
+                    return listRelations(session, metadata, accessControl, tablePrefix).stream()
                             .filter(schemaTableName -> predicate.test(ImmutableMap.of(
                                     TABLE_CATALOG_COLUMN, toNullableValue(schema.getCatalogName()),
                                     TABLE_SCHEMA_COLUMN, toNullableValue(schemaTableName.getSchemaName()),
@@ -278,7 +278,7 @@ public class ColumnJdbcTable
                     QualifiedTablePrefix tablePrefix = tableFilter.isPresent()
                             ? new QualifiedTablePrefix(catalog, schema, tableFilter.get())
                             : new QualifiedTablePrefix(catalog, schema);
-                    Set<SchemaTableName> tables = listTables(session, metadata, accessControl, tablePrefix);
+                    Set<SchemaTableName> tables = listRelations(session, metadata, accessControl, tablePrefix);
                     for (SchemaTableName schemaTableName : tables) {
                         String tableName = schemaTableName.getTableName();
                         if (!tableDomain.includesNullableValue(utf8Slice(tableName))) {

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
@@ -37,7 +37,7 @@ import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
 import static io.trino.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
-import static io.trino.metadata.MetadataListing.listTables;
+import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -105,7 +105,7 @@ public class TableJdbcTable
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
             Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
-            for (SchemaTableName name : listTables(session, metadata, accessControl, prefix)) {
+            for (SchemaTableName name : listRelations(session, metadata, accessControl, prefix)) {
                 boolean isView = views.contains(name);
                 if ((includeTables && !isView) || (includeViews && isView)) {
                     table.addRow(tableRow(catalog, name, isView ? "VIEW" : "TABLE"));

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/TableJdbcTable.java
@@ -26,19 +26,18 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.InMemoryRecordSet.Builder;
 import io.trino.spi.connector.RecordCursor;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
 import static io.trino.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
+import static io.trino.metadata.MetadataListing.getRelationTypes;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
-import static io.trino.metadata.MetadataListing.listRelations;
-import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -104,13 +103,12 @@ public class TableJdbcTable
         for (String catalog : listCatalogNames(session, metadata, accessControl, catalogDomain)) {
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
-            Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
-            for (SchemaTableName name : listRelations(session, metadata, accessControl, prefix)) {
-                boolean isView = views.contains(name);
+            getRelationTypes(session, metadata, accessControl, prefix).forEach((name, type) -> {
+                boolean isView = type == RelationType.VIEW;
                 if ((includeTables && !isView) || (includeViews && isView)) {
                     table.addRow(tableRow(catalog, name, isView ? "VIEW" : "TABLE"));
                 }
-            }
+            });
         }
         return table.build().cursor();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -86,6 +86,6 @@ public class DropSchemaTask
         QualifiedTablePrefix tablePrefix = new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName());
 
         // This is a best effort check that doesn't provide any guarantees against concurrent DDL operations
-        return metadata.listTables(session, tablePrefix).isEmpty();
+        return metadata.listRelations(session, tablePrefix).isEmpty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -162,7 +162,7 @@ public interface Metadata
      * Get the relation names that match the specified table prefix (never null).
      * This includes all relations (e.g. tables, views, materialized views).
      */
-    List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix);
+    List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Gets all of the columns on the specified table, or an empty map if the columns cannot be enumerated.

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -37,6 +37,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -163,6 +164,12 @@ public interface Metadata
      * This includes all relations (e.g. tables, views, materialized views).
      */
     List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix);
+
+    /**
+     * Get the relation names that match the specified table prefix (never null).
+     * This includes all relations (e.g. tables, views, materialized views).
+     */
+    Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Gets all of the columns on the specified table, or an empty map if the columns cannot be enumerated.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -22,6 +22,7 @@ import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.predicate.Domain;
@@ -46,6 +47,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_REDIRECTION_ERROR;
+import static java.util.function.Function.identity;
 
 public final class MetadataListing
 {
@@ -133,22 +135,29 @@ public final class MetadataListing
         return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
     }
 
-    public static Set<SchemaTableName> listViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Map<SchemaTableName, RelationType> getRelationTypes(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
         try {
-            return doListViews(session, metadata, accessControl, prefix);
+            return doGetRelationTypes(session, metadata, accessControl, prefix);
         }
         catch (RuntimeException exception) {
-            throw handleListingException(exception, "views", prefix.getCatalogName());
+            throw handleListingException(exception, "tables", prefix.getCatalogName());
         }
     }
 
-    private static Set<SchemaTableName> doListViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    private static Map<SchemaTableName, RelationType> doGetRelationTypes(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tableNames = metadata.listViews(session, prefix).stream()
-                .map(QualifiedObjectName::asSchemaTableName)
-                .collect(toImmutableSet());
-        return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
+        Map<SchemaTableName, RelationType> relationTypes = metadata.getRelationTypes(session, prefix);
+
+        // Table listing operation only involves getting table names, but not any metadata. So redirected tables are not
+        // handled any differently. The target table or catalog are not involved. Thus the following filter is only called
+        // for the source catalog on source table names.
+        Set<SchemaTableName> accessibleNames = accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), relationTypes.keySet());
+        if (accessibleNames.equals(relationTypes.keySet())) {
+            return relationTypes;
+        }
+        return accessibleNames.stream()
+                .collect(toImmutableMap(identity(), relationTypes::get));
     }
 
     public static Map<SchemaTableName, ViewInfo> getViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -111,19 +111,19 @@ public final class MetadataListing
         return ImmutableSortedSet.copyOf(accessControl.filterSchemas(session.toSecurityContext(), catalogName, schemaNames));
     }
 
-    public static Set<SchemaTableName> listTables(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Set<SchemaTableName> listRelations(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
         try {
-            return doListTables(session, metadata, accessControl, prefix);
+            return doListRelations(session, metadata, accessControl, prefix);
         }
         catch (RuntimeException exception) {
             throw handleListingException(exception, "tables", prefix.getCatalogName());
         }
     }
 
-    private static Set<SchemaTableName> doListTables(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    private static Set<SchemaTableName> doListRelations(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tableNames = metadata.listTables(session, prefix).stream()
+        Set<SchemaTableName> tableNames = metadata.listRelations(session, prefix).stream()
                 .map(QualifiedObjectName::asSchemaTableName)
                 .collect(toImmutableSet());
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -502,7 +502,7 @@ public final class MetadataManager
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
         if (cannotExist(prefix)) {
@@ -518,7 +518,7 @@ public final class MetadataManager
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
-        Set<QualifiedObjectName> tables = new LinkedHashSet<>();
+        Set<QualifiedObjectName> relations = new LinkedHashSet<>();
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
 
@@ -528,13 +528,13 @@ public final class MetadataManager
                 if (isExternalInformationSchema(catalogHandle, prefix.getSchemaName())) {
                     continue;
                 }
-                metadata.listTables(connectorSession, prefix.getSchemaName()).stream()
+                metadata.listRelations(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .filter(table -> !isExternalInformationSchema(catalogHandle, table.getSchemaName()))
-                        .forEach(tables::add);
+                        .forEach(relations::add);
             }
         }
-        return ImmutableList.copyOf(tables);
+        return ImmutableList.copyOf(relations);
     }
 
     private Optional<Boolean> isExistingRelationForListing(Session session, QualifiedObjectName name)

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -69,6 +69,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -511,10 +512,11 @@ public final class MetadataManager
 
         Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
         if (objectName.isPresent()) {
-            Optional<Boolean> exists = isExistingRelationForListing(session, objectName.get());
-            if (exists.isPresent()) {
-                return exists.get() ? ImmutableList.of(objectName.get()) : ImmutableList.of();
+            Optional<RelationType> relationType = getRelationTypeIfExists(session, objectName.get());
+            if (relationType.isPresent()) {
+                return ImmutableList.of(objectName.get());
             }
+            // TODO we can probably return empty lit here
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
@@ -537,25 +539,63 @@ public final class MetadataManager
         return ImmutableList.copyOf(relations);
     }
 
-    private Optional<Boolean> isExistingRelationForListing(Session session, QualifiedObjectName name)
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+        if (cannotExist(prefix)) {
+            return ImmutableMap.of();
+        }
+
+        Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
+        if (objectName.isPresent()) {
+            Optional<RelationType> relationType = getRelationTypeIfExists(session, objectName.get());
+            if (relationType.isPresent()) {
+                return ImmutableMap.of(objectName.get().asSchemaTableName(), relationType.get());
+            }
+            return ImmutableMap.of();
+        }
+
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
+        Map<SchemaTableName, RelationType> relationTypes = new LinkedHashMap<>();
+        if (catalog.isPresent()) {
+            CatalogMetadata catalogMetadata = catalog.get();
+
+            for (CatalogHandle catalogHandle : catalogMetadata.listCatalogHandles()) {
+                ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+                ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
+                if (isExternalInformationSchema(catalogHandle, prefix.getSchemaName())) {
+                    continue;
+                }
+                metadata.getRelationTypes(connectorSession, prefix.getSchemaName()).entrySet().stream()
+                        .filter(entry -> !isExternalInformationSchema(catalogHandle, entry.getKey().getSchemaName()))
+                        .forEach(entry -> relationTypes.put(entry.getKey(), entry.getValue()));
+            }
+        }
+        return ImmutableMap.copyOf(relationTypes);
+    }
+
+    private Optional<RelationType> getRelationTypeIfExists(Session session, QualifiedObjectName name)
     {
         if (isMaterializedView(session, name)) {
-            return Optional.of(true);
+            return Optional.of(RelationType.MATERIALIZED_VIEW);
         }
         if (isView(session, name)) {
-            return Optional.of(true);
+            return Optional.of(RelationType.VIEW);
         }
 
         // TODO: consider a better way to resolve relation names: https://github.com/trinodb/trino/issues/9400
         try {
-            return Optional.of(getRedirectionAwareTableHandle(session, name).tableHandle().isPresent());
+            if (getRedirectionAwareTableHandle(session, name).tableHandle().isPresent()) {
+                return Optional.of(RelationType.TABLE);
+            }
+            return Optional.empty();
         }
         catch (TrinoException e) {
             // ignore redirection errors for consistency with listing
             if (e.getErrorCode().equals(TABLE_REDIRECTION_ERROR.toErrorCode())) {
-                return Optional.of(true);
+                return Optional.of(RelationType.TABLE);
             }
-            // we don't know if it exists or not
             return Optional.empty();
         }
     }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -810,14 +810,14 @@ public class LocalQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {
             return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
-                        return getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema));
+                        return getMetadata().listRelations(transactionSession, new QualifiedTablePrefix(catalog, schema));
                     });
         }
         finally {

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -93,7 +93,7 @@ public interface QueryRunner
         throw new UnsupportedOperationException();
     }
 
-    List<QualifiedObjectName> listTables(Session session, String catalog, String schema);
+    List<QualifiedObjectName> listRelations(Session session, String catalog, String schema);
 
     boolean tableExists(Session session, String table);
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
@@ -127,7 +127,7 @@ public class TestingMetadata
         requireNonNull(prefix, "prefix is null");
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> tableColumns = ImmutableMap.builder();
-        for (SchemaTableName tableName : listTables(session, prefix.getSchema())) {
+        for (SchemaTableName tableName : listRelations(session, prefix.getSchema())) {
             ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
             for (ColumnMetadata column : tables.get(tableName).getColumns()) {
                 columns.add(new ColumnMetadata(column.getName(), column.getType()));

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -259,6 +259,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("listRelations", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRelations(session, schemaName);
+        }
+    }
+
+    @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         Span span = startSpan("listTables", schemaName);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -51,6 +51,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
@@ -273,6 +274,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("listTables", schemaName);
         try (var ignored = scopedSpan(span)) {
             return delegate.listTables(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("getRelationTypes", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRelationTypes(session, schemaName);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -309,11 +309,11 @@ public class TracingMetadata
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
-        Span span = startSpan("listTables", prefix);
+        Span span = startSpan("listRelations", prefix);
         try (var ignored = scopedSpan(span)) {
-            return delegate.listTables(session, prefix);
+            return delegate.listRelations(session, prefix);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -65,6 +65,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -314,6 +315,15 @@ public class TracingMetadata
         Span span = startSpan("listRelations", prefix);
         try (var ignored = scopedSpan(span)) {
             return delegate.listRelations(session, prefix);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("getRelationTypes", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRelationTypes(session, prefix);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -310,7 +310,7 @@ public abstract class BaseDataDefinitionTaskTest
         }
 
         @Override
-        public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+        public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
         {
             List<QualifiedObjectName> tables = ImmutableList.<QualifiedObjectName>builder()
                     .addAll(this.tables.keySet().stream().map(table -> new QualifiedObjectName(catalogName, table.getSchemaName(), table.getTableName())).collect(toImmutableList()))

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -43,6 +43,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -228,6 +229,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -227,7 +227,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -284,6 +284,28 @@ public interface ConnectorMetadata
     }
 
     /**
+     * List table, view and materialized view names, possibly filtered by schema.
+     */
+    default Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        Set<SchemaTableName> materializedViews = Set.copyOf(listMaterializedViews(session, schemaName));
+        Set<SchemaTableName> views = Set.copyOf(listViews(session, schemaName));
+
+        return listRelations(session, schemaName).stream()
+                .collect(toMap(
+                        identity(),
+                        relatioNname -> {
+                            if (materializedViews.contains(relatioNname)) {
+                                return RelationType.MATERIALIZED_VIEW;
+                            }
+                            if (views.contains(relatioNname)) {
+                                return RelationType.VIEW;
+                            }
+                            return RelationType.TABLE;
+                        }));
+    }
+
+    /**
      * @deprecated Use {@link #listRelations(ConnectorSession, Optional)} instead.
      */
     @Deprecated(forRemoval = true)

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/RelationType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/RelationType.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public enum RelationType
+{
+    TABLE,
+    VIEW,
+    MATERIALIZED_VIEW,
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -51,6 +51,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
@@ -299,6 +300,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.listTables(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getRelationTypes(session, schemaName);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -287,6 +287,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listRelations(session, schemaName);
+        }
+    }
+
+    @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
@@ -377,7 +377,7 @@ public class TestBlackHoleSmoke
 
     private List<QualifiedObjectName> listBlackHoleTables()
     {
-        return queryRunner.listTables(queryRunner.getDefaultSession(), "blackhole", "default");
+        return queryRunner.listRelations(queryRunner.getDefaultSession(), "blackhole", "default");
     }
 
     private void assertThatQueryReturnsValue(String sql, Object expected)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -63,7 +63,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         // it would be nice to filter out non-Delta tables; however, we can not call
         // metastore.getTablesWithParameter(schema, TABLE_PROVIDER_PROP, TABLE_PROVIDER_VALUE), because that property
         // contains a dot and must be compared case-insensitive
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -38,8 +38,8 @@ import java.util.Optional;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.CREATE_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.DROP_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_DATABASES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -262,7 +262,7 @@ public class TestDeltaLakeMetastoreAccessOperations
         assertMetastoreInvocations("SHOW TABLES",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .build());
     }
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -17,6 +17,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExampleMetadata.java
+++ b/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExampleMetadata.java
@@ -104,23 +104,23 @@ public class TestExampleMetadata
     }
 
     @Test
-    public void testListTables()
+    public void testListRelations()
     {
         // all schemas
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.empty()))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.empty()))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem")));
 
         // specific schema
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("example")))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("example")))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("example", "numbers")));
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("tpch")))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("tpch")))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem")));
 
         // unknown schema
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("unknown")))).isEqualTo(ImmutableSet.of());
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("unknown")))).isEqualTo(ImmutableSet.of());
     }
 
     @Test

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemAbfs.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemAbfs.java
@@ -91,7 +91,7 @@ public abstract class AbstractTestHiveFileSystemAbfs
                             .put(BUCKETED_BY_PROPERTY, ImmutableList.of())
                             .put(SORTED_BY_PROPERTY, ImmutableList.of())
                             .buildOrThrow());
-            if (!transaction.getMetadata().listTables(newSession(), Optional.of(table.getSchemaName())).contains(table)) {
+            if (!transaction.getMetadata().listRelations(newSession(), Optional.of(table.getSchemaName())).contains(table)) {
                 transaction.getMetadata().createTable(newSession(), tableMetadata, false);
             }
             transaction.commit();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.errorprone.annotations.DoNotCall;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
@@ -789,13 +790,20 @@ public class HiveMetadata
     }
 
     @Override
-    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> optionalSchemaName)
+    @DoNotCall
+    public final List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        throw new UnsupportedOperationException("This method is not supported because listRelations is implemented instead");
+    }
+
+    @Override
+    public List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> optionalSchemaName)
     {
         if (optionalSchemaName.isEmpty()) {
-            Optional<List<SchemaTableName>> allTables = metastore.getAllTables();
-            if (allTables.isPresent()) {
+            Optional<List<SchemaTableName>> relations = metastore.getRelations();
+            if (relations.isPresent()) {
                 return ImmutableSet.<SchemaTableName>builder()
-                        .addAll(allTables.get().stream()
+                        .addAll(relations.get().stream()
                                 .filter(table -> !isHiveSystemSchema(table.getSchemaName()))
                                 .collect(toImmutableList()))
                         .addAll(listMaterializedViews(session, optionalSchemaName))
@@ -803,15 +811,15 @@ public class HiveMetadata
                         .asList();
             }
         }
-        ImmutableSet.Builder<SchemaTableName> tableNames = ImmutableSet.builder();
+        ImmutableSet.Builder<SchemaTableName> relations = ImmutableSet.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllTables(schemaName)) {
-                tableNames.add(new SchemaTableName(schemaName, tableName));
+            for (String tableName : metastore.getRelations(schemaName)) {
+                relations.add(new SchemaTableName(schemaName, tableName));
             }
         }
 
-        tableNames.addAll(listMaterializedViews(session, optionalSchemaName));
-        return tableNames.build().asList();
+        relations.addAll(listMaterializedViews(session, optionalSchemaName));
+        return relations.build().asList();
     }
 
     private List<String> listSchemas(ConnectorSession session, Optional<String> schemaName)
@@ -910,7 +918,7 @@ public class HiveMetadata
             return ImmutableList.of();
         }
         if (prefix.getTable().isEmpty()) {
-            return listTables(session, prefix.getSchema());
+            return listRelations(session, prefix.getSchema());
         }
         SchemaTableName tableName = prefix.toSchemaTableName();
 
@@ -967,7 +975,7 @@ public class HiveMetadata
         if (cascade) {
             // List all objects first because such operations after adding/dropping/altering tables/views in a transaction is disallowed
             List<SchemaTableName> views = listViews(session, Optional.of(schemaName));
-            List<SchemaTableName> tables = listTables(session, Optional.of(schemaName)).stream()
+            List<SchemaTableName> tables = listRelations(session, Optional.of(schemaName)).stream()
                     .filter(table -> !views.contains(table))
                     .collect(toImmutableList());
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -154,14 +154,14 @@ public class HiveMetastoreClosure
         delegate.updatePartitionStatistics(table, updates);
     }
 
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     public List<String> getAllViews(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -30,6 +30,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.function.LanguageFunction;
@@ -162,6 +163,16 @@ public class HiveMetastoreClosure
     public Optional<List<SchemaTableName>> getRelations()
     {
         return delegate.getRelations();
+    }
+
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return delegate.getRelationTypes();
     }
 
     public List<String> getAllViews(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
@@ -67,7 +67,7 @@ public class CoralSemiTransactionalHiveMSCAdapter
     @Override
     public List<String> getAllTables(String dbName)
     {
-        return delegate.getAllTables(dbName);
+        return delegate.getRelations(dbName);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -111,15 +111,15 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -120,6 +121,18 @@ public abstract class ForwardingHiveMetastore
     public Optional<List<SchemaTableName>> getRelations()
     {
         return delegate.getRelations();
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return delegate.getRelationTypes();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -23,6 +23,7 @@ import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -68,6 +69,13 @@ public interface HiveMetastore
      * @return List of tables, views and materialized views names from all schemas or Optional.empty if operation is not supported
      */
     Optional<List<SchemaTableName>> getRelations();
+
+    Map<String, RelationType> getRelationTypes(String databaseName);
+
+    /**
+     * @return empty if operation is not supported
+     */
+    Optional<Map<SchemaTableName, RelationType>> getRelationTypes();
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -62,12 +62,12 @@ public interface HiveMetastore
 
     void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
 
-    List<String> getAllTables(String databaseName);
+    List<String> getRelations(String databaseName);
 
     /**
      * @return List of tables, views and materialized views names from all schemas or Optional.empty if operation is not supported
      */
-    Optional<List<SchemaTableName>> getAllTables();
+    Optional<List<SchemaTableName>> getRelations();
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -234,22 +234,22 @@ public class SemiTransactionalHiveMetastore
         return delegate.getDatabase(databaseName);
     }
 
-    public synchronized List<String> getAllTables(String databaseName)
+    public synchronized List<String> getRelations(String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
-            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
-    public synchronized Optional<List<SchemaTableName>> getAllTables()
+    public synchronized Optional<List<SchemaTableName>> getRelations()
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
-            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     public synchronized Optional<Table> getTable(String databaseName, String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -52,6 +52,7 @@ import io.trino.plugin.hive.security.SqlStandardAccessControlMetadataMetastore;
 import io.trino.plugin.hive.util.ValidTxnWriteIdList;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -250,6 +251,24 @@ public class SemiTransactionalHiveMetastore
             throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
         }
         return delegate.getRelations();
+    }
+
+    public synchronized Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    public synchronized Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getRelationTypes();
     }
 
     public synchronized Optional<Table> getTable(String databaseName, String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -249,16 +249,16 @@ public class SharedHiveMetastoreCache
 
         @Managed
         @Nested
-        public AggregateCacheStatsMBean getTableNamesStats()
+        public AggregateCacheStatsMBean getRelationNamesStats()
         {
-            return new AggregateCacheStatsMBean(CachingHiveMetastore::getTableNamesCache);
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getRelationNamesCache);
         }
 
         @Managed
         @Nested
-        public AggregateCacheStatsMBean getAllTableNamesStats()
+        public AggregateCacheStatsMBean getAllRelationNamesStats()
         {
-            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllTableNamesCache);
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllRelationNamesCache);
         }
 
         @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -256,9 +256,23 @@ public class SharedHiveMetastoreCache
 
         @Managed
         @Nested
+        public AggregateCacheStatsMBean getRelationTypesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getRelationTypesCache);
+        }
+
+        @Managed
+        @Nested
         public AggregateCacheStatsMBean getAllRelationNamesStats()
         {
             return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllRelationNamesCache);
+        }
+
+        @Managed
+        @Nested
+        public AggregateCacheStatsMBean getAllRelationTypesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllRelationTypesCache);
         }
 
         @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -56,6 +56,7 @@ import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompat
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -519,6 +520,21 @@ public class FileHiveMetastore
 
     @Override
     public Optional<List<SchemaTableName>> getRelations()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public synchronized Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
+        getRelations(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
+        return relationTypes.buildKeepingLast();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -214,7 +214,7 @@ public class FileHiveMetastore
         databaseName = databaseName.toLowerCase(ENGLISH);
 
         getRequiredDatabase(databaseName);
-        if (!getAllTables(databaseName).isEmpty()) {
+        if (!getRelations(databaseName).isEmpty()) {
             throw new TrinoException(HIVE_METASTORE_ERROR, "Database " + databaseName + " is not empty");
         }
 
@@ -508,7 +508,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized List<String> getAllTables(String databaseName)
+    public synchronized List<String> getRelations(String databaseName)
     {
         return listAllTables(databaseName).stream()
                 .filter(hideDeltaLakeTables
@@ -518,7 +518,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return Optional.empty();
     }
@@ -590,7 +590,7 @@ public class FileHiveMetastore
     @Override
     public synchronized List<String> getAllViews(String databaseName)
     {
-        return getAllTables(databaseName).stream()
+        return getRelations(databaseName).stream()
                 .map(tableName -> getTable(databaseName, tableName))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -423,13 +423,13 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         return getTableNames(databaseName, tableFilter);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -102,6 +102,7 @@ import io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.GluePa
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -430,6 +431,37 @@ public class GlueHiveMetastore
 
     @Override
     public Optional<List<SchemaTableName>> getRelations()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        try {
+            return getGlueTables(databaseName)
+                    .filter(tableFilter.or(SOME_KIND_OF_VIEW_FILTER))
+                    .collect(toImmutableMap(
+                            com.amazonaws.services.glue.model.Table::getName,
+                            table -> {
+                                // GlueHiveMetastore currently does not distinguish views and materialized views, see getAllViews().
+                                if (SOME_KIND_OF_VIEW_FILTER.test(table)) {
+                                    return RelationType.VIEW;
+                                }
+                                return RelationType.TABLE;
+                            }));
+        }
+        catch (EntityNotFoundException | AccessDeniedException e) {
+            // database does not exist or permission denied
+            return ImmutableMap.of();
+        }
+        catch (AmazonServiceException e) {
+            throw new TrinoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -141,7 +141,7 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         return delegate.getAllTables(databaseName);
     }
@@ -159,7 +159,7 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return delegate.getAllTables();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -34,6 +34,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -147,6 +148,15 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
+        getRelations(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
+        return relationTypes.buildKeepingLast();
+    }
+
+    @Override
     public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
@@ -162,6 +172,17 @@ public class BridgingHiveMetastore
     public Optional<List<SchemaTableName>> getRelations()
     {
         return delegate.getAllTables();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return getRelations().flatMap(relations -> getAllViews().map(views -> {
+            ImmutableMap.Builder<SchemaTableName, RelationType> relationTypes = ImmutableMap.builder();
+            relations.forEach(name -> relationTypes.put(name, RelationType.TABLE));
+            views.forEach(name -> relationTypes.put(name, RelationType.VIEW));
+            return relationTypes.buildKeepingLast();
+        }));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -169,27 +169,27 @@ public class TracingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        Span span = tracer.spanBuilder("HiveMetastore.getAllTables")
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
                 .setAttribute(SCHEMA, databaseName)
                 .startSpan();
         return withTracing(span, () -> {
-            List<String> tables = delegate.getAllTables(databaseName);
-            span.setAttribute(TABLE_RESPONSE_COUNT, tables.size());
-            return tables;
+            List<String> relations = delegate.getRelations(databaseName);
+            span.setAttribute(TABLE_RESPONSE_COUNT, relations.size());
+            return relations;
         });
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        Span span = tracer.spanBuilder("HiveMetastore.getAllTables")
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
                 .startSpan();
         return withTracing(span, () -> {
-            Optional<List<SchemaTableName>> tables = delegate.getAllTables();
-            tables.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
-            return tables;
+            Optional<List<SchemaTableName>> relations = delegate.getRelations();
+            relations.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
+            return relations;
         });
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -31,6 +31,7 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -190,6 +191,31 @@ public class TracingHiveMetastore
             Optional<List<SchemaTableName>> relations = delegate.getRelations();
             relations.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
             return relations;
+        });
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        Span span = tracer.spanBuilder("HiveMetastore.getRelationTypes")
+                .setAttribute(SCHEMA, databaseName)
+                .startSpan();
+        return withTracing(span, () -> {
+            Map<String, RelationType> relationTypes = delegate.getRelationTypes(databaseName);
+            span.setAttribute(TABLE_RESPONSE_COUNT, relationTypes.size());
+            return relationTypes;
+        });
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
+                .startSpan();
+        return withTracing(span, () -> {
+            Optional<Map<SchemaTableName, RelationType>> relationTypes = delegate.getRelationTypes();
+            relationTypes.ifPresent(map -> span.setAttribute(TABLE_RESPONSE_COUNT, map.size()));
+            return relationTypes;
         });
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1062,7 +1062,7 @@ public abstract class AbstractTestHive
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.of(database));
+            List<SchemaTableName> tables = metadata.listRelations(newSession(), Optional.of(database));
             assertThat(tables).contains(tablePartitionFormat);
             assertThat(tables).contains(tableUnpartitioned);
         }
@@ -1073,7 +1073,7 @@ public abstract class AbstractTestHive
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.empty());
+            List<SchemaTableName> tables = metadata.listRelations(newSession(), Optional.empty());
             assertThat(tables).contains(tablePartitionFormat);
             assertThat(tables).contains(tableUnpartitioned);
         }
@@ -1108,7 +1108,7 @@ public abstract class AbstractTestHive
             ConnectorMetadata metadata = transaction.getMetadata();
             ConnectorSession session = newSession();
             assertThat(metadata.getTableHandle(session, new SchemaTableName(INVALID_DATABASE, INVALID_TABLE))).isNull();
-            assertThat(metadata.listTables(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
+            assertThat(metadata.listRelations(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
             assertThat(listTableColumns(metadata, session, new SchemaTablePrefix(INVALID_DATABASE, INVALID_TABLE))).isEqualTo(ImmutableMap.of());
             assertThat(metadata.listViews(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
             assertThat(metadata.getViews(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableMap.of());
@@ -3204,11 +3204,11 @@ public abstract class AbstractTestHive
                 //  as information_schema or MetadataManager may apply additional logic
 
                 // list all tables
-                assertThat(metadata.listTables(session, Optional.empty()))
+                assertThat(metadata.listRelations(session, Optional.empty()))
                         .doesNotContain(tableName);
 
                 // list all tables in a schema
-                assertThat(metadata.listTables(session, Optional.of(tableName.getSchemaName())))
+                assertThat(metadata.listRelations(session, Optional.of(tableName.getSchemaName())))
                         .doesNotContain(tableName);
 
                 // list all columns in a schema

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -177,7 +177,7 @@ public abstract class AbstractTestHiveLocal
             throws IOException
     {
         try {
-            for (String tableName : metastoreClient.getAllTables(database)) {
+            for (String tableName : metastoreClient.getRelations(database)) {
                 metastoreClient.dropTable(database, tableName, true);
             }
             metastoreClient.dropDatabase(testDbName, true);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -35,8 +35,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS;
 
 @ThreadSafe
 public class CountingAccessHiveMetastore
@@ -50,8 +50,8 @@ public class CountingAccessHiveMetastore
         GET_ALL_DATABASES,
         GET_DATABASE,
         GET_TABLE,
-        GET_ALL_TABLES,
-        GET_ALL_TABLES_FROM_DATABASE,
+        GET_RELATIONS,
+        GET_RELATIONS_FROM_DATABASE,
         GET_TABLES_WITH_PARAMETER,
         GET_TABLE_STATISTICS,
         GET_ALL_VIEWS,
@@ -355,20 +355,20 @@ public class CountingAccessHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        methodInvocations.add(Method.GET_ALL_TABLES_FROM_DATABASE);
-        return delegate.getAllTables(databaseName);
+        methodInvocations.add(Method.GET_RELATIONS_FROM_DATABASE);
+        return delegate.getRelations(databaseName);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        Optional<List<SchemaTableName>> allTables = delegate.getAllTables();
-        if (allTables.isPresent()) {
-            methodInvocations.add(GET_ALL_TABLES);
+        Optional<List<SchemaTableName>> relations = delegate.getRelations();
+        if (relations.isPresent()) {
+            methodInvocations.add(GET_RELATIONS);
         }
-        return allTables;
+        return relations;
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -22,6 +22,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -37,6 +38,7 @@ import java.util.function.Function;
 
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATION_TYPES;
 
 @ThreadSafe
 public class CountingAccessHiveMetastore
@@ -52,6 +54,8 @@ public class CountingAccessHiveMetastore
         GET_TABLE,
         GET_RELATIONS,
         GET_RELATIONS_FROM_DATABASE,
+        GET_RELATION_TYPES,
+        GET_RELATION_TYPES_FROM_DATABASE,
         GET_TABLES_WITH_PARAMETER,
         GET_TABLE_STATISTICS,
         GET_ALL_VIEWS,
@@ -369,6 +373,23 @@ public class CountingAccessHiveMetastore
             methodInvocations.add(GET_RELATIONS);
         }
         return relations;
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        methodInvocations.add(Method.GET_RELATION_TYPES_FROM_DATABASE);
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        Optional<Map<SchemaTableName, RelationType>> relationTypes = delegate.getRelationTypes();
+        if (relationTypes.isPresent()) {
+            methodInvocations.add(GET_RELATION_TYPES);
+        }
+        return relationTypes;
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -93,6 +94,18 @@ public class UnimplementedHiveMetastore
 
     @Override
     public Optional<List<SchemaTableName>> getRelations()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -86,13 +86,13 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -181,7 +181,7 @@ public class TestCachingHiveMetastore
                 .usesCache();
 
         assertThatCachingWithDisabledPartitionCache()
-                .whenExecuting(testedMetastore -> testedMetastore.getAllTables(TEST_DATABASE))
+                .whenExecuting(testedMetastore -> testedMetastore.getRelations(TEST_DATABASE))
                 .usesCache();
 
         assertThatCachingWithDisabledPartitionCache()
@@ -227,49 +227,49 @@ public class TestCachingHiveMetastore
     }
 
     @Test
-    public void testGetAllTable()
+    public void testGetRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getTableNamesStats().getRequestCount()).isEqualTo(2);
-        assertThat(metastore.getTableNamesStats().getHitRate()).isEqualTo(0.5);
+        assertThat(metastore.getRelationNamesStats().getRequestCount()).isEqualTo(2);
+        assertThat(metastore.getRelationNamesStats().getHitRate()).isEqualTo(0.5);
 
         metastore.flushCache();
 
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
-        assertThat(metastore.getTableNamesStats().getRequestCount()).isEqualTo(3);
-        assertThat(metastore.getTableNamesStats().getHitRate()).isEqualTo(1.0 / 3);
+        assertThat(metastore.getRelationNamesStats().getRequestCount()).isEqualTo(3);
+        assertThat(metastore.getRelationNamesStats().getHitRate()).isEqualTo(1.0 / 3);
     }
 
     @Test
-    public void testBatchGetAllTable()
+    public void testBatchGetRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
-        assertThat(metastore.getAllTableNamesStats().getRequestCount()).isEqualTo(2);
-        assertThat(metastore.getAllTableNamesStats().getHitRate()).isEqualTo(.5);
+        assertThat(metastore.getAllRelationNamesStats().getRequestCount()).isEqualTo(2);
+        assertThat(metastore.getAllRelationNamesStats().getHitRate()).isEqualTo(.5);
 
         metastore.flushCache();
 
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
-        assertThat(metastore.getAllTableNamesStats().getRequestCount()).isEqualTo(3);
-        assertThat(metastore.getAllTableNamesStats().getHitRate()).isEqualTo(1. / 3);
+        assertThat(metastore.getAllRelationNamesStats().getRequestCount()).isEqualTo(3);
+        assertThat(metastore.getAllRelationNamesStats().getHitRate()).isEqualTo(1. / 3);
     }
 
     @Test
-    public void testInvalidDbGetAllTAbles()
+    public void testInvalidDbGetRelations()
     {
-        assertThat(metastore.getAllTables(BAD_DATABASE).isEmpty()).isTrue();
+        assertThat(metastore.getRelations(BAD_DATABASE).isEmpty()).isTrue();
     }
 
     @Test
@@ -1150,21 +1150,21 @@ public class TestCachingHiveMetastore
     }
 
     @Test
-    public void testAllTables()
+    public void testRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1); // should read it from cache
 
         metastore.dropTable(TEST_DATABASE, TEST_TABLE, false);
         assertThat(mockClient.getAccessCount()).isEqualTo(2); // dropTable check if the table exists
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(3); // should read it from cache
 
         metastore.createTable(
@@ -1177,9 +1177,9 @@ public class TestCachingHiveMetastore
                         .build(),
                 new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()));
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(4);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(4); // should read it from cache
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
@@ -42,10 +42,10 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_DATABASES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS_FROM_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -123,7 +123,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
 
         mockMetastore.setAllTablesViewsImplemented(true);
         Multiset<Method> tables = ImmutableMultiset.<Method>builder()
-                .add(GET_ALL_TABLES)
+                .add(GET_RELATIONS)
                 .add(GET_ALL_VIEWS)
                 .build();
         assertMetastoreInvocations("SELECT * FROM information_schema.tables", tables);
@@ -132,7 +132,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         mockMetastore.setAllTablesViewsImplemented(false);
         tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .build();
         assertMetastoreInvocations("SELECT * FROM information_schema.tables", tables);
@@ -156,13 +156,13 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM information_schema.tables WHERE table_schema = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_schem = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .build());
     }
@@ -177,20 +177,20 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.tables WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
         mockMetastore.setAllTablesViewsImplemented(false);
         Multiset<Method> tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .build();
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_schema LIKE 'test%'", tables);
@@ -207,12 +207,12 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.tables WHERE table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
         Multiset<Method> tables = ImmutableMultiset.<Method>builder()
-                .add(GET_ALL_TABLES)
+                .add(GET_RELATIONS)
                 .add(GET_ALL_VIEWS)
                 .build();
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_name = 'test_table_0'", tables);
@@ -222,7 +222,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         mockMetastore.setAllTablesViewsImplemented(false);
         tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .build();
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_name = 'test_table_0'", tables);
@@ -241,20 +241,20 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.tables WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
         mockMetastore.setAllTablesViewsImplemented(false);
         Multiset<Method> tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .build();
         assertMetastoreInvocations("SELECT * FROM information_schema.tables WHERE table_name LIKE 'test%'", tables);
@@ -271,7 +271,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
@@ -286,7 +286,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -308,7 +308,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM information_schema.views WHERE table_schema = 'test_schema_0'", ImmutableMultiset.of(GET_ALL_VIEWS_FROM_DATABASE));
         assertMetastoreInvocations("SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_schem = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .build());
     }
@@ -328,7 +328,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
@@ -343,7 +343,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -363,7 +363,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
@@ -378,7 +378,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -398,7 +398,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .build());
 
@@ -413,7 +413,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.tables WHERE table_type = 'VIEW' AND table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -425,7 +425,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
 
         mockMetastore.setAllTablesViewsImplemented(true);
         ImmutableMultiset<Method> tables = ImmutableMultiset.<Method>builder()
-                .add(GET_ALL_TABLES)
+                .add(GET_RELATIONS)
                 .add(GET_ALL_VIEWS)
                 .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                 .build();
@@ -435,7 +435,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         mockMetastore.setAllTablesViewsImplemented(false);
         tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                 .build();
@@ -459,26 +459,26 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_schema = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test\\_schema\\_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test_schema_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
@@ -494,7 +494,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -502,7 +502,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
 
@@ -511,7 +511,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -519,7 +519,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
     }
@@ -534,7 +534,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         // TODO When there are many schemas, there are no "prefixes" and we end up calling ConnectorMetadata without any filter whatsoever.
                         //  If such queries are common enough, we could iterate over schemas and for each schema try getting a table by given name.
@@ -556,7 +556,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_SCHEMAS_COUNT)
                         .build());
 
@@ -565,7 +565,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         // TODO When there are many schemas, there are no "prefixes" and we end up calling ConnectorMetadata without any filter whatsoever.
                         //  If such queries are common enough, we could iterate over schemas and for each schema try getting a table by given name.
@@ -587,7 +587,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -601,14 +601,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
 
@@ -617,7 +617,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -625,7 +625,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
     }
@@ -639,14 +639,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM information_schema.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -656,7 +656,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -664,7 +664,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -680,14 +680,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -697,7 +697,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -705,7 +705,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -722,7 +722,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test_schema_0' ESCAPE '\\' AND table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_TABLE)
                         .build());
     }
@@ -755,13 +755,13 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         }
 
         @Override
-        public List<String> getAllTables(String databaseName)
+        public List<String> getRelations(String databaseName)
         {
             return TABLES_PER_SCHEMA;
         }
 
         @Override
-        public Optional<List<SchemaTableName>> getAllTables()
+        public Optional<List<SchemaTableName>> getRelations()
         {
             if (allTablesViewsImplemented) {
                 return Optional.of(ALL_TABLES);

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -205,7 +205,7 @@ public class HudiMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllTables(schemaName)) {
+            for (String tableName : metastore.getRelations(schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -380,7 +380,7 @@ public class TrinoHiveCatalog
     {
         ImmutableSet.Builder<SchemaTableName> tablesListBuilder = ImmutableSet.builder();
         for (String schemaName : listNamespaces(session, namespace)) {
-            metastore.getAllTables(schemaName).forEach(tableName -> tablesListBuilder.add(new SchemaTableName(schemaName, tableName)));
+            metastore.getRelations(schemaName).forEach(tableName -> tablesListBuilder.add(new SchemaTableName(schemaName, tableName)));
         }
         return tablesListBuilder.build().asList();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -102,7 +102,7 @@ public class TestIcebergMetadataListing
     @Test
     public void testTableListing()
     {
-        assertThat(metastore.getAllTables("test_schema"))
+        assertThat(metastore.getRelations("test_schema"))
                 .containsExactlyInAnyOrder(
                         "iceberg_table1",
                         "iceberg_table2",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.CREATE_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.DROP_TABLE;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLES_WITH_PARAMETER;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.REPLACE_TABLE;
@@ -393,7 +393,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval
         assertMetastoreInvocations(session, "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name LIKE 'test_select_i_s_columns%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .addCopies(GET_TABLE, tables * 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 2)
                         .build());
@@ -439,7 +439,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval
         assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name = CURRENT_SCHEMA AND table_name LIKE 'test_select_s_m_t_comments%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .addCopies(GET_TABLE, tables * 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 2)
                         .build());
@@ -447,7 +447,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval for two schemas
         assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent') AND table_name LIKE 'test_select_s_m_t_comments%'",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, 2)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 4)
                         .addCopies(GET_TABLE, tables * 2)
                         .build());
@@ -533,7 +533,7 @@ public class TestIcebergMetastoreAccessOperations
         assertMetastoreInvocations("SHOW TABLES",
                 ImmutableMultiset.builder()
                         .add(GET_DATABASE)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .build());
     }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
@@ -54,7 +54,7 @@ public class TestMinimalFunctionality
     @Test
     public void testTopicExists()
     {
-        assertThat(getQueryRunner().listTables(getSession(), "kafka", "default")).contains(QualifiedObjectName.valueOf("kafka.default." + topicName));
+        assertThat(getQueryRunner().listRelations(getSession(), "kafka", "default")).contains(QualifiedObjectName.valueOf("kafka.default." + topicName));
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -204,7 +204,7 @@ public final class RedshiftQueryRunner
 
     private static synchronized void provisionTables(Session session, QueryRunner queryRunner, Iterable<TpchTable<?>> tables)
     {
-        Set<String> existingTables = queryRunner.listTables(session, session.getCatalog().orElseThrow(), session.getSchema().orElseThrow())
+        Set<String> existingTables = queryRunner.listRelations(session, session.getCatalog().orElseThrow(), session.getSchema().orElseThrow())
                 .stream()
                 .map(QualifiedObjectName::getObjectName)
                 .collect(toUnmodifiableSet());

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -308,9 +308,9 @@ public final class ThriftQueryRunner
         }
 
         @Override
-        public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+        public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
         {
-            return source.listTables(session, catalog, schema);
+            return source.listRelations(session, catalog, schema);
         }
 
         @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -196,7 +196,7 @@ public abstract class AbstractTestingTrinoClient<T>
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
         return inTransaction(session, transactionSession ->
-                trinoServer.getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema)));
+                trinoServer.getMetadata().listRelations(transactionSession, new QualifiedTablePrefix(catalog, schema)));
     }
 
     public boolean tableExists(Session session, String table)

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -454,7 +454,7 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -225,7 +225,7 @@ public final class StandaloneQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -175,14 +175,14 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables",
                 "VALUES (3008, 3008)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables")
+                        .add("ConnectorMetadata.listRelations")
                         .add("ConnectorMetadata.listViews")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
@@ -190,16 +190,16 @@ public class TestInformationSchemaConnector
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema2)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema2)")
                         .add("ConnectorMetadata.listViews(schema=test_schema2)")
                         .build());
         assertMetadataCalls(
@@ -212,7 +212,7 @@ public class TestInformationSchemaConnector
                                 .collect(joining(",", "(", ")")),
                 "VALUES (3000, 3000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables")
+                        .add("ConnectorMetadata.listRelations")
                         .add("ConnectorMetadata.listViews")
                         .build());
         assertMetadataCalls(
@@ -246,10 +246,10 @@ public class TestInformationSchemaConnector
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema2)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema3_empty)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema4_empty)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema2)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema3_empty)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema4_empty)")
                         .add("ConnectorMetadata.listViews(schema=test_schema1)")
                         .add("ConnectorMetadata.listViews(schema=test_schema2)")
                         .add("ConnectorMetadata.listViews(schema=test_schema3_empty)")
@@ -376,7 +376,7 @@ public class TestInformationSchemaConnector
                 "VALUES 1000",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                         // view-related methods such as listViews not being called
                         .build());
     }

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -175,32 +175,27 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables",
                 "VALUES (3008, 3008)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listRelations")
-                        .add("ConnectorMetadata.listViews")
+                        .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema2)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema2)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema IN " +
@@ -212,26 +207,25 @@ public class TestInformationSchemaConnector
                                 .collect(joining(",", "(", ")")),
                 "VALUES (3000, 3000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listRelations")
-                        .add("ConnectorMetadata.listViews")
+                        .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'",
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 5)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema3_empty, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table1)")
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)", 2)
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema2, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema3_empty, table=test_table1)")
@@ -246,28 +240,24 @@ public class TestInformationSchemaConnector
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema2)")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema3_empty)")
-                        .add("ConnectorMetadata.listRelations(schema=test_schema4_empty)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema2)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema3_empty)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema4_empty)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema3_empty)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema4_empty)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1' AND table_name IN ('test_table1', 'test_table2')",
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table2)", 5)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table2)", 4)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table2)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table2)")
@@ -276,14 +266,14 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema3_empty, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table2)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table1)")
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table2)", 2)
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table2)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table2)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema2, table=test_table1)")

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -125,14 +125,14 @@ public class TestMetadataManager
     }
 
     @Test
-    public void testMetadataListTablesReturnsQualifiedView()
+    public void testMetadataListRelationsReturnsQualifiedView()
     {
         TransactionBuilder.transaction(queryRunner.getTransactionManager(), metadataManager, queryRunner.getAccessControl())
                 .execute(
                         TEST_SESSION,
                         transactionSession -> {
                             QualifiedTablePrefix viewName = new QualifiedTablePrefix("upper_case_schema_catalog", "upper_case_schema", "test_view");
-                            assertThat(metadataManager.listTables(transactionSession, viewName)).containsExactly(viewName.asQualifiedObjectName().get());
+                            assertThat(metadataManager.listRelations(transactionSession, viewName)).containsExactly(viewName.asQualifiedObjectName().get());
                         });
     }
 


### PR DESCRIPTION
This reduces number of Glue calls when reading from
`information_schema.tables` or `system.jdbc.tables`.