### PR TITLE
Push down predicate involving timestamp_tz in Delta Lake

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/filter/UtcConstraintExtractor.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/filter/UtcConstraintExtractor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.iceberg;
+package io.trino.plugin.base.filter;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,9 +62,15 @@ import static java.time.ZoneOffset.UTC;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
-public final class ConstraintExtractor
+/**
+ * Some expressions involving the TIMESTAMP WITH TIME ZONE type can be optimized when the time zone is known.
+ * It is not possible in the engine, but can be possible in the connector if the connector follows some
+ * convention regarding time zones. In some connectors, like the Delta Lake connector, or the Iceberg connector,
+ * all values of TIMESTAMP WITH TIME ZONE type are represented using the UTC time zone.
+ */
+public final class UtcConstraintExtractor
 {
-    private ConstraintExtractor() {}
+    private UtcConstraintExtractor() {}
 
     public static ExtractionResult extractTupleDomain(Constraint constraint)
     {

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/filter/TestUtcConstraintExtractor.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/filter/TestUtcConstraintExtractor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.iceberg;
+package io.trino.plugin.base.filter;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnHandle;
@@ -30,9 +30,6 @@ import io.trino.spi.type.DateType;
 import io.trino.spi.type.LongTimestampWithTimeZone;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
-import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
-import io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison;
-import io.trino.sql.planner.iterative.rule.UnwrapYearInComparison;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
@@ -40,7 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.trino.plugin.iceberg.ConstraintExtractor.extractTupleDomain;
+import static io.trino.plugin.base.filter.UtcConstraintExtractor.extractTupleDomain;
 import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
 import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
@@ -61,7 +58,7 @@ import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestConstraintExtractor
+public class TestUtcConstraintExtractor
 {
     private static final ColumnHandle A_BIGINT = new TestingColumnHandle("a_bigint");
     private static final ColumnHandle A_TIMESTAMP_TZ = new TestingColumnHandle("a_timestamp_tz");
@@ -82,11 +79,11 @@ public class TestConstraintExtractor
     }
 
     /**
-     * Test equivalent of {@link UnwrapCastInComparison} for {@link TimestampWithTimeZoneType}.
-     * {@link UnwrapCastInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
-     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Iceberg, we know
+     * Test equivalent of {@code io.trino.sql.planner.iterative.rule.UnwrapCastInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@code UnwrapCastInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. If we know
      * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
-     * so we can unwrap.
+     * we can unwrap.
      */
     @Test
     public void testExtractTimestampTzDateComparison()
@@ -151,11 +148,11 @@ public class TestConstraintExtractor
     }
 
     /**
-     * Test equivalent of {@link UnwrapDateTruncInComparison} for {@link TimestampWithTimeZoneType}.
-     * {@link UnwrapDateTruncInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
-     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Iceberg, we know
+     * Test equivalent of {@code io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@code UnwrapDateTruncInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. If we know
      * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
-     * so we can unwrap.
+     * we can unwrap.
      */
     @Test
     public void testExtractDateTruncTimestampTzComparison()
@@ -236,11 +233,11 @@ public class TestConstraintExtractor
     }
 
     /**
-     * Test equivalent of {@link UnwrapYearInComparison} for {@link TimestampWithTimeZoneType}.
-     * {@link UnwrapYearInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
-     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Iceberg, we know
+     * Test equivalent of {@code io.trino.sql.planner.iterative.rule.UnwrapYearInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@code UnwrapYearInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. If we know
      * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
-     * so we can unwrap.
+     * we can unwrap.
      */
     @Test
     public void testExtractYearTimestampTzComparison()
@@ -350,7 +347,7 @@ public class TestConstraintExtractor
 
     private static TupleDomain<ColumnHandle> extract(Constraint constraint)
     {
-        ConstraintExtractor.ExtractionResult result = extractTupleDomain(constraint);
+        UtcConstraintExtractor.ExtractionResult result = extractTupleDomain(constraint);
         assertThat(result.remainingExpression())
                 .isEqualTo(Constant.TRUE);
         return result.tupleDomain();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ConstraintExtractor.java
@@ -68,11 +68,10 @@ public final class ConstraintExtractor
 
     public static ExtractionResult extractTupleDomain(Constraint constraint)
     {
-        TupleDomain<IcebergColumnHandle> result = constraint.getSummary()
-                .transformKeys(IcebergColumnHandle.class::cast);
+        TupleDomain<ColumnHandle> result = constraint.getSummary();
         ImmutableList.Builder<ConnectorExpression> remainingExpressions = ImmutableList.builder();
         for (ConnectorExpression conjunct : extractConjuncts(constraint.getExpression())) {
-            Optional<TupleDomain<IcebergColumnHandle>> converted = toTupleDomain(conjunct, constraint.getAssignments());
+            Optional<TupleDomain<ColumnHandle>> converted = toTupleDomain(conjunct, constraint.getAssignments());
             if (converted.isEmpty()) {
                 remainingExpressions.add(conjunct);
             }
@@ -86,7 +85,7 @@ public final class ConstraintExtractor
         return new ExtractionResult(result, and(remainingExpressions.build()));
     }
 
-    private static Optional<TupleDomain<IcebergColumnHandle>> toTupleDomain(ConnectorExpression expression, Map<String, ColumnHandle> assignments)
+    private static Optional<TupleDomain<ColumnHandle>> toTupleDomain(ConnectorExpression expression, Map<String, ColumnHandle> assignments)
     {
         if (expression instanceof Call call) {
             return toTupleDomain(call, assignments);
@@ -94,7 +93,7 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static Optional<TupleDomain<IcebergColumnHandle>> toTupleDomain(Call call, Map<String, ColumnHandle> assignments)
+    private static Optional<TupleDomain<ColumnHandle>> toTupleDomain(Call call, Map<String, ColumnHandle> assignments)
     {
         if (call.getArguments().size() == 2) {
             ConnectorExpression firstArgument = call.getArguments().get(0);
@@ -145,7 +144,7 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static Optional<TupleDomain<IcebergColumnHandle>> unwrapCastInComparison(
+    private static Optional<TupleDomain<ColumnHandle>> unwrapCastInComparison(
             // upon invocation, we don't know if this really is a comparison
             FunctionName functionName,
             ConnectorExpression castSource,
@@ -164,13 +163,13 @@ public final class ConstraintExtractor
             return Optional.empty();
         }
 
-        IcebergColumnHandle column = resolve(sourceVariable, assignments);
-        if (column.getType() instanceof TimestampWithTimeZoneType sourceType) {
+        ColumnHandle column = resolve(sourceVariable, assignments);
+        if (sourceVariable.getType() instanceof TimestampWithTimeZoneType columnType) {
             // Iceberg supports only timestamp(6) with time zone
-            checkArgument(sourceType.getPrecision() == 6, "Unexpected type: %s", column.getType());
+            checkArgument(columnType.getPrecision() == 6, "Unexpected type: %s", columnType);
 
             if (constant.getType() == DateType.DATE) {
-                return unwrapTimestampTzToDateCast(column, functionName, (long) constant.getValue())
+                return unwrapTimestampTzToDateCast(column, columnType, functionName, (long) constant.getValue())
                         .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
             }
             // TODO support timestamp constant
@@ -179,10 +178,9 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static Optional<Domain> unwrapTimestampTzToDateCast(IcebergColumnHandle column, FunctionName functionName, long date)
+    private static Optional<Domain> unwrapTimestampTzToDateCast(ColumnHandle column, Type columnType, FunctionName functionName, long date)
     {
-        Type type = column.getType();
-        checkArgument(type.equals(TIMESTAMP_TZ_MICROS), "Column of unexpected type %s: %s", type, column);
+        checkArgument(columnType.equals(TIMESTAMP_TZ_MICROS), "Column of unexpected type %s: %s", columnType, column);
 
         // Verify no overflow. Date values must be in integer range.
         verify(date <= Integer.MAX_VALUE, "Date value out of range: %s", date);
@@ -192,7 +190,7 @@ public final class ConstraintExtractor
         LongTimestampWithTimeZone startOfDate = LongTimestampWithTimeZone.fromEpochMillisAndFraction(date * MILLISECONDS_PER_DAY, 0, UTC_KEY);
         LongTimestampWithTimeZone startOfNextDate = LongTimestampWithTimeZone.fromEpochMillisAndFraction((date + 1) * MILLISECONDS_PER_DAY, 0, UTC_KEY);
 
-        return createDomain(functionName, type, startOfDate, startOfNextDate);
+        return createDomain(functionName, columnType, startOfDate, startOfNextDate);
     }
 
     private static Optional<Domain> unwrapYearInTimestampTzComparison(FunctionName functionName, Type type, Constant constant)
@@ -237,7 +235,7 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static Optional<TupleDomain<IcebergColumnHandle>> unwrapDateTruncInComparison(
+    private static Optional<TupleDomain<ColumnHandle>> unwrapDateTruncInComparison(
             // upon invocation, we don't know if this really is a comparison
             FunctionName functionName,
             Constant unit,
@@ -261,10 +259,10 @@ public final class ConstraintExtractor
             return Optional.empty();
         }
 
-        IcebergColumnHandle column = resolve(sourceVariable, assignments);
-        if (column.getType() instanceof TimestampWithTimeZoneType type) {
+        ColumnHandle column = resolve(sourceVariable, assignments);
+        if (sourceVariable.getType() instanceof TimestampWithTimeZoneType type) {
             // Iceberg supports only timestamp(6) with time zone
-            checkArgument(type.getPrecision() == 6, "Unexpected type: %s", column.getType());
+            checkArgument(type.getPrecision() == 6, "Unexpected type: %s", type);
             verify(constant.getType().equals(type), "This method should not be invoked when type mismatch (i.e. surely not a comparison)");
 
             return unwrapDateTruncInComparison(((Slice) unit.getValue()).toStringUtf8(), functionName, constant)
@@ -352,7 +350,7 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static Optional<TupleDomain<IcebergColumnHandle>> unwrapYearInTimestampTzComparison(
+    private static Optional<TupleDomain<ColumnHandle>> unwrapYearInTimestampTzComparison(
             // upon invocation, we don't know if this really is a comparison
             FunctionName functionName,
             ConnectorExpression yearSource,
@@ -371,10 +369,10 @@ public final class ConstraintExtractor
             return Optional.empty();
         }
 
-        IcebergColumnHandle column = resolve(sourceVariable, assignments);
-        if (column.getType() instanceof TimestampWithTimeZoneType type) {
+        ColumnHandle column = resolve(sourceVariable, assignments);
+        if (sourceVariable.getType() instanceof TimestampWithTimeZoneType type) {
             // Iceberg supports only timestamp(6) with time zone
-            checkArgument(type.getPrecision() == 6, "Unexpected type: %s", column.getType());
+            checkArgument(type.getPrecision() == 6, "Unexpected type: %s", type);
 
             return unwrapYearInTimestampTzComparison(functionName, type, constant)
                     .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
@@ -383,14 +381,14 @@ public final class ConstraintExtractor
         return Optional.empty();
     }
 
-    private static IcebergColumnHandle resolve(Variable variable, Map<String, ColumnHandle> assignments)
+    private static ColumnHandle resolve(Variable variable, Map<String, ColumnHandle> assignments)
     {
         ColumnHandle columnHandle = assignments.get(variable.getName());
         checkArgument(columnHandle != null, "No assignment for %s", variable);
-        return (IcebergColumnHandle) columnHandle;
+        return columnHandle;
     }
 
-    public record ExtractionResult(TupleDomain<IcebergColumnHandle> tupleDomain, ConnectorExpression remainingExpression)
+    public record ExtractionResult(TupleDomain<ColumnHandle> tupleDomain, ConnectorExpression remainingExpression)
     {
         public ExtractionResult
         {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2471,7 +2471,8 @@ public class IcebergMetadata
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
         ConstraintExtractor.ExtractionResult extractionResult = extractTupleDomain(constraint);
-        TupleDomain<IcebergColumnHandle> predicate = extractionResult.tupleDomain();
+        TupleDomain<IcebergColumnHandle> predicate = extractionResult.tupleDomain()
+                .transformKeys(IcebergColumnHandle.class::cast);
         if (predicate.isAll() && constraint.getPredicateColumns().isEmpty()) {
             return Optional.empty();
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -34,6 +34,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
+import io.trino.plugin.base.filter.UtcConstraintExtractor;
 import io.trino.plugin.base.projection.ApplyProjectionUtil;
 import io.trino.plugin.base.projection.ApplyProjectionUtil.ProjectedColumnRepresentation;
 import io.trino.plugin.hive.HiveWrittenPartitions;
@@ -195,10 +196,10 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.collect.Sets.difference;
+import static io.trino.plugin.base.filter.UtcConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.base.projection.ApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.base.util.Procedures.checkProcedureArgument;
-import static io.trino.plugin.iceberg.ConstraintExtractor.extractTupleDomain;
 import static io.trino.plugin.iceberg.ExpressionConverter.isConvertableToIcebergExpression;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergAnalyzeProperties.getColumnNames;
@@ -2470,7 +2471,7 @@ public class IcebergMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
-        ConstraintExtractor.ExtractionResult extractionResult = extractTupleDomain(constraint);
+        UtcConstraintExtractor.ExtractionResult extractionResult = extractTupleDomain(constraint);
         TupleDomain<IcebergColumnHandle> predicate = extractionResult.tupleDomain()
                 .transformKeys(IcebergColumnHandle.class::cast);
         if (predicate.isAll() && constraint.getPredicateColumns().isEmpty()) {

--- a/testing/trino-tests/src/test/java/io/trino/tests/BaseQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/BaseQueryAssertionsTest.java
@@ -334,6 +334,25 @@ public abstract class BaseQueryAssertionsTest
     }
 
     @Test
+    public void testIsReplacedWithEmptyValues()
+    {
+        assertThat(query("SELECT 1 WHERE false")).isReplacedWithEmptyValues();
+
+        // Test that, in case of failure, there is no failure when rendering expected and actual plans
+        assertThatThrownBy(() -> assertThat(query("SELECT 1 WHERE true")).isReplacedWithEmptyValues())
+                .hasMessageContaining(
+                        "Plan does not match, expected [\n" +
+                                "\n" +
+                                "- node(OutputNode)\n")
+                .hasMessageContaining(
+                        "\n" +
+                                "\n" +
+                                "] but found [\n" +
+                                "\n" +
+                                "Output[columnNames = [_col0]]\n");
+    }
+
+    @Test
     public void testIsNotFullyPushedDown()
     {
         assertThat(query("SELECT name FROM nation WHERE rand() = 42")).isNotFullyPushedDown(FilterNode.class);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueryAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueryAssertions.java
@@ -67,6 +67,15 @@ public class TestLocalQueryAssertions
     }
 
     @Test
+    @Override
+    public void testIsReplacedWithEmptyValues()
+    {
+        assertThatThrownBy(() -> assertThat(query("SELECT 1 WHERE false")).isReplacedWithEmptyValues())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("isReplacedWithEmptyValues() currently does not work with LocalQueryRunner");
+    }
+
+    @Test
     public void testNullInErrorMessage()
     {
         assertThatThrownBy(() -> assertThat(query("SELECT CAST(null AS integer)")).matches("SELECT 1"))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Certain expressions involving TIMESTAMP WITH TIME ZONE can be optimized in Delta Lake connector based on the fact that columns of type TIMESTAMP WITH TIME ZONE are represented using the UTC time zone:
- `date_trunc('...', timeztamp_tz_column) <comparison> constant`
- `CAST(timestamp_tz_column AS DATE) <comparison> constant`
- `year(timestamp_tz_column) <comparison> constant`

The optimization is based on similar optimization in the Iceberg connector.

Fixes https://github.com/trinodb/trino/issues/18664

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake connector
* Pushdown filters involving columns of type TIMESTAMP WITH TIME ZONE. ({issue}`18664`)
```
