### PR TITLE
Remove testReadMetadataWithRelationsConcurrentModifications test

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -135,15 +135,6 @@ public class TestJdbcConnectorTest
     }
 
     @Test
-    @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-    {
-        // Under concurrently, H2 sometimes returns null table name in DatabaseMetaData.getTables's ResultSet
-        // See https://github.com/trinodb/trino/issues/16658 for more information
-        abort("Skipped due to H2 problems");
-    }
-
-    @Test
     public void testUnknownTypeAsIgnored()
     {
         try (TestTable table = new TestTable(

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -572,14 +572,6 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Test
-    @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-    {
-        // TODO: Enable this test after fixing "Task did not completed before timeout" (https://github.com/trinodb/trino/issues/14230)
-        abort("Test fails with a timeout sometimes and is flaky");
-    }
-
-    @Test
     public void testSkipUnsupportedType()
     {
         try (TestTable table = new TestTable(

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduConnectorTest.java
@@ -733,30 +733,6 @@ public class TestKuduConnectorTest
 
     @Test
     @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-    {
-        try {
-            super.testReadMetadataWithRelationsConcurrentModifications();
-        }
-        catch (Exception expected) {
-            // The test failure is not guaranteed
-            // TODO (https://github.com/trinodb/trino/issues/12974): shouldn't fail
-            assertThat(expected)
-                    .hasMessageMatching(".* table .* was deleted: Table deleted at .* UTC");
-            abort("to be fixed");
-        }
-    }
-
-    @Override
-    protected String createTableSqlTemplateForConcurrentModifications()
-    {
-        // TODO Remove this overriding method once kudu connector can create tables with default partitions
-        return "CREATE TABLE %s(a integer WITH (primary_key=true)) " +
-                "WITH (partition_by_hash_columns = ARRAY['a'], partition_by_hash_buckets = 2)";
-    }
-
-    @Test
-    @Override
     public void testCreateTableAsSelectNegativeDate()
     {
         // Map date column type to varchar

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/TestRedshiftConnectorTest.java
@@ -604,13 +604,6 @@ public class TestRedshiftConnectorTest
 
     @Test
     @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-    {
-        abort("Test fails with a timeout sometimes and is flaky");
-    }
-
-    @Test
-    @Override
     public void testInsertRowConcurrently()
     {
         abort("Test fails with a timeout sometimes and is flaky");

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -41,7 +41,6 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assumptions.abort;
 
 public abstract class BaseSqlServerConnectorTest
         extends BaseJdbcConnectorTest
@@ -132,26 +131,6 @@ public abstract class BaseSqlServerConnectorTest
     public void testSelectInformationSchemaColumns()
     {
         super.testSelectInformationSchemaColumns();
-    }
-
-    @Test
-    @Override
-    public void testReadMetadataWithRelationsConcurrentModifications()
-    {
-        try {
-            super.testReadMetadataWithRelationsConcurrentModifications();
-        }
-        catch (Exception expected) {
-            // The test failure is not guaranteed
-            assertThat(expected)
-                    .hasMessageMatching("(?s).*(" +
-                            "No task completed before timeout|" +
-                            "was deadlocked on lock resources with another process and has been chosen as the deadlock victim|" +
-                            "Lock request time out period exceeded|" +
-                            // E.g. system.metadata.table_comments can return empty results, when underlying metadata list tables call fails
-                            "Expecting actual not to be empty).*");
-            abort("to be fixed");
-        }
     }
 
     @Override


### PR DESCRIPTION
This test covers an important aspect of Trino connectors -- metadata
listing should work also while tables/views/materialized views are being
created or dropped. It helped discover real problems, e.g.

- in Iceberg, that's why it was created
- in Kudu: https://github.com/trinodb/trino/issues/12974,
- in SQL Server https://github.com/trinodb/trino/blob/8edaa86c6b43e5f5fe03bb9427d3f26439a60d15/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java#L151-L152

However, this turned out to be hard to test. The existing test is pretty complicated, takes a lot of time, has high timeout value and remains one of the more flaky tests. The test author does not know how to make it robust and perhaps does not want to remain as the author of the top flaky test in the project.

Fixes https://github.com/trinodb/trino/issues/19747
Fixes https://github.com/trinodb/trino/issues/14230