### PR TITLE
Respect hive.metastore-stats-cache-ttl is explicitly set

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreConfig.java
@@ -20,16 +20,18 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class CachingHiveMetastoreConfig
 {
-    private Duration metastoreCacheTtl = new Duration(0, TimeUnit.SECONDS);
+    private Duration metastoreCacheTtl = new Duration(0, SECONDS);
     // Use 5 mins for stats cache TTL by default. 5 mins will be sufficient to help
     // significantly when there is high number of concurrent queries.
     // 5 mins will also prevent stats from being stalled for a long time since
     // time window where table data can be altered is limited.
-    private Duration statsCacheTtl = new Duration(5, TimeUnit.MINUTES);
+    private Duration statsCacheTtl = new Duration(5, MINUTES);
     private Optional<Duration> metastoreRefreshInterval = Optional.empty();
     private long metastoreCacheMaximumSize = 10000;
     private int maxMetastoreRefreshThreads = 10;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -78,13 +78,7 @@ public class SharedHiveMetastoreCache
         this.catalogName = catalogName;
 
         metadataCacheTtl = config.getMetastoreCacheTtl();
-        if (metadataCacheTtl.compareTo(config.getStatsCacheTtl()) > 0) {
-            statsCacheTtl = metadataCacheTtl;
-        }
-        else {
-            statsCacheTtl = config.getStatsCacheTtl();
-        }
-
+        statsCacheTtl = config.getStatsCacheTtl();
         maxMetastoreRefreshThreads = config.getMaxMetastoreRefreshThreads();
         metastoreRefreshInterval = config.getMetastoreRefreshInterval();
         metastoreCacheMaximumSize = config.getMetastoreCacheMaximumSize();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -22,9 +22,13 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastoreConfig.DEFAULT_STATS_CACHE_TTL;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestCachingHiveMetastoreConfig
 {
@@ -64,5 +68,26 @@ public class TestCachingHiveMetastoreConfig
                 .setPartitionCacheEnabled(false);
 
         assertFullMapping(properties, expected);
+    }
+
+    @Test
+    public void testStatsCacheTtl()
+    {
+        // enabled by default
+        assertThat(new CachingHiveMetastoreConfig().getStatsCacheTtl()).isEqualTo(DEFAULT_STATS_CACHE_TTL);
+
+        // takes higher of the DEFAULT_STATS_CACHE_TTL or metastoreTtl if not set explicitly
+        assertThat(new CachingHiveMetastoreConfig()
+                .setMetastoreCacheTtl(new Duration(1, SECONDS))
+                .getStatsCacheTtl()).isEqualTo(DEFAULT_STATS_CACHE_TTL);
+        assertThat(new CachingHiveMetastoreConfig()
+                .setMetastoreCacheTtl(new Duration(1111, DAYS))
+                .getStatsCacheTtl()).isEqualTo(new Duration(1111, DAYS));
+
+        // explicit configuration is honored
+        assertThat(new CachingHiveMetastoreConfig()
+                .setStatsCacheTtl(new Duration(135, MILLISECONDS))
+                .setMetastoreCacheTtl(new Duration(1111, DAYS))
+                .getStatsCacheTtl()).isEqualTo(new Duration(135, MILLISECONDS));
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreConfig.java
@@ -18,11 +18,13 @@ import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestCachingHiveMetastoreConfig
 {
@@ -30,8 +32,8 @@ public class TestCachingHiveMetastoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(CachingHiveMetastoreConfig.class)
-                .setMetastoreCacheTtl(new Duration(0, TimeUnit.SECONDS))
-                .setStatsCacheTtl(new Duration(5, TimeUnit.MINUTES))
+                .setMetastoreCacheTtl(new Duration(0, SECONDS))
+                .setStatsCacheTtl(new Duration(5, MINUTES))
                 .setMetastoreRefreshInterval(null)
                 .setMetastoreCacheMaximumSize(10000)
                 .setMaxMetastoreRefreshThreads(10)
@@ -53,9 +55,9 @@ public class TestCachingHiveMetastoreConfig
                 .buildOrThrow();
 
         CachingHiveMetastoreConfig expected = new CachingHiveMetastoreConfig()
-                .setMetastoreCacheTtl(new Duration(2, TimeUnit.HOURS))
-                .setStatsCacheTtl(new Duration(10, TimeUnit.MINUTES))
-                .setMetastoreRefreshInterval(new Duration(30, TimeUnit.MINUTES))
+                .setMetastoreCacheTtl(new Duration(2, HOURS))
+                .setStatsCacheTtl(new Duration(10, MINUTES))
+                .setMetastoreRefreshInterval(new Duration(30, MINUTES))
                 .setMetastoreCacheMaximumSize(5000)
                 .setMaxMetastoreRefreshThreads(2500)
                 .setCacheMissing(false)


### PR DESCRIPTION
Remove the logic that would ignore `hive.metastore-stats-cache-ttl` set by the user, if the chosen value was less than the `hive.metastore-cache-ttl` value.

The logic's purpose was considered necessary to enable statistics cache by default, but the same goal can be achieved differently, by applying default value (fixed duration or `hive.metastore-cache-ttl` whichever is greater) only if the parameter was not set explicitly.

