### PR TITLE
Properly finish stage on noMorePartitions signal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1747,9 +1747,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             }
 
             if (remainingPartitions.isEmpty()) {
-                stage.finish();
-                // TODO close exchange early
-                taskSource.close();
+                finish();
             }
         }
 
@@ -1980,17 +1978,22 @@ public class EventDrivenFaultTolerantQueryScheduler
             sinkOutputSelectorBuilder.include(exchange.getId(), taskId.getPartitionId(), taskId.getAttemptId());
 
             if (noMorePartitions && remainingPartitions.isEmpty() && !stage.getState().isDone()) {
-                dynamicFilterService.stageCannotScheduleMoreTasks(stage.getStageId(), 0, partitions.size());
-                exchange.noMoreSinks();
-                exchange.allRequiredSinksFinished();
-                verify(finalSinkOutputSelector == null, "finalOutputSelector is already set");
-                sinkOutputSelectorBuilder.setPartitionCount(exchange.getId(), partitions.size());
-                sinkOutputSelectorBuilder.setFinal();
-                finalSinkOutputSelector = sinkOutputSelectorBuilder.build();
-                sinkOutputSelectorBuilder = null;
-                stage.finish();
-                taskSource.close();
+                finish();
             }
+        }
+
+        private void finish()
+        {
+            dynamicFilterService.stageCannotScheduleMoreTasks(stage.getStageId(), 0, partitions.size());
+            exchange.noMoreSinks();
+            exchange.allRequiredSinksFinished();
+            verify(finalSinkOutputSelector == null, "finalOutputSelector is already set");
+            sinkOutputSelectorBuilder.setPartitionCount(exchange.getId(), partitions.size());
+            sinkOutputSelectorBuilder.setFinal();
+            finalSinkOutputSelector = sinkOutputSelectorBuilder.build();
+            sinkOutputSelectorBuilder = null;
+            stage.finish();
+            taskSource.close();
         }
 
         private void updateOutputSize(SpoolingOutputStats.Snapshot taskOutputStats)

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1989,6 +1989,7 @@ public class EventDrivenFaultTolerantQueryScheduler
                 finalSinkOutputSelector = sinkOutputSelectorBuilder.build();
                 sinkOutputSelectorBuilder = null;
                 stage.finish();
+                taskSource.close();
             }
         }
 


### PR DESCRIPTION
Theoretically it is possible that all task partitions for a stage
complete before we get noMorePartitions signal from SplitAssigner.
In such case we should execute same finish routie as we do when last
task partition completes and noMorePartitions is already set.

This is cleanup, not a bugfix as currently no SplitAssigner
(even though it is not guaranteed by interface) would seal
all of the task partitions without returning noMorePartitions flag in
the same AssignmentResult object.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
