### PR TITLE
Add diagnostics for stuck FTE scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SystemSessionProperties.isEnableCoordinatorDynamicFiltersDistribution;
@@ -329,9 +330,18 @@ public final class SqlStage
     }
 
     @Override
-    public String toString()
+    // for debugging
+    public synchronized String toString()
     {
-        return stateMachine.toString();
+        return toStringHelper(this)
+                .add("stateMachine", stateMachine)
+                .add("summarizeTaskInfo", summarizeTaskInfo)
+                .add("outboundDynamicFilterIds", outboundDynamicFilterIds)
+                .add("tasks", tasks)
+                .add("allTasks", allTasks)
+                .add("finishedTasks", finishedTasks)
+                .add("tasksWithFinalInfo", tasksWithFinalInfo)
+                .toString();
     }
 
     private class MemoryUsageListener

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingOutputBuffers.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SpoolingOutputBuffers.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -75,5 +76,14 @@ public class SpoolingOutputBuffers
     public SpoolingOutputBuffers withExchangeSinkInstanceHandle(ExchangeSinkInstanceHandle handle)
     {
         return new SpoolingOutputBuffers(getVersion() + 1, handle, outputPartitionCount);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("exchangeSinkInstanceHandle", exchangeSinkInstanceHandle)
+                .add("outputPartitionCount", outputPartitionCount)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/ArbitraryDistributionSplitAssigner.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -314,6 +315,32 @@ class ArbitraryDistributionSplitAssigner
         return assignment.build();
     }
 
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalogRequirement", catalogRequirement)
+                .add("partitionedSources", partitionedSources)
+                .add("replicatedSources", replicatedSources)
+                .add("allSources", allSources)
+                .add("adaptiveGrowthPeriod", adaptiveGrowthPeriod)
+                .add("adaptiveGrowthFactor", adaptiveGrowthFactor)
+                .add("minTargetPartitionSizeInBytes", minTargetPartitionSizeInBytes)
+                .add("maxTargetPartitionSizeInBytes", maxTargetPartitionSizeInBytes)
+                .add("standardSplitSizeInBytes", standardSplitSizeInBytes)
+                .add("maxTaskSplitCount", maxTaskSplitCount)
+                .add("nextPartitionId", nextPartitionId)
+                .add("adaptiveCounter", adaptiveCounter)
+                .add("targetPartitionSizeInBytes", targetPartitionSizeInBytes)
+                .add("roundedTargetPartitionSizeInBytes", roundedTargetPartitionSizeInBytes)
+                .add("allAssignments", allAssignments)
+                .add("openAssignments", openAssignments)
+                .add("completedSources", completedSources)
+                .add("replicatedSplits.size()", replicatedSplits.size())
+                .add("noMoreReplicatedSplits", noMoreReplicatedSplits)
+                .toString();
+    }
+
     private Optional<HostAddress> getHostRequirement(Split split)
     {
         if (split.getConnectorSplit().isRemotelyAccessible()) {
@@ -395,6 +422,17 @@ class ArbitraryDistributionSplitAssigner
         public void setFull(boolean full)
         {
             this.full = full;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("partitionId", partitionId)
+                    .add("assignedDataSizeInBytes", assignedDataSizeInBytes)
+                    .add("assignedSplitCount", assignedSplitCount)
+                    .add("full", full)
+                    .toString();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -458,6 +459,18 @@ public class BinPackingNodeAllocatorService
             else {
                 throw new IllegalStateException("Node " + node + " already released");
             }
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("node", node)
+                    .add("released", released)
+                    .add("memoryLease", memoryLease)
+                    .add("taskId", taskId)
+                    .add("executionClass", executionClass)
+                    .toString();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -2670,17 +2670,50 @@ public class EventDrivenFaultTolerantQueryScheduler
 
     private interface EventListener<T>
     {
-        T onRemoteTaskCompleted(RemoteTaskCompletedEvent event);
+        default T onRemoteTaskCompleted(RemoteTaskCompletedEvent event)
+        {
+            return onRemoteTaskEvent(event);
+        }
 
-        T onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event);
+        default T onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event)
+        {
+            return onRemoteTaskEvent(event);
+        }
 
-        T onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event);
+        default T onRemoteTaskEvent(RemoteTaskEvent event)
+        {
+            return onEvent(event);
+        }
 
-        T onSplitAssignment(SplitAssignmentEvent event);
+        default T onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event)
+        {
+            return onEvent(event);
+        }
 
-        T onStageFailure(StageFailureEvent event);
+        default T onSplitAssignment(SplitAssignmentEvent event)
+        {
+            return onStageEvent(event);
+        }
 
-        T onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent);
+        default T onStageFailure(StageFailureEvent event)
+        {
+            return onStageEvent(event);
+        }
+
+        default T onStageEvent(StageEvent event)
+        {
+            return onEvent(event);
+        }
+
+        default T onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent event)
+        {
+            return onEvent(event);
+        }
+
+        default T onEvent(Event event)
+        {
+            throw new RuntimeException("EventListener no implemented");
+        }
     }
 
     private static class SinkInstanceHandleAcquiredEvent

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -495,7 +495,7 @@ public class EventDrivenFaultTolerantQueryScheduler
     }
 
     private static class Scheduler
-            implements EventListener
+            implements EventListener<Void>
     {
         private static final int EVENT_BUFFER_CAPACITY = 100;
 
@@ -1343,7 +1343,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent)
+        public Void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent)
         {
             ScheduledTask scheduledTask = new ScheduledTask(sinkInstanceHandleAcquiredEvent.getStageId(), sinkInstanceHandleAcquiredEvent.getPartitionId());
             PreSchedulingTaskContext context = preSchedulingTaskContexts.remove(scheduledTask);
@@ -1376,6 +1376,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             if (remoteTask.isEmpty()) {
                 nodeLease.release();
             }
+            return null;
         }
 
         private StateChangeListener<TaskStatus> createExchangeSinkInstanceHandleUpdateRequiredListener()
@@ -1437,7 +1438,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void onRemoteTaskCompleted(RemoteTaskCompletedEvent event)
+        public Void onRemoteTaskCompleted(RemoteTaskCompletedEvent event)
         {
             TaskStatus taskStatus = event.getTaskStatus();
             TaskId taskId = taskStatus.getTaskId();
@@ -1466,26 +1467,29 @@ public class EventDrivenFaultTolerantQueryScheduler
             for (StageId consumerStageId : stageConsumers.get(stageExecution.getStageId())) {
                 getStageExecution(consumerStageId).setSourceOutputSelector(stageExecution.getStageFragmentId(), outputSelector);
             }
+            return null;
         }
 
         @Override
-        public void onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event)
+        public Void onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event)
         {
             TaskId taskId = event.getTaskStatus().getTaskId();
             StageExecution stageExecution = getStageExecution(taskId.getStageId());
             stageExecution.initializeUpdateOfExchangeSinkInstanceHandle(taskId, eventQueue);
+            return null;
         }
 
         @Override
-        public void onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event)
+        public Void onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event)
         {
             TaskId taskId = event.getTaskId();
             StageExecution stageExecution = getStageExecution(taskId.getStageId());
             stageExecution.finalizeUpdateOfExchangeSinkInstanceHandle(taskId, event.getExchangeSinkInstanceHandle());
+            return null;
         }
 
         @Override
-        public void onSplitAssignment(SplitAssignmentEvent event)
+        public Void onSplitAssignment(SplitAssignmentEvent event)
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             AssignmentResult assignment = event.getAssignmentResult();
@@ -1519,13 +1523,15 @@ public class EventDrivenFaultTolerantQueryScheduler
                 stageExecution.noMorePartitions();
             }
             stageExecution.taskDescriptorLoadingComplete();
+            return null;
         }
 
         @Override
-        public void onStageFailure(StageFailureEvent event)
+        public Void onStageFailure(StageFailureEvent event)
         {
             StageExecution stageExecution = getStageExecution(event.getStageId());
             stageExecution.fail(event.getFailure());
+            return null;
         }
 
         private StageExecution getStageExecution(StageId stageId)
@@ -2643,30 +2649,38 @@ public class EventDrivenFaultTolerantQueryScheduler
 
     private interface Event
     {
-        Event ABORT = listener -> {
-            throw new UnsupportedOperationException();
+        Event ABORT = new Event() {
+            @Override
+            public <T> T accept(EventListener<T> listener)
+            {
+                throw new UnsupportedOperationException();
+            }
         };
 
-        Event WAKE_UP = listener -> {
-            throw new UnsupportedOperationException();
+        Event WAKE_UP = new Event() {
+            @Override
+            public <T> T accept(EventListener<T> listener)
+            {
+                throw new UnsupportedOperationException();
+            }
         };
 
-        void accept(EventListener listener);
+        <T> T accept(EventListener<T> listener);
     }
 
-    private interface EventListener
+    private interface EventListener<T>
     {
-        void onRemoteTaskCompleted(RemoteTaskCompletedEvent event);
+        T onRemoteTaskCompleted(RemoteTaskCompletedEvent event);
 
-        void onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event);
+        T onRemoteTaskExchangeSinkUpdateRequired(RemoteTaskExchangeSinkUpdateRequiredEvent event);
 
-        void onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event);
+        T onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event);
 
-        void onSplitAssignment(SplitAssignmentEvent event);
+        T onSplitAssignment(SplitAssignmentEvent event);
 
-        void onStageFailure(StageFailureEvent event);
+        T onStageFailure(StageFailureEvent event);
 
-        void onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent);
+        T onSinkInstanceHandleAcquired(SinkInstanceHandleAcquiredEvent sinkInstanceHandleAcquiredEvent);
     }
 
     private static class SinkInstanceHandleAcquiredEvent
@@ -2713,9 +2727,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onSinkInstanceHandleAcquired(this);
+            return listener.onSinkInstanceHandleAcquired(this);
         }
     }
 
@@ -2728,9 +2742,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onRemoteTaskCompleted(this);
+            return listener.onRemoteTaskCompleted(this);
         }
     }
 
@@ -2743,9 +2757,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onRemoteTaskExchangeSinkUpdateRequired(this);
+            return listener.onRemoteTaskExchangeSinkUpdateRequired(this);
         }
     }
 
@@ -2762,9 +2776,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onRemoteTaskExchangeUpdatedSinkAcquired(this);
+            return listener.onRemoteTaskExchangeUpdatedSinkAcquired(this);
         }
 
         public TaskId getTaskId()
@@ -2811,9 +2825,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onSplitAssignment(this);
+            return listener.onSplitAssignment(this);
         }
     }
 
@@ -2834,9 +2848,9 @@ public class EventDrivenFaultTolerantQueryScheduler
         }
 
         @Override
-        public void accept(EventListener listener)
+        public <T> T accept(EventListener<T> listener)
         {
-            listener.onStageFailure(this);
+            return listener.onStageFailure(this);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -498,6 +498,7 @@ public class EventDrivenFaultTolerantQueryScheduler
             implements EventListener<Void>
     {
         private static final int EVENT_BUFFER_CAPACITY = 100;
+        private static final long EVENT_PROCESSING_ENFORCED_FREQUENCY_MILLIS = new Duration(1, MINUTES).toMillis();
 
         private final QueryStateMachine queryStateMachine;
         private final Metadata metadata;
@@ -675,7 +676,7 @@ public class EventDrivenFaultTolerantQueryScheduler
         private boolean processEvents()
         {
             try {
-                Event event = eventQueue.poll(1, MINUTES);
+                Event event = eventQueue.poll(EVENT_PROCESSING_ENFORCED_FREQUENCY_MILLIS, MILLISECONDS);
                 if (event == null) {
                     return true;
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.SetMultimap;
@@ -108,6 +109,7 @@ import jakarta.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -129,6 +131,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.IntConsumer;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -181,6 +184,7 @@ import static java.lang.Math.min;
 import static java.lang.Math.round;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
+import static java.util.Map.Entry.comparingByKey;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -492,13 +496,163 @@ public class EventDrivenFaultTolerantQueryScheduler
             SqlStage sqlStage = requireNonNull(stages.get(taskId.getStageId()), () -> "stage not found: %s" + taskId.getStageId());
             sqlStage.failTaskRemotely(taskId, failureCause);
         }
+
+        public void logDebugInfo()
+        {
+            if (!log.isDebugEnabled()) {
+                return;
+            }
+            log.debug("SqlStages:");
+            stages.forEach((stageId, stage) -> {
+                log.debug("SqlStage %s: %s", stageId, stage);
+            });
+        }
+    }
+
+    private static class EventDebugInfos
+    {
+        private static final String GLOBAL_EVENTS_BUCKET = "GLOBAL";
+        private static final EventListener<String> GET_BUCKET_LISTENER = new EventListener<>()
+        {
+            @Override
+            public String onRemoteTaskEvent(RemoteTaskEvent event)
+            {
+                return "task_" + event.getTaskStatus().getTaskId().getStageId().toString();
+            }
+
+            @Override
+            public String onRemoteTaskExchangeUpdatedSinkAcquired(RemoteTaskExchangeUpdatedSinkAcquired event)
+            {
+                return "task_" + event.getTaskId().getStageId().toString();
+            }
+
+            @Override
+            public String onStageEvent(StageEvent event)
+            {
+                return event.getStageId().toString();
+            }
+
+            @Override
+            public String onEvent(Event event)
+            {
+                return GLOBAL_EVENTS_BUCKET;
+            }
+        };
+
+        private final String queryId;
+        private final int eventsPerBucket;
+        private long eventsCounter;
+        private long filteredEventsCounter;
+
+        // Using SoftReference to prevent OOM in an unexpected case when this collection grow to substantial size
+        // and VM is short on memory.
+        private SoftReference<ListMultimap<String, String>> eventsDebugInfosReference;
+
+        private EventDebugInfos(String queryId, int eventsPerBucket)
+        {
+            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.eventsPerBucket = eventsPerBucket;
+            eventsDebugInfosReference = new SoftReference<>(LinkedListMultimap.create());
+        }
+
+        /**
+         * @return true if event was recorded; false if it was filtered out
+         */
+        private boolean add(Event event)
+        {
+            ListMultimap<String, String> eventsDebugInfos = getEventsDebugInfos();
+            String bucket = getBucket(event);
+            Optional<String> debugInfo = getFullDebugInfo(eventsCounter, event);
+            eventsCounter++;
+            if (debugInfo.isEmpty()) {
+                filteredEventsCounter++;
+                return false;
+            }
+
+            List<String> bucketDebugInfos = eventsDebugInfos.get(bucket);
+            bucketDebugInfos.add(debugInfo.get());
+            if (bucketDebugInfos.size() > eventsPerBucket) {
+                Iterator<String> iterator = bucketDebugInfos.iterator();
+                iterator.next();
+                iterator.remove();
+            }
+            return true;
+        }
+
+        private ListMultimap<String, String> getEventsDebugInfos()
+        {
+            ListMultimap<String, String> eventsDebugInfos = eventsDebugInfosReference.get();
+            if (eventsDebugInfos == null) {
+                log.debug("eventsDebugInfos for %s has been cleared", queryId);
+                eventsDebugInfos = LinkedListMultimap.create();
+                eventsDebugInfosReference = new SoftReference<>(eventsDebugInfos);
+            }
+            return eventsDebugInfos;
+        }
+
+        private String getBucket(Event event)
+        {
+            if (event == Event.WAKE_UP || event == Event.ABORT) {
+                return GLOBAL_EVENTS_BUCKET;
+            }
+            return event.accept(GET_BUCKET_LISTENER);
+        }
+
+        private Optional<String> getFullDebugInfo(long eventId, Event event)
+        {
+            return getEventDebugInfo(event).map(info -> "[" + eventId + "/" + System.currentTimeMillis() + "/" + info + "]");
+        }
+
+        private static Optional<String> getEventDebugInfo(Event event)
+        {
+            if (event == Event.WAKE_UP) {
+                return Optional.of("WAKE_UP");
+            }
+            if (event == Event.ABORT) {
+                return Optional.of("ABORT");
+            }
+            if (event instanceof SplitAssignmentEvent splitAssignmentEvent) {
+                if (splitAssignmentEvent.getAssignmentResult().isEmpty()) {
+                    // There may be significant amount of empty AssignmentResults so lets skip processing of those.
+                    // It could be that scheduler loop is not really stuck per se. But we are getting empty events all the time - and it just looks like stuck.
+                    // We need to notice that, and still log debug information.
+                    // Also empty events can push important events out of recorded debug information - making debug logs less useful.
+                    return Optional.empty();
+                }
+            }
+
+            return Optional.of(event.toString());
+        }
+
+        public void log()
+        {
+            if (!log.isDebugEnabled()) {
+                return;
+            }
+            ListMultimap<String, String> eventsDebugInfos = getEventsDebugInfos();
+            eventsDebugInfos.asMap().entrySet().stream()
+                    .sorted(comparingByKey())
+                    .forEachOrdered(entry -> {
+                        log.debug("Recent events for " + entry.getKey());
+                        for (String eventDebugInfo : entry.getValue()) {
+                            // logging events in separate log events as some events may be huge and otherwise rarely we could hit logging framework constraints
+                            log.debug("   " + eventDebugInfo);
+                        }
+                    });
+            log.debug("Filtered events count " + filteredEventsCounter);
+        }
     }
 
     private static class Scheduler
             implements EventListener<Void>
     {
         private static final int EVENT_BUFFER_CAPACITY = 100;
-        private static final long EVENT_PROCESSING_ENFORCED_FREQUENCY_MILLIS = new Duration(1, MINUTES).toMillis();
+        private static final long EVENT_PROCESSING_ENFORCED_FREQUENCY_MILLIS = MINUTES.toMillis(1);
+        // If scheduler is stalled for SCHEDULER_STALLED_DURATION_THRESHOLD debug log will be emitted.
+        // This value must be larger than EVENT_PROCESSING_ENFORCED_FREQUENCY as prerequiste for processing is
+        // that there are no events in the event queue.
+        private static final long SCHEDULER_STALLED_DURATION_THRESHOLD_MILLIS = new Duration(5, MINUTES).toMillis();
+        private static final int EVENTS_DEBUG_INFOS_PER_BUCKET = 10;
 
         private final QueryStateMachine queryStateMachine;
         private final Metadata metadata;
@@ -531,6 +685,8 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         private final BlockingQueue<Event> eventQueue = new LinkedBlockingQueue<>();
         private final List<Event> eventBuffer = new ArrayList<>(EVENT_BUFFER_CAPACITY);
+        private final Stopwatch eventDebugInfoStopwatch = Stopwatch.createUnstarted();
+        private final Optional<EventDebugInfos> eventDebugInfos;
 
         private boolean started;
         private boolean runtimeAdaptivePartitioningApplied;
@@ -614,7 +770,15 @@ public class EventDrivenFaultTolerantQueryScheduler
             this.runtimeAdaptivePartitioningMaxTaskSizeInBytes = requireNonNull(runtimeAdaptivePartitioningMaxTaskSize, "runtimeAdaptivePartitioningMaxTaskSize is null").toBytes();
             this.stageEstimationForEagerParentEnabled = stageEstimationForEagerParentEnabled;
 
+            if (log.isDebugEnabled()) {
+                eventDebugInfos = Optional.of(new EventDebugInfos(queryStateMachine.getQueryId().toString(), EVENTS_DEBUG_INFOS_PER_BUCKET));
+            }
+            else {
+                eventDebugInfos = Optional.empty();
+            }
+
             planInTopologicalOrder = sortPlanInTopologicalOrder(plan);
+            eventDebugInfoStopwatch.start();
         }
 
         public void run()
@@ -677,33 +841,107 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             try {
                 Event event = eventQueue.poll(EVENT_PROCESSING_ENFORCED_FREQUENCY_MILLIS, MILLISECONDS);
-                if (event == null) {
-                    return true;
+                if (event != null) {
+                    eventBuffer.add(event);
                 }
-                eventBuffer.add(event);
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
 
-            while (true) {
+            boolean eventDebugInfoRecorded = false;
+            boolean aborted = false;
+            while (!aborted) {
                 // poll multiple events from the queue in one shot to improve efficiency
                 eventQueue.drainTo(eventBuffer, EVENT_BUFFER_CAPACITY - eventBuffer.size());
                 if (eventBuffer.isEmpty()) {
-                    return true;
+                    break;
                 }
+
                 for (Event e : eventBuffer) {
+                    eventDebugInfoRecorded |= recordEventsDebugInfo(e);
                     if (e == Event.ABORT) {
-                        return false;
+                        aborted = true;
+                        break;
                     }
                     if (e == Event.WAKE_UP) {
                         continue;
                     }
                     e.accept(this);
                 }
+
                 eventBuffer.clear();
             }
+
+            if (eventDebugInfoRecorded) {
+                // mark that we processed some events; we filter out some no-op events.
+                // If only no-op events appear in event queue we still treat scheduler as stuck
+                eventDebugInfoStopwatch.reset().start();
+            }
+            else {
+                // if no events were recorded there is a chance scheduler is stalled
+                if (log.isDebugEnabled() && eventDebugInfoStopwatch.elapsed().toMillis() > SCHEDULER_STALLED_DURATION_THRESHOLD_MILLIS) {
+                    logDebugInfoSafe("Scheduler stalled for %s".formatted(eventDebugInfoStopwatch.elapsed()));
+                    eventDebugInfoStopwatch.reset().start(); // reset to prevent extensive logging
+                }
+            }
+
+            return !aborted;
+        }
+
+        private boolean recordEventsDebugInfo(Event event)
+        {
+            if (eventDebugInfos.isEmpty()) {
+                return false;
+            }
+            return eventDebugInfos.orElseThrow().add(event);
+        }
+
+        private void logDebugInfoSafe(String reason)
+        {
+            try {
+                logDebugInfo(reason);
+            }
+            catch (Throwable e) {
+                log.error(e, "Unexpected error while logging debug info for %s", reason);
+            }
+        }
+
+        private void logDebugInfo(String reason)
+        {
+            if (!log.isDebugEnabled()) {
+                return;
+            }
+
+            log.debug("Scheduler debug info for %s START; reason=%s", queryStateMachine.getQueryId(), reason);
+            log.debug("General state: %s", toStringHelper(this)
+                    .add("maxTaskExecutionAttempts", maxTaskExecutionAttempts)
+                    .add("maxTasksWaitingForNode", maxTasksWaitingForNode)
+                    .add("maxTasksWaitingForExecution", maxTasksWaitingForExecution)
+                    .add("maxPartitionCount", maxPartitionCount)
+                    .add("runtimeAdaptivePartitioningEnabled", runtimeAdaptivePartitioningEnabled)
+                    .add("runtimeAdaptivePartitioningPartitionCount", runtimeAdaptivePartitioningPartitionCount)
+                    .add("runtimeAdaptivePartitioningMaxTaskSizeInBytes", runtimeAdaptivePartitioningMaxTaskSizeInBytes)
+                    .add("stageEstimationForEagerParentEnabled", stageEstimationForEagerParentEnabled)
+                    .add("started", started)
+                    .add("runtimeAdaptivePartitioningApplied", runtimeAdaptivePartitioningApplied)
+                    .add("nextSchedulingPriority", nextSchedulingPriority)
+                    .add("preSchedulingTaskContexts", preSchedulingTaskContexts)
+                    .add("schedulingDelayer", schedulingDelayer)
+                    .add("queryOutputSet", queryOutputSet)
+                    .toString());
+
+            stageRegistry.logDebugInfo();
+
+            log.debug("StageExecutions:");
+            stageExecutions.forEach((stageId, stageExecution) -> {
+                stageExecution.logDebugInfo();
+            });
+
+            eventDebugInfos.ifPresent(EventDebugInfos::log);
+
+            log.debug("Scheduler debug info for %s END", queryStateMachine.getQueryId());
         }
 
         private boolean schedule()
@@ -2193,6 +2431,40 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return sinkPartitioningScheme;
         }
+
+        public void logDebugInfo()
+        {
+            if (!log.isDebugEnabled()) {
+                return;
+            }
+
+            log.debug("StageExecution %s: %s",
+                    stage.getStageId(),
+                    toStringHelper(this)
+                            .add("taskDescriptorStorage.getReservedBytes()", taskDescriptorStorage.getReservedBytes())
+                            .add("taskSource", taskSource.getDebugInfo())
+                            .add("sinkPartitioningScheme", sinkPartitioningScheme)
+                            .add("exchange", exchange)
+                            .add("schedulingPriority", schedulingPriority)
+                            .add("eager", eager)
+                            .add("outputDataSize", outputDataSize)
+                            .add("noMorePartitions", noMorePartitions)
+                            .add("runningPartitions", runningPartitions)
+                            .add("remainingPartitions", remainingPartitions)
+                            .add("sinkOutputSelectorBuilder", sinkOutputSelectorBuilder == null ? null : sinkOutputSelectorBuilder.build())
+                            .add("finalSinkOutputSelector", finalSinkOutputSelector)
+                            .add("remoteSourceIds", remoteSourceIds)
+                            .add("remoteSources", remoteSources)
+                            .add("sourceOutputSelectors", sourceOutputSelectors)
+                            .add("taskDescriptorLoadingActive", taskDescriptorLoadingActive)
+                            .add("exchangeClosed", exchangeClosed)
+                            .add("initialMemoryRequirements", initialMemoryRequirements)
+                            .toString());
+
+            partitions.forEach((partitionId, stagePartition) -> {
+                log.debug("   StagePartition %s.%s: %s", stage.getStageId(), partitionId, stagePartition.getDebugInfo());
+            });
+        }
     }
 
     private static class StagePartition
@@ -2447,6 +2719,28 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return finished;
         }
+
+        public String getDebugInfo()
+        {
+            return toStringHelper(this)
+                    .add("stageId", stageId)
+                    .add("partitionId", partitionId)
+                    .add("exchangeSinkHandle", exchangeSinkHandle)
+                    .add("remoteSourceIds", remoteSourceIds)
+                    .add("openTaskDescriptor", openTaskDescriptor)
+                    .add("memoryRequirements", memoryRequirements)
+                    .add("failureObserved", failureObserved)
+                    .add("remainingAttempts", remainingAttempts)
+                    .add("tasks", tasks)
+                    .add("taskOutputBuffers", taskOutputBuffers)
+                    .add("runningTasks", runningTasks)
+                    .add("taskNodeLeases", taskNodeLeases)
+                    .add("finalSelectors", finalSelectors)
+                    .add("noMoreSplits", noMoreSplits)
+                    .add("taskScheduled", taskScheduled)
+                    .add("finished", finished)
+                    .toString();
+        }
     }
 
     private static Split createOutputSelectorSplit(ExchangeSourceOutputSelector selector)
@@ -2646,6 +2940,18 @@ public class EventDrivenFaultTolerantQueryScheduler
             }
             return 0;
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("minRetryDelayInMillis", minRetryDelayInMillis)
+                    .add("maxRetryDelayInMillis", maxRetryDelayInMillis)
+                    .add("retryDelayScaleFactor", retryDelayScaleFactor)
+                    .add("stopwatch", stopwatch)
+                    .add("currentDelayInMillis", currentDelayInMillis)
+                    .toString();
+        }
     }
 
     private interface Event
@@ -2765,6 +3071,18 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return listener.onSinkInstanceHandleAcquired(this);
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("stageId", stageId)
+                    .add("partitionId", partitionId)
+                    .add("nodeLease", nodeLease)
+                    .add("attempt", attempt)
+                    .add("sinkInstanceHandle", sinkInstanceHandle)
+                    .toString();
+        }
     }
 
     private static class RemoteTaskCompletedEvent
@@ -2780,6 +3098,14 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return listener.onRemoteTaskCompleted(this);
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("taskStatus", getTaskStatus())
+                    .toString();
+        }
     }
 
     private static class RemoteTaskExchangeSinkUpdateRequiredEvent
@@ -2794,6 +3120,14 @@ public class EventDrivenFaultTolerantQueryScheduler
         public <T> T accept(EventListener<T> listener)
         {
             return listener.onRemoteTaskExchangeSinkUpdateRequired(this);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("taskStatus", getTaskStatus())
+                    .toString();
         }
     }
 
@@ -2824,6 +3158,15 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return exchangeSinkInstanceHandle;
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("taskId", taskId)
+                    .add("exchangeSinkInstanceHandle", exchangeSinkInstanceHandle)
+                    .toString();
+        }
     }
 
     private abstract static class RemoteTaskEvent
@@ -2839,6 +3182,14 @@ public class EventDrivenFaultTolerantQueryScheduler
         public TaskStatus getTaskStatus()
         {
             return taskStatus;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("taskStatus", taskStatus)
+                    .toString();
         }
     }
 
@@ -2863,6 +3214,15 @@ public class EventDrivenFaultTolerantQueryScheduler
         {
             return listener.onSplitAssignment(this);
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("stageId", getStageId())
+                    .add("assignmentResult", assignmentResult)
+                    .toString();
+        }
     }
 
     private static class StageFailureEvent
@@ -2885,6 +3245,15 @@ public class EventDrivenFaultTolerantQueryScheduler
         public <T> T accept(EventListener<T> listener)
         {
             return listener.onStageFailure(this);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("stageId", getStageId())
+                    .add("failure", failure)
+                    .toString();
         }
     }
 
@@ -2948,6 +3317,16 @@ public class EventDrivenFaultTolerantQueryScheduler
         public void setWaitingForSinkInstanceHandle(boolean waitingForSinkInstanceHandle)
         {
             this.waitingForSinkInstanceHandle = waitingForSinkInstanceHandle;
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("nodeLease", nodeLease)
+                    .add("executionClass", executionClass)
+                    .add("waitingForSinkInstanceHandle", waitingForSinkInstanceHandle)
+                    .toString();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -1414,6 +1414,9 @@ public class EventDrivenFaultTolerantQueryScheduler
                         @Override
                         public void onSuccess(AssignmentResult result)
                         {
+                            // We need to process even empty events here so stageExecution.taskDescriptorLoadingComplete()
+                            // is called in event handler. Otherwise, IdempotentSplitSource may be not called again
+                            // if there is no other SplitAssignmentEvent for this stage in queue.
                             eventQueue.add(new SplitAssignmentEvent(stageExecution.getStageId(), result));
                         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSource.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenTaskSource.java
@@ -56,10 +56,12 @@ import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
+import static com.google.common.collect.Maps.transformValues;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
@@ -221,6 +223,23 @@ class EventDrivenTaskSource
         }
     }
 
+    public String getDebugInfo()
+    {
+        return toStringHelper(this)
+                .add("sourceExchanges", transformValues(sourceExchanges, Exchange::getId))
+                .add("remoteSources", remoteSources)
+                .add("assigner", assigner)
+                .add("splitBatchSize", splitBatchSize)
+                .add("targetExchangeSplitSizeInBytes", targetExchangeSplitSizeInBytes)
+                .add("sourcePartitioningScheme", sourcePartitioningScheme)
+                .add("initialized", initialized)
+                .add("splitSources", splitSources)
+                .add("completedFragments", completedFragments)
+                .add("future", future)
+                .add("closed", closed)
+                .toString();
+    }
+
     private static class IdempotentSplitSource
             implements Closeable
     {
@@ -294,6 +313,19 @@ class EventDrivenTaskSource
         {
             finished = lastBatch;
             future = Optional.empty();
+        }
+
+        @Override
+        public synchronized String toString()
+        {
+            return toStringHelper(this)
+                    .add("planNodeId", planNodeId)
+                    .add("sourceFragmentId", sourceFragmentId)
+                    .add("splitSource", splitSource)
+                    .add("splitBatchSize", splitBatchSize)
+                    .add("closed", closed)
+                    .add("finished", finished)
+                    .toString();
         }
 
         public class SplitBatchReference
@@ -403,6 +435,15 @@ class EventDrivenTaskSource
         public Optional<List<Object>> getTableExecuteSplitsInfo()
         {
             return Optional.empty();
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("handleSource", handleSource)
+                    .add("targetSplitSizeInBytes", targetSplitSizeInBytes)
+                    .toString();
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/FaultTolerantPartitioningScheme.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/FaultTolerantPartitioningScheme.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.ToIntFunction;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -102,5 +103,16 @@ public class FaultTolerantPartitioningScheme
                 this.bucketToPartitionMap,
                 this.splitToBucketFunction,
                 this.partitionToNodeMap);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("partitionCount", partitionCount)
+                .add("bucketToPartitionMap", bucketToPartitionMap.isPresent() ? "present" : "empty")
+                .add("splitToBucketFunction", splitToBucketFunction.isPresent() ? "present" : "empty")
+                .add("partitionToNodeMap", partitionToNodeMap)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/HashDistributionSplitAssigner.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -353,6 +354,16 @@ class HashDistributionSplitAssigner
         {
             return splitBy;
         }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("subPartitions", subPartitions)
+                    .add("splitBy", splitBy)
+                    .add("nextSubPartition", nextSubPartition)
+                    .toString();
+        }
     }
 
     @VisibleForTesting
@@ -375,6 +386,12 @@ class HashDistributionSplitAssigner
         {
             checkState(id.isPresent(), "id is expected to be assigned");
             return id.getAsInt();
+        }
+
+        @Override
+        public String toString()
+        {
+            return id.toString();
         }
     }
 
@@ -401,5 +418,21 @@ class HashDistributionSplitAssigner
         };
 
         return fragment.getRoot().accept(visitor, null);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalogRequirement", catalogRequirement)
+                .add("replicatedSources", replicatedSources)
+                .add("allSources", allSources)
+                .add("sourcePartitioningScheme", sourcePartitioningScheme)
+                .add("sourcePartitionToTaskPartition", sourcePartitionToTaskPartition)
+                .add("createdTaskPartitions", createdTaskPartitions)
+                .add("completedSources", completedSources)
+                .add("replicatedSplits.size()", replicatedSplits.size())
+                .add("allTaskPartitionsCreated", allTaskPartitionsCreated)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SingleDistributionSplitAssigner.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -87,5 +88,16 @@ class SingleDistributionSplitAssigner
                     .setNoMorePartitions();
         }
         return result.build();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("hostRequirement", hostRequirement)
+                .add("allSources", allSources)
+                .add("partitionAdded", partitionAdded)
+                .add("completedSources", completedSources)
+                .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/SplitAssigner.java
@@ -75,6 +75,11 @@ interface SplitAssigner
             partitionUpdates = ImmutableList.copyOf(requireNonNull(partitionUpdates, "partitionUpdates is null"));
         }
 
+        boolean isEmpty()
+        {
+            return partitionsAdded.isEmpty() && !noMorePartitions && partitionUpdates.isEmpty() && sealedPartitions.isEmpty();
+        }
+
         public static AssignmentResult.Builder builder()
         {
             return new AssignmentResult.Builder();

--- a/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.addCallback;
@@ -76,6 +77,15 @@ public class BufferingSplitSource
     public Optional<List<Object>> getTableExecuteSplitsInfo()
     {
         return source.getTableExecuteSplitsInfo();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("bufferSize", bufferSize)
+                .add("source", source)
+                .toString();
     }
 
     private static class GetNextBatch

--- a/core/trino-main/src/main/java/io/trino/split/TracingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/TracingSplitSource.java
@@ -25,6 +25,7 @@ import io.trino.tracing.TrinoAttributes;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
@@ -104,5 +105,13 @@ public class TracingSplitSource
     public Optional<List<Object>> getTableExecuteSplitsInfo()
     {
         return source.getTableExecuteSplitsInfo();
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("source", source)
+                .toString();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/exchange/TestExchangeSourceOutputSelector.java
+++ b/core/trino-main/src/test/java/io/trino/exchange/TestExchangeSourceOutputSelector.java
@@ -195,6 +195,20 @@ public class TestExchangeSourceOutputSelector
                 .hasMessage("decision for partition 0 is already made: 0");
     }
 
+    @Test
+    public void testToString()
+    {
+        ExchangeSourceOutputSelector selector = ExchangeSourceOutputSelector.builder(ImmutableSet.of(EXCHANGE_ID_1, EXCHANGE_ID_2))
+                .include(EXCHANGE_ID_1, 0, 1)
+                .exclude(EXCHANGE_ID_1, 1)
+                .include(EXCHANGE_ID_1, 2, 0)
+                .exclude(EXCHANGE_ID_2, 3)
+                .setPartitionCount(EXCHANGE_ID_2, 4)
+                .build();
+
+        assertThat(selector).hasToString("ExchangeSourceOutputSelector[version=0, values={exchange_1=[0=1,1=E,2=0], exchange_2=[0=U,1=U,2=U,3=E]}, finalSelector=false]");
+    }
+
     private ExchangeSourceOutputSelector serializeDeserialize(ExchangeSourceOutputSelector selector)
     {
         return codec.fromJson(codec.toJson(selector));

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
@@ -16,6 +16,8 @@ package io.trino.spi.exchange;
 import io.trino.spi.Experimental;
 import io.trino.spi.QueryId;
 
+import java.util.StringJoiner;
+
 import static java.util.Objects.requireNonNull;
 
 @Experimental(eta = "2023-09-01")
@@ -38,5 +40,14 @@ public class ExchangeContext
     public ExchangeId getExchangeId()
     {
         return exchangeId;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringJoiner(", ", ExchangeContext.class.getSimpleName() + "[", "]")
+                .add("queryId=" + queryId)
+                .add("exchangeId=" + exchangeId)
+                .toString();
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchange.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -336,5 +337,25 @@ public class FileSystemExchange
             checkArgument(partitionId >= 0, "partitionId is expected to be greater than or equal to zero: %s", partitionId);
             checkArgument(attemptId >= 0, "attemptId is expected to be greater than or equal to zero: %s", attemptId);
         }
+    }
+
+    @Override
+    public synchronized String toString()
+    {
+        return toStringHelper(this)
+                .add("baseDirectories", baseDirectories)
+                .add("exchangeStorage", exchangeStorage.getClass().getName())
+                .add("exchangeContext", exchangeContext)
+                .add("outputPartitionCount", outputPartitionCount)
+                .add("preserveOrderWithinPartition", preserveOrderWithinPartition)
+                .add("fileListingParallelism", fileListingParallelism)
+                .add("exchangeSourceHandleTargetDataSizeInBytes", exchangeSourceHandleTargetDataSizeInBytes)
+                .add("outputDirectories", outputDirectories)
+                .add("allSinks", allSinks)
+                .add("finishedSinks", finishedSinks)
+                .add("noMoreSinks", noMoreSinks)
+                .add("exchangeSourceHandlesCreationStarted", exchangeSourceHandlesCreationStarted)
+                .add("exchangeSourceHandlesFuture", exchangeSourceHandlesFuture)
+                .toString();
     }
 }

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSinkInstanceHandle.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeSinkInstanceHandle.java
@@ -19,6 +19,7 @@ import io.trino.spi.exchange.ExchangeSinkInstanceHandle;
 
 import java.net.URI;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class FileSystemExchangeSinkInstanceHandle
@@ -64,5 +65,16 @@ public class FileSystemExchangeSinkInstanceHandle
     public boolean isPreserveOrderWithinPartition()
     {
         return preserveOrderWithinPartition;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("sinkHandle", sinkHandle)
+                .add("outputDirectory", outputDirectory)
+                .add("outputPartitionCount", outputPartitionCount)
+                .add("preserveOrderWithinPartition", preserveOrderWithinPartition)
+                .toString();
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -80,6 +80,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verify;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
+import static io.airlift.log.Level.DEBUG;
 import static io.airlift.log.Level.ERROR;
 import static io.airlift.log.Level.WARN;
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -234,6 +235,7 @@ public class DistributedQueryRunner
         logging.setLevel("org.hibernate.validator.internal.util.Version", WARN);
         logging.setLevel(PluginManager.class.getName(), WARN);
         logging.setLevel(CoordinatorDynamicCatalogManager.class.getName(), WARN);
+        logging.setLevel("io.trino.execution.scheduler.faulttolerant", DEBUG);
     }
 
     private static TestingTrinoServer createTestingTrinoServer(


### PR DESCRIPTION
Add code which will dump log debug information in case FTE scheduler is not getting any events for 10 minutes. This is to track rare bug where we observe queries running with retry_policy set to FALSE stuck sometimes.

TODO:
 * [x] Test outputSelector tostring