### PR TITLE
Handle S3 paths where bucket name contains "dot digit"

### DIFF
--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HadoopPaths.java
@@ -42,6 +42,7 @@ public final class HadoopPaths
                     location.scheme().orElse(null),
                     location.host().orElse(null),
                     "/" + location.path(),
+                    null,
                     location.path());
         }
         catch (URISyntaxException e) {

--- a/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/hdfs/s3/TestS3HadoopPaths.java
@@ -68,4 +68,14 @@ public class TestS3HadoopPaths
                 .extracting(TrinoS3FileSystem::keyFromPath)
                 .isEqualTo("abc%xyz//test");
     }
+
+    @Test
+    public void testS3NonCanonicalPathWithDotDigitBucketName()
+    {
+        assertThat(hadoopPath(Location.of("s3://test.123/abc//xyz.csv")))
+                .isEqualTo(new Path(URI.create("s3://test.123/abc/xyz.csv#abc//xyz.csv")))
+                .hasToString("s3://test.123/abc/xyz.csv#abc//xyz.csv")
+                .extracting(TrinoS3FileSystem::keyFromPath)
+                .isEqualTo("abc//xyz.csv");
+    }
 }


### PR DESCRIPTION
`HadoopPaths` compatibility layer was failing when S3 bucket name contains a dot followed by a digit:

```
java.net.URISyntaxException: Illegal character in hostname at index 10: s3://test.123/abc//xyz.csv#abc//xyz.csv
	at java.base/java.net.URI$Parser.fail(URI.java:2974)
	at java.base/java.net.URI$Parser.parseHostname(URI.java:3517)
	at java.base/java.net.URI$Parser.parseServer(URI.java:3358)
	at java.base/java.net.URI$Parser.parseAuthority(URI.java:3277)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3219)
	at java.base/java.net.URI$Parser.parse(URI.java:3175)
	at java.base/java.net.URI.<init>(URI.java:708)
	at java.base/java.net.URI.<init>(URI.java:809)
	at io.trino.filesystem.hdfs.HadoopPaths.toPathEncodedUri(HadoopPaths.java:46)
```

Using a different `URI` constructor avoids the problem.
