### PR TITLE
Improve collection assertions

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcWarnings.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcWarnings.java
@@ -168,7 +168,7 @@ public class TestJdbcWarnings
             TestingWarningCollector warningCollector = new TestingWarningCollector(new WarningCollectorConfig(), warningCollectorConfig);
             List<TrinoWarning> expectedWarnings = warningCollector.getWarnings();
             for (TrinoWarning trinoWarning : expectedWarnings) {
-                assertThat(currentWarnings.contains(new WarningEntry(toTrinoSqlWarning(trinoWarning)))).isTrue();
+                assertThat(currentWarnings).contains(new WarningEntry(toTrinoSqlWarning(trinoWarning)));
             }
         }
     }

--- a/core/trino-main/src/test/java/io/trino/block/TestMapBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestMapBlock.java
@@ -337,8 +337,7 @@ public class TestMapBlock
             else {
                 actualValue = BIGINT.getLong(rawValueBlock, rawOffset + i);
             }
-            assertThat(map.containsKey(actualKey)).isTrue();
-            assertThat(actualValue).isEqualTo(map.get(actualKey));
+            assertThat(map).containsEntry(actualKey, actualValue);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -311,7 +311,7 @@ public class TestNodeScheduler
         Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         assertThat(assignments.entries().size()).isEqualTo(assignments.size());
         for (InternalNode node : activeCatalogNodes) {
-            assertThat(assignments.keySet().contains(node)).isTrue();
+            assertThat(assignments.keySet()).contains(node);
         }
     }
 
@@ -370,7 +370,7 @@ public class TestNodeScheduler
         Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
         assertThat(assignments.entries().size()).isEqualTo(activeCatalogNodes.size());
         for (InternalNode node : activeCatalogNodes) {
-            assertThat(assignments.keySet().contains(node)).isTrue();
+            assertThat(assignments.keySet()).contains(node);
         }
     }
 
@@ -492,7 +492,7 @@ public class TestNodeScheduler
         // Check that all splits are being assigned to node1
         assertThat(initialAssignment.size()).isEqualTo(20);
         assertThat(initialAssignment.keySet().size()).isEqualTo(1);
-        assertThat(initialAssignment.keySet().contains(node)).isTrue();
+        assertThat(initialAssignment.keySet()).contains(node);
 
         // Check for assignment of splits beyond maxSplitsPerNode (2 splits should remain unassigned)
         // 1 split with node1 as local node
@@ -504,7 +504,7 @@ public class TestNodeScheduler
         // Check that only 20 splits are being assigned as there is a single task
         assertThat(finalAssignment.size()).isEqualTo(20);
         assertThat(finalAssignment.keySet().size()).isEqualTo(1);
-        assertThat(finalAssignment.keySet().contains(node)).isTrue();
+        assertThat(finalAssignment.keySet()).contains(node);
 
         // When optimized-local-scheduling is enabled, the split with node1 as local node should be assigned
         long countLocalSplits = finalAssignment.values().stream()
@@ -535,7 +535,7 @@ public class TestNodeScheduler
         // Check that all splits are being assigned to node1
         assertThat(initialAssignment.size()).isEqualTo(20);
         assertThat(initialAssignment.keySet().size()).isEqualTo(1);
-        assertThat(initialAssignment.keySet().contains(node)).isTrue();
+        assertThat(initialAssignment.keySet()).contains(node);
 
         // Check for assignment of splits beyond maxSplitsPerNode (2 splits should remain unassigned)
         // 1 split with node1 as local node
@@ -547,7 +547,7 @@ public class TestNodeScheduler
         // Check that only 20 splits are being assigned as there is a single task
         assertThat(finalAssignment.size()).isEqualTo(20);
         assertThat(finalAssignment.keySet().size()).isEqualTo(1);
-        assertThat(finalAssignment.keySet().contains(node)).isTrue();
+        assertThat(finalAssignment.keySet()).contains(node);
 
         // When optimized-local-scheduling is enabled, all 11 splits with node1 as local node should be assigned
         long countLocalSplits = finalAssignment.values().stream()
@@ -575,8 +575,8 @@ public class TestNodeScheduler
         // Check that all 20 splits are being assigned to node1 as optimized-local-scheduling is enabled
         assertThat(assignments1.size()).isEqualTo(20);
         assertThat(assignments1.keySet().size()).isEqualTo(2);
-        assertThat(assignments1.keySet().contains(node1)).isTrue();
-        assertThat(assignments1.keySet().contains(node2)).isTrue();
+        assertThat(assignments1.keySet()).contains(node1);
+        assertThat(assignments1.keySet()).contains(node2);
 
         // 19 splits with node2 as local node to be assigned in the first iteration of computeAssignments
         for (int i = 0; i < 19; i++) {
@@ -586,8 +586,8 @@ public class TestNodeScheduler
         // Check that all 39 splits are being assigned (20 splits assigned to node1 and 19 splits assigned to node2)
         assertThat(assignments2.size()).isEqualTo(39);
         assertThat(assignments2.keySet().size()).isEqualTo(2);
-        assertThat(assignments2.keySet().contains(node1)).isTrue();
-        assertThat(assignments2.keySet().contains(node2)).isTrue();
+        assertThat(assignments2.keySet()).contains(node1);
+        assertThat(assignments2.keySet()).contains(node2);
 
         long node1Splits = assignments2.values().stream()
                 .map(Split::getConnectorSplit)
@@ -610,8 +610,8 @@ public class TestNodeScheduler
         // Check that only 40 splits are being assigned as there is a single task
         assertThat(assignments3.size()).isEqualTo(40);
         assertThat(assignments3.keySet().size()).isEqualTo(2);
-        assertThat(assignments3.keySet().contains(node1)).isTrue();
-        assertThat(assignments3.keySet().contains(node2)).isTrue();
+        assertThat(assignments3.keySet()).contains(node1);
+        assertThat(assignments3.keySet()).contains(node2);
 
         // The first 20 splits have node1 as local, the next 19 have node2 as local, the 40th split has node1 as local and the 41st has node2 as local
         // If optimized-local-scheduling is disabled, the 41st split will be unassigned (the last slot in node2 will be taken up by the 40th split with node1 as local)
@@ -856,7 +856,7 @@ public class TestNodeScheduler
         // Attempt to schedule again, only the node with the unblocked task should be chosen
         splitPlacements = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(tasks));
         assertThat(splitPlacements.getAssignments().size()).isEqualTo(1);
-        assertThat(splitPlacements.getAssignments().keySet().contains(nodes.get(0))).isTrue();
+        assertThat(splitPlacements.getAssignments().keySet()).contains(nodes.get(0));
 
         // Make the first node appear to have no splits, unacknowledged splits alone should force the splits to be spread across nodes
         taskOne.clearSplits();

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -103,7 +103,7 @@ public class TestSetTimeZoneTask
 
         Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
         assertThat(setSessionProperties).hasSize(1);
-        assertThat(setSessionProperties.get(TIME_ZONE_ID)).isEqualTo("America/Los_Angeles");
+        assertThat(setSessionProperties).containsEntry(TIME_ZONE_ID, "America/Los_Angeles");
     }
 
     @Test
@@ -129,7 +129,7 @@ public class TestSetTimeZoneTask
 
         Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
         assertThat(setSessionProperties).hasSize(1);
-        assertThat(setSessionProperties.get(TIME_ZONE_ID)).isEqualTo("America/Los_Angeles");
+        assertThat(setSessionProperties).containsEntry(TIME_ZONE_ID, "America/Los_Angeles");
     }
 
     @Test
@@ -170,7 +170,7 @@ public class TestSetTimeZoneTask
 
         Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
         assertThat(setSessionProperties).hasSize(1);
-        assertThat(setSessionProperties.get(TIME_ZONE_ID)).isEqualTo("+10:00");
+        assertThat(setSessionProperties).containsEntry(TIME_ZONE_ID, "+10:00");
     }
 
     @Test
@@ -190,7 +190,7 @@ public class TestSetTimeZoneTask
 
         Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
         assertThat(setSessionProperties).hasSize(1);
-        assertThat(setSessionProperties.get(TIME_ZONE_ID)).isEqualTo("+08:00");
+        assertThat(setSessionProperties).containsEntry(TIME_ZONE_ID, "+08:00");
     }
 
     @Test
@@ -246,7 +246,7 @@ public class TestSetTimeZoneTask
 
         Map<String, String> setSessionProperties = stateMachine.getSetSessionProperties();
         assertThat(setSessionProperties).hasSize(1);
-        assertThat(setSessionProperties.get(TIME_ZONE_ID)).isEqualTo("-08:00");
+        assertThat(setSessionProperties).containsEntry(TIME_ZONE_ID, "-08:00");
     }
 
     private QueryStateMachine createQueryStateMachine(String query)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestPartitionedPipelinedOutputBufferManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestPartitionedPipelinedOutputBufferManager.java
@@ -59,7 +59,7 @@ public class TestPartitionedPipelinedOutputBufferManager
         Map<OutputBufferId, Integer> buffers = outputBuffers.getBuffers();
         assertThat(buffers.size()).isEqualTo(4);
         for (int partition = 0; partition < 4; partition++) {
-            assertThat(buffers.get(new OutputBufferId(partition))).isEqualTo(Integer.valueOf(partition));
+            assertThat(buffers).containsEntry(new OutputBufferId(partition), Integer.valueOf(partition));
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkService.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/jwt/TestJwkService.java
@@ -197,8 +197,8 @@ public class TestJwkService
     {
         Map<String, PublicKey> keys = service.getKeys();
         assertThat(keys.size()).isEqualTo(3);
-        assertThat(keys.containsKey("test-rsa")).isTrue();
-        assertThat(keys.containsKey("test-ec")).isTrue();
-        assertThat(keys.containsKey("test-certificate-chain")).isTrue();
+        assertThat(keys).containsKey("test-rsa");
+        assertThat(keys).containsKey("test-ec");
+        assertThat(keys).containsKey("test-certificate-chain");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPartialTranslator.java
@@ -103,7 +103,7 @@ public class TestPartialTranslator
         Map<NodeRef<Expression>, ConnectorExpression> translation = extractPartialTranslations(expression, TEST_SESSION, TYPE_ANALYZER, TYPE_PROVIDER, PLANNER_CONTEXT);
         assertThat(subexpressions.size()).isEqualTo(translation.size());
         for (Expression subexpression : subexpressions) {
-            assertThat(translation.get(NodeRef.of(subexpression))).isEqualTo(translate(TEST_SESSION, subexpression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
+            assertThat(translation).containsEntry(NodeRef.of(subexpression), translate(TEST_SESSION, subexpression, TYPE_PROVIDER, PLANNER_CONTEXT, TYPE_ANALYZER).get());
         }
     }
 

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestKdbTree.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestKdbTree.java
@@ -96,8 +96,8 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = treeCopy.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(2);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 4.5, 4));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(4.5, 0, 9, 4));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 4.5, 4));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(4.5, 0, 9, 4));
 
         assertPartitions(treeCopy, new Rectangle(1, 1, 2, 2), ImmutableSet.of(0));
         assertPartitions(treeCopy, new Rectangle(1, 1, 5, 2), ImmutableSet.of(0, 1));
@@ -125,8 +125,8 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(2);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 4, 4.5));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(0, 4.5, 4, 9));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 4, 4.5));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(0, 4.5, 4, 9));
 
         // points inside and outside partitions
         assertPartitions(tree, new Rectangle(1, 1, 1, 1), ImmutableSet.of(0));
@@ -172,12 +172,12 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(6);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1, 2, 3, 4, 5));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 2.5, 2.5));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(0, 2.5, 2.5, 4));
-        assertThat(leafNodes.get(2)).isEqualTo(new Rectangle(2.5, 0, 4.5, 4));
-        assertThat(leafNodes.get(3)).isEqualTo(new Rectangle(4.5, 0, 7.5, 2.5));
-        assertThat(leafNodes.get(4)).isEqualTo(new Rectangle(4.5, 2.5, 7.5, 4));
-        assertThat(leafNodes.get(5)).isEqualTo(new Rectangle(7.5, 0, 9, 4));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 2.5, 2.5));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(0, 2.5, 2.5, 4));
+        assertThat(leafNodes).containsEntry(2, new Rectangle(2.5, 0, 4.5, 4));
+        assertThat(leafNodes).containsEntry(3, new Rectangle(4.5, 0, 7.5, 2.5));
+        assertThat(leafNodes).containsEntry(4, new Rectangle(4.5, 2.5, 7.5, 4));
+        assertThat(leafNodes).containsEntry(5, new Rectangle(7.5, 0, 9, 4));
     }
 
     @Test
@@ -208,15 +208,15 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(9);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 1.5, 2.5));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(1.5, 0, 3.5, 2.5));
-        assertThat(leafNodes.get(2)).isEqualTo(new Rectangle(0, 2.5, 3.5, 4));
-        assertThat(leafNodes.get(3)).isEqualTo(new Rectangle(3.5, 0, 5.1, 1.75));
-        assertThat(leafNodes.get(4)).isEqualTo(new Rectangle(3.5, 1.75, 5.1, 4));
-        assertThat(leafNodes.get(5)).isEqualTo(new Rectangle(5.1, 0, 5.9, 1.75));
-        assertThat(leafNodes.get(6)).isEqualTo(new Rectangle(5.9, 0, 9, 1.75));
-        assertThat(leafNodes.get(7)).isEqualTo(new Rectangle(5.1, 1.75, 7.5, 4));
-        assertThat(leafNodes.get(8)).isEqualTo(new Rectangle(7.5, 1.75, 9, 4));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 1.5, 2.5));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(1.5, 0, 3.5, 2.5));
+        assertThat(leafNodes).containsEntry(2, new Rectangle(0, 2.5, 3.5, 4));
+        assertThat(leafNodes).containsEntry(3, new Rectangle(3.5, 0, 5.1, 1.75));
+        assertThat(leafNodes).containsEntry(4, new Rectangle(3.5, 1.75, 5.1, 4));
+        assertThat(leafNodes).containsEntry(5, new Rectangle(5.1, 0, 5.9, 1.75));
+        assertThat(leafNodes).containsEntry(6, new Rectangle(5.9, 0, 9, 1.75));
+        assertThat(leafNodes).containsEntry(7, new Rectangle(5.1, 1.75, 7.5, 4));
+        assertThat(leafNodes).containsEntry(8, new Rectangle(7.5, 1.75, 9, 4));
     }
 
     @Test
@@ -242,16 +242,16 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(10);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 4.5, 0.5));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(0, 0.5, 4.5, 1.5));
-        assertThat(leafNodes.get(2)).isEqualTo(new Rectangle(0, 1.5, 4.5, 2.5));
-        assertThat(leafNodes.get(3)).isEqualTo(new Rectangle(0, 2.5, 4.5, 3.5));
-        assertThat(leafNodes.get(4)).isEqualTo(new Rectangle(0, 3.5, 4.5, 4 + height));
-        assertThat(leafNodes.get(5)).isEqualTo(new Rectangle(4.5, 0, 9 + width, 0.5));
-        assertThat(leafNodes.get(6)).isEqualTo(new Rectangle(4.5, 0.5, 9 + width, 1.5));
-        assertThat(leafNodes.get(7)).isEqualTo(new Rectangle(4.5, 1.5, 9 + width, 2.5));
-        assertThat(leafNodes.get(8)).isEqualTo(new Rectangle(4.5, 2.5, 9 + width, 3.5));
-        assertThat(leafNodes.get(9)).isEqualTo(new Rectangle(4.5, 3.5, 9 + width, 4 + height));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 4.5, 0.5));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(0, 0.5, 4.5, 1.5));
+        assertThat(leafNodes).containsEntry(2, new Rectangle(0, 1.5, 4.5, 2.5));
+        assertThat(leafNodes).containsEntry(3, new Rectangle(0, 2.5, 4.5, 3.5));
+        assertThat(leafNodes).containsEntry(4, new Rectangle(0, 3.5, 4.5, 4 + height));
+        assertThat(leafNodes).containsEntry(5, new Rectangle(4.5, 0, 9 + width, 0.5));
+        assertThat(leafNodes).containsEntry(6, new Rectangle(4.5, 0.5, 9 + width, 1.5));
+        assertThat(leafNodes).containsEntry(7, new Rectangle(4.5, 1.5, 9 + width, 2.5));
+        assertThat(leafNodes).containsEntry(8, new Rectangle(4.5, 2.5, 9 + width, 3.5));
+        assertThat(leafNodes).containsEntry(9, new Rectangle(4.5, 3.5, 9 + width, 4 + height));
     }
 
     @Test
@@ -277,7 +277,7 @@ public class TestKdbTree
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertThat(leafNodes.size()).isEqualTo(2);
         assertThat(leafNodes.keySet()).isEqualTo(ImmutableSet.of(0, 1));
-        assertThat(leafNodes.get(0)).isEqualTo(new Rectangle(0, 0, 4.5, 4 + height));
-        assertThat(leafNodes.get(1)).isEqualTo(new Rectangle(4.5, 0, 9 + width, 4 + height));
+        assertThat(leafNodes).containsEntry(0, new Rectangle(0, 0, 4.5, 4 + height));
+        assertThat(leafNodes).containsEntry(1, new Rectangle(4.5, 0, 9 + width, 4 + height));
     }
 }

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestHdfsConfig.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/TestHdfsConfig.java
@@ -104,7 +104,7 @@ public class TestHdfsConfig
         HdfsConfig expected = new HdfsConfig()
                 .setNewDirectoryPermissions("skip");
 
-        assertThat(properties.get("hive.fs.new-directory-permissions")).isEqualTo(expected.getNewDirectoryPermissions());
+        assertThat(properties).containsEntry("hive.fs.new-directory-permissions", expected.getNewDirectoryPermissions());
         assertThat(Optional.empty()).isEqualTo(expected.getNewDirectoryFsPermissions());
     }
 }

--- a/lib/trino-record-decoder/src/test/java/io/trino/decoder/json/JsonFieldDecoderTester.java
+++ b/lib/trino-record-decoder/src/test/java/io/trino/decoder/json/JsonFieldDecoderTester.java
@@ -145,9 +145,7 @@ public class JsonFieldDecoderTester
         RowDecoder rowDecoder = DECODER_FACTORY.create(TESTING_SESSION, new RowDecoderSpec(JsonRowDecoder.NAME, emptyMap(), ImmutableSet.of(columnHandle)));
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = rowDecoder.decodeRow(json.getBytes(UTF_8))
                 .orElseThrow(AssertionError::new);
-        assertThat(decodedRow.containsKey(columnHandle))
-                .describedAs(format("column '%s' not found in decoded row", columnHandle.getName()))
-                .isTrue();
+        assertThat(decodedRow).containsKey(columnHandle);
         return decodedRow.get(columnHandle);
     }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
@@ -155,14 +155,14 @@ public class TestCassandraConnector
     public void testGetDatabaseNames()
     {
         List<String> databases = metadata.listSchemaNames(SESSION);
-        assertThat(databases.contains(database.toLowerCase(ENGLISH))).isTrue();
+        assertThat(databases).contains(database.toLowerCase(ENGLISH));
     }
 
     @Test
     public void testGetTableNames()
     {
         List<SchemaTableName> tables = metadata.listTables(SESSION, Optional.of(database));
-        assertThat(tables.contains(table)).isTrue();
+        assertThat(tables).contains(table);
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAnalyze.java
@@ -1006,8 +1006,8 @@ public class TestDeltaLakeAnalyze
         assertThat(transactionLogAfterUpdate).hasSize(2);
         AddFileEntry updateAddFileEntry = transactionLogAfterUpdate.get(1).getAdd();
         DeltaLakeFileStatistics updateStats = updateAddFileEntry.getStats().orElseThrow();
-        assertThat(updateStats.getMinValues().orElseThrow().get("c_Int")).isEqualTo(2);
-        assertThat(updateStats.getMaxValues().orElseThrow().get("c_Int")).isEqualTo(11);
+        assertThat(updateStats.getMinValues().orElseThrow()).containsEntry("c_Int", 2);
+        assertThat(updateStats.getMaxValues().orElseThrow()).containsEntry("c_Int", 11);
         assertThat(updateStats.getNullCount("c_Int").orElseThrow()).isEqualTo(1);
         assertThat(updateStats.getNullCount("c_Str").orElseThrow()).isEqualTo(1);
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -200,8 +200,9 @@ public class TestDeltaLakeBasic
 
         assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN second_col row(a array(integer), b map(integer, integer), c row(field integer))");
         MetadataEntry metadata = loadMetadataEntry(1, tableLocation);
-        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
-                .isEqualTo("6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
+        assertThat(metadata.getConfiguration()).containsEntry(
+                "delta.columnMapping.maxColumnId",
+                "6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
 
         JsonNode schema = OBJECT_MAPPER.readTree(metadata.getSchemaString());
         List<JsonNode> fields = ImmutableList.copyOf(schema.get("fields").elements());
@@ -301,8 +302,8 @@ public class TestDeltaLakeBasic
         assertThat(transactionLog.get(4).getAdd()).isNotNull();
         AddFileEntry addFileEntry = transactionLog.get(4).getAdd();
         DeltaLakeFileStatistics stats = addFileEntry.getStats().orElseThrow();
-        assertThat(stats.getMinValues().orElseThrow().get(physicalName)).isEqualTo(10);
-        assertThat(stats.getMaxValues().orElseThrow().get(physicalName)).isEqualTo(20);
+        assertThat(stats.getMinValues().orElseThrow()).containsEntry(physicalName, 10);
+        assertThat(stats.getMaxValues().orElseThrow()).containsEntry(physicalName, 20);
         assertThat(stats.getNullCount(physicalName).orElseThrow()).isEqualTo(1);
 
         // Verify optimized parquet file contains the expected physical id and name
@@ -347,8 +348,7 @@ public class TestDeltaLakeBasic
 
         assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN second_col row(a array(integer), b map(integer, integer), c row(field integer))");
         MetadataEntry metadata = loadMetadataEntry(1, tableLocation);
-        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
-                .isEqualTo("6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
+        assertThat(metadata.getConfiguration()).containsEntry("delta.columnMapping.maxColumnId", "6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
         assertThat(metadata.getSchemaString())
                 .containsPattern("(delta\\.columnMapping\\.id.*?){6}")
                 .containsPattern("(delta\\.columnMapping\\.physicalName.*?){6}");
@@ -401,8 +401,7 @@ public class TestDeltaLakeBasic
 
         assertUpdate("ALTER TABLE " + tableName + " ADD COLUMN second_col row(a array(integer), b map(integer, integer), c row(field integer))");
         MetadataEntry metadata = loadMetadataEntry(1, tableLocation);
-        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
-                .isEqualTo("6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
+        assertThat(metadata.getConfiguration()).containsEntry("delta.columnMapping.maxColumnId", "6"); // +5 comes from second_col + second_col.a + second_col.b + second_col.c + second_col.c.field
         assertThat(metadata.getSchemaString())
                 .containsPattern("(delta\\.columnMapping\\.id.*?){6}")
                 .containsPattern("(delta\\.columnMapping\\.physicalName.*?){6}");
@@ -522,8 +521,8 @@ public class TestDeltaLakeBasic
         assertThat(transactionLog).hasSize(2);
         AddFileEntry addFileEntry = transactionLog.get(1).getAdd();
         DeltaLakeFileStatistics stats = addFileEntry.getStats().orElseThrow();
-        assertThat(stats.getMinValues().orElseThrow().get("UPPER_CASE")).isEqualTo(10);
-        assertThat(stats.getMaxValues().orElseThrow().get("UPPER_CASE")).isEqualTo(20);
+        assertThat(stats.getMinValues().orElseThrow()).containsEntry("UPPER_CASE", 10);
+        assertThat(stats.getMaxValues().orElseThrow()).containsEntry("UPPER_CASE", 20);
         assertThat(stats.getNullCount("UPPER_CASE").orElseThrow()).isEqualTo(1);
 
         assertUpdate("UPDATE " + tableName + " SET upper_case = upper_case + 10", 3);
@@ -532,8 +531,8 @@ public class TestDeltaLakeBasic
         assertThat(transactionLogAfterUpdate).hasSize(3);
         AddFileEntry updateAddFileEntry = transactionLogAfterUpdate.get(2).getAdd();
         DeltaLakeFileStatistics updateStats = updateAddFileEntry.getStats().orElseThrow();
-        assertThat(updateStats.getMinValues().orElseThrow().get("UPPER_CASE")).isEqualTo(20);
-        assertThat(updateStats.getMaxValues().orElseThrow().get("UPPER_CASE")).isEqualTo(30);
+        assertThat(updateStats.getMinValues().orElseThrow()).containsEntry("UPPER_CASE", 20);
+        assertThat(updateStats.getMaxValues().orElseThrow()).containsEntry("UPPER_CASE", 30);
         assertThat(updateStats.getNullCount("UPPER_CASE").orElseThrow()).isEqualTo(1);
 
         assertQuery(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeColumnMapping.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeColumnMapping.java
@@ -98,8 +98,7 @@ public class TestDeltaLakeColumnMapping
         String tableLocation = getTableLocation(tableName);
         MetadataEntry metadata = loadMetadataEntry(0, Path.of(tableLocation));
 
-        assertThat(metadata.getConfiguration().get("delta.columnMapping.maxColumnId"))
-                .isEqualTo("3"); // 3 comes from a_int + a_row + a_row.x
+        assertThat(metadata.getConfiguration()).containsEntry("delta.columnMapping.maxColumnId", "3"); // 3 comes from a_int + a_row + a_row.x
 
         JsonNode schema = OBJECT_MAPPER.readTree(metadata.getSchemaString());
         List<JsonNode> fields = ImmutableList.copyOf(schema.get("fields").elements());

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1803,7 +1803,7 @@ public abstract class BaseElasticsearchConnectorTest
         createIndex(indexName, mappings);
 
         assertQuery(format("SELECT column_name FROM information_schema.columns WHERE table_name = '%s'", indexName), "VALUES ('dummy_column')");
-        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet().contains(indexName)).isTrue();
+        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains(indexName);
         assertQueryReturnsEmptyResult("SELECT * FROM " + indexName);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3776,8 +3776,8 @@ public class HiveMetadata
 
     private static void validateTimestampTypes(Type type, HiveTimestampPrecision precision, ColumnMetadata column)
     {
-        if (type instanceof TimestampType) {
-            if (((TimestampType) type).getPrecision() != precision.getPrecision()) {
+        if (type instanceof TimestampType timestampType) {
+            if (timestampType.getPrecision() != precision.getPrecision()) {
                 throw new TrinoException(NOT_SUPPORTED, format(
                         "Incorrect timestamp precision for %s; the configured precision is %s; column name: %s",
                         type,
@@ -3785,15 +3785,15 @@ public class HiveMetadata
                         column.getName()));
             }
         }
-        else if (type instanceof ArrayType) {
-            validateTimestampTypes(((ArrayType) type).getElementType(), precision, column);
+        else if (type instanceof ArrayType arrayType) {
+            validateTimestampTypes(arrayType.getElementType(), precision, column);
         }
-        else if (type instanceof MapType) {
-            validateTimestampTypes(((MapType) type).getKeyType(), precision, column);
-            validateTimestampTypes(((MapType) type).getValueType(), precision, column);
+        else if (type instanceof MapType mapType) {
+            validateTimestampTypes(mapType.getKeyType(), precision, column);
+            validateTimestampTypes(mapType.getValueType(), precision, column);
         }
         else if (type instanceof RowType) {
-            for (Type fieldType : ((RowType) type).getTypeParameters()) {
+            for (Type fieldType : type.getTypeParameters()) {
                 validateTimestampTypes(fieldType, precision, column);
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -4218,8 +4218,8 @@ public abstract class AbstractTestHive
 
             // verify the node version and query ID in table
             Table table = getMetastoreClient().getTable(tableName.getSchemaName(), tableName.getTableName()).get();
-            assertThat(table.getParameters().get(PRESTO_VERSION_NAME)).isEqualTo(TEST_SERVER_VERSION);
-            assertThat(table.getParameters().get(PRESTO_QUERY_ID_NAME)).isEqualTo(queryId);
+            assertThat(table.getParameters()).containsEntry(PRESTO_VERSION_NAME, TEST_SERVER_VERSION);
+            assertThat(table.getParameters()).containsEntry(PRESTO_QUERY_ID_NAME, queryId);
 
             // verify basic statistics
             HiveBasicStatistics statistics = getBasicStatisticsForTable(transaction, tableName);
@@ -4282,8 +4282,8 @@ public abstract class AbstractTestHive
             assertThat(table.getStorage().getStorageFormat().getInputFormat()).isEqualTo(storageFormat.getInputFormat());
 
             // verify the node version and query ID
-            assertThat(table.getParameters().get(PRESTO_VERSION_NAME)).isEqualTo(TEST_SERVER_VERSION);
-            assertThat(table.getParameters().get(PRESTO_QUERY_ID_NAME)).isEqualTo(queryId);
+            assertThat(table.getParameters()).containsEntry(PRESTO_VERSION_NAME, TEST_SERVER_VERSION);
+            assertThat(table.getParameters()).containsEntry(PRESTO_QUERY_ID_NAME, queryId);
 
             // verify the table is empty
             List<ColumnHandle> columnHandles = filterNonHiddenColumnHandles(metadata.getColumnHandles(session, tableHandle).values());
@@ -4643,8 +4643,8 @@ public abstract class AbstractTestHive
             assertThat(partitions.size()).isEqualTo(partitionNames.size());
             for (String partitionName : partitionNames) {
                 Partition partition = partitions.get(partitionName).get();
-                assertThat(partition.getParameters().get(PRESTO_VERSION_NAME)).isEqualTo(TEST_SERVER_VERSION);
-                assertThat(partition.getParameters().get(PRESTO_QUERY_ID_NAME)).isEqualTo(queryId);
+                assertThat(partition.getParameters()).containsEntry(PRESTO_VERSION_NAME, TEST_SERVER_VERSION);
+                assertThat(partition.getParameters()).containsEntry(PRESTO_QUERY_ID_NAME, queryId);
             }
 
             // load the new table

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1053,7 +1053,7 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             List<String> databases = metadata.listSchemaNames(newSession());
-            assertThat(databases.contains(database)).isTrue();
+            assertThat(databases).contains(database);
         }
     }
 
@@ -1063,8 +1063,8 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.of(database));
-            assertThat(tables.contains(tablePartitionFormat)).isTrue();
-            assertThat(tables.contains(tableUnpartitioned)).isTrue();
+            assertThat(tables).contains(tablePartitionFormat);
+            assertThat(tables).contains(tableUnpartitioned);
         }
     }
 
@@ -1074,8 +1074,8 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.empty());
-            assertThat(tables.contains(tablePartitionFormat)).isTrue();
-            assertThat(tables.contains(tableUnpartitioned)).isTrue();
+            assertThat(tables).contains(tablePartitionFormat);
+            assertThat(tables).contains(tableUnpartitioned);
         }
     }
 
@@ -4165,7 +4165,7 @@ public abstract class AbstractTestHive
             assertThat(views.size()).isEqualTo(1);
             assertThat(views.get(viewName).getOriginalSql()).isEqualTo(definition.getOriginalSql());
 
-            assertThat(metadata.listViews(newSession(), Optional.of(viewName.getSchemaName())).contains(viewName)).isTrue();
+            assertThat(metadata.listViews(newSession(), Optional.of(viewName.getSchemaName()))).contains(viewName);
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1085,8 +1085,8 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             Map<SchemaTableName, List<ColumnMetadata>> allColumns = listTableColumns(metadata, newSession(), new SchemaTablePrefix());
-            assertThat(allColumns.containsKey(tablePartitionFormat)).isTrue();
-            assertThat(allColumns.containsKey(tableUnpartitioned)).isTrue();
+            assertThat(allColumns).containsKey(tablePartitionFormat);
+            assertThat(allColumns).containsKey(tableUnpartitioned);
         }
     }
 
@@ -1096,8 +1096,8 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             Map<SchemaTableName, List<ColumnMetadata>> allColumns = listTableColumns(metadata, newSession(), new SchemaTablePrefix(database));
-            assertThat(allColumns.containsKey(tablePartitionFormat)).isTrue();
-            assertThat(allColumns.containsKey(tableUnpartitioned)).isTrue();
+            assertThat(allColumns).containsKey(tablePartitionFormat);
+            assertThat(allColumns).containsKey(tableUnpartitioned);
         }
     }
 
@@ -3573,7 +3573,7 @@ public abstract class AbstractTestHive
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             Map<SchemaTableName, List<ColumnMetadata>> allColumns = listTableColumns(metadata, newSession(), new SchemaTablePrefix(schemaTableName.getSchemaName()));
-            assertThat(allColumns.containsKey(schemaTableName)).isTrue();
+            assertThat(allColumns).containsKey(schemaTableName);
         }
         finally {
             dropTable(schemaTableName);
@@ -3968,7 +3968,7 @@ public abstract class AbstractTestHive
 
         for (String variable : expectedAssignments.keySet()) {
             Type expectedType = expectedAssignments.get(variable);
-            assertThat(actualAssignments.containsKey(variable)).isTrue();
+            assertThat(actualAssignments).containsKey(variable);
             assertThat(actualAssignments.get(variable).getType()).isEqualTo(expectedType);
             assertThat(((HiveColumnHandle) actualAssignments.get(variable).getColumn()).getType()).isEqualTo(expectedType);
         }
@@ -5519,7 +5519,7 @@ public abstract class AbstractTestHive
 
     private static void assertPrimitiveField(Map<String, ColumnMetadata> map, String name, Type type, boolean partitionKey)
     {
-        assertThat(map.containsKey(name)).isTrue();
+        assertThat(map).containsKey(name);
         ColumnMetadata column = map.get(name);
         assertThat(column.getType())
                 .describedAs(name)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -814,7 +814,7 @@ public abstract class AbstractTestHiveFileSystem
             // verify the metadata
             ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(session, getTableHandle(metadata, tableName));
             assertThat(filterNonHiddenColumnMetadata(tableMetadata.getColumns())).isEqualTo(columns);
-            assertThat(tableMetadata.getProperties().get("external_location")).isEqualTo(externalLocation);
+            assertThat(tableMetadata.getProperties()).containsEntry("external_location", externalLocation);
 
             // verify the data
             metadata.beginQuery(session);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -1670,7 +1670,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_partitioned_table");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         List<String> partitionedBy = ImmutableList.of(
                 "_partition_string",
@@ -1685,7 +1685,7 @@ public abstract class BaseHiveConnectorTest
                 "_partition_decimal_long",
                 "_partition_date",
                 "_partition_timestamp");
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(partitionedBy);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, partitionedBy);
         for (ColumnMetadata columnMetadata : tableMetadata.getColumns()) {
             boolean partitionKey = partitionedBy.contains(columnMetadata.getName());
             assertThat(columnMetadata.getExtraInfo()).isEqualTo(columnExtraInfo(partitionKey));
@@ -1796,7 +1796,7 @@ public abstract class BaseHiveConnectorTest
 
         // Verify the partition keys are correctly created
         List<String> partitionedBy = ImmutableList.of("partition_bigint", "partition_decimal_long");
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(partitionedBy);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, partitionedBy);
 
         // Verify the column types
         assertColumnType(tableMetadata, "string_col", createUnboundedVarcharType());
@@ -1897,7 +1897,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTableAs, 1);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_format_table");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         assertColumnType(tableMetadata, "_varchar", createVarcharType(3));
         assertColumnType(tableMetadata, "_char", createCharType(10));
@@ -1933,8 +1933,8 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable, "SELECT count(*) FROM orders");
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_create_partitioned_table_as");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("ship_priority", "order_status"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("ship_priority", "order_status"));
 
         List<?> partitions = getPartitions("test_create_partitioned_table_as");
         assertThat(partitions.size()).isEqualTo(3);
@@ -2171,11 +2171,11 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isNull();
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("bucket_key"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("bucket_key"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
 
         assertThat(computeActual("SELECT * from " + tableName).getRowCount()).isEqualTo(0);
 
@@ -2233,11 +2233,11 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(parallelWriter, createTable, 3);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isNull();
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("bucket_key"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("bucket_key"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
 
         assertQuery("SELECT * from " + tableName, "VALUES ('a', 'b', 'c'), ('aa', 'bb', 'cc'), ('aaa', 'bbb', 'ccc')");
 
@@ -2690,11 +2690,11 @@ public abstract class BaseHiveConnectorTest
     private void verifyPartitionedBucketedTable(HiveStorageFormat storageFormat, String tableName)
     {
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("orderstatus"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("custkey", "custkey2"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("orderstatus"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("custkey", "custkey2"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
 
         List<?> partitions = getPartitions(tableName);
         assertThat(partitions.size()).isEqualTo(3);
@@ -2858,11 +2858,11 @@ public abstract class BaseHiveConnectorTest
     private void verifyPartitionedBucketedTableAsFewRows(HiveStorageFormat storageFormat, String tableName)
     {
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("partition_key"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("bucket_key"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("partition_key"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("bucket_key"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
 
         List<?> partitions = getPartitions(tableName);
         assertThat(partitions.size()).isEqualTo(3);
@@ -3178,7 +3178,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_insert_format_table");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         assertColumnType(tableMetadata, "_string", createUnboundedVarcharType());
         assertColumnType(tableMetadata, "_varchar", createVarcharType(65535));
@@ -3249,8 +3249,8 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_insert_partitioned_table");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("ship_priority", "order_status"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("ship_priority", "order_status"));
 
         String partitionsTable = "\"test_insert_partitioned_table$partitions\"";
 
@@ -3322,8 +3322,8 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("order_status"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("order_status"));
 
         for (int i = 0; i < 3; i++) {
             assertUpdate(
@@ -3380,8 +3380,8 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("order_status"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("order_status"));
 
         for (int i = 0; i < 3; i++) {
             assertUpdate(
@@ -3495,7 +3495,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("part"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("part"));
 
         // insert 1200 partitions
         for (int i = 0; i < 12; i++) {
@@ -3697,7 +3697,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(session, createTable);
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         for (int i = 0; i < 3; i++) {
             assertUpdate(
@@ -4057,12 +4057,12 @@ public abstract class BaseHiveConnectorTest
         String bucketedSchema = bucketedSession.getSchema().get();
 
         TableMetadata ordersTableMetadata = getTableMetadata(bucketedCatalog, bucketedSchema, "orders");
-        assertThat(ordersTableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("custkey"));
-        assertThat(ordersTableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(ordersTableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("custkey"));
+        assertThat(ordersTableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
 
         TableMetadata customerTableMetadata = getTableMetadata(bucketedCatalog, bucketedSchema, "customer");
-        assertThat(customerTableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("custkey"));
-        assertThat(customerTableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(11);
+        assertThat(customerTableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("custkey"));
+        assertThat(customerTableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 11);
     }
 
     @Test
@@ -4727,7 +4727,7 @@ public abstract class BaseHiveConnectorTest
         assertThat(getQueryRunner().tableExists(getSession(), "test_path")).isTrue();
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_path");
-        assertThat(tableMetadata.getMetadata().getProperties().get(STORAGE_FORMAT_PROPERTY)).isEqualTo(storageFormat);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(STORAGE_FORMAT_PROPERTY, storageFormat);
 
         List<String> columnNames = ImmutableList.of("col0", "col1", PATH_COLUMN_NAME, FILE_SIZE_COLUMN_NAME, FILE_MODIFIED_TIME_COLUMN_NAME, PARTITION_COLUMN_NAME);
         List<ColumnMetadata> columnMetadatas = tableMetadata.getColumns();
@@ -4755,7 +4755,7 @@ public abstract class BaseHiveConnectorTest
             assertThat(col0 % 3).isEqualTo(col1);
             if (partitionPathMap.containsKey(col1)) {
                 // the rows in the same partition should be in the same partition directory
-                assertThat(partitionPathMap.get(col1)).isEqualTo(parentDirectory);
+                assertThat(partitionPathMap).containsEntry(col1, parentDirectory);
             }
             else {
                 partitionPathMap.put(col1, parentDirectory);
@@ -4784,8 +4784,8 @@ public abstract class BaseHiveConnectorTest
         assertThat(getQueryRunner().tableExists(getSession(), "test_bucket_hidden_column")).isTrue();
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_bucket_hidden_column");
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKETED_BY_PROPERTY)).isEqualTo(ImmutableList.of("col0"));
-        assertThat(tableMetadata.getMetadata().getProperties().get(BUCKET_COUNT_PROPERTY)).isEqualTo(2);
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKETED_BY_PROPERTY, ImmutableList.of("col0"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(BUCKET_COUNT_PROPERTY, 2);
 
         List<String> columnNames = ImmutableList.of("col0", "col1", PATH_COLUMN_NAME, BUCKET_COLUMN_NAME, FILE_SIZE_COLUMN_NAME, FILE_MODIFIED_TIME_COLUMN_NAME);
         List<ColumnMetadata> columnMetadatas = tableMetadata.getColumns();
@@ -4923,7 +4923,7 @@ public abstract class BaseHiveConnectorTest
             assertThat(fileModifiedTime.toEpochMilli()).isCloseTo(testStartTime, offset(2000L));
             assertThat(col0 % 3).isEqualTo(col1);
             if (fileModifiedTimeMap.containsKey(col1)) {
-                assertThat(fileModifiedTimeMap.get(col1)).isEqualTo(fileModifiedTime);
+                assertThat(fileModifiedTimeMap).containsEntry(col1, fileModifiedTime);
             }
             else {
                 fileModifiedTimeMap.put(col1, fileModifiedTime);
@@ -4950,7 +4950,7 @@ public abstract class BaseHiveConnectorTest
         assertThat(getQueryRunner().tableExists(getSession(), "test_partition_hidden_column")).isTrue();
 
         TableMetadata tableMetadata = getTableMetadata(catalog, TPCH_SCHEMA, "test_partition_hidden_column");
-        assertThat(tableMetadata.getMetadata().getProperties().get(PARTITIONED_BY_PROPERTY)).isEqualTo(ImmutableList.of("col1", "col2"));
+        assertThat(tableMetadata.getMetadata().getProperties()).containsEntry(PARTITIONED_BY_PROPERTY, ImmutableList.of("col1", "col2"));
 
         List<String> columnNames = ImmutableList.of("col0", "col1", "col2", PATH_COLUMN_NAME, FILE_SIZE_COLUMN_NAME, FILE_MODIFIED_TIME_COLUMN_NAME, PARTITION_COLUMN_NAME);
         List<ColumnMetadata> columnMetadatas = tableMetadata.getColumns();
@@ -8797,7 +8797,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(createTableSql, 1500L);
 
         TableMetadata tableMetadataDefaults = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadataDefaults.getMetadata().getProperties().get(AUTO_PURGE)).isEqualTo(null);
+        assertThat(tableMetadataDefaults.getMetadata().getProperties()).doesNotContainKey(AUTO_PURGE);
 
         assertUpdate("DROP TABLE " + tableName);
 
@@ -8811,7 +8811,7 @@ public abstract class BaseHiveConnectorTest
         assertUpdate(createTableSqlWithAutoPurge, 1500L);
 
         TableMetadata tableMetadataWithPurge = getTableMetadata(catalog, TPCH_SCHEMA, tableName);
-        assertThat(tableMetadataWithPurge.getMetadata().getProperties().get(AUTO_PURGE)).isEqualTo(true);
+        assertThat(tableMetadataWithPurge.getMetadata().getProperties()).containsEntry(AUTO_PURGE, true);
 
         assertUpdate("DROP TABLE " + tableName);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -230,7 +230,7 @@ public class TestHiveSplitSource
 
             // wait for thread to get the split
             ConnectorSplit split = splits.get(800, TimeUnit.MILLISECONDS);
-            assertThat(((HiveSplit) split).getSchema().get("id")).isEqualTo("33");
+            assertThat(((HiveSplit) split).getSchema()).containsEntry("id", "33");
         }
         finally {
             // make sure the thread exits

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -1428,7 +1428,7 @@ public class TestHiveGlueMetastore
             assertThat(metastore.getTable(tableName.getSchemaName(), tableName.getTableName()).orElseThrow().getParameters()).doesNotContainKey(TABLE_COMMENT);
             metastore.commentTable(tableName.getSchemaName(), tableName.getTableName(), Optional.of("a table comment"));
             Map<String, String> tableParameters = metastore.getTable(tableName.getSchemaName(), tableName.getTableName()).orElseThrow().getParameters();
-            assertThat(tableParameters.get(TABLE_COMMENT)).isEqualTo("a table comment");
+            assertThat(tableParameters).containsEntry(TABLE_COMMENT, "a table comment");
 
             metastore.commentTable(tableName.getSchemaName(), tableName.getTableName(), Optional.empty());
             tableParameters = metastore.getTable(tableName.getSchemaName(), tableName.getTableName()).orElseThrow().getParameters();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/predicate/TestParquetPredicateUtils.java
@@ -164,7 +164,7 @@ public class TestParquetPredicateUtils
         TupleDomain<ColumnDescriptor> calculatedTupleDomain = getParquetTupleDomain(descriptorsByPath, tupleDomain, fileSchema, useColumNames);
         assertThat(calculatedTupleDomain.getDomains().get().size()).isEqualTo(1);
         ColumnDescriptor selectedColumnDescriptor = descriptorsByPath.get(ImmutableList.of("row_field", "b"));
-        assertThat(calculatedTupleDomain.getDomains().get().get(selectedColumnDescriptor)).isEqualTo(predicateDomain);
+        assertThat(calculatedTupleDomain.getDomains().get()).containsEntry(selectedColumnDescriptor, predicateDomain);
     }
 
     @Test(dataProvider = "useColumnNames")

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestStatistics.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestStatistics.java
@@ -332,14 +332,12 @@ public class TestStatistics
 
         assertThat(columnStatistics).hasSize(2);
         assertThat(columnStatistics.keySet()).contains("a_column", "b_column");
-        assertThat(columnStatistics.get("a_column")).isEqualTo(
-                HiveColumnStatistics.builder()
+        assertThat(columnStatistics).containsEntry("a_column", HiveColumnStatistics.builder()
                         .setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(5)))
                         .setNullsCount(0)
                         .setDistinctValuesCount(5)
                         .build());
-        assertThat(columnStatistics.get("b_column")).isEqualTo(
-                HiveColumnStatistics.builder()
+        assertThat(columnStatistics).containsEntry("b_column", HiveColumnStatistics.builder()
                         .setNullsCount(1)
                         .build());
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -246,27 +246,27 @@ public class TestIcebergOrcMetricsCollection
 
         // Check per-column lower bound
         Map<Integer, String> lowerBounds = datafile.getLowerBounds();
-        assertThat(lowerBounds.get(1)).isEqualTo("1");
-        assertThat(lowerBounds.get(2)).isEqualTo("1");
-        assertThat(lowerBounds.get(3)).isEqualTo("F");
-        assertThat(lowerBounds.get(4)).isEqualTo("874.89");
-        assertThat(lowerBounds.get(5)).isEqualTo("1992-01-01");
-        assertThat(lowerBounds.get(6)).isEqualTo("1-URGENT");
-        assertThat(lowerBounds.get(7)).isEqualTo("Clerk#000000001");
-        assertThat(lowerBounds.get(8)).isEqualTo("0");
-        assertThat(lowerBounds.get(9)).isEqualTo(" about the accou");
+        assertThat(lowerBounds).containsEntry(1, "1");
+        assertThat(lowerBounds).containsEntry(2, "1");
+        assertThat(lowerBounds).containsEntry(3, "F");
+        assertThat(lowerBounds).containsEntry(4, "874.89");
+        assertThat(lowerBounds).containsEntry(5, "1992-01-01");
+        assertThat(lowerBounds).containsEntry(6, "1-URGENT");
+        assertThat(lowerBounds).containsEntry(7, "Clerk#000000001");
+        assertThat(lowerBounds).containsEntry(8, "0");
+        assertThat(lowerBounds).containsEntry(9, " about the accou");
 
         // Check per-column upper bound
         Map<Integer, String> upperBounds = datafile.getUpperBounds();
-        assertThat(upperBounds.get(1)).isEqualTo("60000");
-        assertThat(upperBounds.get(2)).isEqualTo("1499");
-        assertThat(upperBounds.get(3)).isEqualTo("P");
-        assertThat(upperBounds.get(4)).isEqualTo("466001.28");
-        assertThat(upperBounds.get(5)).isEqualTo("1998-08-02");
-        assertThat(upperBounds.get(6)).isEqualTo("5-LOW");
-        assertThat(upperBounds.get(7)).isEqualTo("Clerk#000001000");
-        assertThat(upperBounds.get(8)).isEqualTo("0");
-        assertThat(upperBounds.get(9)).isEqualTo("zzle. carefully!");
+        assertThat(upperBounds).containsEntry(1, "60000");
+        assertThat(upperBounds).containsEntry(2, "1499");
+        assertThat(upperBounds).containsEntry(3, "P");
+        assertThat(upperBounds).containsEntry(4, "466001.28");
+        assertThat(upperBounds).containsEntry(5, "1998-08-02");
+        assertThat(upperBounds).containsEntry(6, "5-LOW");
+        assertThat(upperBounds).containsEntry(7, "Clerk#000001000");
+        assertThat(upperBounds).containsEntry(8, "0");
+        assertThat(upperBounds).containsEntry(9, "zzle. carefully!");
 
         assertUpdate("DROP TABLE orders");
     }
@@ -288,16 +288,16 @@ public class TestIcebergOrcMetricsCollection
         datafile.getValueCounts().values().forEach(valueCount -> assertThat(valueCount).isEqualTo((Long) 4L));
 
         // Check per-column null value count
-        assertThat(datafile.getNullValueCounts().get(1)).isEqualTo((Long) 1L);
-        assertThat(datafile.getNullValueCounts().get(2)).isEqualTo((Long) 2L);
-        assertThat(datafile.getNullValueCounts().get(3)).isEqualTo((Long) 0L);
-        assertThat(datafile.getNullValueCounts().get(4)).isEqualTo((Long) 2L);
+        assertThat(datafile.getNullValueCounts()).containsEntry(1, (Long) 1L);
+        assertThat(datafile.getNullValueCounts()).containsEntry(2, (Long) 2L);
+        assertThat(datafile.getNullValueCounts()).containsEntry(3, (Long) 0L);
+        assertThat(datafile.getNullValueCounts()).containsEntry(4, (Long) 2L);
 
         // Check per-column lower bound
-        assertThat(datafile.getLowerBounds().get(1)).isEqualTo("3");
-        assertThat(datafile.getLowerBounds().get(2)).isEqualTo("3.4");
-        assertThat(datafile.getLowerBounds().get(3)).isEqualTo("aaa");
-        assertThat(datafile.getLowerBounds().get(4)).isEqualTo("2020-01-01T00:00:00.123");
+        assertThat(datafile.getLowerBounds()).containsEntry(1, "3");
+        assertThat(datafile.getLowerBounds()).containsEntry(2, "3.4");
+        assertThat(datafile.getLowerBounds()).containsEntry(3, "aaa");
+        assertThat(datafile.getLowerBounds()).containsEntry(4, "2020-01-01T00:00:00.123");
 
         assertUpdate("DROP TABLE test_with_nulls");
 
@@ -308,10 +308,10 @@ public class TestIcebergOrcMetricsCollection
         datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
 
         // Check per-column value count
-        assertThat(datafile.getValueCounts().get(1)).isEqualTo((Long) 3L);
+        assertThat(datafile.getValueCounts()).containsEntry(1, (Long) 3L);
 
         // Check per-column null value count
-        assertThat(datafile.getNullValueCounts().get(1)).isEqualTo((Long) 3L);
+        assertThat(datafile.getNullValueCounts()).containsEntry(1, (Long) 3L);
 
         // Check that lower bounds and upper bounds are nulls. (There's no non-null record)
         assertThat(datafile.getLowerBounds()).isNull();
@@ -334,8 +334,8 @@ public class TestIcebergOrcMetricsCollection
 
         // Check per-column nan value count
         assertThat(datafile.getNanValueCounts().size()).isEqualTo(2);
-        assertThat(datafile.getNanValueCounts().get(2)).isEqualTo((Long) 1L);
-        assertThat(datafile.getNanValueCounts().get(3)).isEqualTo((Long) 1L);
+        assertThat(datafile.getNanValueCounts()).containsEntry(2, (Long) 1L);
+        assertThat(datafile.getNanValueCounts()).containsEntry(3, (Long) 1L);
 
         assertThat(datafile.getLowerBounds().get(2)).isNull();
         assertThat(datafile.getLowerBounds().get(3)).isNull();
@@ -369,16 +369,16 @@ public class TestIcebergOrcMetricsCollection
         assertThat(upperBounds.size()).isEqualTo(3);
 
         // col1
-        assertThat(lowerBounds.get(1)).isEqualTo("-9");
-        assertThat(upperBounds.get(1)).isEqualTo("8");
+        assertThat(lowerBounds).containsEntry(1, "-9");
+        assertThat(upperBounds).containsEntry(1, "8");
 
         // col2.f1 (key in lowerBounds/upperBounds is Iceberg ID)
-        assertThat(lowerBounds.get(3)).isEqualTo("0");
-        assertThat(upperBounds.get(3)).isEqualTo("10");
+        assertThat(lowerBounds).containsEntry(3, "0");
+        assertThat(upperBounds).containsEntry(3, "10");
 
         // col2.f3 (key in lowerBounds/upperBounds is Iceberg ID)
-        assertThat(lowerBounds.get(5)).isEqualTo("-2.9");
-        assertThat(upperBounds.get(5)).isEqualTo("4.9");
+        assertThat(lowerBounds).containsEntry(5, "-2.9");
+        assertThat(upperBounds).containsEntry(5, "4.9");
 
         assertUpdate("DROP TABLE test_nested_types");
     }
@@ -408,11 +408,11 @@ public class TestIcebergOrcMetricsCollection
         datafile.getNullValueCounts().values().forEach(nullValueCount -> assertThat(nullValueCount).isEqualTo((Long) 0L));
 
         // Check column lower bound. Min timestamp doesn't rely on file-level statistics and will not be truncated to milliseconds.
-        assertThat(datafile.getLowerBounds().get(1)).isEqualTo("2021-01-01T00:00:00.111");
+        assertThat(datafile.getLowerBounds()).containsEntry(1, "2021-01-01T00:00:00.111");
         assertQuery("SELECT min(_timestamp) FROM test_timestamp", "VALUES '2021-01-01 00:00:00.111111'");
 
         // Check column upper bound. Max timestamp doesn't rely on file-level statistics and will not be truncated to milliseconds.
-        assertThat(datafile.getUpperBounds().get(1)).isEqualTo("2021-01-31T00:00:00.333999");
+        assertThat(datafile.getUpperBounds()).containsEntry(1, "2021-01-31T00:00:00.333999");
         assertQuery("SELECT max(_timestamp) FROM test_timestamp", "VALUES '2021-01-31 00:00:00.333333'");
 
         assertUpdate("DROP TABLE test_timestamp");

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaSslConfig.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaSslConfig.java
@@ -134,7 +134,7 @@ public class TestKafkaSslConfig
         }
         Map<String, Object> securityProperties = config.getKafkaClientProperties();
         assertThat(securityProperties).containsKey(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
-        assertThat(securityProperties.get(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG)).isEqualTo("");
+        assertThat(securityProperties).containsEntry(SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
     }
 
     @Test

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
@@ -54,7 +54,7 @@ public class TestMinimalFunctionality
     @Test
     public void testTopicExists()
     {
-        assertThat(getQueryRunner().listTables(getSession(), "kafka", "default").contains(QualifiedObjectName.valueOf("kafka.default." + topicName))).isTrue();
+        assertThat(getQueryRunner().listTables(getSession(), "kafka", "default")).contains(QualifiedObjectName.valueOf("kafka.default." + topicName));
     }
 
     @Test

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestConfluentSchemaRegistryTableDescriptionSupplier.java
@@ -57,7 +57,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
         String subject = topicName + "-value";
         SCHEMA_REGISTRY_CLIENT.register(subject, getAvroSchema(schemaTableName.getTableName(), ""));
 
-        assertThat(tableDescriptionSupplier.listTables().contains(schemaTableName)).isTrue();
+        assertThat(tableDescriptionSupplier.listTables()).contains(schemaTableName);
 
         assertThat(getKafkaTopicDescription(tableDescriptionSupplier, schemaTableName))
                 .isEqualTo(
@@ -82,7 +82,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
 
         SCHEMA_REGISTRY_CLIENT.register(subject, getAvroSchema(schemaTableName.getTableName(), ""));
 
-        assertThat(tableDescriptionSupplier.listTables().contains(schemaTableName)).isTrue();
+        assertThat(tableDescriptionSupplier.listTables()).contains(schemaTableName);
 
         assertThat(getKafkaTopicDescription(tableDescriptionSupplier, schemaTableName))
                 .isEqualTo(
@@ -107,7 +107,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
         SCHEMA_REGISTRY_CLIENT.register(topicName + "-key", getAvroSchema(schemaTableName.getTableName(), ""));
         SCHEMA_REGISTRY_CLIENT.register(topicName.toUpperCase(ENGLISH) + "-key", getAvroSchema(schemaTableName.getTableName(), ""));
 
-        assertThat(tableDescriptionSupplier.listTables().contains(schemaTableName)).isTrue();
+        assertThat(tableDescriptionSupplier.listTables()).contains(schemaTableName);
 
         assertThatThrownBy(() ->
                 tableDescriptionSupplier.getTopicDescription(
@@ -131,7 +131,7 @@ public class TestConfluentSchemaRegistryTableDescriptionSupplier
         String overriddenSubject = "overriddenSubject";
         SCHEMA_REGISTRY_CLIENT.register(overriddenSubject, getAvroSchema(schemaTableName.getTableName(), "overridden_"));
 
-        assertThat(tableDescriptionSupplier.listTables().contains(schemaTableName)).isTrue();
+        assertThat(tableDescriptionSupplier.listTables()).contains(schemaTableName);
 
         assertThat(getKafkaTopicDescription(tableDescriptionSupplier, schemaTableName))
                 .isEqualTo(

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -577,7 +577,7 @@ public class TestMemoryConnectorTest
 
         assertQuery("SELECT * FROM test_view", query);
 
-        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet().contains("test_view")).isTrue();
+        assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains("test_view");
 
         assertUpdate("DROP VIEW test_view");
         assertQueryFails("DROP VIEW test_view", "line 1:1: View 'memory.default.test_view' does not exist");

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -139,8 +139,8 @@ public class TestMemoryConnectorTest
     public void testCustomMetricsScanFilter()
     {
         Metrics metrics = collectCustomMetrics("SELECT partkey FROM part WHERE partkey % 1000 > 0");
-        assertThat(metrics.getMetrics().get("rows")).isEqualTo(new LongCount(PART_COUNT));
-        assertThat(metrics.getMetrics().get("started")).isEqualTo(metrics.getMetrics().get("finished"));
+        assertThat(metrics.getMetrics()).containsEntry("rows", new LongCount(PART_COUNT));
+        assertThat(metrics.getMetrics()).containsEntry("started", metrics.getMetrics().get("finished"));
         assertThat(((Count<?>) metrics.getMetrics().get("finished")).getTotal()).isGreaterThan(0);
     }
 
@@ -149,8 +149,8 @@ public class TestMemoryConnectorTest
     public void testCustomMetricsScanOnly()
     {
         Metrics metrics = collectCustomMetrics("SELECT partkey FROM part");
-        assertThat(metrics.getMetrics().get("rows")).isEqualTo(new LongCount(PART_COUNT));
-        assertThat(metrics.getMetrics().get("started")).isEqualTo(metrics.getMetrics().get("finished"));
+        assertThat(metrics.getMetrics()).containsEntry("rows", new LongCount(PART_COUNT));
+        assertThat(metrics.getMetrics()).containsEntry("started", metrics.getMetrics().get("finished"));
         assertThat(((Count<?>) metrics.getMetrics().get("finished")).getTotal()).isGreaterThan(0);
     }
 

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryMetadata.java
@@ -105,7 +105,7 @@ public class TestMemoryMetadata
         MemoryTableHandle firstTableHandle = (MemoryTableHandle) metadata.getTableHandle(SESSION, firstTableName, Optional.empty(), Optional.empty());
         long firstTableId = firstTableHandle.getId();
 
-        assertThat(metadata.beginInsert(SESSION, firstTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds().contains(firstTableId)).isTrue();
+        assertThat(metadata.beginInsert(SESSION, firstTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds()).contains(firstTableId);
 
         SchemaTableName secondTableName = new SchemaTableName("default", "second_table");
         metadata.createTable(SESSION, new ConnectorTableMetadata(secondTableName, ImmutableList.of(), ImmutableMap.of()), false);
@@ -115,8 +115,8 @@ public class TestMemoryMetadata
 
         assertThat(firstTableId)
                 .isNotEqualTo(secondTableId);
-        assertThat(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds().contains(firstTableId)).isTrue();
-        assertThat(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds().contains(secondTableId)).isTrue();
+        assertThat(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds()).contains(firstTableId);
+        assertThat(metadata.beginInsert(SESSION, secondTableHandle, ImmutableList.of(), NO_RETRIES).getActiveTableIds()).contains(secondTableId);
     }
 
     @Test

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusCaseInsensitiveNameMatching.java
@@ -55,7 +55,7 @@ public class TestPrometheusCaseInsensitiveNameMatching
 
         Set<String> tableNames = client.getTableNames(DEFAULT_SCHEMA);
         assertThat(tableNames).hasSize(1);
-        assertThat(tableNames.contains(UPPER_CASE_METRIC)).isTrue();
+        assertThat(tableNames).contains(UPPER_CASE_METRIC);
 
         PrometheusMetadata metadata = new PrometheusMetadata(client);
         List<SchemaTableName> tables = metadata.listTables(null, Optional.of(DEFAULT_SCHEMA));
@@ -76,7 +76,7 @@ public class TestPrometheusCaseInsensitiveNameMatching
 
         Set<String> tableNames = client.getTableNames(DEFAULT_SCHEMA);
         assertThat(tableNames).hasSize(1);
-        assertThat(tableNames.contains(UPPER_CASE_METRIC)).isTrue();
+        assertThat(tableNames).contains(UPPER_CASE_METRIC);
 
         PrometheusMetadata metadata = new PrometheusMetadata(client);
         List<SchemaTableName> tables = metadata.listTables(null, Optional.of(DEFAULT_SCHEMA));

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryMatrixResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryMatrixResponseParse.java
@@ -51,7 +51,7 @@ public class TestPrometheusQueryMatrixResponseParse
             throws IOException
     {
         List<PrometheusMetricResult> results = new PrometheusQueryResponseParse(promMatrixResponse).getResults();
-        assertThat(results.get(0).getMetricHeader().get("__name__")).isEqualTo("up");
+        assertThat(results.get(0).getMetricHeader()).containsEntry("__name__", "up");
     }
 
     @Test

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryScalarResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryScalarResponseParse.java
@@ -41,7 +41,7 @@ public class TestPrometheusQueryScalarResponseParse
     {
         try (InputStream promVectorResponse = openStream()) {
             List<PrometheusMetricResult> results = new PrometheusQueryResponseParse(promVectorResponse).getResults();
-            assertThat(results.get(0).getMetricHeader().get("__name__")).isEqualTo("scalar");
+            assertThat(results.get(0).getMetricHeader()).containsEntry("__name__", "scalar");
         }
     }
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryVectorResponseParse.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusQueryVectorResponseParse.java
@@ -41,7 +41,7 @@ public class TestPrometheusQueryVectorResponseParse
     {
         try (InputStream promVectorResponse = openStream()) {
             List<PrometheusMetricResult> results = new PrometheusQueryResponseParse(promVectorResponse).getResults();
-            assertThat(results.get(0).getMetricHeader().get("__name__")).isEqualTo("up");
+            assertThat(results.get(0).getMetricHeader()).containsEntry("__name__", "up");
         }
     }
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusSplit.java
@@ -207,8 +207,8 @@ public class TestPrometheusSplit
         Map<String, String> paramsMap1 = parse(URI.create(split1.getUri()), StandardCharsets.UTF_8).stream().collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
         PrometheusSplit split2 = (PrometheusSplit) splits.getNextBatch(1).getNow(null).getSplits().get(0);
         Map<String, String> paramsMap2 = parse(URI.create(split2.getUri()), StandardCharsets.UTF_8).stream().collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
-        assertThat(paramsMap1.get("query")).isEqualTo("up[1d]");
-        assertThat(paramsMap2.get("query")).isEqualTo("up[1d]");
+        assertThat(paramsMap1).containsEntry("query", "up[1d]");
+        assertThat(paramsMap2).containsEntry("query", "up[1d]");
         long diff = Double.valueOf(paramsMap2.get("time")).longValue() - Double.valueOf(paramsMap1.get("time")).longValue();
         assertEquals(config.getQueryChunkSizeDuration().getValue(TimeUnit.SECONDS), diff, 0.0001);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardDao.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestShardDao.java
@@ -249,10 +249,10 @@ public class TestShardDao
         Set<UUID> shards = dao.getShards(tableId);
         assertThat(shards.size()).isEqualTo(4);
 
-        assertThat(shards.contains(shardUuid1)).isTrue();
-        assertThat(shards.contains(shardUuid2)).isTrue();
-        assertThat(shards.contains(shardUuid3)).isTrue();
-        assertThat(shards.contains(shardUuid4)).isTrue();
+        assertThat(shards).contains(shardUuid1);
+        assertThat(shards).contains(shardUuid2);
+        assertThat(shards).contains(shardUuid3);
+        assertThat(shards).contains(shardUuid4);
 
         assertThat(dao.getShardNodes(tableId).size()).isEqualTo(0);
 
@@ -283,6 +283,6 @@ public class TestShardDao
 
     private static void assertContainsShardNode(Set<ShardNode> nodes, String nodeName, UUID shardUuid)
     {
-        assertThat(nodes.contains(new ShardNode(shardUuid, nodeName))).isTrue();
+        assertThat(nodes).contains(new ShardNode(shardUuid, nodeName));
     }
 }

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
@@ -137,28 +137,32 @@ public class TestDbSessionPropertyManager
         SessionConfigurationContext context1 = new SessionConfigurationContext("foo123", Optional.of("src1"),
                 ImmutableSet.of(), Optional.empty(), TEST_RG);
         Map<String, String> sessionProperties1 = manager.getSystemSessionProperties(context1);
-        assertThat(sessionProperties1.get("prop_1")).isEqualTo("val_1");
-        assertThat(sessionProperties1.containsKey("prop_2")).isFalse();
+        assertThat(sessionProperties1)
+                .containsEntry("prop_1", "val_1")
+                .doesNotContainKey("prop_2");
 
         specsProvider.refresh();
         SessionConfigurationContext context2 = new SessionConfigurationContext("bar123", Optional.of("bar123"),
                 ImmutableSet.of(), Optional.empty(), TEST_RG);
         Map<String, String> sessionProperties2 = manager.getSystemSessionProperties(context2);
-        assertThat(sessionProperties2.get("prop_2")).isEqualTo("val_2");
-        assertThat(sessionProperties2.containsKey("prop_1")).isFalse();
+        assertThat(sessionProperties2)
+                .doesNotContainKey("prop_1")
+                .containsEntry("prop_2", "val_2");
 
         specsProvider.refresh();
         SessionConfigurationContext context3 = new SessionConfigurationContext("foo123", Optional.of("bar123"),
                 ImmutableSet.of(), Optional.empty(), TEST_RG);
         Map<String, String> sessionProperties3 = manager.getSystemSessionProperties(context3);
-        assertThat(sessionProperties3.get("prop_1")).isEqualTo("val_1");
-        assertThat(sessionProperties3.get("prop_2")).isEqualTo("val_2");
+        assertThat(sessionProperties3)
+                .containsEntry("prop_1", "val_1")
+                .containsEntry("prop_2", "val_2");
 
         specsProvider.refresh();
         SessionConfigurationContext context4 = new SessionConfigurationContext("abc", Optional.empty(), ImmutableSet.of(), Optional.empty(), TEST_RG);
         Map<String, String> sessionProperties4 = manager.getSystemSessionProperties(context4);
-        assertThat(sessionProperties4.containsKey("prop_1")).isFalse();
-        assertThat(sessionProperties4.containsKey("prop_2")).isFalse();
+        assertThat(sessionProperties4)
+                .doesNotContainKey("prop_1")
+                .doesNotContainKey("prop_2");
     }
 
     /**

--- a/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
+++ b/plugin/trino-session-property-managers/src/test/java/io/trino/plugin/session/db/TestDbSessionPropertyManager.java
@@ -193,8 +193,8 @@ public class TestDbSessionPropertyManager
         // Failed reloading, use cached configurations
         assertThat(failuresAfter - failuresBefore).isEqualTo(1);
         Map<String, String> sessionProperties1 = manager.getSystemSessionProperties(context1);
-        assertThat(sessionProperties1.get("prop_1")).isEqualTo("val_1");
-        assertThat(sessionProperties1.get("prop_3")).isEqualTo(null);
+        assertThat(sessionProperties1).containsEntry("prop_1", "val_1");
+        assertThat(sessionProperties1).doesNotContainKey("prop_3");
     }
 
     /**
@@ -219,9 +219,9 @@ public class TestDbSessionPropertyManager
 
         SessionConfigurationContext context = new SessionConfigurationContext("foo", Optional.of("bar"), ImmutableSet.of(), Optional.empty(), TEST_RG);
         Map<String, String> sessionProperties = manager.getSystemSessionProperties(context);
-        assertThat(sessionProperties.get("prop_1")).isEqualTo("val_1_3");
-        assertThat(sessionProperties.get("prop_2")).isEqualTo("val_2_2");
-        assertThat(sessionProperties.get("prop_3")).isEqualTo("val_3_1");
+        assertThat(sessionProperties).containsEntry("prop_1", "val_1_3");
+        assertThat(sessionProperties).containsEntry("prop_2", "val_2_2");
+        assertThat(sessionProperties).containsEntry("prop_3", "val_3_1");
         assertThat(sessionProperties.size()).isEqualTo(3);
     }
 

--- a/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsMetadataStatistics.java
+++ b/plugin/trino-tpcds/src/test/java/io/trino/plugin/tpcds/TestTpcdsMetadataStatistics.java
@@ -63,7 +63,7 @@ public class TestTpcdsMetadataStatistics
                             TableStatistics tableStatistics = metadata.getTableStatistics(session, tableHandle);
                             assertThat(tableStatistics.getRowCount().isUnknown()).isFalse();
                             for (ColumnHandle column : metadata.getColumnHandles(session, tableHandle).values()) {
-                                assertThat(tableStatistics.getColumnStatistics().containsKey(column)).isTrue();
+                                assertThat(tableStatistics.getColumnStatistics()).containsKey(column);
                                 assertThat(tableStatistics.getColumnStatistics().get(column)).isNotNull();
                             }
                         }));
@@ -81,7 +81,7 @@ public class TestTpcdsMetadataStatistics
         // all columns have stats
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
         for (ColumnHandle column : columnHandles.values()) {
-            assertThat(tableStatistics.getColumnStatistics().containsKey(column)).isTrue();
+            assertThat(tableStatistics.getColumnStatistics()).containsKey(column);
             assertThat(tableStatistics.getColumnStatistics().get(column)).isNotNull();
         }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6122,7 +6122,7 @@ public abstract class AbstractTestEngineOnlyQueries
     public void testShowCatalogs()
     {
         MaterializedResult result = computeActual("SHOW CATALOGS");
-        assertThat(result.getOnlyColumnAsSet().contains(getSession().getCatalog().get())).isTrue();
+        assertThat(result.getOnlyColumnAsSet()).contains(getSession().getCatalog().get());
     }
 
     @Test


### PR DESCRIPTION
Use assertion patterns that produce useful error messages on failures.

- Use `AbstractIterableAssert#contains` instead of `assertThat(list.contains(...)).isTrue()`
- Use `AbstractMapAssert#containsKey` instead of `assertThat(map.containsKey(...)).isTrue()`.
- Use `AbstractMapAssert#containsEntry` instead of `assertThat(map.get(...)).isEqualTo(...)`