### PR TITLE
Rename listTables to listRelations to avoid confusion

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1330,7 +1330,7 @@ public class TestTrinoDatabaseMetaData
                     list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17", "varchar")),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listSchemaNames")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
@@ -1350,7 +1350,7 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .add("ConnectorMetadata.listSchemaNames")
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 4)
                             .add("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)")
                             .add("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)")
@@ -1388,10 +1388,10 @@ public class TestTrinoDatabaseMetaData
                             .collect(toImmutableList()),
                     ImmutableMultiset.<String>builder()
                             .addCopies("ConnectorMetadata.listSchemaNames", 5)
-                            .add("ConnectorMetadata.listTables(schema=test_schema1)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema2)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema3_empty)")
-                            .add("ConnectorMetadata.listTables(schema=test_schema4_empty)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema1)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema2)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema3_empty)")
+                            .add("ConnectorMetadata.listRelations(schema=test_schema4_empty)")
                             .addCopies("ConnectorMetadata.getSystemTable(schema=test_schema1, table=test_table1)", 20)
                             .addCopies("ConnectorMetadata.getMaterializedView(schema=test_schema1, table=test_table1)", 5)
                             .addCopies("ConnectorMetadata.getView(schema=test_schema1, table=test_table1)", 5)

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -299,7 +299,7 @@ public class InformationSchemaMetadata
         }
 
         Set<QualifiedTablePrefix> tablePrefixes = prefixes.stream()
-                .flatMap(prefix -> metadata.listTables(session, prefix).stream())
+                .flatMap(prefix -> metadata.listRelations(session, prefix).stream())
                 .filter(objectName -> predicate.get().test(asFixedValues(objectName)))
                 .map(QualifiedObjectName::asQualifiedTablePrefix)
                 .distinct()

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -56,10 +56,10 @@ import static io.trino.connector.informationschema.InformationSchemaMetadata.def
 import static io.trino.connector.informationschema.InformationSchemaMetadata.isTablesEnumeratingTable;
 import static io.trino.metadata.MetadataListing.getRelationTypes;
 import static io.trino.metadata.MetadataListing.getViews;
+import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
 import static io.trino.metadata.MetadataListing.listTablePrivileges;
-import static io.trino.metadata.MetadataListing.listTables;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static io.trino.type.TypeUtils.getDisplayLabel;
@@ -289,7 +289,7 @@ public class InformationSchemaPageSource
                     .collect(toImmutableSet());
         }
         else {
-            relations = listTables(session, metadata, accessControl, prefix);
+            relations = listRelations(session, metadata, accessControl, prefix);
             views = Set.of();
         }
         // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views

--- a/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/jdbc/ColumnJdbcTable.java
@@ -69,9 +69,9 @@ import static io.trino.connector.system.jdbc.FilterUtil.isImpossibleObjectName;
 import static io.trino.connector.system.jdbc.FilterUtil.tablePrefix;
 import static io.trino.connector.system.jdbc.FilterUtil.tryGetSingleVarcharValue;
 import static io.trino.metadata.MetadataListing.listCatalogNames;
+import static io.trino.metadata.MetadataListing.listRelations;
 import static io.trino.metadata.MetadataListing.listSchemas;
 import static io.trino.metadata.MetadataListing.listTableColumns;
-import static io.trino.metadata.MetadataListing.listTables;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -211,7 +211,7 @@ public class ColumnJdbcTable
                     QualifiedTablePrefix tablePrefix = tableFilter.isPresent()
                             ? new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName(), tableFilter.get())
                             : new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName());
-                    return listTables(session, metadata, accessControl, tablePrefix).stream()
+                    return listRelations(session, metadata, accessControl, tablePrefix).stream()
                             .filter(schemaTableName -> predicate.test(ImmutableMap.of(
                                     TABLE_CATALOG_COLUMN, toNullableValue(schema.getCatalogName()),
                                     TABLE_SCHEMA_COLUMN, toNullableValue(schemaTableName.getSchemaName()),
@@ -278,7 +278,7 @@ public class ColumnJdbcTable
                     QualifiedTablePrefix tablePrefix = tableFilter.isPresent()
                             ? new QualifiedTablePrefix(catalog, schema, tableFilter.get())
                             : new QualifiedTablePrefix(catalog, schema);
-                    Set<SchemaTableName> tables = listTables(session, metadata, accessControl, tablePrefix);
+                    Set<SchemaTableName> tables = listRelations(session, metadata, accessControl, tablePrefix);
                     for (SchemaTableName schemaTableName : tables) {
                         String tableName = schemaTableName.getTableName();
                         if (!tableDomain.includesNullableValue(utf8Slice(tableName))) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -86,6 +86,6 @@ public class DropSchemaTask
         QualifiedTablePrefix tablePrefix = new QualifiedTablePrefix(schema.getCatalogName(), schema.getSchemaName());
 
         // This is a best effort check that doesn't provide any guarantees against concurrent DDL operations
-        return metadata.listTables(session, tablePrefix).isEmpty();
+        return metadata.listRelations(session, tablePrefix).isEmpty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -163,7 +163,7 @@ public interface Metadata
      * Get the relation names that match the specified table prefix (never null).
      * This includes all relations (e.g. tables, views, materialized views).
      */
-    List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix);
+    List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Get the relation names that match the specified table prefix (never null).

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -113,19 +113,19 @@ public final class MetadataListing
         return ImmutableSortedSet.copyOf(accessControl.filterSchemas(session.toSecurityContext(), catalogName, schemaNames));
     }
 
-    public static Set<SchemaTableName> listTables(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Set<SchemaTableName> listRelations(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
         try {
-            return doListTables(session, metadata, accessControl, prefix);
+            return doListRelations(session, metadata, accessControl, prefix);
         }
         catch (RuntimeException exception) {
             throw handleListingException(exception, "tables", prefix.getCatalogName());
         }
     }
 
-    private static Set<SchemaTableName> doListTables(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    private static Set<SchemaTableName> doListRelations(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Set<SchemaTableName> tableNames = metadata.listTables(session, prefix).stream()
+        Set<SchemaTableName> tableNames = metadata.listRelations(session, prefix).stream()
                 .map(QualifiedObjectName::asSchemaTableName)
                 .collect(toImmutableSet());
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -503,7 +503,7 @@ public final class MetadataManager
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
         requireNonNull(prefix, "prefix is null");
         if (cannotExist(prefix)) {
@@ -520,7 +520,7 @@ public final class MetadataManager
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());
-        Set<QualifiedObjectName> tables = new LinkedHashSet<>();
+        Set<QualifiedObjectName> relations = new LinkedHashSet<>();
         if (catalog.isPresent()) {
             CatalogMetadata catalogMetadata = catalog.get();
 
@@ -530,13 +530,13 @@ public final class MetadataManager
                 if (isExternalInformationSchema(catalogHandle, prefix.getSchemaName())) {
                     continue;
                 }
-                metadata.listTables(connectorSession, prefix.getSchemaName()).stream()
+                metadata.listRelations(connectorSession, prefix.getSchemaName()).stream()
                         .map(convertFromSchemaTableName(prefix.getCatalogName()))
                         .filter(table -> !isExternalInformationSchema(catalogHandle, table.getSchemaName()))
-                        .forEach(tables::add);
+                        .forEach(relations::add);
             }
         }
-        return ImmutableList.copyOf(tables);
+        return ImmutableList.copyOf(relations);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -810,14 +810,14 @@ public class LocalQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {
             return transaction(transactionManager, plannerContext.getMetadata(), accessControl)
                     .readOnly()
                     .execute(session, transactionSession -> {
-                        return getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema));
+                        return getMetadata().listRelations(transactionSession, new QualifiedTablePrefix(catalog, schema));
                     });
         }
         finally {

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -93,7 +93,7 @@ public interface QueryRunner
         throw new UnsupportedOperationException();
     }
 
-    List<QualifiedObjectName> listTables(Session session, String catalog, String schema);
+    List<QualifiedObjectName> listRelations(Session session, String catalog, String schema);
 
     boolean tableExists(Session session, String table);
 

--- a/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
@@ -127,7 +127,7 @@ public class TestingMetadata
         requireNonNull(prefix, "prefix is null");
 
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> tableColumns = ImmutableMap.builder();
-        for (SchemaTableName tableName : listTables(session, prefix.getSchema())) {
+        for (SchemaTableName tableName : listRelations(session, prefix.getSchema())) {
             ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
             for (ColumnMetadata column : tables.get(tableName).getColumns()) {
                 columns.add(new ColumnMetadata(column.getName(), column.getType()));

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -259,6 +259,15 @@ public class TracingConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> schemaName)
+    {
+        Span span = startSpan("listRelations", schemaName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.listRelations(session, schemaName);
+        }
+    }
+
+    @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         Span span = startSpan("listTables", schemaName);

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -309,11 +309,11 @@ public class TracingMetadata
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
-        Span span = startSpan("listTables", prefix);
+        Span span = startSpan("listRelations", prefix);
         try (var ignored = scopedSpan(span)) {
-            return delegate.listTables(session, prefix);
+            return delegate.listRelations(session, prefix);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -310,7 +310,7 @@ public abstract class BaseDataDefinitionTaskTest
         }
 
         @Override
-        public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+        public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
         {
             List<QualifiedObjectName> tables = ImmutableList.<QualifiedObjectName>builder()
                     .addAll(this.tables.keySet().stream().map(table -> new QualifiedObjectName(catalogName, table.getSchemaName(), table.getTableName())).collect(toImmutableList()))

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -228,7 +228,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, QualifiedTablePrefix prefix)
+    public List<QualifiedObjectName> listRelations(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -278,6 +278,15 @@ public interface ConnectorMetadata
      * @see #listViews(ConnectorSession, Optional)
      * @see #listMaterializedViews(ConnectorSession, Optional)
      */
+    default List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> schemaName)
+    {
+        return listTables(session, schemaName);
+    }
+
+    /**
+     * @deprecated Use {@link #listRelations(ConnectorSession, Optional)} instead.
+     */
+    @Deprecated(forRemoval = true)
     default List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         return emptyList();
@@ -352,7 +361,7 @@ public interface ConnectorMetadata
 
     /**
      * Gets columns for all relations (tables, views, materialized views), possibly filtered by schemaName.
-     * (e.g. for all relations that would be returned by {@link #listTables(ConnectorSession, Optional)}).
+     * (e.g. for all relations that would be returned by {@link #listRelations(ConnectorSession, Optional)}).
      * Redirected table names are included, but the comment for them is not.
      */
     @Experimental(eta = "2024-01-01")
@@ -391,7 +400,7 @@ public interface ConnectorMetadata
 
     /**
      * Gets comments for all relations (tables, views, materialized views), possibly filtered by schemaName.
-     * (e.g. for all relations that would be returned by {@link #listTables(ConnectorSession, Optional)}).
+     * (e.g. for all relations that would be returned by {@link #listRelations(ConnectorSession, Optional)}).
      * Redirected table names are included, but the comment for them is not.
      */
     @Experimental(eta = "2024-01-01")
@@ -411,7 +420,7 @@ public interface ConnectorMetadata
         Set<SchemaTableName> mvAndViewNames = Stream.concat(mvNames.stream(), views.stream().map(RelationCommentMetadata::name))
                 .collect(toUnmodifiableSet());
 
-        List<RelationCommentMetadata> tables = listTables(session, schemaName).stream()
+        List<RelationCommentMetadata> tables = listRelations(session, schemaName).stream()
                 .filter(tableName -> !mvAndViewNames.contains(tableName))
                 .collect(collectingAndThen(toUnmodifiableSet(), relationFilter)).stream()
                 .map(tableName -> {
@@ -444,7 +453,7 @@ public interface ConnectorMetadata
                             // getTableHandle or getTableMetadata failed call may fail if table disappeared during listing or is unsupported.
                             Helper.juliLogger.log(Level.WARNING, e, () -> "Failed to get metadata for table: " + tableName);
                         }
-                        // Since the getTableHandle did not return null (i.e. succeeded or failed), we assume the table would be returned by listTables
+                        // Since the getTableHandle did not return null (i.e. succeeded or failed), we assume the table would be returned by listRelations
                         return RelationCommentMetadata.forRelation(tableName, Optional.empty());
                     }
                 })
@@ -782,7 +791,7 @@ public interface ConnectorMetadata
 
     /**
      * Begin the atomic creation of a table with data.
-     *
+     * <p>
      * <p/>
      * If connector does not support execution with retries, the method should throw:
      * <pre>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -288,6 +288,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> listRelations(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listRelations(session, schemaName);
+        }
+    }
+
+    @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
+++ b/plugin/trino-blackhole/src/test/java/io/trino/plugin/blackhole/TestBlackHoleSmoke.java
@@ -377,7 +377,7 @@ public class TestBlackHoleSmoke
 
     private List<QualifiedObjectName> listBlackHoleTables()
     {
-        return queryRunner.listTables(queryRunner.getDefaultSession(), "blackhole", "default");
+        return queryRunner.listRelations(queryRunner.getDefaultSession(), "blackhole", "default");
     }
 
     private void assertThatQueryReturnsValue(String sql, Object expected)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -63,7 +63,7 @@ public class HiveMetastoreBackedDeltaLakeMetastore
         // it would be nice to filter out non-Delta tables; however, we can not call
         // metastore.getTablesWithParameter(schema, TABLE_PROVIDER_PROP, TABLE_PROVIDER_VALUE), because that property
         // contains a dot and must be compared case-insensitive
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -38,8 +38,8 @@ import java.util.Optional;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.CREATE_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.DROP_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_DATABASES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.file.TestingFileHiveMetastore.createTestingFileHiveMetastore;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -262,7 +262,7 @@ public class TestDeltaLakeMetastoreAccessOperations
         assertMetastoreInvocations("SHOW TABLES",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .build());
     }
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -17,6 +17,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExampleMetadata.java
+++ b/plugin/trino-example-http/src/test/java/io/trino/plugin/example/TestExampleMetadata.java
@@ -104,23 +104,23 @@ public class TestExampleMetadata
     }
 
     @Test
-    public void testListTables()
+    public void testListRelations()
     {
         // all schemas
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.empty()))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.empty()))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("example", "numbers"),
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem")));
 
         // specific schema
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("example")))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("example")))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("example", "numbers")));
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("tpch")))).isEqualTo(ImmutableSet.of(
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("tpch")))).isEqualTo(ImmutableSet.of(
                 new SchemaTableName("tpch", "orders"),
                 new SchemaTableName("tpch", "lineitem")));
 
         // unknown schema
-        assertThat(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("unknown")))).isEqualTo(ImmutableSet.of());
+        assertThat(ImmutableSet.copyOf(metadata.listRelations(SESSION, Optional.of("unknown")))).isEqualTo(ImmutableSet.of());
     }
 
     @Test

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemAbfs.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystemAbfs.java
@@ -91,7 +91,7 @@ public abstract class AbstractTestHiveFileSystemAbfs
                             .put(BUCKETED_BY_PROPERTY, ImmutableList.of())
                             .put(SORTED_BY_PROPERTY, ImmutableList.of())
                             .buildOrThrow());
-            if (!transaction.getMetadata().listTables(newSession(), Optional.of(table.getSchemaName())).contains(table)) {
+            if (!transaction.getMetadata().listRelations(newSession(), Optional.of(table.getSchemaName())).contains(table)) {
                 transaction.getMetadata().createTable(newSession(), tableMetadata, false);
             }
             transaction.commit();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -155,14 +155,14 @@ public class HiveMetastoreClosure
         delegate.updatePartitionStatistics(table, updates);
     }
 
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     public Map<String, RelationType> getRelationTypes(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
@@ -67,7 +67,7 @@ public class CoralSemiTransactionalHiveMSCAdapter
     @Override
     public List<String> getAllTables(String dbName)
     {
-        return delegate.getAllTables(dbName);
+        return delegate.getRelations(dbName);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -112,15 +112,15 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -63,12 +63,12 @@ public interface HiveMetastore
 
     void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
 
-    List<String> getAllTables(String databaseName);
+    List<String> getRelations(String databaseName);
 
     /**
      * @return List of tables, views and materialized views names from all schemas or Optional.empty if operation is not supported
      */
-    Optional<List<SchemaTableName>> getAllTables();
+    Optional<List<SchemaTableName>> getRelations();
 
     Map<String, RelationType> getRelationTypes(String databaseName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -235,22 +235,22 @@ public class SemiTransactionalHiveMetastore
         return delegate.getDatabase(databaseName);
     }
 
-    public synchronized List<String> getAllTables(String databaseName)
+    public synchronized List<String> getRelations(String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
-            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllTables(databaseName);
+        return delegate.getRelations(databaseName);
     }
 
-    public synchronized Optional<List<SchemaTableName>> getAllTables()
+    public synchronized Optional<List<SchemaTableName>> getRelations()
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
-            throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
+            throw new UnsupportedOperationException("Listing all relations after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllTables();
+        return delegate.getRelations();
     }
 
     public synchronized Map<String, RelationType> getRelationTypes(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/SharedHiveMetastoreCache.java
@@ -243,16 +243,16 @@ public class SharedHiveMetastoreCache
 
         @Managed
         @Nested
-        public AggregateCacheStatsMBean getTableNamesStats()
+        public AggregateCacheStatsMBean getRelationNamesStats()
         {
-            return new AggregateCacheStatsMBean(CachingHiveMetastore::getTableNamesCache);
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getRelationNamesCache);
         }
 
         @Managed
         @Nested
-        public AggregateCacheStatsMBean getAllTableNamesStats()
+        public AggregateCacheStatsMBean getAllRelationNamesStats()
         {
-            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllTableNamesCache);
+            return new AggregateCacheStatsMBean(CachingHiveMetastore::getAllRelationNamesCache);
         }
 
         @Managed

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -215,7 +215,7 @@ public class FileHiveMetastore
         databaseName = databaseName.toLowerCase(ENGLISH);
 
         getRequiredDatabase(databaseName);
-        if (!getAllTables(databaseName).isEmpty()) {
+        if (!getRelations(databaseName).isEmpty()) {
             throw new TrinoException(HIVE_METASTORE_ERROR, "Database " + databaseName + " is not empty");
         }
 
@@ -509,7 +509,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized List<String> getAllTables(String databaseName)
+    public synchronized List<String> getRelations(String databaseName)
     {
         return listAllTables(databaseName).stream()
                 .filter(hideDeltaLakeTables
@@ -519,7 +519,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return Optional.empty();
     }
@@ -528,7 +528,7 @@ public class FileHiveMetastore
     public synchronized Map<String, RelationType> getRelationTypes(String databaseName)
     {
         ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
-        getAllTables(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getRelations(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
         getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
         return relationTypes.buildKeepingLast();
     }
@@ -606,7 +606,7 @@ public class FileHiveMetastore
     @Override
     public synchronized List<String> getAllViews(String databaseName)
     {
-        return getAllTables(databaseName).stream()
+        return getRelations(databaseName).stream()
                 .map(tableName -> getTable(databaseName, tableName))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -423,13 +423,13 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         return getTableNames(databaseName, tableFilter);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return Optional.empty();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -142,7 +142,7 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         return delegate.getAllTables(databaseName);
     }
@@ -151,7 +151,7 @@ public class BridgingHiveMetastore
     public Map<String, RelationType> getRelationTypes(String databaseName)
     {
         ImmutableMap.Builder<String, RelationType> relationTypes = ImmutableMap.builder();
-        getAllTables(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
+        getRelations(databaseName).forEach(name -> relationTypes.put(name, RelationType.TABLE));
         getAllViews(databaseName).forEach(name -> relationTypes.put(name, RelationType.VIEW));
         return relationTypes.buildKeepingLast();
     }
@@ -169,7 +169,7 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         return delegate.getAllTables();
     }
@@ -177,7 +177,7 @@ public class BridgingHiveMetastore
     @Override
     public Optional<Map<SchemaTableName, RelationType>> getRelationTypes()
     {
-        return getAllTables().flatMap(relations -> getAllViews().map(views -> {
+        return getRelations().flatMap(relations -> getAllViews().map(views -> {
             ImmutableMap.Builder<SchemaTableName, RelationType> relationTypes = ImmutableMap.builder();
             relations.forEach(name -> relationTypes.put(name, RelationType.TABLE));
             views.forEach(name -> relationTypes.put(name, RelationType.VIEW));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -170,27 +170,27 @@ public class TracingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        Span span = tracer.spanBuilder("HiveMetastore.getAllTables")
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
                 .setAttribute(SCHEMA, databaseName)
                 .startSpan();
         return withTracing(span, () -> {
-            List<String> tables = delegate.getAllTables(databaseName);
-            span.setAttribute(TABLE_RESPONSE_COUNT, tables.size());
-            return tables;
+            List<String> relations = delegate.getRelations(databaseName);
+            span.setAttribute(TABLE_RESPONSE_COUNT, relations.size());
+            return relations;
         });
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        Span span = tracer.spanBuilder("HiveMetastore.getAllTables")
+        Span span = tracer.spanBuilder("HiveMetastore.getRelations")
                 .startSpan();
         return withTracing(span, () -> {
-            Optional<List<SchemaTableName>> tables = delegate.getAllTables();
-            tables.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
-            return tables;
+            Optional<List<SchemaTableName>> relations = delegate.getRelations();
+            relations.ifPresent(list -> span.setAttribute(TABLE_RESPONSE_COUNT, list.size()));
+            return relations;
         });
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -1062,7 +1062,7 @@ public abstract class AbstractTestHive
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.of(database));
+            List<SchemaTableName> tables = metadata.listRelations(newSession(), Optional.of(database));
             assertThat(tables).contains(tablePartitionFormat);
             assertThat(tables).contains(tableUnpartitioned);
         }
@@ -1073,7 +1073,7 @@ public abstract class AbstractTestHive
     {
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            List<SchemaTableName> tables = metadata.listTables(newSession(), Optional.empty());
+            List<SchemaTableName> tables = metadata.listRelations(newSession(), Optional.empty());
             assertThat(tables).contains(tablePartitionFormat);
             assertThat(tables).contains(tableUnpartitioned);
         }
@@ -1108,7 +1108,7 @@ public abstract class AbstractTestHive
             ConnectorMetadata metadata = transaction.getMetadata();
             ConnectorSession session = newSession();
             assertThat(metadata.getTableHandle(session, new SchemaTableName(INVALID_DATABASE, INVALID_TABLE))).isNull();
-            assertThat(metadata.listTables(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
+            assertThat(metadata.listRelations(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
             assertThat(listTableColumns(metadata, session, new SchemaTablePrefix(INVALID_DATABASE, INVALID_TABLE))).isEqualTo(ImmutableMap.of());
             assertThat(metadata.listViews(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableList.of());
             assertThat(metadata.getViews(session, Optional.of(INVALID_DATABASE))).isEqualTo(ImmutableMap.of());
@@ -3204,11 +3204,11 @@ public abstract class AbstractTestHive
                 //  as information_schema or MetadataManager may apply additional logic
 
                 // list all tables
-                assertThat(metadata.listTables(session, Optional.empty()))
+                assertThat(metadata.listRelations(session, Optional.empty()))
                         .doesNotContain(tableName);
 
                 // list all tables in a schema
-                assertThat(metadata.listTables(session, Optional.of(tableName.getSchemaName())))
+                assertThat(metadata.listRelations(session, Optional.of(tableName.getSchemaName())))
                         .doesNotContain(tableName);
 
                 // list all columns in a schema

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -177,7 +177,7 @@ public abstract class AbstractTestHiveLocal
             throws IOException
     {
         try {
-            for (String tableName : metastoreClient.getAllTables(database)) {
+            for (String tableName : metastoreClient.getRelations(database)) {
                 metastoreClient.dropTable(database, tableName, true);
             }
             metastoreClient.dropDatabase(testDbName, true);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/CountingAccessHiveMetastore.java
@@ -37,8 +37,8 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_RELATION_TYPES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATION_TYPES_FROM_DATABASE;
 
 @ThreadSafe
@@ -53,8 +53,8 @@ public class CountingAccessHiveMetastore
         GET_ALL_DATABASES,
         GET_DATABASE,
         GET_TABLE,
-        GET_ALL_TABLES,
-        GET_ALL_TABLES_FROM_DATABASE,
+        GET_RELATIONS,
+        GET_RELATIONS_FROM_DATABASE,
         GET_RELATION_TYPES_FROM_DATABASE,
         GET_ALL_RELATION_TYPES,
         GET_TABLES_WITH_PARAMETER,
@@ -360,20 +360,20 @@ public class CountingAccessHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
-        methodInvocations.add(Method.GET_ALL_TABLES_FROM_DATABASE);
-        return delegate.getAllTables(databaseName);
+        methodInvocations.add(Method.GET_RELATIONS_FROM_DATABASE);
+        return delegate.getRelations(databaseName);
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
-        Optional<List<SchemaTableName>> allTables = delegate.getAllTables();
-        if (allTables.isPresent()) {
-            methodInvocations.add(GET_ALL_TABLES);
+        Optional<List<SchemaTableName>> relations = delegate.getRelations();
+        if (relations.isPresent()) {
+            methodInvocations.add(GET_RELATIONS);
         }
-        return allTables;
+        return relations;
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -87,13 +87,13 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getRelations(String databaseName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Optional<List<SchemaTableName>> getAllTables()
+    public Optional<List<SchemaTableName>> getRelations()
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -181,7 +181,7 @@ public class TestCachingHiveMetastore
                 .usesCache();
 
         assertThatCachingWithDisabledPartitionCache()
-                .whenExecuting(testedMetastore -> testedMetastore.getAllTables(TEST_DATABASE))
+                .whenExecuting(testedMetastore -> testedMetastore.getRelations(TEST_DATABASE))
                 .usesCache();
 
         assertThatCachingWithDisabledPartitionCache()
@@ -227,49 +227,49 @@ public class TestCachingHiveMetastore
     }
 
     @Test
-    public void testGetAllTable()
+    public void testGetRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getTableNamesStats().getRequestCount()).isEqualTo(2);
-        assertThat(metastore.getTableNamesStats().getHitRate()).isEqualTo(0.5);
+        assertThat(metastore.getRelationNamesStats().getRequestCount()).isEqualTo(2);
+        assertThat(metastore.getRelationNamesStats().getHitRate()).isEqualTo(0.5);
 
         metastore.flushCache();
 
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
-        assertThat(metastore.getTableNamesStats().getRequestCount()).isEqualTo(3);
-        assertThat(metastore.getTableNamesStats().getHitRate()).isEqualTo(1.0 / 3);
+        assertThat(metastore.getRelationNamesStats().getRequestCount()).isEqualTo(3);
+        assertThat(metastore.getRelationNamesStats().getHitRate()).isEqualTo(1.0 / 3);
     }
 
     @Test
-    public void testBatchGetAllTable()
+    public void testBatchGetRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
+        assertThat(metastore.getRelations(TEST_DATABASE)).isEqualTo(ImmutableList.of(TEST_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
-        assertThat(metastore.getAllTableNamesStats().getRequestCount()).isEqualTo(2);
-        assertThat(metastore.getAllTableNamesStats().getHitRate()).isEqualTo(.5);
+        assertThat(metastore.getAllRelationNamesStats().getRequestCount()).isEqualTo(2);
+        assertThat(metastore.getAllRelationNamesStats().getHitRate()).isEqualTo(.5);
 
         metastore.flushCache();
 
-        assertThat(metastore.getAllTables()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
+        assertThat(metastore.getRelations()).isEqualTo(Optional.of(ImmutableList.of(TEST_SCHEMA_TABLE)));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
-        assertThat(metastore.getAllTableNamesStats().getRequestCount()).isEqualTo(3);
-        assertThat(metastore.getAllTableNamesStats().getHitRate()).isEqualTo(1. / 3);
+        assertThat(metastore.getAllRelationNamesStats().getRequestCount()).isEqualTo(3);
+        assertThat(metastore.getAllRelationNamesStats().getHitRate()).isEqualTo(1. / 3);
     }
 
     @Test
-    public void testInvalidDbGetAllTAbles()
+    public void testInvalidDbGetRelations()
     {
-        assertThat(metastore.getAllTables(BAD_DATABASE).isEmpty()).isTrue();
+        assertThat(metastore.getRelations(BAD_DATABASE).isEmpty()).isTrue();
     }
 
     @Test
@@ -1150,21 +1150,21 @@ public class TestCachingHiveMetastore
     }
 
     @Test
-    public void testAllTables()
+    public void testRelations()
     {
         assertThat(mockClient.getAccessCount()).isEqualTo(0);
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(1); // should read it from cache
 
         metastore.dropTable(TEST_DATABASE, TEST_TABLE, false);
         assertThat(mockClient.getAccessCount()).isEqualTo(2); // dropTable check if the table exists
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(3); // should read it from cache
 
         metastore.createTable(
@@ -1177,9 +1177,9 @@ public class TestCachingHiveMetastore
                         .build(),
                 new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()));
 
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(4);
-        assertThat(metastore.getAllTables()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
+        assertThat(metastore.getRelations()).contains(ImmutableList.of(TEST_SCHEMA_TABLE));
         assertThat(mockClient.getAccessCount()).isEqualTo(4); // should read it from cache
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
@@ -46,10 +46,10 @@ import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_DATABASES;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_RELATION_TYPES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_VIEWS_FROM_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATION_TYPES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -408,7 +408,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
 
         mockMetastore.setAllTablesViewsImplemented(true);
         ImmutableMultiset<Method> tables = ImmutableMultiset.<Method>builder()
-                .add(GET_ALL_TABLES)
+                .add(GET_RELATIONS)
                 .add(GET_ALL_VIEWS)
                 .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                 .build();
@@ -418,7 +418,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         mockMetastore.setAllTablesViewsImplemented(false);
         tables = ImmutableMultiset.<Method>builder()
                 .add(GET_ALL_DATABASES)
-                .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                 .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                 .build();
@@ -442,26 +442,26 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_schema = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem = 'test_schema_0'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test\\_schema\\_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test_schema_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_ALL_VIEWS_FROM_DATABASE)
                         .addCopies(GET_TABLE, TEST_TABLES_IN_SCHEMA_COUNT)
                         .build());
@@ -477,7 +477,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -485,7 +485,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
 
@@ -494,7 +494,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_schema LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -502,7 +502,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
     }
@@ -517,7 +517,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         // TODO When there are many schemas, there are no "prefixes" and we end up calling ConnectorMetadata without any filter whatsoever.
                         //  If such queries are common enough, we could iterate over schemas and for each schema try getting a table by given name.
@@ -539,7 +539,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_SCHEMAS_COUNT)
                         .build());
 
@@ -548,7 +548,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name = 'test_table_0'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         // TODO When there are many schemas, there are no "prefixes" and we end up calling ConnectorMetadata without any filter whatsoever.
                         //  If such queries are common enough, we could iterate over schemas and for each schema try getting a table by given name.
@@ -570,7 +570,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_SCHEMAS_COUNT)
                         .build());
     }
@@ -584,14 +584,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM information_schema.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
 
@@ -600,7 +600,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -608,7 +608,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE table_name LIKE 'test%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
     }
@@ -622,14 +622,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations(
                 "SELECT * FROM information_schema.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -639,7 +639,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -647,7 +647,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE column_name = 'name'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -663,14 +663,14 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
         assertMetastoreInvocations(
                 "SELECT * FROM system.jdbc.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES)
+                        .add(GET_RELATIONS)
                         .add(GET_ALL_VIEWS)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -680,7 +680,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM information_schema.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -688,7 +688,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 "SELECT * FROM system.jdbc.columns WHERE column_name LIKE 'n%'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, TEST_SCHEMAS_COUNT)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_ALL_VIEWS_FROM_DATABASE, TEST_SCHEMAS_COUNT)
                         .addCopies(GET_TABLE, TEST_ALL_TABLES_COUNT)
                         .build());
@@ -705,7 +705,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         assertMetastoreInvocations("SELECT * FROM system.jdbc.columns WHERE table_schem LIKE 'test_schema_0' ESCAPE '\\' AND table_name LIKE 'test_table_0' ESCAPE '\\'",
                 ImmutableMultiset.builder()
                         .add(GET_ALL_DATABASES)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .add(GET_TABLE)
                         .build());
     }
@@ -738,13 +738,13 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
         }
 
         @Override
-        public List<String> getAllTables(String databaseName)
+        public List<String> getRelations(String databaseName)
         {
             return TABLES_PER_SCHEMA;
         }
 
         @Override
-        public Optional<List<SchemaTableName>> getAllTables()
+        public Optional<List<SchemaTableName>> getRelations()
         {
             if (allTablesViewsImplemented) {
                 return Optional.of(ALL_TABLES);

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiMetadata.java
@@ -205,7 +205,7 @@ public class HudiMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllTables(schemaName)) {
+            for (String tableName : metastore.getRelations(schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -383,7 +383,7 @@ public class TrinoHiveCatalog
     {
         ImmutableSet.Builder<SchemaTableName> tablesListBuilder = ImmutableSet.builder();
         for (String schemaName : listNamespaces(session, namespace)) {
-            metastore.getAllTables(schemaName).forEach(tableName -> tablesListBuilder.add(new SchemaTableName(schemaName, tableName)));
+            metastore.getRelations(schemaName).forEach(tableName -> tablesListBuilder.add(new SchemaTableName(schemaName, tableName)));
         }
         return tablesListBuilder.build().asList();
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -102,7 +102,7 @@ public class TestIcebergMetadataListing
     @Test
     public void testTableListing()
     {
-        assertThat(metastore.getAllTables("test_schema"))
+        assertThat(metastore.getRelations("test_schema"))
                 .containsExactlyInAnyOrder(
                         "iceberg_table1",
                         "iceberg_table2",

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.CREATE_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.DROP_TABLE;
-import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_ALL_TABLES_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_DATABASE;
+import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_RELATIONS_FROM_DATABASE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLE;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.GET_TABLES_WITH_PARAMETER;
 import static io.trino.plugin.hive.metastore.CountingAccessHiveMetastore.Method.REPLACE_TABLE;
@@ -393,7 +393,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval
         assertMetastoreInvocations(session, "SELECT * FROM information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name LIKE 'test_select_i_s_columns%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .addCopies(GET_TABLE, tables * 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 2)
                         .build());
@@ -439,7 +439,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval
         assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name = CURRENT_SCHEMA AND table_name LIKE 'test_select_s_m_t_comments%'",
                 ImmutableMultiset.builder()
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .addCopies(GET_TABLE, tables * 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 2)
                         .build());
@@ -447,7 +447,7 @@ public class TestIcebergMetastoreAccessOperations
         // Bulk retrieval for two schemas
         assertMetastoreInvocations(session, "SELECT * FROM system.metadata.table_comments WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent') AND table_name LIKE 'test_select_s_m_t_comments%'",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_ALL_TABLES_FROM_DATABASE, 2)
+                        .addCopies(GET_RELATIONS_FROM_DATABASE, 2)
                         .addCopies(GET_TABLES_WITH_PARAMETER, 4)
                         .addCopies(GET_TABLE, tables * 2)
                         .build());
@@ -533,7 +533,7 @@ public class TestIcebergMetastoreAccessOperations
         assertMetastoreInvocations("SHOW TABLES",
                 ImmutableMultiset.builder()
                         .add(GET_DATABASE)
-                        .add(GET_ALL_TABLES_FROM_DATABASE)
+                        .add(GET_RELATIONS_FROM_DATABASE)
                         .build());
     }
 

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestMinimalFunctionality.java
@@ -54,7 +54,7 @@ public class TestMinimalFunctionality
     @Test
     public void testTopicExists()
     {
-        assertThat(getQueryRunner().listTables(getSession(), "kafka", "default")).contains(QualifiedObjectName.valueOf("kafka.default." + topicName));
+        assertThat(getQueryRunner().listRelations(getSession(), "kafka", "default")).contains(QualifiedObjectName.valueOf("kafka.default." + topicName));
     }
 
     @Test

--- a/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
+++ b/plugin/trino-redshift/src/test/java/io/trino/plugin/redshift/RedshiftQueryRunner.java
@@ -204,7 +204,7 @@ public final class RedshiftQueryRunner
 
     private static synchronized void provisionTables(Session session, QueryRunner queryRunner, Iterable<TpchTable<?>> tables)
     {
-        Set<String> existingTables = queryRunner.listTables(session, session.getCatalog().orElseThrow(), session.getSchema().orElseThrow())
+        Set<String> existingTables = queryRunner.listRelations(session, session.getCatalog().orElseThrow(), session.getSchema().orElseThrow())
                 .stream()
                 .map(QualifiedObjectName::getObjectName)
                 .collect(toUnmodifiableSet());

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -308,9 +308,9 @@ public final class ThriftQueryRunner
         }
 
         @Override
-        public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+        public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
         {
-            return source.listTables(session, catalog, schema);
+            return source.listRelations(session, catalog, schema);
         }
 
         @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -196,7 +196,7 @@ public abstract class AbstractTestingTrinoClient<T>
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
     {
         return inTransaction(session, transactionSession ->
-                trinoServer.getMetadata().listTables(transactionSession, new QualifiedTablePrefix(catalog, schema)));
+                trinoServer.getMetadata().listRelations(transactionSession, new QualifiedTablePrefix(catalog, schema)));
     }
 
     public boolean tableExists(Session session, String table)

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -455,7 +455,7 @@ public class DistributedQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -225,7 +225,7 @@ public final class StandaloneQueryRunner
     }
 
     @Override
-    public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)
+    public List<QualifiedObjectName> listRelations(Session session, String catalog, String schema)
     {
         lock.readLock().lock();
         try {

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -366,7 +366,7 @@ public class TestInformationSchemaConnector
                 "VALUES 1000",
                 ImmutableMultiset.<String>builder()
                         .add("ConnectorMetadata.listSchemaNames")
-                        .add("ConnectorMetadata.listTables(schema=test_schema1)")
+                        .add("ConnectorMetadata.listRelations(schema=test_schema1)")
                         // view-related methods such as listViews not being called
                         .build());
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -125,14 +125,14 @@ public class TestMetadataManager
     }
 
     @Test
-    public void testMetadataListTablesReturnsQualifiedView()
+    public void testMetadataListRelationsReturnsQualifiedView()
     {
         TransactionBuilder.transaction(queryRunner.getTransactionManager(), metadataManager, queryRunner.getAccessControl())
                 .execute(
                         TEST_SESSION,
                         transactionSession -> {
                             QualifiedTablePrefix viewName = new QualifiedTablePrefix("upper_case_schema_catalog", "upper_case_schema", "test_view");
-                            assertThat(metadataManager.listTables(transactionSession, viewName)).containsExactly(viewName.asQualifiedObjectName().get());
+                            assertThat(metadataManager.listRelations(transactionSession, viewName)).containsExactly(viewName.asQualifiedObjectName().get());
                         });
     }
 


### PR DESCRIPTION
The "tables" is often used to refer to tables only. "Relations"
better indicates the method includes tables, views and materialized
views.

Extracted from https://github.com/trinodb/trino/pull/19832 