### PR TITLE
Remove implicit passthrough for partition by columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1766,11 +1766,6 @@ class StatementAnalyzer
                     argumentScope.getRelationType().getAllFields()
                             .forEach(fields::add);
                 }
-                else if (argument.getPartitionBy().isPresent()) {
-                    argument.getPartitionBy().get().stream()
-                            .map(expression -> validateAndGetInputField(expression, argumentScope))
-                            .forEach(fields::add);
-                }
             }
 
             analysis.setTableFunctionAnalysis(node, new TableFunctionInvocationAnalysis(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -444,15 +444,6 @@ class RelationPlanner
                         .map(symbol -> new PassThroughColumn(symbol, partitionBy.contains(symbol)))
                         .forEach(passThroughColumns::add);
             }
-            else if (tableArgument.getPartitionBy().isPresent()) {
-                tableArgument.getPartitionBy().get().stream()
-                        // the original symbols for partitioning columns, not coerced
-                        .map(sourcePlanBuilder::translate)
-                        .forEach(symbol -> {
-                            outputSymbols.add(symbol);
-                            passThroughColumns.add(new PassThroughColumn(symbol, true));
-                        });
-            }
 
             sources.add(sourcePlanBuilder.getRoot());
             sourceProperties.add(new TableArgumentProperties(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableFunctionInvocation.java
@@ -109,8 +109,7 @@ public class TestTableFunctionInvocation
                                         "INPUT_3",
                                         tableArgument(2)
                                                 .specification(specification(ImmutableList.of("c3"), ImmutableList.of(), ImmutableMap.of()))
-                                                .pruneWhenEmpty()
-                                                .passThroughSymbols(ImmutableSet.of("c3")))
+                                                .pruneWhenEmpty())
                                 .addTableArgument(
                                         "INPUT_2",
                                         tableArgument(1)
@@ -146,13 +145,11 @@ public class TestTableFunctionInvocation
                                 .addTableArgument(
                                         "INPUT1",
                                         tableArgument(0)
-                                                .specification(specification(ImmutableList.of("c1_coerced"), ImmutableList.of(), ImmutableMap.of()))
-                                                .passThroughSymbols(ImmutableSet.of("c1")))
+                                                .specification(specification(ImmutableList.of("c1_coerced"), ImmutableList.of(), ImmutableMap.of())))
                                 .addTableArgument(
                                         "INPUT2",
                                         tableArgument(1)
-                                                .specification(specification(ImmutableList.of("c2"), ImmutableList.of(), ImmutableMap.of()))
-                                                .passThroughSymbols(ImmutableSet.of("c2")))
+                                                .specification(specification(ImmutableList.of("c2"), ImmutableList.of(), ImmutableMap.of())))
                                 .addCopartitioning(ImmutableList.of("INPUT1", "INPUT2"))
                                 .properOutputs(ImmutableList.of("COLUMN")),
                         project(ImmutableMap.of("c1_coerced", expression("CAST(c1 AS INTEGER)")),


### PR DESCRIPTION
## Description
Remove implicit addition of partition by columns in table functions.

## Additional context and related issues
Open to discussion in #19865.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
* Update table functions to not implicitly include partition by columns as passthrough.
```
