### PR TITLE
Remove duplicate 'are' in docs for sql routine examples

### DIFF
--- a/docs/src/main/sphinx/routines/examples.md
+++ b/docs/src/main/sphinx/routines/examples.md
@@ -201,7 +201,7 @@ SELECT simple_case(null,null); -- null .. but really??
 ## Fibonacci example
 
 This routine calculates the `n`-th value in the Fibonacci series, in which each
-number is the sum of the two preceding ones. The two initial values are are set
+number is the sum of the two preceding ones. The two initial values are set
 to `1` as the defaults for `a` and `b`. The routine uses an `IF` statement
 condition to return `1` for all input values of `2` or less. The `WHILE` block
 then starts to calculate each number in the series, starting with `a=1` and

--- a/docs/src/main/sphinx/routines/examples.md
+++ b/docs/src/main/sphinx/routines/examples.md
@@ -208,7 +208,7 @@ then starts to calculate each number in the series, starting with `a=1` and
 `b=1` and iterates until it reaches the `n`-th position. In each iteration is
 sets `a` and `b` for the preceding to values, so it can calculate the sum, and
 finally return it. Note that processing the routine takes longer and longer with
-higher `n` values, and the result it deterministic.
+higher `n` values, and the result is deterministic.
 
 ```sql
 FUNCTION fib(n bigint)
@@ -246,7 +246,7 @@ SELECT fib(8); -- 21
 
 ## Labels and loops
 
-This routing uses the `top` label to name the `WHILE` block, and then controls
+This routine uses the `top` label to name the `WHILE` block, and then controls
 the flow with conditional statements, `ITERATE`, and `LEAVE`. For the values of
 `a=1` and `a=2` in the first two iterations of the loop the `ITERATE` call moves
 the flow up to `top` before `b` is ever increased. Then `b` is increased for the


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Removes duplicate 'are' in docs for sql routines


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
