### PR TITLE
JDBC refactoring + connection keep-alive

### DIFF
--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -135,6 +135,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>node</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/inject/Decorator.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/inject/Decorator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.inject;
+
+@FunctionalInterface
+public interface Decorator<T>
+        extends Comparable<Decorator<T>>
+{
+    @Override
+    default int compareTo(Decorator<T> other)
+    {
+        // By default, sort by priority
+        return Integer.compare(this.priority(), other.priority());
+    }
+
+    T apply(T value);
+
+    default boolean appliesTo(T value)
+    {
+        return true;
+    }
+
+    default int priority()
+    {
+        return 0;
+    }
+
+    static <T> Decorator<T> nonModifyingDecorator()
+    {
+        return new Decorator<>()
+        {
+            @Override
+            public T apply(T value)
+            {
+                return value;
+            }
+
+            @Override
+            public boolean appliesTo(T value)
+            {
+                return false;
+            }
+
+            @Override
+            public int priority()
+            {
+                return -1;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "nonModifyingDecorator";
+            }
+        };
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/inject/DecoratorBinder.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/inject/DecoratorBinder.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.inject;
+
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.multibindings.Multibinder;
+import io.airlift.log.Logger;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static com.google.inject.util.Types.newParameterizedType;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class DecoratorBinder<T>
+{
+    private final Multibinder<Decorator<T>> decorators;
+
+    private DecoratorBinder(Binder binder, Class<T> clazz, Class<? extends Annotation> annotation)
+    {
+        //noinspection unchecked
+        this.decorators = newSetBinder(binder, Key.get((TypeLiteral<Decorator<T>>) TypeLiteral.get(newParameterizedType(Decorator.class, clazz)), annotation));
+        binder.install(new DecoratorModule<>(clazz, annotation));
+    }
+
+    public static <T> DecoratorBinder<T> newDecoratorBinder(Binder binder, Class<T> clazz, Class<? extends Annotation> annotation)
+    {
+        return new DecoratorBinder<>(binder, clazz, annotation);
+    }
+
+    public DecoratorBinder<T> addBinding(Class<? extends Decorator<T>> decoratorClass)
+    {
+        decorators.addBinding().to(decoratorClass).in(Scopes.SINGLETON);
+        return this;
+    }
+
+    public DecoratorBinder<T> addInstanceBinding(Decorator<T> decoratorInstance)
+    {
+        decorators.addBinding().toInstance(decoratorInstance);
+
+        return this;
+    }
+
+    public DecoratorBinder<T> addProviderBinding(Provider<Decorator<T>> decoratorProvider)
+    {
+        decorators.addBinding().toProvider(decoratorProvider);
+        return this;
+    }
+
+    private static class DecoratingProvider<T>
+            implements Provider<T>
+    {
+        private final Class<T> valueType;
+        private final Class<? extends Annotation> valueAnnotation;
+        private Injector injector;
+
+        public DecoratingProvider(Class<T> valueType, Class<? extends Annotation> valueAnnotation)
+        {
+            this.valueType = requireNonNull(valueType, "valueType is null");
+            this.valueAnnotation = requireNonNull(valueAnnotation, "valueAnnotation is null");
+        }
+
+        @Inject
+        void setInjector(Injector injector)
+        {
+            this.injector = requireNonNull(injector, "injector is null");
+        }
+
+        @Override
+        public T get()
+        {
+            checkState(injector != null, "injector wasn't injected");
+            T instance = requireNonNull(injector.getInstance(Key.get(TypeLiteral.get(valueType), valueAnnotation)), "decorated instance is null");
+
+            @SuppressWarnings("unchecked") List<Decorator<T>> decorators = sortedList((Set<Decorator<T>>)
+                    injector.getInstance(Key.get(newParameterizedType(Set.class, newParameterizedType(Decorator.class, valueType)), valueAnnotation)));
+
+            if (decorators.isEmpty()) {
+                return instance;
+            }
+
+            Logger log = Logger.get(instance.getClass());
+
+            if (log.isDebugEnabled()) {
+                String separator = "\n\t-> ";
+                String chainOfDecorators = decorators.stream()
+                        .filter(decorator -> decorator.appliesTo(instance))
+                        .map(decorator -> "%s [priority: %d]".formatted(decorator, decorator.priority()))
+                        .collect(joining(separator));
+
+                log.info("Decorating %s with decorators:%s%s", instance, separator, chainOfDecorators);
+            }
+
+            T currentValue = instance;
+            for (Decorator<T> decorator : decorators) {
+                if (decorator.appliesTo(instance)) {
+                    currentValue = requireNonNull(decorator.apply(currentValue), () -> "decorator %s returned null value".formatted(decorator));
+                }
+            }
+            return currentValue;
+        }
+
+        private static <T> List<Decorator<T>> sortedList(Set<Decorator<T>> decorators)
+        {
+            return decorators.stream()
+                    .sorted()
+                    .collect(toImmutableList());
+        }
+    }
+
+    private static class DecoratorModule<T>
+            implements Module
+    {
+        private final Class<T> valueType;
+        private final Class<? extends Annotation> valueAnnotation;
+
+        public DecoratorModule(Class<T> valueType, Class<? extends Annotation> valueAnnotation)
+        {
+            this.valueType = requireNonNull(valueType, "valueType is null");
+            this.valueAnnotation = requireNonNull(valueAnnotation, "valueAnnotation is null");
+        }
+
+        @Override
+        public void configure(Binder binder)
+        {
+            binder.bind(Key.get(valueType)).toProvider(new DecoratingProvider<>(valueType, valueAnnotation)).in(Scopes.SINGLETON);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DecoratorModule<?> that = (DecoratorModule<?>) o;
+
+            if (!Objects.equals(valueType, that.valueType)) {
+                return false;
+            }
+            return Objects.equals(valueAnnotation, that.valueAnnotation);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = valueType != null ? valueType.hashCode() : 0;
+            result = 31 * result + (valueAnnotation != null ? valueAnnotation.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/inject/TestDecoratorBinder.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/inject/TestDecoratorBinder.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.inject;
+
+import com.google.inject.Binder;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Level;
+import io.airlift.log.Logging;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Retention;
+import java.util.List;
+import java.util.function.Function;
+
+import static io.trino.plugin.base.inject.DecoratorBinder.newDecoratorBinder;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TestDecoratorBinder
+{
+    @BeforeAll
+    public static void setupLogging()
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel(String.class.getName(), Level.DEBUG);
+    }
+
+    @Test
+    public void testNoDecorators()
+    {
+        assertFinalValue("test", "test", List.of());
+    }
+
+    @Test
+    public void testSingleDecorator()
+    {
+        assertFinalValue("test", "TEST", List.of(new Transformation(1, value -> value.toUpperCase(ENGLISH))));
+    }
+
+    @Test
+    public void testMultipleDecorator()
+    {
+        assertFinalValue("test", "second(first(test))", List.of(
+                new Transformation(1, value -> "first(" + value + ")"),
+                new Transformation(2, value -> "second(" + value + ")")));
+    }
+
+    @Test
+    public void testMultipleDecoratorSortedByPriority()
+    {
+        assertFinalValue("test", "SECond(firST(test))", List.of(
+                new Transformation(2, value -> "SECond(" + value + ")"),
+                new Transformation(1, value -> "firST(" + value + ")")));
+
+        assertFinalValue("test2", "3rd(second(FIR_ST(test2)))", List.of(
+                new Transformation(2, value -> "second(" + value + ")"),
+                new Transformation(1, value -> "FIR_ST(" + value + ")"),
+                new Transformation(3, value -> "3rd(" + value + ")")));
+
+        assertFinalValue("test3", "third(second(second(first(test3))))", List.of(
+                new Transformation(2, value -> "second(" + value + ")"),
+                new Transformation(2, value -> "second(" + value + ")"),
+                new Transformation(1, value -> "first(" + value + ")"),
+                new Transformation(3, value -> "third(" + value + ")")));
+    }
+
+    @Test
+    public void testMultipleDecoratorSortedByPriorityShouldSkip()
+    {
+        assertFinalValue("test", "second(first(test))", List.of(
+                new Transformation(2, value -> "second(" + value + ")"),
+                new Transformation(0, value -> "skipped(" + value + ")"),
+                new Transformation(1, value -> "first(" + value + ")")));
+
+        assertFinalValue("test2", "third(second(first(test2)))", List.of(
+                new Transformation(2, value -> "second(" + value + ")"),
+                new Transformation(1, value -> "first(" + value + ")"),
+                new Transformation(0, value -> "skipped(" + value + ")"),
+                new Transformation(3, value -> "third(" + value + ")")));
+    }
+
+    @Test
+    public void testMisbehavingDecorator()
+    {
+        assertThatThrownBy(() -> assertFinalValue("test", "second(first(test))", List.of(
+                new Transformation(2, value -> null))))
+                .hasMessageContaining("NullPointerException: decorator f(x) = null returned null value");
+    }
+
+    private static void assertFinalValue(String initialValue, String finalValue, List<Transformation> transformations)
+    {
+        assertThat(finalValue(initialValue, transformations))
+                .isEqualTo(finalValue);
+    }
+
+    private static String finalValue(String initial, List<Transformation> transformations)
+    {
+        Injector injector = new Bootstrap(new AbstractConfigurationAwareModule()
+        {
+            @Override
+            protected void setup(Binder binder)
+            {
+                binder
+                        .bind(String.class)
+                        .annotatedWith(InitialValue.class)
+                        .toInstance(initial);
+
+                DecoratorBinder<String> decoratorBinder = newDecoratorBinder(binder, String.class, InitialValue.class);
+                for (Transformation transformation : transformations) {
+                    decoratorBinder.addInstanceBinding(transformation);
+                }
+            }
+        })
+                .initialize();
+
+        return injector.getInstance(String.class);
+    }
+
+    static class Transformation
+            implements Decorator<String>
+    {
+        private final Function<String, String> transformation;
+        private final int priority;
+
+        public Transformation(int priority, Function<String, String> transformation)
+        {
+            this.priority = priority;
+            this.transformation = requireNonNull(transformation, "transformation is null");
+        }
+
+        @Override
+        public String apply(String instance)
+        {
+            return transformation.apply(instance);
+        }
+
+        @Override
+        public int priority()
+        {
+            return priority;
+        }
+
+        @Override
+        public boolean appliesTo(String instance)
+        {
+            return priority > 0;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "f(x) = " + transformation.apply("x");
+        }
+    }
+
+    @BindingAnnotation
+    @Retention(RUNTIME)
+    public @interface InitialValue {}
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConfiguringConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConfiguringConnectionFactory.java
@@ -21,7 +21,7 @@ import java.sql.SQLException;
 import static java.util.Objects.requireNonNull;
 
 public final class ConfiguringConnectionFactory
-        implements ConnectionFactory
+        extends ForwardingConnectionFactory
 {
     private final ConnectionFactory delegate;
     private final Configurator configurator;
@@ -30,6 +30,12 @@ public final class ConfiguringConnectionFactory
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.configurator = requireNonNull(configurator, "configurator is null");
+    }
+
+    @Override
+    protected ConnectionFactory delegate()
+    {
+        return delegate;
     }
 
     @Override
@@ -46,13 +52,6 @@ public final class ConfiguringConnectionFactory
             }
         }
         return connection;
-    }
-
-    @Override
-    public void close()
-            throws SQLException
-    {
-        delegate.close();
     }
 
     @FunctionalInterface

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactory.java
@@ -23,6 +23,18 @@ import java.sql.SQLException;
 public interface ConnectionFactory
         extends AutoCloseable
 {
+    /**
+     * Order in which connection factories will wrap around each other
+     * Lowest priority is the outermost wrapping.
+     * Gaps in the numbering allows for injecting custom behaviour
+     * in between the default ones provided by base-jdbc.
+     * **/
+    int STATISTICS_CONNECTION_FACTORY_PRIORITY = 1;
+    int LAZY_CONNECTION_FACTORY_PRIORITY = 101;
+    int RETRYING_CONNECTION_FACTORY_PRIORITY = 201;
+    int REUSABLE_CONNECTION_FACTORY_PRIORITY = 301;
+    int KEEP_ALIVE_CONNECTION_FACTORY_PRIORITY = 401;
+
     Connection openConnection(ConnectorSession session)
             throws SQLException;
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactoryModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactoryModule.java
@@ -14,29 +14,20 @@
 package io.trino.plugin.jdbc;
 
 import com.google.inject.Binder;
-import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.plugin.jdbc.RetryingConnectionFactory.DefaultRetryStrategy;
-import io.trino.plugin.jdbc.RetryingConnectionFactory.RetryStrategy;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.base.inject.DecoratorBinder.newDecoratorBinder;
 
-public class RetryingConnectionFactoryModule
+public class ConnectionFactoryModule
         extends AbstractConfigurationAwareModule
 {
     @Override
-    public void setup(Binder binder)
+    protected void setup(Binder binder)
     {
-        configBinder(binder).bindConfig(QueryConfig.class);
-
         newDecoratorBinder(binder, ConnectionFactory.class, ForBaseJdbc.class)
-                .addBinding(RetryingConnectionFactory.FactoryDecorator.class);
+                .addBinding(RetryingConnectionFactory.FactoryDecorator.class)
+                .addBinding(LazyConnectionFactory.FactoryDecorator.class);
 
-        newOptionalBinder(binder, RetryStrategy.class)
-                .setDefault()
-                .to(DefaultRetryStrategy.class)
-                .in(Scopes.SINGLETON);
+        install(new RetryingConnectionFactoryModule());
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactoryModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionFactoryModule.java
@@ -15,6 +15,7 @@ package io.trino.plugin.jdbc;
 
 import com.google.inject.Binder;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.jdbc.keepalive.KeepAliveConnectionFactory;
 
 import static io.trino.plugin.base.inject.DecoratorBinder.newDecoratorBinder;
 
@@ -25,8 +26,8 @@ public class ConnectionFactoryModule
     protected void setup(Binder binder)
     {
         newDecoratorBinder(binder, ConnectionFactory.class, ForBaseJdbc.class)
-                .addBinding(RetryingConnectionFactory.FactoryDecorator.class)
-                .addBinding(LazyConnectionFactory.FactoryDecorator.class);
+                .addBinding(LazyConnectionFactory.FactoryDecorator.class)
+                .addBinding(KeepAliveConnectionFactory.FactoryDecorator.class);
 
         install(new RetryingConnectionFactoryModule());
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingConnectionFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.spi.connector.ConnectorSession;
+import jakarta.annotation.PreDestroy;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public abstract class ForwardingConnectionFactory
+        implements ConnectionFactory
+{
+    protected abstract ConnectionFactory delegate();
+
+    @Override
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return delegate().openConnection(session);
+    }
+
+    @Override
+    @PreDestroy
+    public void close()
+            throws SQLException
+    {
+        delegate().close();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -50,7 +50,7 @@ public class JdbcModule
         install(new JdbcDiagnosticModule());
         install(new IdentifierMappingModule());
         install(new RemoteQueryModifierModule());
-        install(new RetryingConnectionFactoryModule());
+        install(new ConnectionFactoryModule());
 
         newOptionalBinder(binder, ConnectorAccessControl.class);
         newOptionalBinder(binder, QueryBuilder.class).setDefault().to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);
@@ -92,8 +92,7 @@ public class JdbcModule
         install(conditionalModule(
                 QueryConfig.class,
                 QueryConfig::isReuseConnection,
-                new ReusableConnectionFactoryModule(),
-                innerBinder -> innerBinder.bind(ConnectionFactory.class).to(LazyConnectionFactory.class).in(Scopes.SINGLETON)));
+                new ReusableConnectionFactoryModule()));
 
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class));
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
@@ -24,7 +24,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.trino.plugin.jdbc.jmx.StatisticsAwareConnectionFactory.FactoryDecorator.STATISTICS_PRIORITY;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -99,12 +98,10 @@ public final class LazyConnectionFactory
     public static class FactoryDecorator
             implements Decorator<ConnectionFactory>
     {
-        public static final int LAZY_CONNECTION_PRIORITY = STATISTICS_PRIORITY + 1;
-
         @Override
         public int priority()
         {
-            return LAZY_CONNECTION_PRIORITY;
+            return LAZY_CONNECTION_FACTORY_PRIORITY;
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
@@ -27,7 +27,7 @@ import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public final class LazyConnectionFactory
-        implements ConnectionFactory
+        extends ForwardingConnectionFactory
 {
     private final ConnectionFactory delegate;
 
@@ -38,17 +38,16 @@ public final class LazyConnectionFactory
     }
 
     @Override
+    protected ConnectionFactory delegate()
+    {
+        return delegate;
+    }
+
+    @Override
     public Connection openConnection(ConnectorSession session)
             throws SQLException
     {
         return new LazyConnection(() -> delegate.openConnection(session));
-    }
-
-    @Override
-    public void close()
-            throws SQLException
-    {
-        delegate.close();
     }
 
     private static final class LazyConnection

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryConfig.java
@@ -15,10 +15,15 @@ package io.trino.plugin.jdbc;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MaxDuration;
+import io.airlift.units.MinDuration;
 
 public class QueryConfig
 {
     private boolean reuseConnection = true;
+    private boolean keepAlive;
+    private Duration keepAliveInterval = Duration.valueOf("30s");
 
     public boolean isReuseConnection()
     {
@@ -30,6 +35,34 @@ public class QueryConfig
     public QueryConfig setReuseConnection(boolean reuseConnection)
     {
         this.reuseConnection = reuseConnection;
+        return this;
+    }
+
+    public boolean isKeepAlive()
+    {
+        return keepAlive;
+    }
+
+    @Config("query.keep-alive-connection")
+    @ConfigDescription("Enables JDBC connection watchdog to ensure that connection won't be closed by the database when idle")
+    public QueryConfig setKeepAlive(boolean keepAlive)
+    {
+        this.keepAlive = keepAlive;
+        return this;
+    }
+
+    @MinDuration("5s")
+    @MaxDuration("1h")
+    public Duration getKeepAliveInterval()
+    {
+        return keepAliveInterval;
+    }
+
+    @Config("query.keep-alive-interval")
+    @ConfigDescription("Interval to check for JDBC connection validity")
+    public QueryConfig setKeepAliveInterval(Duration keepAliveInterval)
+    {
+        this.keepAliveInterval = keepAliveInterval;
         return this;
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionFactory.java
@@ -26,7 +26,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTransientException;
 
-import static io.trino.plugin.jdbc.LazyConnectionFactory.FactoryDecorator.LAZY_CONNECTION_PRIORITY;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Objects.requireNonNull;
@@ -91,7 +90,6 @@ public class RetryingConnectionFactory
     public static class FactoryDecorator
             implements Decorator<ConnectionFactory>
     {
-        public static final int RETRYING_PRIORITY = LAZY_CONNECTION_PRIORITY + 1;
         private final RetryStrategy strategy;
 
         @Inject
@@ -103,7 +101,7 @@ public class RetryingConnectionFactory
         @Override
         public int priority()
         {
-            return RETRYING_PRIORITY;
+            return RETRYING_CONNECTION_FACTORY_PRIORITY;
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
@@ -18,7 +18,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalNotification;
 import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import com.google.inject.Inject;
+import io.trino.plugin.base.inject.Decorator;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import org.gaul.modernizer_maven_annotations.SuppressModernizer;
@@ -30,21 +30,21 @@ import java.time.Duration;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.cache.RemovalCause.EXPLICIT;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.trino.plugin.jdbc.RetryingConnectionFactory.FactoryDecorator.RETRYING_PRIORITY;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public final class ReusableConnectionFactory
         extends ForwardingConnectionFactory
-        implements JdbcQueryEventListener
 {
     @GuardedBy("this")
     private final Cache<String, Connection> connections;
     private ConnectionFactory delegate;
 
-    @Inject
-    public ReusableConnectionFactory(@ForReusableConnectionFactory ConnectionFactory delegate)
+    public ReusableConnectionFactory(ConnectionFactory delegate, DelegatingListener listener)
     {
         this(delegate, Duration.ofSeconds(2), 10);
+        listener.setFactory(this);
     }
 
     ReusableConnectionFactory(ConnectionFactory delegate, Duration duration, long maximumSize)
@@ -106,10 +106,6 @@ public final class ReusableConnectionFactory
         return super.openConnection(session);
     }
 
-    @Override
-    public void beginQuery(ConnectorSession session) {}
-
-    @Override
     public void cleanupQuery(ConnectorSession session)
     {
         Connection connection = connections.asMap().remove(session.getQueryId());
@@ -132,6 +128,30 @@ public final class ReusableConnectionFactory
         }
         connections.invalidateAll();
         super.close();
+    }
+
+    public static class DelegatingListener
+            implements JdbcQueryEventListener
+    {
+        private ReusableConnectionFactory factory;
+
+        public void setFactory(ReusableConnectionFactory factory)
+        {
+            this.factory = requireNonNull(factory, "factory is null");
+        }
+
+        @Override
+        public void beginQuery(ConnectorSession session)
+        {
+            // noop
+        }
+
+        @Override
+        public void cleanupQuery(ConnectorSession session)
+        {
+            checkState(factory != null, "factory was null");
+            factory.cleanupQuery(session);
+        }
     }
 
     final class CachedConnection
@@ -185,6 +205,30 @@ public final class ReusableConnectionFactory
             else if (!delegate.isClosed()) {
                 connections.put(queryId, delegate);
             }
+        }
+    }
+
+    public static class FactoryDecorator
+            implements Decorator<ConnectionFactory>
+    {
+        public static final int REUSABLE_PRIORITY = RETRYING_PRIORITY + 1;
+        private final DelegatingListener listener;
+
+        public FactoryDecorator(DelegatingListener listener)
+        {
+            this.listener = requireNonNull(listener, "listener is null");
+        }
+
+        @Override
+        public int priority()
+        {
+            return REUSABLE_PRIORITY;
+        }
+
+        @Override
+        public ConnectionFactory apply(ConnectionFactory delegate)
+        {
+            return new ReusableConnectionFactory(delegate, listener);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReusableConnectionFactory.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.cache.RemovalCause.EXPLICIT;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
-import static io.trino.plugin.jdbc.RetryingConnectionFactory.FactoryDecorator.RETRYING_PRIORITY;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -211,7 +210,6 @@ public final class ReusableConnectionFactory
     public static class FactoryDecorator
             implements Decorator<ConnectionFactory>
     {
-        public static final int REUSABLE_PRIORITY = RETRYING_PRIORITY + 1;
         private final DelegatingListener listener;
 
         public FactoryDecorator(DelegatingListener listener)
@@ -222,7 +220,7 @@ public final class ReusableConnectionFactory
         @Override
         public int priority()
         {
-            return REUSABLE_PRIORITY;
+            return REUSABLE_CONNECTION_FACTORY_PRIORITY;
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/ConnectionFactoryStats.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/ConnectionFactoryStats.java
@@ -11,21 +11,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.jdbc;
+package io.trino.plugin.jdbc.jmx;
 
-import com.google.inject.BindingAnnotation;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-@Retention(RUNTIME)
-@Target({FIELD, PARAMETER, METHOD})
-@BindingAnnotation
-public @interface ForReusableConnectionFactory
+public class ConnectionFactoryStats
 {
+    private final JdbcApiStats openConnection = new JdbcApiStats();
+    private final JdbcApiStats closeConnection = new JdbcApiStats();
+
+    @Managed
+    @Nested
+    public JdbcApiStats getOpenConnection()
+    {
+        return openConnection;
+    }
+
+    @Managed
+    @Nested
+    public JdbcApiStats getCloseConnection()
+    {
+        return closeConnection;
+    }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.jmx;
 import com.google.inject.Inject;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.ForwardingConnectionFactory;
 import io.trino.spi.connector.ConnectorSession;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -26,16 +27,22 @@ import java.sql.SQLException;
 import static java.util.Objects.requireNonNull;
 
 public class StatisticsAwareConnectionFactory
-        implements ConnectionFactory
+        extends ForwardingConnectionFactory
 {
+    private final ConnectionFactory delegate;
     private final JdbcApiStats openConnection = new JdbcApiStats();
     private final JdbcApiStats closeConnection = new JdbcApiStats();
-    private final ConnectionFactory delegate;
 
     @Inject
     public StatisticsAwareConnectionFactory(@ForBaseJdbc ConnectionFactory delegate)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    protected ConnectionFactory delegate()
+    {
+        return delegate;
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareConnectionFactory.java
@@ -79,7 +79,6 @@ public class StatisticsAwareConnectionFactory
     public static class FactoryDecorator
             implements Decorator<ConnectionFactory>
     {
-        public static final int STATISTICS_PRIORITY = 1;
         private final ConnectionFactoryStats stats;
 
         @Inject
@@ -92,7 +91,7 @@ public class StatisticsAwareConnectionFactory
         public int priority()
         {
             // Lowest priority wraps around the raw instance
-            return STATISTICS_PRIORITY;
+            return STATISTICS_CONNECTION_FACTORY_PRIORITY;
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc.jmx;
 
 import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ForwardingJdbcClient;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
@@ -62,7 +63,7 @@ import java.util.Set;
 import static java.util.Objects.requireNonNull;
 
 public final class StatisticsAwareJdbcClient
-        implements JdbcClient
+        extends ForwardingJdbcClient
 {
     private final JdbcClientStats stats = new JdbcClientStats();
     private final JdbcClient delegate;
@@ -72,7 +73,8 @@ public final class StatisticsAwareJdbcClient
         this.delegate = requireNonNull(delegate, "delegate is null");
     }
 
-    private JdbcClient delegate()
+    @Override
+    protected JdbcClient delegate()
     {
         return delegate;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnection.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnection.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.keepalive;
+
+import io.airlift.units.Duration;
+import io.trino.plugin.jdbc.ForwardingConnection;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class KeepAliveConnection
+        extends ForwardingConnection
+{
+    private final Connection delegate;
+    private ScheduledFuture<?> future;
+
+    public KeepAliveConnection(Connection delegate, ScheduledExecutorService executorService, Duration interval)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.future = executorService.scheduleAtFixedRate(this::keepConnectionAlive, interval.toMillis(), interval.toMillis(), MILLISECONDS);
+    }
+
+    private void keepConnectionAlive()
+    {
+        try {
+            // Validate the connection to check whether it's still alive
+            delegate().isValid(0);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close()
+            throws SQLException
+    {
+        synchronized (this) {
+            if (future != null) {
+                future.cancel(true);
+                future = null;
+            }
+        }
+
+        delegate().close();
+    }
+
+    @Override
+    protected Connection delegate()
+            throws SQLException
+    {
+        return delegate;
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnectionFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.keepalive;
+
+import com.google.inject.Inject;
+import io.airlift.units.Duration;
+import io.trino.plugin.base.inject.Decorator;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.ForwardingConnectionFactory;
+import io.trino.plugin.jdbc.QueryConfig;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static io.airlift.concurrent.Threads.threadsNamed;
+import static io.trino.plugin.jdbc.ReusableConnectionFactory.FactoryDecorator.REUSABLE_PRIORITY;
+import static java.util.Objects.requireNonNull;
+
+public class KeepAliveConnectionFactory
+        extends ForwardingConnectionFactory
+{
+    private final ConnectionFactory delegate;
+    private final Duration interval;
+    private final ScheduledExecutorService executorService;
+
+    public KeepAliveConnectionFactory(ConnectionFactory delegate, Duration interval, ScheduledExecutorService executorService)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.interval = requireNonNull(interval, "interval is null");
+        this.executorService = requireNonNull(executorService, "executorService is null");
+    }
+
+    @Override
+    protected ConnectionFactory delegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return new KeepAliveConnection(super.openConnection(session), executorService, interval);
+    }
+
+    public static class FactoryDecorator
+            implements Decorator<ConnectionFactory>
+    {
+        public static final int KEEP_ALIVE_PRIORITY = REUSABLE_PRIORITY + 1;
+        private final Duration interval;
+
+        @Inject
+        public FactoryDecorator(QueryConfig config)
+        {
+            this.interval = config.getKeepAliveInterval();
+        }
+
+        @Override
+        public int priority()
+        {
+            return KEEP_ALIVE_PRIORITY;
+        }
+
+        @Override
+        public ConnectionFactory apply(ConnectionFactory delegate)
+        {
+            return new KeepAliveConnectionFactory(delegate, interval, Executors.newScheduledThreadPool(4, threadsNamed("jdbc-keep-alive-%d")));
+        }
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/keepalive/KeepAliveConnectionFactory.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static io.airlift.concurrent.Threads.threadsNamed;
-import static io.trino.plugin.jdbc.ReusableConnectionFactory.FactoryDecorator.REUSABLE_PRIORITY;
 import static java.util.Objects.requireNonNull;
 
 public class KeepAliveConnectionFactory
@@ -60,7 +59,6 @@ public class KeepAliveConnectionFactory
     public static class FactoryDecorator
             implements Decorator<ConnectionFactory>
     {
-        public static final int KEEP_ALIVE_PRIORITY = REUSABLE_PRIORITY + 1;
         private final Duration interval;
 
         @Inject
@@ -72,7 +70,7 @@ public class KeepAliveConnectionFactory
         @Override
         public int priority()
         {
-            return KEEP_ALIVE_PRIORITY;
+            return KEEP_ALIVE_CONNECTION_FACTORY_PRIORITY;
         }
 
         @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestQueryConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -28,7 +29,9 @@ public class TestQueryConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(QueryConfig.class)
-                .setReuseConnection(true));
+                .setReuseConnection(true)
+                .setKeepAlive(false)
+                .setKeepAliveInterval(Duration.valueOf("30s")));
     }
 
     @Test
@@ -36,10 +39,14 @@ public class TestQueryConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("query.reuse-connection", "false")
+                .put("query.keep-alive-connection", "true")
+                .put("query.keep-alive-interval", "5m")
                 .buildOrThrow();
 
         QueryConfig expected = new QueryConfig()
-                .setReuseConnection(false);
+                .setReuseConnection(false)
+                .setKeepAlive(true)
+                .setKeepAliveInterval(Duration.valueOf("5m"));
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/jmx/TestStatisticsAwareConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/jmx/TestStatisticsAwareConnectionFactory.java
@@ -16,13 +16,16 @@ package io.trino.plugin.jdbc.jmx;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
 public class TestStatisticsAwareConnectionFactory
 {
     @Test
     public void testEverythingImplemented()
+            throws NoSuchMethodException
     {
-        assertAllMethodsOverridden(ConnectionFactory.class, StatisticsAwareConnectionFactory.class);
+        assertAllMethodsOverridden(ConnectionFactory.class, StatisticsAwareConnectionFactory.class, Set.of(ConnectionFactory.class.getMethod("close")));
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -24,6 +24,7 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.RetryingConnectionFactory;
 import io.trino.plugin.jdbc.RetryingConnectionFactory.DefaultRetryStrategy;
 import io.trino.plugin.jdbc.credential.StaticCredentialProvider;
+import io.trino.plugin.jdbc.jmx.ConnectionFactoryStats;
 import io.trino.plugin.jdbc.jmx.StatisticsAwareConnectionFactory;
 import io.trino.testing.ResourcePresence;
 import oracle.jdbc.OracleDriver;
@@ -130,7 +131,8 @@ public class TestingOracleServer
         StatisticsAwareConnectionFactory connectionFactory = new StatisticsAwareConnectionFactory(new DriverConnectionFactory(
                 new OracleDriver(),
                 new BaseJdbcConfig().setConnectionUrl(connectionUrl),
-                StaticCredentialProvider.of(username, password)));
+                StaticCredentialProvider.of(username, password)),
+                new ConnectionFactoryStats());
         return new RetryingConnectionFactory(connectionFactory, new DefaultRetryStrategy());
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -44,7 +44,6 @@ import io.trino.plugin.jdbc.JdbcMetadataConfig;
 import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
 import io.trino.plugin.jdbc.JdbcWriteConfig;
 import io.trino.plugin.jdbc.JdbcWriteSessionProperties;
-import io.trino.plugin.jdbc.LazyConnectionFactory;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
 import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RetryingConnectionFactoryModule;
@@ -134,8 +133,7 @@ public class PhoenixClientModule
         install(conditionalModule(
                 PhoenixConfig.class,
                 PhoenixConfig::isReuseConnection,
-                new ReusableConnectionFactoryModule(),
-                innerBinder -> innerBinder.bind(ConnectionFactory.class).to(LazyConnectionFactory.class).in(Scopes.SINGLETON)));
+                new ReusableConnectionFactoryModule()));
 
         bindTablePropertiesProvider(binder, PhoenixTableProperties.class);
         binder.bind(PhoenixColumnProperties.class).in(Scopes.SINGLETON);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -73,6 +73,8 @@ public final class PostgreSqlQueryRunner
             connectorProperties.putIfAbsent("connection-user", server.getUser());
             connectorProperties.putIfAbsent("connection-password", server.getPassword());
             connectorProperties.putIfAbsent("postgresql.include-system-tables", "true");
+            connectorProperties.putIfAbsent("query.keep-alive-connection", "true");
+            connectorProperties.putIfAbsent("query.keep-alive-interval", "10s");
             //connectorProperties.putIfAbsent("postgresql.experimental.enable-string-pushdown-with-collate", "true");
 
             queryRunner.installPlugin(new PostgreSqlPlugin());


### PR DESCRIPTION
Minor refactoring of connection factories structure that makes it easier to introduce new connection factories without adding new annotations