### PR TITLE
Unify and supplement short-circuiting in MetadataManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -49,7 +49,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Sets.union;
 import static io.trino.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
@@ -285,7 +284,7 @@ public class InformationSchemaPageSource
         }
         // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views
 
-        for (SchemaTableName name : union(tables, views)) {
+        for (SchemaTableName name : tables) {
             String type = null;
             if (needsTableType) {
                 // if table and view names overlap, the view wins

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -270,9 +270,7 @@ public final class MetadataManager
     public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName table, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
     {
         requireNonNull(table, "table is null");
-
-        if (table.getCatalogName().isEmpty() || table.getSchemaName().isEmpty() || table.getObjectName().isEmpty()) {
-            // Table cannot exist
+        if (cannotExist(table)) {
             return Optional.empty();
         }
 
@@ -506,6 +504,9 @@ public final class MetadataManager
     public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
+        if (cannotExist(prefix)) {
+            return ImmutableList.of();
+        }
 
         Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
         if (objectName.isPresent()) {
@@ -562,17 +563,13 @@ public final class MetadataManager
     public List<TableColumnsMetadata> listTableColumns(Session session, QualifiedTablePrefix prefix, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
         requireNonNull(prefix, "prefix is null");
+        if (cannotExist(prefix)) {
+            return ImmutableList.of();
+        }
 
         String catalogName = prefix.getCatalogName();
         Optional<String> schemaName = prefix.getSchemaName();
         Optional<String> relationName = prefix.getTableName();
-
-        if (catalogName.isEmpty() ||
-                (schemaName.isPresent() && schemaName.get().isEmpty()) ||
-                (relationName.isPresent() && relationName.get().isEmpty())) {
-            // Cannot exist
-            return ImmutableList.of();
-        }
 
         if (relationName.isPresent()) {
             QualifiedObjectName objectName = new QualifiedObjectName(catalogName, schemaName.orElseThrow(), relationName.get());
@@ -698,6 +695,10 @@ public final class MetadataManager
     @Override
     public List<RelationCommentMetadata> listRelationComments(Session session, String catalogName, Optional<String> schemaName, UnaryOperator<Set<SchemaTableName>> relationFilter)
     {
+        if (cannotExist(new QualifiedTablePrefix(catalogName, schemaName, Optional.empty()))) {
+            return ImmutableList.of();
+        }
+
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, catalogName);
 
         ImmutableList.Builder<RelationCommentMetadata> tableComments = ImmutableList.builder();
@@ -1260,6 +1261,9 @@ public final class MetadataManager
     public List<QualifiedObjectName> listViews(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
+        if (cannotExist(prefix)) {
+            return ImmutableList.of();
+        }
 
         Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
         if (objectName.isPresent()) {
@@ -1293,6 +1297,9 @@ public final class MetadataManager
     public Map<QualifiedObjectName, ViewInfo> getViews(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
+        if (cannotExist(prefix)) {
+            return ImmutableMap.of();
+        }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
 
@@ -1407,8 +1414,7 @@ public final class MetadataManager
 
     private Optional<ConnectorViewDefinition> getViewInternal(Session session, QualifiedObjectName viewName)
     {
-        if (viewName.getCatalogName().isEmpty() || viewName.getSchemaName().isEmpty() || viewName.getObjectName().isEmpty()) {
-            // View cannot exist
+        if (cannotExist(viewName)) {
             return Optional.empty();
         }
 
@@ -1629,8 +1635,7 @@ public final class MetadataManager
 
     private Optional<ConnectorMaterializedViewDefinition> getMaterializedViewInternal(Session session, QualifiedObjectName viewName)
     {
-        if (viewName.getCatalogName().isEmpty() || viewName.getSchemaName().isEmpty() || viewName.getObjectName().isEmpty()) {
-            // View cannot exist
+        if (cannotExist(viewName)) {
             return Optional.empty();
         }
 
@@ -1720,9 +1725,7 @@ public final class MetadataManager
     {
         requireNonNull(session, "session is null");
         requireNonNull(originalTableName, "originalTableName is null");
-
-        if (originalTableName.getCatalogName().isEmpty() || originalTableName.getSchemaName().isEmpty() || originalTableName.getObjectName().isEmpty()) {
-            // table cannot exist
+        if (cannotExist(originalTableName)) {
             return originalTableName;
         }
 
@@ -2624,6 +2627,18 @@ public final class MetadataManager
             connectorVersion = Optional.of(new ConnectorTableVersion(version.get().getPointerType(), version.get().getObjectType(), version.get().getPointer()));
         }
         return connectorVersion;
+    }
+
+    private static boolean cannotExist(QualifiedTablePrefix prefix)
+    {
+        return prefix.getCatalogName().isEmpty() ||
+                (prefix.getSchemaName().isPresent() && prefix.getSchemaName().get().isEmpty()) ||
+                (prefix.getTableName().isPresent() && prefix.getTableName().get().isEmpty());
+    }
+
+    private static boolean cannotExist(QualifiedObjectName name)
+    {
+        return name.getCatalogName().isEmpty() || name.getSchemaName().isEmpty() || name.getObjectName().isEmpty();
     }
 
     public static MetadataManager createTestMetadataManager()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -794,15 +794,16 @@ public class HiveMetadata
         if (optionalSchemaName.isEmpty()) {
             Optional<List<SchemaTableName>> allTables = metastore.getAllTables();
             if (allTables.isPresent()) {
-                return ImmutableList.<SchemaTableName>builder()
+                return ImmutableSet.<SchemaTableName>builder()
                         .addAll(allTables.get().stream()
                                 .filter(table -> !isHiveSystemSchema(table.getSchemaName()))
                                 .collect(toImmutableList()))
                         .addAll(listMaterializedViews(session, optionalSchemaName))
-                        .build();
+                        .build()
+                        .asList();
             }
         }
-        ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
+        ImmutableSet.Builder<SchemaTableName> tableNames = ImmutableSet.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
             for (String tableName : metastore.getAllTables(schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
@@ -810,7 +811,7 @@ public class HiveMetadata
         }
 
         tableNames.addAll(listMaterializedViews(session, optionalSchemaName));
-        return tableNames.build();
+        return tableNames.build().asList();
     }
 
     private List<String> listSchemas(ConnectorSession session, Optional<String> schemaName)

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -360,10 +360,7 @@ public class TestInformationSchemaConnector
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = ''",
                 "VALUES (0, 0)",
-                ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables(schema=)")
-                        .add("ConnectorMetadata.listViews(schema=)")
-                        .build());
+                ImmutableMultiset.of());
 
         // Empty table name
         assertMetadataCalls(


### PR DESCRIPTION
Prevent passing impossible names down to the connectors.
E.g. prevents failures if a connector chooses to convert input to
something that validates name is not impossible, like
`SchemaTablePrefix`.