### PR TITLE
Remove unnecessary locks on DiscoveryNodeManager

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
@@ -82,14 +82,11 @@ public final class DiscoveryNodeManager
     private final InternalNode currentNode;
     private final boolean allCatalogsOnAllNodes;
 
-    @GuardedBy("this")
     private Optional<SetMultimap<CatalogHandle, InternalNode>> activeNodesByCatalogHandle = Optional.empty();
 
-    @GuardedBy("this")
-    private AllNodes allNodes;
+    private volatile AllNodes allNodes;
 
-    @GuardedBy("this")
-    private Set<InternalNode> coordinators;
+    private volatile Set<InternalNode> coordinators;
 
     @GuardedBy("this")
     private final List<Consumer<AllNodes>> listeners = new ArrayList<>();
@@ -305,7 +302,7 @@ public final class DiscoveryNodeManager
     }
 
     @Override
-    public synchronized AllNodes getAllNodes()
+    public AllNodes getAllNodes()
     {
         return allNodes;
     }
@@ -343,7 +340,7 @@ public final class DiscoveryNodeManager
     }
 
     @Override
-    public synchronized Set<InternalNode> getActiveCatalogNodes(CatalogHandle catalogHandle)
+    public Set<InternalNode> getActiveCatalogNodes(CatalogHandle catalogHandle)
     {
         // activeNodesByCatalogName is immutable
         return activeNodesByCatalogHandle
@@ -352,7 +349,7 @@ public final class DiscoveryNodeManager
     }
 
     @Override
-    public synchronized NodesSnapshot getActiveNodesSnapshot()
+    public NodesSnapshot getActiveNodesSnapshot()
     {
         return new NodesSnapshot(allNodes.getActiveNodes(), activeNodesByCatalogHandle);
     }
@@ -364,7 +361,7 @@ public final class DiscoveryNodeManager
     }
 
     @Override
-    public synchronized Set<InternalNode> getCoordinators()
+    public Set<InternalNode> getCoordinators()
     {
         return coordinators;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Threads which try to 'getAllNode' or 'getActiveConnectorNodes' could be against with thread that are refreshing workers state. This control of race condition seems unnecessary, so removing locks may be improve performance slightly.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
No related issues so far.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
