### PR TITLE
Allow fetching relation names with their types (v2)

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1116,8 +1116,7 @@ public class TestTrinoDatabaseMetaData
                             databaseMetaData -> databaseMetaData.getTables(null, null, null, null),
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on catalog name
@@ -1127,8 +1126,7 @@ public class TestTrinoDatabaseMetaData
                             databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, null, null),
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on schema name
@@ -1142,8 +1140,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                             .build());
 
             // LIKE predicate on schema name
@@ -1157,8 +1154,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on table name
@@ -1171,8 +1167,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE"),
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // LIKE predicate on table name
@@ -1185,8 +1180,7 @@ public class TestTrinoDatabaseMetaData
                             list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE"),
                             list(COUNTING_CATALOG, "test_schema2", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // Equality predicate on schema name and table name
@@ -1197,8 +1191,8 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                            .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
+                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                            .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
@@ -1212,8 +1206,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews")
-                            .add("ConnectorMetadata.listTables")
+                            .add("ConnectorMetadata.getRelationTypes")
                             .build());
 
             // catalog does not exist
@@ -1530,8 +1523,7 @@ public class TestTrinoDatabaseMetaData
                             .map(schemaTableName -> list(COUNTING_CATALOG, schemaTableName.getSchemaName(), schemaTableName.getTableName(), "TABLE"))
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                             .build());
 
             // getTables's schema and table name patterns treated as literals
@@ -1542,8 +1534,8 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
                     ImmutableMultiset.<String>builder()
-                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                            .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
+                            .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                            .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getTableHandle(schema=test_schema1, table=test_table1)")
@@ -1557,8 +1549,7 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(),
                     ImmutableMultiset.<String>builder()
-                            .add("ConnectorMetadata.listViews(schema=test_schema_)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema_)")
+                            .add("ConnectorMetadata.getRelationTypes(schema=test_schema_)")
                             .build());
 
             // getColumns's schema and table name patterns treated as literals

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -26,6 +26,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GrantInfo;
@@ -37,6 +38,7 @@ import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Queue;
@@ -52,12 +54,12 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.defaultPrefixes;
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
+import static io.trino.metadata.MetadataListing.getRelationTypes;
 import static io.trino.metadata.MetadataListing.getViews;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
 import static io.trino.metadata.MetadataListing.listTablePrivileges;
 import static io.trino.metadata.MetadataListing.listTables;
-import static io.trino.metadata.MetadataListing.listViews;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.type.TypeUtils.getDisplayLabel;
@@ -245,7 +247,7 @@ public class InformationSchemaPageSource
 
     private void addColumnsRecords(QualifiedTablePrefix prefix)
     {
-        for (Map.Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
+        for (Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
             SchemaTableName tableName = entry.getKey();
             long ordinalPosition = 1;
 
@@ -275,16 +277,24 @@ public class InformationSchemaPageSource
 
     private void addTablesRecords(QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
         boolean needsTableType = requiredColumns.contains("table_type");
-        Set<SchemaTableName> views = Set.of();
+        Set<SchemaTableName> relations;
+        Set<SchemaTableName> views;
         if (needsTableType) {
-            // TODO introduce a dedicated method for getting relations with their type from the connector, instead of calling (potentially much more expensive) getViews
-            views = listViews(session, metadata, accessControl, prefix);
+            Map<SchemaTableName, RelationType> relationTypes = getRelationTypes(session, metadata, accessControl, prefix);
+            relations = relationTypes.keySet();
+            views = relationTypes.entrySet().stream()
+                    .filter(entry -> entry.getValue() == RelationType.VIEW)
+                    .map(Entry::getKey)
+                    .collect(toImmutableSet());
+        }
+        else {
+            relations = listTables(session, metadata, accessControl, prefix);
+            views = Set.of();
         }
         // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views
 
-        for (SchemaTableName name : tables) {
+        for (SchemaTableName name : relations) {
             String type = null;
             if (needsTableType) {
                 // if table and view names overlap, the view wins
@@ -304,7 +314,7 @@ public class InformationSchemaPageSource
 
     private void addViewsRecords(QualifiedTablePrefix prefix)
     {
-        for (Map.Entry<SchemaTableName, ViewInfo> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
+        for (Entry<SchemaTableName, ViewInfo> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
             addRecord(
                     prefix.getCatalogName(),
                     entry.getKey().getSchemaName(),

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -37,6 +37,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -163,6 +164,12 @@ public interface Metadata
      * This includes all relations (e.g. tables, views, materialized views).
      */
     List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix);
+
+    /**
+     * Get the relation names that match the specified table prefix (never null).
+     * This includes all relations (e.g. tables, views, materialized views).
+     */
+    Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Gets all of the columns on the specified table, or an empty map if the columns cannot be enumerated.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -22,6 +22,7 @@ import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.predicate.Domain;
@@ -46,6 +47,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.TABLE_REDIRECTION_ERROR;
+import static java.util.function.Function.identity;
 
 public final class MetadataListing
 {
@@ -133,22 +135,29 @@ public final class MetadataListing
         return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
     }
 
-    public static Set<SchemaTableName> listViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Map<SchemaTableName, RelationType> getRelationTypes(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
         try {
-            return doListViews(session, metadata, accessControl, prefix);
+            return doGetRelationTypes(session, metadata, accessControl, prefix);
         }
         catch (RuntimeException exception) {
-            throw handleListingException(exception, "views", prefix.getCatalogName());
+            throw handleListingException(exception, "tables", prefix.getCatalogName());
         }
     }
 
-    private static Set<SchemaTableName> doListViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    private static Map<SchemaTableName, RelationType> doGetRelationTypes(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tableNames = metadata.listViews(session, prefix).stream()
-                .map(QualifiedObjectName::asSchemaTableName)
-                .collect(toImmutableSet());
-        return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
+        Map<SchemaTableName, RelationType> relationTypes = metadata.getRelationTypes(session, prefix);
+
+        // Table listing operation only involves getting table names, but not any metadata. So redirected tables are not
+        // handled any differently. The target table or catalog are not involved. Thus the following filter is only called
+        // for the source catalog on source table names.
+        Set<SchemaTableName> accessibleNames = accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), relationTypes.keySet());
+        if (accessibleNames.equals(relationTypes.keySet())) {
+            return relationTypes;
+        }
+        return accessibleNames.stream()
+                .collect(toImmutableMap(identity(), relationTypes::get));
     }
 
     public static Map<SchemaTableName, ViewInfo> getViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -51,6 +51,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
@@ -264,6 +265,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("listTables", schemaName);
         try (var ignored = scopedSpan(span)) {
             return delegate.listTables(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("getRelationTypes", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRelationTypes(session, schemaName);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -65,6 +65,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -314,6 +315,15 @@ public class TracingMetadata
         Span span = startSpan("listTables", prefix);
         try (var ignored = scopedSpan(span)) {
             return delegate.listTables(session, prefix);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix)
+    {
+        Span span = startSpan("getRelationTypes", prefix);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getRelationTypes(session, prefix);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -43,6 +43,7 @@ import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -228,6 +229,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/RelationType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/RelationType.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public enum RelationType
+{
+    TABLE,
+    VIEW,
+    MATERIALIZED_VIEW,
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -51,6 +51,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SampleApplicationResult;
@@ -291,6 +292,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.listTables(session, schemaName);
+        }
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getRelationTypes(session, schemaName);
         }
     }
 

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -536,7 +536,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>**/TestHiveGlueMetastore.java</exclude>
+                                <exclude>**/TestGlueHiveMetastore.java</exclude>
                                 <exclude>**/TestHiveS3AndGlueMetastoreTest.java</exclude>
                                 <exclude>**/TestHiveConcurrentModificationGlueMetastore.java</exclude>
                                 <exclude>**/TestFullParquetReader.java</exclude>
@@ -593,7 +593,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
-                                <include>**/TestHiveGlueMetastore.java</include>
+                                <include>**/TestGlueHiveMetastore.java</include>
                                 <include>**/TestHiveS3AndGlueMetastoreTest.java</include>
                                 <include>**/TestHiveConcurrentModificationGlueMetastore.java</include>
                             </includes>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -88,6 +88,7 @@ import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.connector.ProjectionApplicationResult;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SchemaNotFoundException;
@@ -137,6 +138,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -814,6 +816,34 @@ public class HiveMetadata
         return tableNames.build().asList();
     }
 
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> optionalSchemaName)
+    {
+        ImmutableMap.Builder<SchemaTableName, RelationType> result = ImmutableMap.builder();
+
+        boolean fetched = false;
+        if (optionalSchemaName.isEmpty()) {
+            Optional<Map<SchemaTableName, RelationType>> relationTypes = metastore.getRelationTypes();
+            if (relationTypes.isPresent()) {
+                relationTypes.get().entrySet().stream()
+                        .filter(entry -> !isHiveSystemSchema(entry.getKey().getSchemaName()))
+                        .forEach(result::put);
+                fetched = true;
+            }
+        }
+        if (!fetched) {
+            for (String schemaName : listSchemas(session, optionalSchemaName)) {
+                for (Entry<String, RelationType> entry : metastore.getRelationTypes(schemaName).entrySet()) {
+                    result.put(new SchemaTableName(schemaName, entry.getKey()), entry.getValue());
+                }
+            }
+        }
+
+        listMaterializedViews(session, optionalSchemaName)
+                .forEach(name -> result.put(name, RelationType.MATERIALIZED_VIEW));
+        return result.buildKeepingLast();
+    }
+
     private List<String> listSchemas(ConnectorSession session, Optional<String> schemaName)
     {
         if (schemaName.isPresent()) {
@@ -892,7 +922,7 @@ public class HiveMetadata
                 .collect(toImmutableMap(HiveColumnHandle::getName, Function.identity()));
 
         Map<String, Type> columnTypes = columns.entrySet().stream()
-                .collect(toImmutableMap(Map.Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
+                .collect(toImmutableMap(Entry::getKey, entry -> getColumnMetadata(session, tableHandle, entry.getValue()).getType()));
         HivePartitionResult partitionResult = partitionManager.getPartitions(metastore, tableHandle, new Constraint(hiveTableHandle.getEnforcedConstraint()));
         // If partitions are not loaded, then don't generate table statistics.
         // Note that the computation is not persisted in the table handle, so can be redone many times
@@ -3075,7 +3105,7 @@ public class HiveMetadata
         ImmutableMap.Builder<ConnectorExpression, Variable> newVariablesBuilder = ImmutableMap.builder();
         ImmutableSet.Builder<ColumnHandle> projectedColumnsBuilder = ImmutableSet.builder();
 
-        for (Map.Entry<ConnectorExpression, ProjectedColumnRepresentation> entry : columnProjections.entrySet()) {
+        for (Entry<ConnectorExpression, ProjectedColumnRepresentation> entry : columnProjections.entrySet()) {
             ConnectorExpression expression = entry.getKey();
             ProjectedColumnRepresentation projectedColumn = entry.getValue();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -30,6 +30,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.projection.PartitionProjection;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.function.LanguageFunction;
@@ -162,6 +163,16 @@ public class HiveMetastoreClosure
     public Optional<List<SchemaTableName>> getAllTables()
     {
         return delegate.getAllTables();
+    }
+
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return delegate.getRelationTypes();
     }
 
     public List<String> getAllViews(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -21,6 +21,7 @@ import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -120,6 +121,18 @@ public abstract class ForwardingHiveMetastore
     public Optional<List<SchemaTableName>> getAllTables()
     {
         return delegate.getAllTables();
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return delegate.getRelationTypes();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -23,6 +23,7 @@ import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -68,6 +69,13 @@ public interface HiveMetastore
      * @return List of tables, views and materialized views names from all schemas or Optional.empty if operation is not supported
      */
     Optional<List<SchemaTableName>> getAllTables();
+
+    Map<String, RelationType> getRelationTypes(String databaseName);
+
+    /**
+     * @return empty if operation is not supported
+     */
+    Optional<Map<SchemaTableName, RelationType>> getRelationTypes();
 
     List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -52,6 +52,7 @@ import io.trino.plugin.hive.security.SqlStandardAccessControlMetadataMetastore;
 import io.trino.plugin.hive.util.ValidTxnWriteIdList;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -250,6 +251,24 @@ public class SemiTransactionalHiveMetastore
             throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
         }
         return delegate.getAllTables();
+    }
+
+    public synchronized Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    public synchronized Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        checkReadable();
+        if (!tableActions.isEmpty()) {
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
+        }
+        return delegate.getRelationTypes();
     }
 
     public synchronized Optional<Table> getTable(String databaseName, String tableName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -263,6 +263,20 @@ public class SharedHiveMetastoreCache
 
         @Managed
         @Nested
+        public AggregateCacheStatsMBean getRelationTypesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getRelationTypesCache);
+        }
+
+        @Managed
+        @Nested
+        public AggregateCacheStatsMBean getAllRelationTypesStats()
+        {
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllRelationTypesCache);
+        }
+
+        @Managed
+        @Nested
         public AggregateCacheStatsMBean getTableWithParameterStats()
         {
             return new AggregateCacheStatsMBean(CachingHiveMetastore::getTablesWithParameterCache);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -56,6 +56,7 @@ import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompat
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnNotFoundException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -519,6 +520,21 @@ public class FileHiveMetastore
 
     @Override
     public Optional<List<SchemaTableName>> getAllTables()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public synchronized Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
+        getAllTables(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
+        return relationTypes.buildKeepingLast();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -34,6 +34,7 @@ import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
@@ -147,6 +148,15 @@ public class BridgingHiveMetastore
     }
 
     @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
+        getAllTables(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
+        return relationTypes.buildKeepingLast();
+    }
+
+    @Override
     public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
     {
         return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
@@ -162,6 +172,17 @@ public class BridgingHiveMetastore
     public Optional<List<SchemaTableName>> getAllTables()
     {
         return delegate.getAllTables();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        return getAllTables().flatMap(relations -> getAllViews().map(views -> {
+            ImmutableMap.Builder<SchemaTableName, RelationType> relationTypes = ImmutableMap.builder();
+            relations.forEach(name -> relationTypes.put(name, RelationType.TABLE));
+            views.forEach(name -> relationTypes.put(name, RelationType.VIEW));
+            return relationTypes.buildKeepingLast();
+        }));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -31,6 +31,7 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -190,6 +191,31 @@ public class TracingHiveMetastore
             Optional<List<SchemaTableName>> tables = delegate.getAllTables();
             tables.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
             return tables;
+        });
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        Span span = tracer.spanBuilder("HiveMetastore.getRelationTypes")
+                .setAttribute(SCHEMA, databaseName)
+                .startSpan();
+        return withTracing(span, () -> {
+            Map<String, RelationType> relationTypes = delegate.getRelationTypes(databaseName);
+            span.setAttribute(TABLE_RESPONSE_COUNT, relationTypes.size());
+            return relationTypes;
+        });
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
+                .startSpan();
+        return withTracing(span, () -> {
+            Optional<Map<SchemaTableName, RelationType>> relationTypes = delegate.getRelationTypes();
+            relationTypes.ifPresent(map -> span.setAttribute(TABLE_RESPONSE_COUNT, map.size()));
+            return relationTypes;
         });
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -22,6 +22,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -35,8 +36,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_RELATION_TYPES;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATION_TYPES_FROM_DATABASE;
 
 @ThreadSafe
 public class CountingAccessHiveMetastore
@@ -52,6 +55,8 @@ public class CountingAccessHiveMetastore
         GET_TABLE,
         GET_ALL_TABLES,
         GET_ALL_TABLES_FROM_DATABASE,
+        GET_RELATION_TYPES_FROM_DATABASE,
+        GET_ALL_RELATION_TYPES,
         GET_TABLES_WITH_PARAMETER,
         GET_TABLE_STATISTICS,
         GET_ALL_VIEWS,
@@ -369,6 +374,23 @@ public class CountingAccessHiveMetastore
             methodInvocations.add(GET_ALL_TABLES);
         }
         return allTables;
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        methodInvocations.add(GET_RELATION_TYPES_FROM_DATABASE);
+        return delegate.getRelationTypes(databaseName);
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
+    {
+        Optional<Map<SchemaTableName, RelationType>> relationTypes = delegate.getRelationTypes();
+        if (relationTypes.isPresent()) {
+            methodInvocations.add(GET_ALL_RELATION_TYPES);
+        }
+        return relationTypes;
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -18,6 +18,7 @@ import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.LanguageFunction;
 import io.trino.spi.predicate.TupleDomain;
@@ -93,6 +94,18 @@ public class UnimplementedHiveMetastore
 
     @Override
     public Optional<List<SchemaTableName>> getAllTables()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, RelationType> getRelationTypes(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastore.java
@@ -132,10 +132,10 @@ import static org.junit.jupiter.api.Assumptions.abort;
  * See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
  * on ways to set your AWS credentials which will be needed to run this test.
  */
-public class TestHiveGlueMetastore
+public class TestGlueHiveMetastore
         extends AbstractTestHiveLocal
 {
-    private static final Logger log = Logger.get(TestHiveGlueMetastore.class);
+    private static final Logger log = Logger.get(TestGlueHiveMetastore.class);
 
     private static final String PARTITION_KEY = "part_key_1";
     private static final String PARTITION_KEY2 = "part_key_2";
@@ -191,7 +191,7 @@ public class TestHiveGlueMetastore
     private HiveMetastoreClosure metastore;
     private AWSGlueAsync glueClient;
 
-    public TestHiveGlueMetastore()
+    public TestGlueHiveMetastore()
     {
         super(TEST_DATABASE_NAME_PREFIX + randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -80,6 +80,7 @@ import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.RowChangeParadigm;
 import io.trino.spi.connector.SaveMode;
@@ -683,6 +684,12 @@ public class IcebergMetadata
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         return catalog.listTables(session, schemaName);
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> schemaName)
+    {
+        return catalog.getRelationTypes(session, schemaName);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
 import org.apache.iceberg.BaseTable;
@@ -74,6 +75,8 @@ public interface TrinoCatalog
     void renameNamespace(ConnectorSession session, String source, String target);
 
     List<SchemaTableName> listTables(ConnectorSession session, Optional<String> namespace);
+
+    Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> namespace);
 
     Optional<Iterator<RelationColumnsMetadata>> streamRelationColumns(
             ConnectorSession session,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.RelationColumnsMetadata;
 import io.trino.spi.connector.RelationCommentMetadata;
+import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
@@ -57,6 +58,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.transformValues;
@@ -72,6 +74,7 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 import static org.apache.iceberg.CatalogUtil.dropTableData;
 
 public class TrinoJdbcCatalog
@@ -178,6 +181,16 @@ public class TrinoJdbcCatalog
             }
         }
         return tablesListBuilder.build().asList();
+    }
+
+    @Override
+    public Map<SchemaTableName, RelationType> getRelationTypes(ConnectorSession session, Optional<String> namespace)
+    {
+        // views and materialized views are currently not supported
+        verify(listViews(session, namespace).isEmpty(), "Unexpected views support");
+        verify(listMaterializedViews(session, namespace).isEmpty(), "Unexpected views support");
+        return listTables(session, namespace).stream()
+                .collect(toImmutableMap(identity(), ignore -> RelationType.TABLE));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -498,7 +498,7 @@ public class TestIcebergGlueCatalogAccessOperations
                         session,
                         "SELECT * FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA",
                         ImmutableMultiset.<GlueMetastoreMethod>builder()
-                                .addCopies(GET_TABLES, 3) // TODO regression, it used to be 2
+                                .add(GET_TABLES)
                                 .build(),
                         ImmutableMultiset.of());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -498,7 +498,7 @@ public class TestIcebergGlueCatalogAccessOperations
                         session,
                         "SELECT * FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA",
                         ImmutableMultiset.<GlueMetastoreMethod>builder()
-                                .addCopies(GET_TABLES, 2)
+                                .addCopies(GET_TABLES, 3) // TODO regression, it used to be 2
                                 .build(),
                         ImmutableMultiset.of());
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogAccessOperations.java
@@ -458,7 +458,7 @@ public class TestIcebergGlueCatalogAccessOperations
     }
 
     @Test
-    public void testInformationSchemaColumns()
+    public void testInformationSchemaTableAndColumns()
     {
         String schemaName = "test_i_s_columns_schema" + randomNameSuffix();
         assertUpdate("CREATE SCHEMA " + schemaName);
@@ -483,7 +483,7 @@ public class TestIcebergGlueCatalogAccessOperations
                         assertUpdate(session, "CREATE TABLE test_other_select_i_s_columns" + i + "(id varchar, age integer)"); // won't match the filter
                     }
 
-                    // Bulk retrieval
+                    // Bulk columns retrieval
                     assertInvocations(
                             session,
                             "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name LIKE 'test_select_i_s_columns%'",
@@ -493,7 +493,16 @@ public class TestIcebergGlueCatalogAccessOperations
                             ImmutableMultiset.of());
                 }
 
-                // Pointed lookup
+                // Tables listing
+                assertInvocations(
+                        session,
+                        "SELECT * FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA",
+                        ImmutableMultiset.<GlueMetastoreMethod>builder()
+                                .addCopies(GET_TABLES, 2)
+                                .build(),
+                        ImmutableMultiset.of());
+
+                // Pointed columns lookup
                 assertInvocations(
                         session,
                         "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name = 'test_select_i_s_columns0'",
@@ -504,7 +513,7 @@ public class TestIcebergGlueCatalogAccessOperations
                                 .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                                 .build());
 
-                // Pointed lookup via DESCRIBE (which does some additional things before delegating to information_schema.columns)
+                // Pointed columns lookup via DESCRIBE (which does some additional things before delegating to information_schema.columns)
                 assertInvocations(
                         session,
                         "DESCRIBE test_select_i_s_columns0",

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -175,32 +175,27 @@ public class TestInformationSchemaConnector
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables",
                 "VALUES (3008, 3008)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables")
-                        .add("ConnectorMetadata.listViews")
+                        .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema = 'test_schema1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1'",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema LIKE 'test_sch_ma1' AND table_schema IN ('test_schema1', 'test_schema2')",
                 "VALUES (1000, 1000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema2)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema2)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_schema IN " +
@@ -212,26 +207,25 @@ public class TestInformationSchemaConnector
                                 .collect(joining(",", "(", ")")),
                 "VALUES (3000, 3000)",
                 ImmutableMultiset.<String>builder()
-                        .add("ConnectorMetadata.listTables")
-                        .add("ConnectorMetadata.listViews")
+                        .add("ConnectorMetadata.getRelationTypes")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'",
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 5)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema3_empty, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table1)")
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)", 2)
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema2, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema3_empty, table=test_table1)")
@@ -246,28 +240,24 @@ public class TestInformationSchemaConnector
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema2)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema3_empty)")
-                        .add("ConnectorMetadata.listTables(schema=test_schema4_empty)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema1)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema2)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema3_empty)")
-                        .add("ConnectorMetadata.listViews(schema=test_schema4_empty)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema1)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema2)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema3_empty)")
+                        .add("ConnectorMetadata.getRelationTypes(schema=test_schema4_empty)")
                         .build());
         assertMetadataCalls(
                 "SELECT count(table_name), count(table_type) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1' AND table_name IN ('test_table1', 'test_table2')",
                 "VALUES (2, 2)",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table2)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 5)
-                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table2)", 5)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema2, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema3_empty, table=test_table2)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table1)", 4)
+                        .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema4_empty, table=test_table2)", 4)
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table2)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema2, table=test_table2)")
@@ -276,14 +266,14 @@ public class TestInformationSchemaConnector
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema3_empty, table=test_table1)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table2)")
                         .add("ConnectorMetadata.getMaterializedView(schema=test_schema4_empty, table=test_table1)")
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema2, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table2)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)", 2)
-                        .addCopies("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table2)", 2)
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema2, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema3_empty, table=test_table2)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table1)")
+                        .add("ConnectorMetadata.getView(schema=test_schema4_empty, table=test_table2)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table1)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema1, table=test_table2)")
                         .add("ConnectorMetadata.redirectTable(schema=test_schema2, table=test_table1)")


### PR DESCRIPTION
This reduces number of Glue calls when reading from
`information_schema.tables` or `system.jdbc.tables`.

Like https://github.com/trinodb/trino/pull/19832 but avoids contentious rename (https://github.com/trinodb/trino/pull/19832#discussion_r1399768605).