### PR TITLE
Fix incorrect comparison for negative zero

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DoubleType.java
@@ -242,7 +242,7 @@ public final class DoubleType
     @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonUnorderedLastOperator(double left, double right)
     {
-        return Double.compare(left, right);
+        return compare(left, right);
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_FIRST)
@@ -258,7 +258,8 @@ public final class DoubleType
         if (Double.isNaN(right)) {
             return 1;
         }
-        return Double.compare(left, right);
+
+        return compare(left, right);
     }
 
     @ScalarOperator(LESS_THAN)
@@ -271,5 +272,14 @@ public final class DoubleType
     private static boolean lessThanOrEqualOperator(double left, double right)
     {
         return left <= right;
+    }
+
+    private static int compare(double left, double right)
+    {
+        if (left == right) { // Double.compare considers 0.0 and -0.0 different from each other
+            return 0;
+        }
+
+        return Double.compare(left, right);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RealType.java
@@ -183,7 +183,7 @@ public final class RealType
     @ScalarOperator(COMPARISON_UNORDERED_LAST)
     private static long comparisonUnorderedLastOperator(long left, long right)
     {
-        return Float.compare(intBitsToFloat((int) left), intBitsToFloat((int) right));
+        return compare(intBitsToFloat((int) left), intBitsToFloat((int) right));
     }
 
     @ScalarOperator(COMPARISON_UNORDERED_FIRST)
@@ -201,7 +201,7 @@ public final class RealType
         if (Float.isNaN(right)) {
             return 1;
         }
-        return Float.compare(left, right);
+        return compare(left, right);
     }
 
     @ScalarOperator(LESS_THAN)
@@ -214,5 +214,14 @@ public final class RealType
     private static boolean lessThanOrEqualOperator(long left, long right)
     {
         return intBitsToFloat((int) left) <= intBitsToFloat((int) right);
+    }
+
+    private static int compare(float left, float right)
+    {
+        if (left == right) { // Float.compare considers 0.0 and -0.0 different from each other
+            return 0;
+        }
+
+        return Float.compare(left, right);
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestTupleDomain.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestTupleDomain.java
@@ -462,6 +462,16 @@ public class TestTupleDomain
                 ImmutableMap.of(
                         A, Domain.singleValue(BIGINT, 0L),
                         B, Domain.none(VARCHAR)))).isTrue();
+
+        assertThat(contains(
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, 0.0)),
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, -0.0))))
+                .isTrue();
+
+        assertThat(contains(
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, -0.0)),
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, 0.0))))
+                .isTrue();
     }
 
     @Test
@@ -575,6 +585,11 @@ public class TestTupleDomain
                 ImmutableMap.of(
                         A, Domain.singleValue(BIGINT, 0L),
                         C, Domain.singleValue(DOUBLE, 0.0)))).isFalse();
+
+        assertThat(equals(
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, 0.0)),
+                ImmutableMap.of(A, Domain.singleValue(DOUBLE, -0.0))))
+                .isTrue();
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/19828

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect results for queries involving comparisons between `double` and `real` zero and negative zero. ({issue}`19828`)
```
