### PR TITLE
Make mapping of Trino schema to BigQuery dataset more explicit

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -112,6 +112,11 @@ public class BigQueryClient
         this.configProjectId = requireNonNull(configProjectId, "projectId is null");
     }
 
+    public Optional<RemoteDatabaseObject> toRemoteDataset(DatasetId datasetId)
+    {
+        return toRemoteDataset(datasetId.getProject(), datasetId.getDataset());
+    }
+
     public Optional<RemoteDatabaseObject> toRemoteDataset(String projectId, String datasetName)
     {
         requireNonNull(projectId, "projectId is null");
@@ -219,6 +224,16 @@ public class BigQueryClient
         String projectId = configProjectId.orElseGet(() -> bigQuery.getOptions().getProjectId());
         checkState(projectId.toLowerCase(ENGLISH).equals(projectId), "projectId must be lowercase but it's " + projectId);
         return projectId;
+    }
+
+    public DatasetId toDatasetId(String schemaName)
+    {
+        return DatasetId.of(getProjectId(), schemaName);
+    }
+
+    public String toSchemaName(DatasetId datasetId)
+    {
+        return datasetId.getDataset();
     }
 
     public Iterable<Dataset> listDatasets(String projectId)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -226,12 +226,12 @@ public class BigQueryClient
         return projectId;
     }
 
-    public DatasetId toDatasetId(String schemaName)
+    protected DatasetId toDatasetId(String schemaName)
     {
         return DatasetId.of(getProjectId(), schemaName);
     }
 
-    public String toSchemaName(DatasetId datasetId)
+    protected String toSchemaName(DatasetId datasetId)
     {
         return datasetId.getDataset();
     }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -169,13 +169,13 @@ public class BigQueryMetadata
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
+        DatasetId localDatasetId = client.toDatasetId(schemaName);
 
         // Overridden to make sure an error message is returned in case of an ambiguous schema name
         log.debug("schemaExists(session=%s)", session);
-        String projectId = client.getProjectId();
-        return client.toRemoteDataset(projectId, schemaName)
+        return client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
-                .filter(remoteSchema -> client.getDataset(DatasetId.of(projectId, remoteSchema)) != null)
+                .filter(remoteSchema -> client.getDataset(DatasetId.of(localDatasetId.getProject(), remoteSchema)) != null)
                 .isPresent();
     }
 
@@ -185,15 +185,23 @@ public class BigQueryMetadata
         BigQueryClient client = bigQueryClientFactory.create(session);
 
         log.debug("listTables(session=%s, schemaName=%s)", session, schemaName);
-        String projectId = client.getProjectId();
+        String projectId;
 
-        // filter ambiguous schemas
-        Optional<String> remoteSchema = schemaName.flatMap(schema -> client.toRemoteDataset(projectId, schema)
-                .filter(dataset -> !dataset.isAmbiguous())
-                .map(RemoteDatabaseObject::getOnlyRemoteName));
+        Set<String> remoteSchemaNames;
+        if (schemaName.isPresent()) {
+            DatasetId localDatasetId = client.toDatasetId(schemaName.get());
+            projectId = localDatasetId.getProject();
+            // filter ambiguous schemas
+            Optional<String> remoteSchema = client.toRemoteDataset(localDatasetId)
+                    .filter(dataset -> !dataset.isAmbiguous())
+                    .map(RemoteDatabaseObject::getOnlyRemoteName);
 
-        Set<String> remoteSchemaNames = remoteSchema.map(ImmutableSet::of)
-                .orElseGet(() -> ImmutableSet.copyOf(listRemoteSchemaNames(session)));
+            remoteSchemaNames = remoteSchema.map(ImmutableSet::of).orElse(ImmutableSet.of());
+        }
+        else {
+            projectId = client.getProjectId();
+            remoteSchemaNames = ImmutableSet.copyOf(listRemoteSchemaNames(session));
+        }
 
         return processInParallel(remoteSchemaNames.stream().toList(), remoteSchemaName -> listTablesInRemoteSchema(client, projectId, remoteSchemaName))
                 .flatMap(Collection::stream)
@@ -211,7 +219,7 @@ public class BigQueryMetadata
                         .filter(RemoteDatabaseObject::isAmbiguous)
                         .ifPresentOrElse(
                                 remoteTable -> log.debug("Filtered out [%s.%s] from list of tables due to ambiguous name", remoteSchemaName, table.getTableId().getTable()),
-                                () -> tableNames.add(new SchemaTableName(table.getTableId().getDataset(), table.getTableId().getTable())));
+                                () -> tableNames.add(new SchemaTableName(client.toSchemaName(DatasetId.of(projectId, table.getTableId().getDataset())), table.getTableId().getTable())));
             }
         }
         catch (BigQueryException e) {
@@ -230,15 +238,15 @@ public class BigQueryMetadata
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        String projectId = client.getProjectId();
         log.debug("getTableHandle(session=%s, schemaTableName=%s)", session, schemaTableName);
-        String remoteSchemaName = client.toRemoteDataset(projectId, schemaTableName.getSchemaName())
+        DatasetId localDatasetId = client.toDatasetId(schemaTableName.getSchemaName());
+        String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
-                .orElse(schemaTableName.getSchemaName());
-        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
+                .orElse(localDatasetId.getDataset());
+        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElse(schemaTableName.getTableName());
-        Optional<TableInfo> tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
+        Optional<TableInfo> tableInfo = client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName));
         if (tableInfo.isEmpty()) {
             log.debug("Table [%s.%s] was not found", schemaTableName.getSchemaName(), schemaTableName.getTableName());
             return null;
@@ -263,14 +271,14 @@ public class BigQueryMetadata
     private ConnectorTableHandle getTableHandleIgnoringConflicts(ConnectorSession session, SchemaTableName schemaTableName)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        String projectId = client.getProjectId();
-        String remoteSchemaName = client.toRemoteDataset(projectId, schemaTableName.getSchemaName())
+        DatasetId localDatasetId = client.toDatasetId(schemaTableName.getSchemaName());
+        String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getAnyRemoteName)
-                .orElse(schemaTableName.getSchemaName());
-        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
+                .orElse(localDatasetId.getDataset());
+        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getAnyRemoteName)
                 .orElse(schemaTableName.getTableName());
-        Optional<TableInfo> tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
+        Optional<TableInfo> tableInfo = client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName));
         if (tableInfo.isEmpty()) {
             log.debug("Table [%s.%s] was not found", schemaTableName.getSchemaName(), schemaTableName.getTableName());
             return null;
@@ -309,14 +317,14 @@ public class BigQueryMetadata
     private Optional<SystemTable> getViewDefinitionSystemTable(ConnectorSession session, SchemaTableName viewDefinitionTableName, SchemaTableName sourceTableName)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        String projectId = client.getProjectId();
-        String remoteSchemaName = client.toRemoteDataset(projectId, sourceTableName.getSchemaName())
+        DatasetId localDatasetId = client.toDatasetId(sourceTableName.getSchemaName());
+        String remoteSchemaName = client.toRemoteDataset(localDatasetId)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, sourceTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(localDatasetId.getProject(), remoteSchemaName, sourceTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        TableInfo tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName))
+        TableInfo tableInfo = client.getTable(TableId.of(localDatasetId.getProject(), remoteSchemaName, remoteTableName))
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
         if (!(tableInfo.getDefinition() instanceof ViewDefinition)) {
             throw new TableNotFoundException(viewDefinitionTableName);
@@ -422,7 +430,7 @@ public class BigQueryMetadata
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
         checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
-        DatasetInfo datasetInfo = DatasetInfo.newBuilder(client.getProjectId(), schemaName).build();
+        DatasetInfo datasetInfo = DatasetInfo.newBuilder(client.toDatasetId(schemaName)).build();
         client.createSchema(datasetInfo);
     }
 
@@ -430,9 +438,9 @@ public class BigQueryMetadata
     public void dropSchema(ConnectorSession session, String schemaName, boolean cascade)
     {
         BigQueryClient client = bigQueryClientFactory.create(session);
-        String projectId = client.getProjectId();
-        String remoteSchemaName = getRemoteSchemaName(client, projectId, schemaName);
-        client.dropSchema(DatasetId.of(projectId, remoteSchemaName), cascade);
+        DatasetId localDatasetId = client.toDatasetId(schemaName);
+        String remoteSchemaName = getRemoteSchemaName(client, localDatasetId.getProject(), localDatasetId.getDataset());
+        client.dropSchema(DatasetId.of(localDatasetId.getProject(), remoteSchemaName), cascade);
     }
 
     private void setRollback(Runnable action)
@@ -492,8 +500,8 @@ public class BigQueryMetadata
         }
 
         BigQueryClient client = bigQueryClientFactory.create(session);
-        String projectId = client.getProjectId();
-        String remoteSchemaName = getRemoteSchemaName(client, projectId, schemaName);
+        DatasetId localDatasetId = client.toDatasetId(schemaName);
+        String remoteSchemaName = getRemoteSchemaName(client, localDatasetId.getProject(), localDatasetId.getDataset());
 
         Closer closer = Closer.create();
         setRollback(() -> {
@@ -505,13 +513,13 @@ public class BigQueryMetadata
             }
         });
 
-        TableId tableId = createTable(client, projectId, remoteSchemaName, tableName, fields.build(), tableMetadata.getComment());
+        TableId tableId = createTable(client, localDatasetId.getProject(), remoteSchemaName, tableName, fields.build(), tableMetadata.getComment());
         closer.register(() -> bigQueryClientFactory.create(session).dropTable(tableId));
 
         Optional<String> temporaryTableName = pageSinkIdColumn.map(column -> {
             tempFields.add(typeManager.toField(column.getName(), column.getType(), column.getComment()));
             String tempTableName = generateTemporaryTableName(session);
-            TableId tempTableId = createTable(client, projectId, remoteSchemaName, tempTableName, tempFields.build(), tableMetadata.getComment());
+            TableId tempTableId = createTable(client, localDatasetId.getProject(), remoteSchemaName, tempTableName, tempFields.build(), tableMetadata.getComment());
             closer.register(() -> bigQueryClientFactory.create(session).dropTable(tempTableId));
             return tempTableName;
         });

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryOptionsConfigurer.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryOptionsConfigurer.java
@@ -18,7 +18,7 @@ import com.google.cloud.bigquery.storage.v1.BigQueryReadSettings;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteSettings;
 import io.trino.spi.connector.ConnectorSession;
 
-interface BigQueryOptionsConfigurer
+public interface BigQueryOptionsConfigurer
 {
     BigQueryOptions.Builder configure(BigQueryOptions.Builder builder, ConnectorSession session);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When reading through the BigQuery metadata class, it's hard to spot where exactly we map Trino schemas to BigQuery datasets, especially with the code that disambiguates them. This refactor is supposed to make it more explicit.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
