### PR TITLE
Fix flaky TestIcebergFileMetastoreCreateTableFailure

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestIcebergFileMetastoreCreateTableFailure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/file/TestIcebergFileMetastoreCreateTableFailure.java
@@ -28,6 +28,7 @@ import io.trino.testing.DistributedQueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,8 +44,10 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
+@Execution(SAME_THREAD) // testException is shared mutable state
 public class TestIcebergFileMetastoreCreateTableFailure
         extends AbstractTestQueryFramework
 {


### PR DESCRIPTION
## Description

```
Error:  io.trino.plugin.iceberg.catalog.file.TestIcebergFileMetastoreCreateTableFailure.testCreateTableFailureMetadataCleanedUp -- Time elapsed: 0.014 s <<< FAILURE!
java.lang.AssertionError: 

Expecting throwable message:
  "Test-simulated metastore runtime exception"
to contain:
  "Test-simulated metastore schema not found exception"
but did not.
```
https://github.com/trinodb/trino/actions/runs/7010135638/job/19071177674

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
