### PR TITLE
Move formatting out from ParquetCorruptionException

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCompressionUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCompressionUtils.java
@@ -56,7 +56,7 @@ public final class ParquetCompressionUtils
             case LZO -> decompressLZO(input, uncompressedSize);
             case LZ4 -> decompressLz4(input, uncompressedSize);
             case ZSTD -> decompressZstd(input, uncompressedSize);
-            case BROTLI, LZ4_RAW -> throw new ParquetCorruptionException(dataSourceId, "Codec not supported in Parquet: %s", codec);
+            case BROTLI, LZ4_RAW -> throw new ParquetCorruptionException(dataSourceId, format("Codec not supported in Parquet: %s", codec));
         };
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCorruptionException.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCorruptionException.java
@@ -13,34 +13,23 @@
  */
 package io.trino.parquet;
 
-import com.google.errorprone.annotations.FormatMethod;
-
 import java.io.IOException;
-
-import static java.lang.String.format;
 
 public class ParquetCorruptionException
         extends IOException
 {
     public ParquetCorruptionException(ParquetDataSourceId dataSourceId, String message)
     {
-        this(dataSourceId, "%s", message);
+        super(formatMessage(dataSourceId, message));
     }
 
-    @FormatMethod
-    public ParquetCorruptionException(Throwable cause, ParquetDataSourceId dataSourceId, String messageFormat, Object... args)
+    public ParquetCorruptionException(ParquetDataSourceId dataSourceId, String message, Throwable cause)
     {
-        super(formatMessage(dataSourceId, messageFormat, args), cause);
+        super(formatMessage(dataSourceId, message), cause);
     }
 
-    @FormatMethod
-    public ParquetCorruptionException(ParquetDataSourceId dataSourceId, String messageFormat, Object... args)
+    private static String formatMessage(ParquetDataSourceId dataSourceId, String message)
     {
-        super(formatMessage(dataSourceId, messageFormat, args));
-    }
-
-    private static String formatMessage(ParquetDataSourceId dataSourceId, String messageFormat, Object[] args)
-    {
-        return "Malformed Parquet file. " + format(messageFormat, args) + " [" + dataSourceId + "]";
+        return "Malformed Parquet file. " + message + " [" + dataSourceId + "]";
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetValidationUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetValidationUtils.java
@@ -15,6 +15,8 @@ package io.trino.parquet;
 
 import com.google.errorprone.annotations.FormatMethod;
 
+import static java.lang.String.format;
+
 public final class ParquetValidationUtils
 {
     private ParquetValidationUtils() {}
@@ -24,7 +26,7 @@ public final class ParquetValidationUtils
             throws ParquetCorruptionException
     {
         if (!condition) {
-            throw new ParquetCorruptionException(dataSourceId, formatString, args);
+            throw new ParquetCorruptionException(dataSourceId, format(formatString, args));
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetWriteValidation.java
@@ -53,6 +53,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.trino.parquet.ColumnStatisticsValidation.ColumnStatistics;
 import static io.trino.parquet.ParquetValidationUtils.validateParquet;
 import static io.trino.parquet.ParquetWriteValidation.IndexReferenceValidation.fromIndexReference;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ParquetWriteValidation
@@ -582,12 +583,13 @@ public class ParquetWriteValidation
         if (!condition) {
             throw new ParquetCorruptionException(
                     dataSourceId,
-                    "%s [%s] for column %s in row group %d did not match [%s]",
-                    name,
-                    actual,
-                    path,
-                    rowGroup,
-                    expected);
+                    format(
+                            "%s [%s] for column %s in row group %d did not match [%s]",
+                            name,
+                            actual,
+                            path,
+                            rowGroup,
+                            expected));
         }
     }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -601,12 +601,12 @@ public class TupleDomainParquetPredicate
 
     private static ParquetCorruptionException corruptionException(String column, ParquetDataSourceId id, Statistics<?> statistics, Exception cause)
     {
-        return new ParquetCorruptionException(cause, id, "Corrupted statistics for column \"%s\": [%s]", column, statistics);
+        return new ParquetCorruptionException(id, format("Corrupted statistics for column \"%s\": [%s]", column, statistics), cause);
     }
 
     private static ParquetCorruptionException corruptionException(String column, ParquetDataSourceId id, ColumnIndex columnIndex, Exception cause)
     {
-        return new ParquetCorruptionException(cause, id, "Corrupted statistics for column \"%s\". Corrupted column index: [%s]", column, columnIndex);
+        return new ParquetCorruptionException(id, format("Corrupted statistics for column \"%s\". Corrupted column index: [%s]", column, columnIndex), cause);
     }
 
     private static boolean isCorruptedColumnIndex(

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunkIterator.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetColumnChunkIterator.java
@@ -37,6 +37,7 @@ import java.util.OptionalLong;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.parquet.ParquetTypeUtils.getParquetEncoding;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public final class ParquetColumnChunkIterator
@@ -87,7 +88,7 @@ public final class ParquetColumnChunkIterator
             switch (pageHeader.type) {
                 case DICTIONARY_PAGE:
                     if (dataPageCount != 0) {
-                        throw new ParquetCorruptionException(dataSourceId, "Column (%s) has a dictionary page after the first position in column chunk", descriptor);
+                        throw new ParquetCorruptionException(dataSourceId, format("Column (%s) has a dictionary page after the first position in column chunk", descriptor));
                     }
                     result = readDictionaryPage(pageHeader, pageHeader.getUncompressed_page_size(), pageHeader.getCompressed_page_size());
                     break;

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -375,7 +375,7 @@ public class ParquetReader
         }
 
         if (columnChunk == null) {
-            throw new ParquetCorruptionException(dataSource.getId(), "Struct field does not have any children: %s", field);
+            throw new ParquetCorruptionException(dataSource.getId(), format("Struct field does not have any children: %s", field));
         }
 
         StructColumnReader.RowBlockPositions structIsNull = StructColumnReader.calculateStructOffsets(field, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());
@@ -498,7 +498,7 @@ public class ParquetReader
                 return metadata;
             }
         }
-        throw new ParquetCorruptionException(dataSource.getId(), "Metadata is missing for column: %s", columnDescriptor);
+        throw new ParquetCorruptionException(dataSource.getId(), format("Metadata is missing for column: %s", columnDescriptor));
     }
 
     private void initializeColumnReaders()
@@ -614,13 +614,12 @@ public class ParquetReader
         }
     }
 
-    @SuppressWarnings("FormatStringAnnotation")
     @FormatMethod
     private void validateWrite(java.util.function.Predicate<ParquetWriteValidation> test, String messageFormat, Object... args)
             throws ParquetCorruptionException
     {
         if (writeValidation.isPresent() && !test.test(writeValidation.get())) {
-            throw new ParquetCorruptionException(dataSource.getId(), "Write validation failed: " + messageFormat, args);
+            throw new ParquetCorruptionException(dataSource.getId(), format("Write validation failed: " + messageFormat, args));
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -69,6 +69,7 @@ import static io.trino.parquet.ParquetWriteValidation.ParquetWriteValidationBuil
 import static io.trino.parquet.writer.ParquetDataOutput.createDataOutput;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
@@ -227,7 +228,7 @@ public class ParquetWriter
             if (e instanceof ParquetCorruptionException) {
                 throw (ParquetCorruptionException) e;
             }
-            throw new ParquetCorruptionException(input.getId(), "Validation failed with exception %s", e);
+            throw new ParquetCorruptionException(input.getId(), format("Validation failed with exception %s", e));
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

...to its callers, to make the exception class more focused. This in fact makes it consistent with how other exception classes were transformed, though I don't remember the exact commits right now.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

These are the remnants of #14933 and #15963 (and kind of #15052 too) after #19899 (specifically f3c803e56aae2a3dd4a360f6220959c2af83ac8a) made them mostly obsolete.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
