### PR TITLE
Add missing ClassLoaderSafe and refactor ConnectorTableFunction binding in Hive

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeTableFunctionProcessorProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeTableFunctionProcessorProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.classloader;
+
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.function.table.ConnectorTableFunctionHandle;
+import io.trino.spi.function.table.TableFunctionDataProcessor;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ClassLoaderSafeTableFunctionProcessorProvider
+        implements TableFunctionProcessorProvider
+{
+    private final TableFunctionProcessorProvider delegate;
+    private final ClassLoader classLoader;
+
+    public ClassLoaderSafeTableFunctionProcessorProvider(TableFunctionProcessorProvider delegate, ClassLoader classLoader)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public TableFunctionDataProcessor getDataProcessor(ConnectorTableFunctionHandle handle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getDataProcessor(handle);
+        }
+    }
+
+    @Override
+    public TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle, ConnectorSplit split)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getSplitProcessor(session, handle, split);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeTableFunctionSplitProcessor.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeTableFunctionSplitProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.classloader;
+
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.function.table.TableFunctionProcessorState;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ClassLoaderSafeTableFunctionSplitProcessor
+        implements TableFunctionSplitProcessor
+{
+    private final TableFunctionSplitProcessor delegate;
+    private final ClassLoader classLoader;
+
+    public ClassLoaderSafeTableFunctionSplitProcessor(TableFunctionSplitProcessor delegate, ClassLoader classLoader)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public TableFunctionProcessorState process()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.process();
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
@@ -27,6 +27,7 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.function.table.TableFunctionSplitProcessor;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -58,6 +59,7 @@ public class TestClassLoaderSafeWrappers
         testClassLoaderSafe(RecordSet.class, ClassLoaderSafeRecordSet.class);
         testClassLoaderSafe(EventListener.class, ClassLoaderSafeEventListener.class);
         testClassLoaderSafe(ConnectorTableFunction.class, ClassLoaderSafeConnectorTableFunction.class);
+        testClassLoaderSafe(TableFunctionSplitProcessor.class, ClassLoaderSafeTableFunctionSplitProcessor.class);
     }
 
     private static <I, C extends I> void testClassLoaderSafe(Class<I> iface, Class<C> clazz)

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/classloader/TestClassLoaderSafeWrappers.java
@@ -27,6 +27,7 @@ import io.trino.spi.connector.RecordSet;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.function.table.ConnectorTableFunction;
+import io.trino.spi.function.table.TableFunctionProcessorProvider;
 import io.trino.spi.function.table.TableFunctionSplitProcessor;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +61,7 @@ public class TestClassLoaderSafeWrappers
         testClassLoaderSafe(EventListener.class, ClassLoaderSafeEventListener.class);
         testClassLoaderSafe(ConnectorTableFunction.class, ClassLoaderSafeConnectorTableFunction.class);
         testClassLoaderSafe(TableFunctionSplitProcessor.class, ClassLoaderSafeTableFunctionSplitProcessor.class);
+        testClassLoaderSafe(TableFunctionProcessorProvider.class, ClassLoaderSafeTableFunctionProcessorProvider.class);
     }
 
     private static <I, C extends I> void testClassLoaderSafe(Class<I> iface, Class<C> clazz)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeFunctionProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeFunctionProvider.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.deltalake;
 
 import com.google.inject.Inject;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionProcessorProvider;
 import io.trino.plugin.deltalake.functions.tablechanges.TableChangesProcessorProvider;
 import io.trino.plugin.deltalake.functions.tablechanges.TableChangesTableFunctionHandle;
 import io.trino.spi.function.FunctionProvider;
@@ -37,7 +38,7 @@ public class DeltaLakeFunctionProvider
     public TableFunctionProcessorProvider getTableFunctionProcessorProvider(ConnectorTableFunctionHandle functionHandle)
     {
         if (functionHandle instanceof TableChangesTableFunctionHandle) {
-            return tableChangesProcessorProvider;
+            return new ClassLoaderSafeTableFunctionProcessorProvider(tableChangesProcessorProvider, getClass().getClassLoader());
         }
         throw new UnsupportedOperationException("Unsupported function: " + functionHandle);
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesProcessorProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/functions/tablechanges/TableChangesProcessorProvider.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake.functions.tablechanges;
 import com.google.inject.Inject;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.parquet.ParquetReaderOptions;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionSplitProcessor;
 import io.trino.plugin.deltalake.DeltaLakeConfig;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -54,7 +55,7 @@ public class TableChangesProcessorProvider
     @Override
     public TableFunctionSplitProcessor getSplitProcessor(ConnectorSession session, ConnectorTableFunctionHandle handle, ConnectorSplit split)
     {
-        return new TableChangesFunctionProcessor(
+        return new ClassLoaderSafeTableFunctionSplitProcessor(new TableChangesFunctionProcessor(
                 session,
                 fileSystemFactory,
                 parquetDateTimeZone,
@@ -62,6 +63,7 @@ public class TableChangesProcessorProvider
                 fileFormatDataSourceStats,
                 parquetReaderOptions,
                 (TableChangesTableFunctionHandle) handle,
-                (TableChangesSplit) split);
+                (TableChangesSplit) split),
+                getClass().getClassLoader());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -70,7 +70,7 @@ public class HiveConnector
 
     private final HiveTransactionManager transactionManager;
     private final Set<ConnectorTableFunction> connectorTableFunctions;
-    private final Optional<FunctionProvider> functionProvider;
+    private final FunctionProvider functionProvider;
     private final boolean singleStatementWritesOnly;
 
     public HiveConnector(
@@ -92,7 +92,7 @@ public class HiveConnector
             List<PropertyMetadata<?>> materializedViewProperties,
             Optional<ConnectorAccessControl> accessControl,
             Set<ConnectorTableFunction> connectorTableFunctions,
-            Optional<FunctionProvider> functionProvider,
+            FunctionProvider functionProvider,
             boolean singleStatementWritesOnly,
             ClassLoader classLoader)
     {
@@ -243,7 +243,7 @@ public class HiveConnector
     @Override
     public Optional<FunctionProvider> getFunctionProvider()
     {
-        return functionProvider;
+        return Optional.of(functionProvider);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -19,7 +19,6 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import io.airlift.event.client.EventClient;
 import io.trino.plugin.base.CatalogName;
@@ -57,7 +56,6 @@ import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.function.FunctionProvider;
 import io.trino.spi.function.table.ConnectorTableFunction;
 
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -149,7 +147,7 @@ public class HiveModule
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
         fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
 
-        newOptionalBinder(binder, new TypeLiteral<Optional<FunctionProvider>>(){}).setDefault().toInstance(Optional.empty());
+        newOptionalBinder(binder, FunctionProvider.class).setDefault().toInstance(new NoopFunctionProvider());
         newSetBinder(binder, ConnectorTableFunction.class);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -174,7 +174,7 @@ public final class InternalHiveConnectorFactory
                     hiveMaterializedViewPropertiesProvider.getMaterializedViewProperties(),
                     hiveAccessControl,
                     injector.getInstance(Key.get(new TypeLiteral<Set<ConnectorTableFunction>>() {})),
-                    injector.getInstance(Key.get(new TypeLiteral<Optional<FunctionProvider>>() {})),
+                    injector.getInstance(FunctionProvider.class),
                     injector.getInstance(HiveConfig.class).isSingleStatementWritesOnly(),
                     classLoader);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoopFunctionProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoopFunctionProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.spi.function.FunctionProvider;
+
+public class NoopFunctionProvider
+        implements FunctionProvider
+{}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/IcebergFunctionProvider.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.functions;
 
 import com.google.inject.Inject;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionProcessorProvider;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionHandle;
 import io.trino.plugin.iceberg.functions.tablechanges.TableChangesFunctionProcessorProvider;
 import io.trino.spi.function.FunctionProvider;
@@ -37,7 +38,7 @@ public class IcebergFunctionProvider
     public TableFunctionProcessorProvider getTableFunctionProcessorProvider(ConnectorTableFunctionHandle functionHandle)
     {
         if (functionHandle instanceof TableChangesFunctionHandle) {
-            return tableChangesFunctionProcessorProvider;
+            return new ClassLoaderSafeTableFunctionProcessorProvider(tableChangesFunctionProcessorProvider, getClass().getClassLoader());
         }
 
         throw new UnsupportedOperationException("Unsupported function: " + functionHandle);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessorProvider.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg.functions.tablechanges;
 
 import com.google.inject.Inject;
+import io.trino.plugin.base.classloader.ClassLoaderSafeTableFunctionSplitProcessor;
 import io.trino.plugin.iceberg.IcebergPageSourceProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplit;
@@ -40,10 +41,11 @@ public class TableChangesFunctionProcessorProvider
             ConnectorTableFunctionHandle handle,
             ConnectorSplit split)
     {
-        return new TableChangesFunctionProcessor(
+        return new ClassLoaderSafeTableFunctionSplitProcessor(new TableChangesFunctionProcessor(
                 session,
                 (TableChangesFunctionHandle) handle,
                 (TableChangesSplit) split,
-                icebergPageSourceProvider);
+                icebergPageSourceProvider),
+                getClass().getClassLoader());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Adding missing ClassLoaderSafeTableFunctionProcessorProvider and ClassLoaderSafeTableFunctionSplitProcessor
Also refactoring ConnectorTableFunction binding in Hive.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Lack of usage of `ClassLoaderSafe..` may have resulted in queries failure when some criterias were met:
- data was stored on hdfs
- query involved table function that used either `TableFunctionProcessorProvider` or `TableFunctionSplitProcessor` or both
- query was the first query touching hdfs that was run on the node after it started
In such case trino would fail to instantiate specific FileSystem and query would fail


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix issue when table function could fail if its invocation was a first query run a on worker ({issue}`issuenumber`)
```
