### PR TITLE
Allow caching stats in JDBC but not metadata 

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcConfig.java
@@ -36,6 +36,7 @@ public class BaseJdbcConfig
     private static final String METADATA_CACHE_TTL = "metadata.cache-ttl";
     private static final String METADATA_SCHEMAS_CACHE_TTL = "metadata.schemas.cache-ttl";
     private static final String METADATA_TABLES_CACHE_TTL = "metadata.tables.cache-ttl";
+    private static final String METADATA_STATISTICS_CACHE_TTL = "metadata.statistics.cache-ttl";
     private static final String METADATA_CACHE_MAXIMUM_SIZE = "metadata.cache-maximum-size";
     private static final long DEFAULT_METADATA_CACHE_SIZE = 10000;
 
@@ -44,6 +45,7 @@ public class BaseJdbcConfig
     private Duration metadataCacheTtl = new Duration(0, SECONDS);
     private Optional<Duration> schemaNamesCacheTtl = Optional.empty();
     private Optional<Duration> tableNamesCacheTtl = Optional.empty();
+    private Optional<Duration> statisticsCacheTtl = Optional.empty();
     private boolean cacheMissing;
     private Optional<Long> cacheMaximumSize = Optional.empty();
 
@@ -117,6 +119,20 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @NotNull
+    public Duration getStatisticsCacheTtl()
+    {
+        return statisticsCacheTtl.orElse(metadataCacheTtl);
+    }
+
+    @Config(METADATA_STATISTICS_CACHE_TTL)
+    @ConfigDescription("Determines how long table statistics information will be cached")
+    public BaseJdbcConfig setStatisticsCacheTtl(Duration statisticsCacheTtl)
+    {
+        this.statisticsCacheTtl = Optional.ofNullable(statisticsCacheTtl);
+        return this;
+    }
+
     public boolean isCacheMissing()
     {
         return cacheMissing;
@@ -144,10 +160,12 @@ public class BaseJdbcConfig
         return this;
     }
 
-    @AssertTrue(message = METADATA_CACHE_TTL + " must be set to a non-zero value when " + METADATA_CACHE_MAXIMUM_SIZE + " is set")
+    @AssertTrue(message = METADATA_CACHE_TTL + " or " + METADATA_STATISTICS_CACHE_TTL + " must be set to a non-zero value when " + METADATA_CACHE_MAXIMUM_SIZE + " is set")
     public boolean isCacheMaximumSizeConsistent()
     {
-        return !metadataCacheTtl.isZero() || cacheMaximumSize.isEmpty();
+        return !metadataCacheTtl.isZero() ||
+                (statisticsCacheTtl.isPresent() && !statisticsCacheTtl.get().isZero()) ||
+                cacheMaximumSize.isEmpty();
     }
 
     @AssertTrue(message = METADATA_SCHEMAS_CACHE_TTL + " must not be set when " + METADATA_CACHE_TTL + " is not set")

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -111,24 +111,6 @@ public class CachingJdbcClient
             Set<SessionPropertiesProvider> sessionPropertiesProviders,
             IdentityCacheMapping identityMapping,
             Duration metadataCachingTtl,
-            boolean cacheMissing,
-            long cacheMaximumSize)
-    {
-        this(delegate,
-                sessionPropertiesProviders,
-                identityMapping,
-                metadataCachingTtl,
-                metadataCachingTtl,
-                metadataCachingTtl,
-                cacheMissing,
-                cacheMaximumSize);
-    }
-
-    public CachingJdbcClient(
-            JdbcClient delegate,
-            Set<SessionPropertiesProvider> sessionPropertiesProviders,
-            IdentityCacheMapping identityMapping,
-            Duration metadataCachingTtl,
             Duration schemaNamesCachingTtl,
             Duration tableNamesCachingTtl,
             boolean cacheMissing,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -66,7 +66,6 @@ import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.cache.CacheUtils.invalidateAllIf;
-import static io.trino.plugin.jdbc.BaseJdbcConfig.CACHING_DISABLED;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -142,7 +141,7 @@ public class CachingJdbcClient
         this.cacheMissing = cacheMissing;
         this.identityMapping = requireNonNull(identityMapping, "identityMapping is null");
 
-        long cacheSize = metadataCachingTtl.equals(CACHING_DISABLED)
+        long cacheSize = metadataCachingTtl.isZero()
                 // Disables the cache entirely
                 ? 0
                 : cacheMaximumSize;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -102,6 +102,7 @@ public class CachingJdbcClient
                 config.getMetadataCacheTtl(),
                 config.getSchemaNamesCacheTtl(),
                 config.getTableNamesCacheTtl(),
+                config.getStatisticsCacheTtl(),
                 config.isCacheMissing(),
                 config.getCacheMaximumSize());
     }
@@ -113,6 +114,7 @@ public class CachingJdbcClient
             Duration metadataCachingTtl,
             Duration schemaNamesCachingTtl,
             Duration tableNamesCachingTtl,
+            Duration statisticsCachingTtl,
             boolean cacheMissing,
             long cacheMaximumSize)
     {
@@ -129,7 +131,7 @@ public class CachingJdbcClient
         tableHandlesByQueryCache = buildCache(cacheMaximumSize, metadataCachingTtl);
         procedureHandlesByQueryCache = buildCache(cacheMaximumSize, metadataCachingTtl);
         columnsCache = buildCache(cacheMaximumSize, metadataCachingTtl);
-        statisticsCache = buildCache(cacheMaximumSize, metadataCachingTtl);
+        statisticsCache = buildCache(cacheMaximumSize, statisticsCachingTtl);
     }
 
     private static <K, V> Cache<K, V> buildCache(long cacheSize, Duration cachingTtl)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -123,18 +123,13 @@ public class CachingJdbcClient
         this.cacheMissing = cacheMissing;
         this.identityMapping = requireNonNull(identityMapping, "identityMapping is null");
 
-        long cacheSize = metadataCachingTtl.isZero()
-                // Disables the cache entirely
-                ? 0
-                : cacheMaximumSize;
-
-        schemaNamesCache = buildCache(cacheSize, schemaNamesCachingTtl);
-        tableNamesCache = buildCache(cacheSize, tableNamesCachingTtl);
-        tableHandlesByNameCache = buildCache(cacheSize, metadataCachingTtl);
-        tableHandlesByQueryCache = buildCache(cacheSize, metadataCachingTtl);
-        procedureHandlesByQueryCache = buildCache(cacheSize, metadataCachingTtl);
-        columnsCache = buildCache(cacheSize, metadataCachingTtl);
-        statisticsCache = buildCache(cacheSize, metadataCachingTtl);
+        schemaNamesCache = buildCache(cacheMaximumSize, schemaNamesCachingTtl);
+        tableNamesCache = buildCache(cacheMaximumSize, tableNamesCachingTtl);
+        tableHandlesByNameCache = buildCache(cacheMaximumSize, metadataCachingTtl);
+        tableHandlesByQueryCache = buildCache(cacheMaximumSize, metadataCachingTtl);
+        procedureHandlesByQueryCache = buildCache(cacheMaximumSize, metadataCachingTtl);
+        columnsCache = buildCache(cacheMaximumSize, metadataCachingTtl);
+        statisticsCache = buildCache(cacheMaximumSize, metadataCachingTtl);
     }
 
     private static <K, V> Cache<K, V> buildCache(long cacheSize, Duration cachingTtl)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
@@ -45,6 +45,8 @@ public class DefaultJdbcMetadataFactory
                 Set.of(),
                 new SingletonIdentityCacheMapping(),
                 new Duration(1, DAYS),
+                new Duration(1, DAYS),
+                new Duration(1, DAYS),
                 true,
                 Integer.MAX_VALUE));
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
@@ -47,6 +47,7 @@ public class DefaultJdbcMetadataFactory
                 new Duration(1, DAYS),
                 new Duration(1, DAYS),
                 new Duration(1, DAYS),
+                new Duration(1, DAYS),
                 true,
                 Integer.MAX_VALUE));
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
@@ -41,12 +41,12 @@ public class DefaultJdbcMetadataFactory
         // Session stays the same per transaction, therefore session properties don't need to
         // be a part of cache keys in CachingJdbcClient.
         return create(new CachingJdbcClient(
-                        jdbcClient,
-                        Set.of(),
-                        new SingletonIdentityCacheMapping(),
-                        new Duration(1, DAYS),
-                        true,
-                        Integer.MAX_VALUE));
+                jdbcClient,
+                Set.of(),
+                new SingletonIdentityCacheMapping(),
+                new Duration(1, DAYS),
+                true,
+                Integer.MAX_VALUE));
     }
 
     protected JdbcMetadata create(JdbcClient transactionCachingJdbcClient)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc;
 
+import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import io.airlift.units.Duration;
@@ -41,6 +42,7 @@ public class DefaultJdbcMetadataFactory
         // Session stays the same per transaction, therefore session properties don't need to
         // be a part of cache keys in CachingJdbcClient.
         return create(new CachingJdbcClient(
+                Ticker.systemTicker(),
                 jdbcClient,
                 Set.of(),
                 new SingletonIdentityCacheMapping(),

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -26,15 +26,13 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDe
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.testing.ValidationAssertions.assertFailsValidation;
 import static io.airlift.testing.ValidationAssertions.assertValidates;
-import static java.util.concurrent.TimeUnit.MINUTES;
+import static io.airlift.units.Duration.ZERO;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestBaseJdbcConfig
 {
-    private static final Duration ZERO = Duration.succinctDuration(0, MINUTES);
-
     @Test
     public void testDefaults()
     {
@@ -100,20 +98,23 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setMetadataCacheTtl(new Duration(1, SECONDS)));
 
-        assertFailsValidation(new BaseJdbcConfig()
-                .setCacheMaximumSize(5000),
+        assertFailsValidation(
+                new BaseJdbcConfig()
+                        .setCacheMaximumSize(5000),
                 "cacheMaximumSizeConsistent",
                 "metadata.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set",
                 AssertTrue.class);
 
-        assertFailsValidation(new BaseJdbcConfig()
-                .setSchemaNamesCacheTtl(new Duration(1, SECONDS)),
+        assertFailsValidation(
+                new BaseJdbcConfig()
+                        .setSchemaNamesCacheTtl(new Duration(1, SECONDS)),
                 "schemaNamesCacheTtlConsistent",
                 "metadata.schemas.cache-ttl must not be set when metadata.cache-ttl is not set",
                 AssertTrue.class);
 
-        assertFailsValidation(new BaseJdbcConfig()
-                .setTableNamesCacheTtl(new Duration(1, SECONDS)),
+        assertFailsValidation(
+                new BaseJdbcConfig()
+                        .setTableNamesCacheTtl(new Duration(1, SECONDS)),
                 "tableNamesCacheTtlConsistent",
                 "metadata.tables.cache-ttl must not be set when metadata.cache-ttl is not set",
                 AssertTrue.class);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -42,6 +42,7 @@ public class TestBaseJdbcConfig
                 .setMetadataCacheTtl(ZERO)
                 .setSchemaNamesCacheTtl(null)
                 .setTableNamesCacheTtl(null)
+                .setStatisticsCacheTtl(null)
                 .setCacheMissing(false)
                 .setCacheMaximumSize(10000));
     }
@@ -55,6 +56,7 @@ public class TestBaseJdbcConfig
                 .put("metadata.cache-ttl", "1s")
                 .put("metadata.schemas.cache-ttl", "2s")
                 .put("metadata.tables.cache-ttl", "3s")
+                .put("metadata.statistics.cache-ttl", "7s")
                 .put("metadata.cache-missing", "true")
                 .put("metadata.cache-maximum-size", "5000")
                 .buildOrThrow();
@@ -65,6 +67,7 @@ public class TestBaseJdbcConfig
                 .setMetadataCacheTtl(new Duration(1, SECONDS))
                 .setSchemaNamesCacheTtl(new Duration(2, SECONDS))
                 .setTableNamesCacheTtl(new Duration(3, SECONDS))
+                .setStatisticsCacheTtl(new Duration(7, SECONDS))
                 .setCacheMissing(true)
                 .setCacheMaximumSize(5000);
 
@@ -96,13 +99,18 @@ public class TestBaseJdbcConfig
 
         assertValidates(new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
+                .setStatisticsCacheTtl(new Duration(7, SECONDS))
+                .setCacheMaximumSize(5000));
+
+        assertValidates(new BaseJdbcConfig()
+                .setConnectionUrl("jdbc:h2:mem:config")
                 .setMetadataCacheTtl(new Duration(1, SECONDS)));
 
         assertFailsValidation(
                 new BaseJdbcConfig()
                         .setCacheMaximumSize(5000),
                 "cacheMaximumSizeConsistent",
-                "metadata.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set",
+                "metadata.cache-ttl or metadata.statistics.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set",
                 AssertTrue.class);
 
         assertFailsValidation(

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -111,7 +111,7 @@ public class TestCachingJdbcClient
             throws Exception
     {
         database = new TestingDatabase();
-        cachingJdbcClient = createCachingJdbcClient(true, 10000);
+        cachingJdbcClient = createCachingJdbcClient(new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         jdbcClient = database.getJdbcClient();
         schema = jdbcClient.getSchemaNames(SESSION).iterator().next();
         executor = newCachedThreadPool(daemonThreadsNamed("TestCachingJdbcClient-%s"));
@@ -219,6 +219,7 @@ public class TestCachingJdbcClient
     public void testTableHandleOfQueryCached()
             throws Exception
     {
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         SchemaTableName phantomTable = new SchemaTableName(schema, "phantom_table");
 
         createTable(phantomTable);
@@ -378,6 +379,7 @@ public class TestCachingJdbcClient
     @Test
     public void testEmptyTableHandleIsCachedWhenCacheMissingIsTrue()
     {
+        CachingJdbcClient cachingJdbcClient = createCachingJdbcClient(true, 10000);
         SchemaTableName phantomTable = new SchemaTableName(schema, "phantom_table");
 
         assertThat(cachingJdbcClient.getTableHandle(SESSION, phantomTable)).isEmpty();
@@ -592,7 +594,7 @@ public class TestCachingJdbcClient
     @Test
     public void testGetTableStatistics()
     {
-        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, true, 10000);
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         ConnectorSession session = createSession("first");
 
         JdbcTableHandle first = createTable(new SchemaTableName(schema, "first"));
@@ -640,7 +642,7 @@ public class TestCachingJdbcClient
     @Test
     public void testCacheGetTableStatisticsWithQueryRelationHandle()
     {
-        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, true, 10000);
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         ConnectorSession session = createSession("some test session name");
 
         JdbcTableHandle first = createTable(new SchemaTableName(schema, "first"));
@@ -687,7 +689,7 @@ public class TestCachingJdbcClient
     @Test
     public void testTruncateTable()
     {
-        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, true, 10000);
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         ConnectorSession session = createSession("table");
 
         JdbcTableHandle table = createTable(new SchemaTableName(schema, "table"));
@@ -797,7 +799,7 @@ public class TestCachingJdbcClient
                 FOREVER,
                 FOREVER,
                 FOREVER,
-                true,
+                new BaseJdbcConfig().isCacheMissing(),
                 10000);
         ConnectorSession alice = createUserSession("alice");
         ConnectorSession bob = createUserSession("bob");
@@ -821,7 +823,7 @@ public class TestCachingJdbcClient
     @Test
     public void testFlushCache()
     {
-        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, true, 10000);
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         ConnectorSession session = createSession("asession");
 
         JdbcTableHandle first = createTable(new SchemaTableName(schema, "atable"));
@@ -858,7 +860,7 @@ public class TestCachingJdbcClient
     @Timeout(60)
     public void testConcurrentSchemaCreateAndDrop()
     {
-        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, true, 10000);
+        CachingJdbcClient cachingJdbcClient = cachingStatisticsAwareJdbcClient(FOREVER, new BaseJdbcConfig().isCacheMissing(), new BaseJdbcConfig().getCacheMaximumSize());
         ConnectorSession session = createSession("asession");
         List<Future<?>> futures = new ArrayList<>();
         for (int i = 0; i < 5; i++) {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -736,7 +736,15 @@ public class TestCachingJdbcClient
                 return NON_EMPTY_STATS;
             }
         };
-        return new CachingJdbcClient(statsAwareJdbcClient, SESSION_PROPERTIES_PROVIDERS, new SingletonIdentityCacheMapping(), duration, cacheMissing, cacheMaximumSize);
+        return new CachingJdbcClient(
+                statsAwareJdbcClient,
+                SESSION_PROPERTIES_PROVIDERS,
+                new SingletonIdentityCacheMapping(),
+                duration,
+                duration,
+                duration,
+                cacheMissing,
+                cacheMaximumSize);
     }
 
     @Test
@@ -786,6 +794,8 @@ public class TestCachingJdbcClient
                 new ExtraCredentialsBasedIdentityCacheMapping(new ExtraCredentialConfig()
                         .setUserCredentialName("user")
                         .setPasswordCredentialName("password")),
+                FOREVER,
+                FOREVER,
                 FOREVER,
                 true,
                 10000);
@@ -905,6 +915,8 @@ public class TestCachingJdbcClient
                 SESSION_PROPERTIES_PROVIDERS,
                 new SingletonIdentityCacheMapping(),
                 // ttl is 0, cache is disabled
+                new Duration(0, DAYS),
+                new Duration(0, DAYS),
                 new Duration(0, DAYS),
                 true,
                 10);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestCachingJdbcClient.java
@@ -61,6 +61,7 @@ import java.util.stream.Stream;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.Duration.ZERO;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -71,7 +72,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.DAYS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,8 +81,7 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
 @TestInstance(PER_METHOD)
 public class TestCachingJdbcClient
 {
-    private static final Duration FOREVER = Duration.succinctDuration(1, DAYS);
-    private static final Duration ZERO = Duration.succinctDuration(0, MILLISECONDS);
+    private static final Duration FOREVER = new Duration(1, DAYS);
 
     private static final ImmutableList<PropertyMetadata<?>> PROPERTY_METADATA = ImmutableList.of(
             stringProperty(
@@ -943,8 +942,8 @@ public class TestCachingJdbcClient
     {
         CachingJdbcClient cachingJdbcClient = createCachingJdbcClient(
                 FOREVER,
-                Duration.succinctDuration(3, SECONDS),
-                Duration.succinctDuration(2, SECONDS),
+                new Duration(3, SECONDS),
+                new Duration(2, SECONDS),
                 false, // decreased ttl for schema and table names mostly makes sense with cacheMissing == false
                 10000);
         String secondSchema = schema + "_two";


### PR DESCRIPTION
Apply `CachingHiveMetastore` capabilities in JDBC. Allow turning on
statistics caching without having to use caching for all of the
metadata. In common case caching statistics has much fewer side effects
than caching other stuff.