### PR TITLE
Add missing `@Test` annotations

### DIFF
--- a/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableCache.java
+++ b/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableCache.java
@@ -286,6 +286,7 @@ public class TestEvictableCache
         assertThat(value).isEqualTo("abc");
     }
 
+    @Test
     @Timeout(TEST_TIMEOUT_SECONDS)
     public void testLoadFailure()
             throws Exception
@@ -475,6 +476,7 @@ public class TestEvictableCache
     /**
      * Covers https://github.com/google/guava/issues/1881
      */
+    @Test
     @Timeout(TEST_TIMEOUT_SECONDS)
     public void testInvalidateAndLoadConcurrently()
             throws Exception


### PR DESCRIPTION
For TestNG we have a detection reporting unannotated test methods (`ReportBadTestAnnotations`), but apparently the annotation disappeared when migrating to JUnit.
