### PR TITLE
Move testNonDeltaTablesCannotBeAccessed in Delta Lake

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -488,18 +488,6 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     }
 
     @Test
-    public void testNonDeltaTablesCannotBeAccessed()
-    {
-        String schemaName = "test_schema" + randomNameSuffix();
-        String tableName = "hive_table";
-        hiveHadoop.runOnHive("CREATE DATABASE " + schemaName);
-        hiveHadoop.runOnHive(format("CREATE TABLE %s.%s (id BIGINT)", schemaName, tableName));
-        assertThat(computeScalar(format("SHOW TABLES FROM %s LIKE '%s'", schemaName, tableName))).isEqualTo(tableName);
-        assertThatThrownBy(() -> computeActual("DESCRIBE " + schemaName + "." + tableName)).hasMessageContaining(tableName + " is not a Delta Lake table");
-        hiveHadoop.runOnHive("DROP DATABASE " + schemaName + " CASCADE");
-    }
-
-    @Test
     public void testDropDatabricksTable()
     {
         testDropTable(


### PR DESCRIPTION
## Description

testNonDeltaTablesCannotBeAccessed was flaky because BaseDeltaLakeConnectorSmokeTest uses metadata cache. 
Fixes #19799

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
