### PR TITLE
Fix orc input stream ArrayIndexOutOfBoundsException

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/OrcInputStream.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/OrcInputStream.java
@@ -227,7 +227,9 @@ public final class OrcInputStream
         int decompressedOffset = decodeDecompressedOffset(checkpoint);
         // if checkpoint is within the current buffer, seek locally
         int currentDecompressedBufferOffset = decodeDecompressedOffset(lastCheckpoint);
-        if (current != null && compressedOffset == decodeCompressedBlockOffset(lastCheckpoint) && decompressedOffset < currentDecompressedBufferOffset + current.length()) {
+        if (current != null && compressedOffset == decodeCompressedBlockOffset(lastCheckpoint)
+                && decompressedOffset >= currentDecompressedBufferOffset
+                && decompressedOffset < currentDecompressedBufferOffset + current.length()) {
             current.setPosition(decompressedOffset - currentDecompressedBufferOffset);
             return;
         }

--- a/lib/trino-orc/src/test/java/io/trino/orc/stream/TestLongStreamV2.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/stream/TestLongStreamV2.java
@@ -33,7 +33,7 @@ public class TestLongStreamV2
         extends AbstractTestValueStream<Long, LongStreamCheckpoint, LongOutputStreamV2, LongInputStreamV2>
 {
     @Test
-    public void test()
+    public void testLargeValue()
             throws IOException
     {
         List<List<Long>> groups = new ArrayList<>();
@@ -41,6 +41,21 @@ public class TestLongStreamV2
             List<Long> group = new ArrayList<>();
             for (int i = 0; i < 1000; i++) {
                 group.add((long) (groupIndex * 10_000 + i));
+            }
+            groups.add(group);
+        }
+        testWriteValue(groups);
+    }
+
+    @Test
+    public void testSmallValue()
+            throws IOException
+    {
+        List<List<Long>> groups = new ArrayList<>();
+        for (int groupIndex = 0; groupIndex < 22; groupIndex++) {
+            List<Long> group = new ArrayList<>();
+            for (int i = 0; i < 1_000_000; i++) {
+                group.add((long) (groupIndex * 0 + i));
             }
             groups.add(group);
         }


### PR DESCRIPTION
## Description
Fix ORC input stream ArrayIndexOutOfBoundsException #19934

## Additional context and related issues
### 1. Background
#### 1.1 Trino ORC
- StripeReader.selectRowGroups
Filter out the Row Group set (Set<Integer>) matching the domain based on ORC Index Data.
- OrcInputStream.seekToCheckpoint
When reading a Row Group in ORC Stream, it is used to set the Checkpoint of the Row Group (compressed block start address, decompressed data offset position, the number of values consumed in the RLE).

### 2.Reproduction BUG Example
#### 2.1 Brief
Reader filters out Row Group 2 and Row Group 3 based on the ORC Index. They are in the same Compress Chunk 1. At the same time, the reading order is to read Row Group 3 first and then Row Group 2, then a BUG will be triggered. As shown in the picture:
![image](https://github.com/trinodb/trino/assets/150880684/f949c70e-ca8c-4cdc-8c50-df55a40f4e94)
#### 2.2 Detail Description
1）The result returned by the StripeReader.selectRowGroups function is a set. The order of the set cannot be guaranteed. That is, when traversing, it is possible to obtain Row Group 3 first and then Row Group 2.
2）Read Row Group 3
Locate the starting address of Chunk 1, read and decompress the data block. Starting from the decompressed data offset position of Row Group 3, intercept Slice for RG3, as shown in the figure:
![image](https://github.com/trinodb/trino/assets/150880684/32a61b26-5d27-48f3-be29-e24384dc9cb0)
3）OrcInputStream cache Slice for RG3
4）Read Row Group 2
OrcInputStream.seekToCheckpoint sets the checkpoint of Row Group 2. First, it is judged whether the cache is valid. The judgment logic is: whether the starting address of the compressed block is the same, and the offset position of the decompressed data is less than the lower boundary of the cache, that is, the cache is considered satisfied.

However, this is wrong. The starting address of the Row Group 2 compressed block is the same as the cached address, and the decompressed data offset position is smaller than the lower boundary of the cache, but in fact it is not in the cache range, resulting in an array out-of-bounds error when intercepting the cache.

#### 2.3 Unit Test
io.trino.orc.stream.TestLongStreamV2 adds testSamllValue, so unit testing can reproduce the problem stably.

#### 2.4 Solution
The logic of OrcInputStream.seekToCheckpoint to determine whether the cache is satisfied adds a judgment condition: the offset position of the decompressed data is greater than the offset position of the cache.





<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(  ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
Fix ORC input stream ArrayIndexOutOfBoundsException #19934
```
