### PR TITLE
Fix invalid boolean expression in ScalarFunctionAdapter.adaptParameter

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -302,7 +302,7 @@ public final class ScalarFunctionAdapter
             InvocationReturnConvention returnConvention)
     {
         // For value block, cast specialized parameter to ValueBlock
-        if (actualArgumentConvention == VALUE_BLOCK_POSITION || actualArgumentConvention == VALUE_BLOCK_POSITION_NOT_NULL && methodHandle.type().parameterType(parameterIndex) != ValueBlock.class) {
+        if ((actualArgumentConvention == VALUE_BLOCK_POSITION || actualArgumentConvention == VALUE_BLOCK_POSITION_NOT_NULL) && methodHandle.type().parameterType(parameterIndex) != ValueBlock.class) {
             methodHandle = methodHandle.asType(methodHandle.type().changeParameterType(parameterIndex, ValueBlock.class));
         }
 


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
