### PR TITLE
Remove EnforceSingleRowNode support from PlanNodeDecorrelator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubqueryPlanner.java
@@ -268,7 +268,9 @@ class SubqueryPlanner
                 subPlan,
                 root,
                 scalarSubquery.getQuery(),
-                CorrelatedJoinNode.Type.LEFT,
+                // Scalar subquery always contains EnforceSingleRowNode. Therefore, it's guaranteed
+                // that subquery will return single row. Hence, correlated join can be of INNER type.
+                CorrelatedJoinNode.Type.INNER,
                 TRUE_LITERAL,
                 mapAll(cluster, subPlan.getScope(), column));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -35,6 +35,7 @@ import io.trino.sql.tree.WhenClause;
 
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.matching.Pattern.nonEmpty;
 import static io.trino.spi.StandardErrorCode.SUBQUERY_MULTIPLE_ROWS;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -101,6 +102,8 @@ public class TransformCorrelatedScalarSubquery
     @Override
     public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
+        // lateral references are only allowed for INNER or LEFT correlated join
+        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: " + correlatedJoinNode.getType());
         PlanNode subquery = context.getLookup().resolve(correlatedJoinNode.getSubquery());
 
         if (!searchFrom(subquery, context.getLookup())
@@ -124,7 +127,10 @@ public class TransformCorrelatedScalarSubquery
                     correlatedJoinNode.getInput(),
                     rewrittenSubquery,
                     correlatedJoinNode.getCorrelation(),
-                    producesSingleRow ? INNER : correlatedJoinNode.getType(),
+                    // EnforceSingleRowNode guarantees that exactly single matching row is produced
+                    // for every input row (independently of correlated join type). Decorrelated plan
+                    // must preserve this semantics.
+                    producesSingleRow ? INNER : LEFT,
                     correlatedJoinNode.getFilter(),
                     correlatedJoinNode.getOriginSubquery()));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -395,7 +395,7 @@ public class PlanNodeDecorrelator
         {
             // Aggregation with global grouping cannot be converted to aggregation grouped on constants.
             // Theoretically, if there are no constants to group on, the aggregation could be successfully decorrelated.
-            // However, it can only happen in the when where Aggregation's source plan is not correlated.
+            // However, it can only happen when Aggregation's source plan is not correlated.
             // Then:
             // - either we should not reach here because uncorrelated subplans of correlated filters are not explored,
             // - or the aggregation contains correlation which is unresolvable. This is indicated by returning Optional.empty().

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -35,7 +35,6 @@ import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.DataOrganizationSpecification;
-import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.LimitNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -389,13 +388,6 @@ public class PlanNodeDecorrelator
                 return Optional.empty();
             }
             return Optional.of(new OrderingScheme(nonConstantOrderBy.build(), nonConstantOrderings.buildOrThrow()));
-        }
-
-        @Override
-        public Optional<DecorrelationResult> visitEnforceSingleRow(EnforceSingleRowNode node, Void context)
-        {
-            Optional<DecorrelationResult> childDecorrelationResultOptional = node.getSource().accept(this, null);
-            return childDecorrelationResultOptional.filter(result -> result.atMostSingleRow);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedJoinToJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedJoinToJoin.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.JoinNode.Type;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.LongLiteral;
@@ -143,6 +144,22 @@ public class TestTransformCorrelatedJoinToJoin
                                         filter(
                                                 TRUE_LITERAL,
                                                 values("b")))));
+    }
+
+    @Test
+    public void doesNotFireForEnforceSingleRow()
+    {
+        tester().assertThat(new TransformCorrelatedJoinToJoin(tester().getPlannerContext()))
+                .on(p -> p.correlatedJoin(
+                        ImmutableList.of(p.symbol("corr")),
+                        p.values(p.symbol("corr")),
+                        INNER,
+                        TRUE_LITERAL,
+                        p.enforceSingleRow(
+                                p.filter(
+                                        PlanBuilder.expression("corr = a"),
+                                        p.values(p.symbol("a"))))))
+                .doesNotFire();
     }
 
     @Test


### PR DESCRIPTION
EnforceSingleRowNode guarantees that exactly single row is produced. Therefore, PlanNodeDecorrelator was incorrectly removing EnforceSingleRowNode even if decorrelated subplan could produce 0 rows.
Additionally, TransformCorrelatedJoinToJoin was completing with TransformCorrelatedScalarSubquery to decorrelate EnforceSingleRowNode.
This changes removes support for EnforceSingleRowNode from PlanNodeDecorrelator and makes TransformCorrelatedScalarSubquery the only rule that (correctly) decorrelates that node.

