### PR TITLE
Partial revert of increase split scheduling config

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskManagerConfig.java
@@ -56,10 +56,10 @@ public class TaskManagerConfig
     private boolean shareIndexLoading;
     private int maxWorkerThreads = Runtime.getRuntime().availableProcessors() * 2;
     private Integer minDrivers;
-    private int initialSplitsPerNode = Runtime.getRuntime().availableProcessors() * 4;
+    private int initialSplitsPerNode = maxWorkerThreads;
     private int minDriversPerTask = 3;
     private int maxDriversPerTask = Integer.MAX_VALUE;
-    private Duration splitConcurrencyAdjustmentInterval = new Duration(1, TimeUnit.SECONDS);
+    private Duration splitConcurrencyAdjustmentInterval = new Duration(100, TimeUnit.MILLISECONDS);
 
     private DataSize sinkMaxBufferSize = DataSize.of(32, Unit.MEGABYTE);
     private DataSize sinkMaxBroadcastBufferSize = DataSize.of(200, Unit.MEGABYTE);

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskManagerConfig.java
@@ -41,8 +41,8 @@ public class TestTaskManagerConfig
     {
         assertRecordedDefaults(recordDefaults(TaskManagerConfig.class)
                 .setThreadPerDriverSchedulerEnabled(false)
-                .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 4)
-                .setSplitConcurrencyAdjustmentInterval(new Duration(1, TimeUnit.SECONDS))
+                .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 2)
+                .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
                 .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
                 .setInfoUpdateInterval(new Duration(3, TimeUnit.SECONDS))
                 .setTaskTerminationTimeout(new Duration(1, TimeUnit.MINUTES))


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Partially revert #19487, reduce regressions in tpch q18/q21


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
