### PR TITLE
Correct secret usage with dynamic catalogs

### DIFF
--- a/docs/src/main/sphinx/sql/create-catalog.md
+++ b/docs/src/main/sphinx/sql/create-catalog.md
@@ -73,8 +73,8 @@ WITH (
 ```
 
 This example assumes that the `POSTGRES_USER` and `POSTGRES_PASSWORD`
-environmental variables are set as [secrets](/security/secrets) on the
-coordinator node.
+environmental variables are set as [secrets](/security/secrets) on all nodes of
+the cluster.
 
 ## See also
 


### PR DESCRIPTION
## Description

As result of testing and discussion slack https://trinodb.slack.com/archives/CGB0QHWSW/p1699634554649649

Turns out the env variable is not resolved and propagated to the workers, but the value of the properties is left as is .. so kinda less dynamic for this scenario. But maybe more secure... worth thinking about if this is by design or a bug maybe @dain .. I can think of pros and cons for each

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
