### PR TITLE
Speed up Materialized Views metadata access

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -160,8 +160,7 @@ public class CreateMaterializedViewTask
                         // system path elements are not stored
                         .filter(element -> !element.getCatalogName().equals(GlobalSystemConnector.NAME))
                         .collect(toImmutableList()),
-                Optional.empty(),
-                properties);
+                Optional.empty());
 
         Set<String> specifiedPropertyKeys = statement.getProperties().stream()
                 // property names are case-insensitive and normalized to lower case
@@ -172,7 +171,7 @@ public class CreateMaterializedViewTask
                 .filter(specifiedPropertyKeys::contains)
                 .collect(toImmutableMap(Function.identity(), properties::get));
         accessControl.checkCanCreateMaterializedView(session.toSecurityContext(), name, explicitlySetProperties);
-        plannerContext.getMetadata().createMaterializedView(session, name, definition, statement.isReplace(), statement.isNotExists());
+        plannerContext.getMetadata().createMaterializedView(session, name, definition, properties, statement.isReplace(), statement.isNotExists());
 
         stateMachine.setOutput(analysis.getTarget());
         stateMachine.setReferencedTables(analysis.getReferencedTables());

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -13,7 +13,6 @@
  */
 package io.trino.metadata;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
@@ -21,7 +20,6 @@ import io.trino.spi.security.Identity;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -34,7 +32,6 @@ public class MaterializedViewDefinition
 {
     private final Optional<Duration> gracePeriod;
     private final Optional<CatalogSchemaTableName> storageTable;
-    private final Map<String, Object> properties;
 
     public MaterializedViewDefinition(
             String originalSql,
@@ -45,14 +42,12 @@ public class MaterializedViewDefinition
             Optional<String> comment,
             Identity owner,
             List<CatalogSchemaName> path,
-            Optional<CatalogSchemaTableName> storageTable,
-            Map<String, Object> properties)
+            Optional<CatalogSchemaTableName> storageTable)
     {
         super(originalSql, catalog, schema, columns, comment, Optional.of(owner), path);
         checkArgument(gracePeriod.isEmpty() || !gracePeriod.get().isNegative(), "gracePeriod cannot be negative: %s", gracePeriod);
         this.gracePeriod = gracePeriod;
         this.storageTable = requireNonNull(storageTable, "storageTable is null");
-        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
     }
 
     public Optional<Duration> getGracePeriod()
@@ -63,11 +58,6 @@ public class MaterializedViewDefinition
     public Optional<CatalogSchemaTableName> getStorageTable()
     {
         return storageTable;
-    }
-
-    public Map<String, Object> getProperties()
-    {
-        return properties;
     }
 
     public ConnectorMaterializedViewDefinition toConnectorMaterializedViewDefinition()
@@ -83,8 +73,7 @@ public class MaterializedViewDefinition
                 getGracePeriod(),
                 getComment(),
                 getRunAsIdentity().map(Identity::getUser),
-                getPath(),
-                properties);
+                getPath());
     }
 
     @Override
@@ -100,7 +89,6 @@ public class MaterializedViewDefinition
                 .add("runAsIdentity", getRunAsIdentity())
                 .add("path", getPath())
                 .add("storageTable", storageTable.orElse(null))
-                .add("properties", properties)
                 .toString();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -710,7 +710,13 @@ public interface Metadata
     /**
      * Creates the specified materialized view with the specified view definition.
      */
-    void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting);
+    void createMaterializedView(
+            Session session,
+            QualifiedObjectName viewName,
+            MaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting);
 
     /**
      * Drops the specified materialized view.
@@ -739,6 +745,8 @@ public interface Metadata
      * Returns the materialized view definition for the specified view name.
      */
     Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);
+
+    Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName objectName, MaterializedViewDefinition materializedViewDefinition);
 
     /**
      * Method to get difference between the states of table at two different points in time/or as of given token-ids.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1530,7 +1530,13 @@ public final class MetadataManager
     }
 
     @Override
-    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            Session session,
+            QualifiedObjectName viewName,
+            MaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, viewName.getCatalogName());
         CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle();
@@ -1540,6 +1546,7 @@ public final class MetadataManager
                 session.toConnectorSession(catalogHandle),
                 viewName.asSchemaTableName(),
                 definition.toConnectorMaterializedViewDefinition(),
+                properties,
                 replace,
                 ignoreExisting);
         if (catalogMetadata.getSecurityManagement() == SYSTEM) {
@@ -1673,8 +1680,7 @@ public final class MetadataManager
                 view.getComment(),
                 runAsIdentity,
                 view.getPath(),
-                view.getStorageTable(),
-                view.getProperties());
+                view.getStorageTable());
     }
 
     private Optional<ConnectorMaterializedViewDefinition> getMaterializedViewInternal(Session session, QualifiedObjectName viewName)
@@ -1693,6 +1699,24 @@ public final class MetadataManager
             return metadata.getMaterializedView(connectorSession, viewName.asSchemaTableName());
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName viewName, MaterializedViewDefinition materializedViewDefinition)
+    {
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, viewName.getCatalogName());
+        if (catalog.isPresent()) {
+            CatalogMetadata catalogMetadata = catalog.get();
+            CatalogHandle catalogHandle = catalogMetadata.getCatalogHandle(session, viewName);
+            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(session, catalogHandle);
+
+            ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
+            return ImmutableMap.copyOf(metadata.getMaterializedViewProperties(
+                    connectorSession,
+                    viewName.asSchemaTableName(),
+                    materializedViewDefinition.toConnectorMaterializedViewDefinition()));
+        }
+        return ImmutableMap.of();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -606,7 +606,7 @@ public final class ShowQueriesRewrite
 
                 accessControl.checkCanShowCreateTable(session.toSecurityContext(), new QualifiedObjectName(catalogName.getValue(), schemaName.getValue(), tableName.getValue()));
 
-                Map<String, Object> properties = viewDefinition.get().getProperties();
+                Map<String, Object> properties = metadata.getMaterializedViewProperties(session, objectName, viewDefinition.get());
                 CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, node, catalogName.getValue());
                 Collection<PropertyMetadata<?>> allMaterializedViewProperties = materializedViewPropertyManager.getAllProperties(catalogHandle);
                 List<Property> propertyNodes = buildProperties(objectName, Optional.empty(), INVALID_MATERIALIZED_VIEW_PROPERTY, properties, allMaterializedViewProperties);

--- a/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingMetadata.java
@@ -234,7 +234,13 @@ public class TestingMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         if (replace) {
             materializedViews.put(viewName, definition);
@@ -262,6 +268,12 @@ public class TestingMetadata
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         return Optional.ofNullable(materializedViews.get(viewName));
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+    {
+        return ImmutableMap.of();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingConnectorMetadata.java
@@ -1245,11 +1245,17 @@ public class TracingConnectorMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         Span span = startSpan("createMaterializedView", viewName);
         try (var ignored = scopedSpan(span)) {
-            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+            delegate.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
         }
     }
 
@@ -1286,6 +1292,15 @@ public class TracingConnectorMetadata
         Span span = startSpan("getMaterializedView", viewName);
         try (var ignored = scopedSpan(span)) {
             return delegate.getMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+    {
+        Span span = startSpan("getMaterializedViewProperties", viewName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViewProperties(session, viewName, materializedViewDefinition);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TracingMetadata.java
@@ -1302,11 +1302,17 @@ public class TracingMetadata
     }
 
     @Override
-    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            Session session,
+            QualifiedObjectName viewName,
+            MaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         Span span = startSpan("createMaterializedView", viewName);
         try (var ignored = scopedSpan(span)) {
-            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+            delegate.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
         }
     }
 
@@ -1352,6 +1358,15 @@ public class TracingMetadata
         Span span = startSpan("getMaterializedView", viewName);
         try (var ignored = scopedSpan(span)) {
             return delegate.getMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName objectName, MaterializedViewDefinition materializedViewDefinition)
+    {
+        Span span = startSpan("getMaterializedViewProperties", objectName);
+        try (var ignored = scopedSpan(span)) {
+            return delegate.getMaterializedViewProperties(session, objectName, materializedViewDefinition);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -665,7 +665,13 @@ public class MockConnector
         public void dropView(ConnectorSession session, SchemaTableName viewName) {}
 
         @Override
-        public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting) {}
+        public void createMaterializedView(
+                ConnectorSession session,
+                SchemaTableName viewName,
+                ConnectorMaterializedViewDefinition definition,
+                Map<String, Object> properties,
+                boolean replace,
+                boolean ignoreExisting) {}
 
         @Override
         public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
@@ -678,6 +684,12 @@ public class MockConnector
         public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
         {
             return Optional.ofNullable(getMaterializedViews.apply(session, viewName.toSchemaTablePrefix()).get(viewName));
+        }
+
+        @Override
+        public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+        {
+            return ImmutableMap.of();
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/execution/TestAddColumnTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestAddColumnTask.java
@@ -163,7 +163,7 @@ public class TestAddColumnTask
     public void testAddColumnOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeAddColumn(asQualifiedName(materializedViewName), QualifiedName.of("test"), INTEGER, Optional.empty(), false, false)))
                 .hasErrorCode(TABLE_NOT_FOUND)

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommentTask.java
@@ -69,7 +69,7 @@ public class TestCommentTask
     public void testCommentTableOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(TABLE, asQualifiedName(materializedViewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
@@ -102,7 +102,7 @@ public class TestCommentTask
     public void testCommentViewOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(setComment(VIEW, asQualifiedName(materializedViewName), Optional.of("new comment"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
@@ -145,7 +145,7 @@ public class TestCommentTask
     public void testCommentMaterializedViewColumn()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
         assertThat(metadata.isMaterializedView(testSession, materializedViewName)).isTrue();
 
         QualifiedName columnName = qualifiedColumnName("existing_materialized_view", "test");

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateViewTask.java
@@ -127,7 +127,7 @@ public class TestCreateViewTask
     public void testCreateViewOnMaterializedView()
     {
         QualifiedObjectName viewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, viewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, viewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeCreateView(asQualifiedName(viewName), false)))
                 .hasErrorCode(TABLE_ALREADY_EXISTS)

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropColumnTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropColumnTask.java
@@ -156,7 +156,7 @@ public class TestDropColumnTask
     public void testDropColumnOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropColumn(asQualifiedName(materializedViewName), QualifiedName.of("test"), false, false)))
                 .hasErrorCode(TABLE_NOT_FOUND)

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
@@ -36,7 +36,7 @@ public class TestDropMaterializedViewTask
     public void testDropExistingMaterializedView()
     {
         QualifiedObjectName viewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, viewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, viewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
         assertThat(metadata.isMaterializedView(testSession, viewName)).isTrue();
 
         getFutureValue(executeDropMaterializedView(asQualifiedName(viewName), false));

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
@@ -107,7 +107,7 @@ public class TestDropTableTask
     public void testDropTableOnMaterializedView()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
@@ -118,7 +118,7 @@ public class TestDropTableTask
     public void testDropTableIfExistsOnMaterializedView()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, true)))
                 .hasErrorCode(GENERIC_USER_ERROR)

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
@@ -88,7 +88,7 @@ public class TestDropViewTask
     public void testDropViewOnMaterializedView()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropView(viewName, false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
@@ -99,7 +99,7 @@ public class TestDropViewTask
     public void testDropViewOnMaterializedViewIfExists()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropView(viewName, true)))
                 .hasErrorCode(GENERIC_USER_ERROR)

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameColumnTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameColumnTask.java
@@ -117,7 +117,7 @@ public class TestRenameColumnTask
     public void testRenameColumnOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameColumn(asQualifiedName(materializedViewName), QualifiedName.of("a"), identifier("a_renamed"), false, false)))
                 .hasErrorCode(TABLE_NOT_FOUND)
@@ -211,7 +211,7 @@ public class TestRenameColumnTask
     public void testRenameFieldOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameColumn(asQualifiedName(materializedViewName), QualifiedName.of("test"), identifier("x"), false, false)))
                 .hasErrorCode(TABLE_NOT_FOUND)

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -38,7 +38,7 @@ public class TestRenameMaterializedViewTask
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
         QualifiedObjectName newMaterializedViewName = qualifiedObjectName("existing_materialized_view_new");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         getFutureValue(executeRenameMaterializedView(asQualifiedName(materializedViewName), asQualifiedName(newMaterializedViewName)));
         assertThat(metadata.isMaterializedView(testSession, materializedViewName)).isFalse();
@@ -90,7 +90,7 @@ public class TestRenameMaterializedViewTask
     public void testRenameMaterializedViewTargetTableExists()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
         QualifiedObjectName tableName = qualifiedObjectName("existing_table");
         metadata.createTable(testSession, TEST_CATALOG_NAME, someTable(tableName), FAIL);
 
@@ -125,7 +125,7 @@ public class TestRenameMaterializedViewTask
     public void testRenameMaterializedViewTargetViewExists()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
         QualifiedName viewName = qualifiedName("existing_view");
         metadata.createView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someView(), false);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -90,7 +90,7 @@ public class TestRenameTableTask
     public void testRenameTableOnMaterializedView()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), false)))
                 .hasErrorCode(GENERIC_USER_ERROR)
@@ -101,7 +101,7 @@ public class TestRenameTableTask
     public void testRenameTableOnMaterializedViewIfExists()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), true)))
                 .hasErrorCode(GENERIC_USER_ERROR)
@@ -127,7 +127,7 @@ public class TestRenameTableTask
         QualifiedObjectName tableName = qualifiedObjectName("existing_table");
         metadata.createTable(testSession, TEST_CATALOG_NAME, someTable(tableName), FAIL);
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(asQualifiedName(tableName), asQualifiedName(materializedViewName), false)))
                 .hasErrorCode(GENERIC_USER_ERROR)

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -71,7 +71,7 @@ public class TestRenameViewTask
     public void testRenameViewOnMaterializedView()
     {
         QualifiedName viewName = qualifiedName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, qualifiedName("existing_materialized_view_new"))))
                 .hasErrorCode(TABLE_NOT_FOUND)
@@ -97,7 +97,7 @@ public class TestRenameViewTask
         QualifiedName viewName = qualifiedName("existing_view");
         metadata.createView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someView(), false);
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, asQualifiedName(materializedViewName))))
                 .hasErrorCode(GENERIC_USER_ERROR)

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetColumnTypeTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetColumnTypeTask.java
@@ -113,7 +113,7 @@ public class TestSetColumnTypeTask
     public void testSetDataTypeOnMaterializedView()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("existing_materialized_view");
-        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(materializedViewName.toString()), someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         assertTrinoExceptionThrownBy(() -> getFutureValue(executeSetColumnType(asQualifiedName(materializedViewName), QualifiedName.of("test"), toSqlType(INTEGER), false)))
                 .hasErrorCode(TABLE_NOT_FOUND)

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPropertiesTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPropertiesTask.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogServiceProvider;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.security.AllowAllAccessControl;
@@ -37,7 +38,7 @@ public class TestSetPropertiesTask
     public void testSetMaterializedViewProperties()
     {
         QualifiedObjectName materializedViewName = qualifiedObjectName("test_materialized_view");
-        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
+        metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), MATERIALIZED_VIEW_PROPERTIES, false, false);
 
         // set all properties to non-DEFAULT values and check the results
         executeSetProperties(
@@ -47,7 +48,8 @@ public class TestSetPropertiesTask
                         ImmutableList.of(
                                 new Property(new Identifier(MATERIALIZED_VIEW_PROPERTY_1_NAME), new LongLiteral("111")),
                                 new Property(new Identifier(MATERIALIZED_VIEW_PROPERTY_2_NAME), new StringLiteral("abc")))));
-        assertThat(metadata.getMaterializedView(testSession, materializedViewName).get().getProperties()).isEqualTo(
+        MaterializedViewDefinition materializedViewDefinition = metadata.getMaterializedView(testSession, materializedViewName).orElseThrow();
+        assertThat(metadata.getMaterializedViewProperties(testSession, materializedViewName, materializedViewDefinition)).isEqualTo(
                 ImmutableMap.of(
                         MATERIALIZED_VIEW_PROPERTY_1_NAME, 111L,
                         MATERIALIZED_VIEW_PROPERTY_2_NAME, "abc"));
@@ -62,7 +64,7 @@ public class TestSetPropertiesTask
                                 new Property(new Identifier(MATERIALIZED_VIEW_PROPERTY_2_NAME)))));
         // since the default value of property 1 is null, property 1 should not appear in the result, whereas property 2 should appear in
         // the result with its (non-null) default value
-        assertThat(metadata.getMaterializedView(testSession, materializedViewName).get().getProperties()).isEqualTo(
+        assertThat(metadata.getMaterializedViewProperties(testSession, materializedViewName, materializedViewDefinition)).isEqualTo(
                 ImmutableMap.of(MATERIALIZED_VIEW_PROPERTY_2_NAME, MATERIALIZED_VIEW_PROPERTY_2_DEFAULT_VALUE));
     }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -910,7 +910,13 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            Session session,
+            QualifiedObjectName viewName,
+            MaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         throw new UnsupportedOperationException();
     }
@@ -935,6 +941,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(Session session, QualifiedObjectName viewName, MaterializedViewDefinition materializedViewDefinition)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -6847,9 +6847,14 @@ public class TestAnalyzer
                 Optional.of("comment"),
                 Identity.ofUser("user"),
                 ImmutableList.of(),
-                Optional.empty(),
-                ImmutableMap.of());
-        inSetupTransaction(session -> metadata.createMaterializedView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "mv1"), materializedViewData1, false, true));
+                Optional.empty());
+        inSetupTransaction(session -> metadata.createMaterializedView(
+                session,
+                new QualifiedObjectName(TPCH_CATALOG, "s1", "mv1"),
+                materializedViewData1,
+                ImmutableMap.of(),
+                false,
+                true));
 
         // valid view referencing table in same schema
         ViewDefinition viewData1 = new ViewDefinition(
@@ -6971,8 +6976,8 @@ public class TestAnalyzer
                         Optional.empty(),
                         Identity.ofUser("some user"),
                         ImmutableList.of(),
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t1")),
-                        ImmutableMap.of()),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t1"))),
+                ImmutableMap.of(),
                 false,
                 false));
         ViewDefinition viewDefinition = new ViewDefinition(
@@ -7024,8 +7029,8 @@ public class TestAnalyzer
                         Identity.ofUser("some user"),
                         ImmutableList.of(),
                         // t3 has a, b column and hidden column x
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t3")),
-                        ImmutableMap.of()),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t3"))),
+                ImmutableMap.of(),
                 false,
                 false));
         testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedView.asSchemaTableName());
@@ -7043,8 +7048,8 @@ public class TestAnalyzer
                         Optional.empty(),
                         Identity.ofUser("some user"),
                         ImmutableList.of(),
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
-                        ImmutableMap.of()),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2"))),
+                ImmutableMap.of(),
                 false,
                 false));
         testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedViewMismatchedColumnCount.asSchemaTableName());
@@ -7062,8 +7067,8 @@ public class TestAnalyzer
                         Optional.empty(),
                         Identity.ofUser("some user"),
                         ImmutableList.of(),
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
-                        ImmutableMap.of()),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2"))),
+                ImmutableMap.of(),
                 false,
                 false));
         testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedMismatchedColumnName.asSchemaTableName());
@@ -7081,8 +7086,8 @@ public class TestAnalyzer
                         Optional.empty(),
                         Identity.ofUser("some user"),
                         ImmutableList.of(),
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
-                        ImmutableMap.of()),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2"))),
+                ImmutableMap.of(),
                 false,
                 false));
         testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedMismatchedColumnType.asSchemaTableName());

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -134,13 +134,13 @@ public class TestMaterializedViews
                 Optional.empty(),
                 Identity.ofUser("some user"),
                 ImmutableList.of(),
-                Optional.of(new CatalogSchemaTableName(TEST_CATALOG_NAME, SCHEMA, "storage_table")),
-                ImmutableMap.of());
+                Optional.of(new CatalogSchemaTableName(TEST_CATALOG_NAME, SCHEMA, "storage_table")));
         queryRunner.inTransaction(session -> {
             metadata.createMaterializedView(
                     session,
                     freshMaterializedView,
                     materializedViewDefinition,
+                    ImmutableMap.of(),
                     false,
                     false);
             return null;
@@ -153,6 +153,7 @@ public class TestMaterializedViews
                     session,
                     notFreshMaterializedView,
                     materializedViewDefinition,
+                    ImmutableMap.of(),
                     false,
                     false);
             return null;
@@ -167,14 +168,14 @@ public class TestMaterializedViews
                 Optional.empty(),
                 Identity.ofUser("some user"),
                 ImmutableList.of(),
-                Optional.of(new CatalogSchemaTableName(TEST_CATALOG_NAME, SCHEMA, "storage_table_with_casts")),
-                ImmutableMap.of());
+                Optional.of(new CatalogSchemaTableName(TEST_CATALOG_NAME, SCHEMA, "storage_table_with_casts")));
         QualifiedObjectName materializedViewWithCasts = new QualifiedObjectName(TEST_CATALOG_NAME, SCHEMA, "materialized_view_with_casts");
         queryRunner.inTransaction(session -> {
             metadata.createMaterializedView(
                     session,
                     materializedViewWithCasts,
                     materializedViewDefinitionWithCasts,
+                    ImmutableMap.of(),
                     false,
                     false);
             return null;
@@ -186,6 +187,7 @@ public class TestMaterializedViews
                     session,
                     new QualifiedObjectName(TEST_CATALOG_NAME, SCHEMA, "stale_materialized_view_with_casts"),
                     materializedViewDefinitionWithCasts,
+                    ImmutableMap.of(),
                     false,
                     false);
             return null;

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -122,8 +122,7 @@ public class TestColumnMask
                 Optional.of(Duration.ZERO),
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
-                ImmutableList.of(),
-                ImmutableMap.of());
+                ImmutableList.of());
 
         ConnectorMaterializedViewDefinition freshMaterializedView = new ConnectorMaterializedViewDefinition(
                 "SELECT * FROM local.tiny.nation",
@@ -138,8 +137,7 @@ public class TestColumnMask
                 Optional.of(Duration.ZERO),
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
-                ImmutableList.of(),
-                ImmutableMap.of());
+                ImmutableList.of());
 
         ConnectorMaterializedViewDefinition materializedViewWithCasts = new ConnectorMaterializedViewDefinition(
                 "SELECT nationkey, cast(name as varchar(1)) as name, regionkey, comment FROM local.tiny.nation",
@@ -154,8 +152,7 @@ public class TestColumnMask
                 Optional.of(Duration.ZERO),
                 Optional.empty(),
                 Optional.of(VIEW_OWNER),
-                ImmutableList.of(),
-                ImmutableMap.of());
+                ImmutableList.of());
 
         MockConnectorFactory mock = MockConnectorFactory.builder()
                 .withGetColumns(schemaTableName -> {

--- a/core/trino-main/src/test/java/io/trino/testing/TestTestingMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/testing/TestTestingMetadata.java
@@ -43,7 +43,7 @@ public class TestTestingMetadata
         SchemaTableName newName = schemaTableName("schema", target);
         TestingMetadata metadata = new TestingMetadata();
         ConnectorMaterializedViewDefinition viewDefinition = someMaterializedView();
-        metadata.createMaterializedView(SESSION, initialName, viewDefinition, false, false);
+        metadata.createMaterializedView(SESSION, initialName, viewDefinition, ImmutableMap.of(), false, false);
 
         metadata.renameMaterializedView(SESSION, initialName, newName);
 
@@ -62,7 +62,6 @@ public class TestTestingMetadata
                 Optional.of(Duration.ZERO),
                 Optional.empty(),
                 Optional.of("owner"),
-                ImmutableList.of(),
-                ImmutableMap.of());
+                ImmutableList.of());
     }
 }

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -212,6 +212,20 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.connector.ConnectorMaterializedViewDefinition::&lt;init&gt;(java.lang.String, java.util.Optional&lt;io.trino.spi.connector.CatalogSchemaTableName&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.CatalogSchemaName&gt;, java.util.Map&lt;java.lang.String, java.lang.Object&gt;)</old>
+                                    <new>method void io.trino.spi.connector.ConnectorMaterializedViewDefinition::&lt;init&gt;(java.lang.String, java.util.Optional&lt;io.trino.spi.connector.CatalogSchemaTableName&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column&gt;, java.util.Optional&lt;java.time.Duration&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.List&lt;io.trino.spi.connector.CatalogSchemaName&gt;)</new>
+                                </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method java.util.Map&lt;java.lang.String, java.lang.Object&gt; io.trino.spi.connector.ConnectorMaterializedViewDefinition::getProperties()</old>
+                                </item>
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.connector.ConnectorMetadata::createMaterializedView(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.SchemaTableName, io.trino.spi.connector.ConnectorMaterializedViewDefinition, boolean, boolean)</old>
+                                    <new>method void io.trino.spi.connector.ConnectorMetadata::createMaterializedView(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.SchemaTableName, io.trino.spi.connector.ConnectorMaterializedViewDefinition, java.util.Map&lt;java.lang.String, java.lang.Object&gt;, boolean, boolean)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
@@ -17,7 +17,6 @@ import io.trino.spi.type.TypeId;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -37,7 +36,6 @@ public class ConnectorMaterializedViewDefinition
     private final Optional<String> comment;
     private final Optional<String> owner;
     private final List<CatalogSchemaName> path;
-    private final Map<String, Object> properties;
 
     public ConnectorMaterializedViewDefinition(
             String originalSql,
@@ -48,8 +46,7 @@ public class ConnectorMaterializedViewDefinition
             Optional<Duration> gracePeriod,
             Optional<String> comment,
             Optional<String> owner,
-            List<CatalogSchemaName> path,
-            Map<String, Object> properties)
+            List<CatalogSchemaName> path)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
         this.storageTable = requireNonNull(storageTable, "storageTable is null");
@@ -61,7 +58,6 @@ public class ConnectorMaterializedViewDefinition
         this.comment = requireNonNull(comment, "comment is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.path = List.copyOf(path);
-        this.properties = requireNonNull(properties, "properties are null");
 
         if (catalog.isEmpty() && schema.isPresent()) {
             throw new IllegalArgumentException("catalog must be present if schema is present");
@@ -116,11 +112,6 @@ public class ConnectorMaterializedViewDefinition
         return path;
     }
 
-    public Map<String, Object> getProperties()
-    {
-        return properties;
-    }
-
     @Override
     public String toString()
     {
@@ -133,9 +124,8 @@ public class ConnectorMaterializedViewDefinition
         gracePeriod.ifPresent(value -> joiner.add("gracePeriod=" + gracePeriod));
         comment.ifPresent(value -> joiner.add("comment=" + value));
         joiner.add("owner=" + owner);
-        joiner.add("properties=" + properties);
         joiner.add(path.stream().map(CatalogSchemaName::toString).collect(joining(", ", "path=(", ")")));
-        return getClass().getSimpleName() + joiner.toString();
+        return getClass().getSimpleName() + joiner;
     }
 
     @Override
@@ -156,14 +146,13 @@ public class ConnectorMaterializedViewDefinition
                 Objects.equals(gracePeriod, that.gracePeriod) &&
                 Objects.equals(comment, that.comment) &&
                 Objects.equals(owner, that.owner) &&
-                Objects.equals(path, that.path) &&
-                Objects.equals(properties, that.properties);
+                Objects.equals(path, that.path);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(originalSql, storageTable, catalog, schema, columns, gracePeriod, comment, owner, path, properties);
+        return Objects.hash(originalSql, storageTable, catalog, schema, columns, gracePeriod, comment, owner, path);
     }
 
     public static final class Column

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1661,7 +1661,13 @@ public interface ConnectorMetadata
      *
      * @throws TrinoException with {@code ALREADY_EXISTS} if the object already exists and {@param ignoreExisting} is not set
      */
-    default void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    default void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating materialized views");
     }
@@ -1707,6 +1713,11 @@ public interface ConnectorMetadata
     default Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         return Optional.empty();
+    }
+
+    default Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition materializedViewDefinition)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support materialized views");
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -1089,10 +1089,16 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+            delegate.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
         }
     }
 
@@ -1125,6 +1131,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getMaterializedView(session, viewName);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition viewDefinition)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMaterializedViewProperties(session, viewName, viewDefinition);
         }
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -723,10 +723,16 @@ public class BigQueryMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         // TODO Fix BaseBigQueryFailureRecoveryTest when implementing this method
-        ConnectorMetadata.super.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+        ConnectorMetadata.super.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMaterializedViewMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMaterializedViewMetadata.java
@@ -25,7 +25,13 @@ import java.util.concurrent.CompletableFuture;
 
 public interface HiveMaterializedViewMetadata
 {
-    void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting);
+    void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting);
 
     void dropMaterializedView(ConnectorSession session, SchemaTableName viewName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3857,9 +3857,15 @@ public class HiveMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
-        hiveMaterializedViewMetadata.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+        hiveMaterializedViewMetadata.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoneHiveMaterializedViewMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoneHiveMaterializedViewMetadata.java
@@ -33,7 +33,13 @@ public class NoneHiveMaterializedViewMetadata
         implements HiveMaterializedViewMetadata
 {
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating materialized views");
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2749,9 +2749,15 @@ public class IcebergMetadata
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> properties,
+            boolean replace,
+            boolean ignoreExisting)
     {
-        catalog.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
+        catalog.createMaterializedView(session, viewName, definition, properties, replace, ignoreExisting);
     }
 
     @Override
@@ -2879,6 +2885,12 @@ public class IcebergMetadata
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         return catalog.getMaterializedView(session, viewName);
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    {
+        return catalog.getMaterializedViewProperties(session, viewName, definition);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -77,6 +77,7 @@ import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueToTrinoConverter.mappedCopy;
 import static io.trino.plugin.hive.util.HiveUtil.escapeTableName;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_FILESYSTEM_ERROR;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.STORAGE_SCHEMA;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewAdditionalProperties.getStorageSchema;
 import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
@@ -201,6 +202,25 @@ public abstract class AbstractTrinoCatalog
 
     protected abstract Optional<ConnectorMaterializedViewDefinition> doGetMaterializedView(ConnectorSession session, SchemaTableName schemaViewName);
 
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    {
+        SchemaTableName storageTableName = definition.getStorageTable()
+                .orElseThrow(() -> new TrinoException(ICEBERG_INVALID_METADATA, "Materialized view definition is missing a storage table"))
+                .getSchemaTableName();
+
+        try {
+            Table storageTable = loadTable(session, definition.getStorageTable().orElseThrow().getSchemaTableName());
+            return ImmutableMap.<String, Object>builder()
+                    .putAll(getIcebergTableProperties(storageTable))
+                    .put(STORAGE_SCHEMA, storageTableName.getSchemaName())
+                    .buildOrThrow();
+        }
+        catch (RuntimeException e) {
+            throw new TrinoException(ICEBERG_FILESYSTEM_ERROR, "Unable to load storage table metadata for materialized view: " + viewName);
+        }
+    }
+
     protected Transaction newCreateTableTransaction(
             ConnectorSession session,
             SchemaTableName schemaTableName,
@@ -281,20 +301,24 @@ public abstract class AbstractTrinoCatalog
         }
     }
 
-    protected Location createMaterializedViewStorage(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    protected Location createMaterializedViewStorage(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties)
     {
-        if (getStorageSchema(definition.getProperties()).isPresent()) {
+        if (getStorageSchema(materializedViewProperties).isPresent()) {
             throw new TrinoException(NOT_SUPPORTED, "Materialized view property '%s' is not supported when hiding materialized view storage tables is enabled".formatted(STORAGE_SCHEMA));
         }
         SchemaTableName storageTableName = new SchemaTableName(viewName.getSchemaName(), tableNameWithType(viewName.getTableName(), MATERIALIZED_VIEW_STORAGE));
-        String tableLocation = getTableLocation(definition.getProperties())
+        String tableLocation = getTableLocation(materializedViewProperties)
                 .orElseGet(() -> defaultTableLocation(session, viewName));
-        List<ColumnMetadata> columns = columnsForMaterializedView(definition);
+        List<ColumnMetadata> columns = columnsForMaterializedView(definition, materializedViewProperties);
 
         Schema schema = schemaFromMetadata(columns);
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(definition.getProperties()));
-        SortOrder sortOrder = parseSortFields(schema, getSortOrder(definition.getProperties()));
-        Map<String, String> properties = createTableProperties(new ConnectorTableMetadata(storageTableName, columns, definition.getProperties(), Optional.empty()));
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(materializedViewProperties));
+        SortOrder sortOrder = parseSortFields(schema, getSortOrder(materializedViewProperties));
+        Map<String, String> properties = createTableProperties(new ConnectorTableMetadata(storageTableName, columns, materializedViewProperties, Optional.empty()));
 
         TableMetadata metadata = newTableMetadata(schema, partitionSpec, sortOrder, tableLocation, properties);
 
@@ -307,17 +331,21 @@ public abstract class AbstractTrinoCatalog
         return metadataFileLocation;
     }
 
-    protected SchemaTableName createMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    protected SchemaTableName createMaterializedViewStorageTable(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties)
     {
         // Generate a storage table name and create a storage table. The properties in the definition are table properties for the
         // storage table as indicated in the materialized view definition.
         String storageTableName = "st_" + randomUUID().toString().replace("-", "");
 
-        String storageSchema = getStorageSchema(definition.getProperties()).orElse(viewName.getSchemaName());
+        String storageSchema = getStorageSchema(materializedViewProperties).orElse(viewName.getSchemaName());
         SchemaTableName storageTable = new SchemaTableName(storageSchema, storageTableName);
-        List<ColumnMetadata> columns = columnsForMaterializedView(definition);
+        List<ColumnMetadata> columns = columnsForMaterializedView(definition, materializedViewProperties);
 
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(storageTable, columns, definition.getProperties(), Optional.empty());
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(storageTable, columns, materializedViewProperties, Optional.empty());
         Transaction transaction = IcebergUtil.newCreateTableTransaction(this, tableMetadata, session, false);
         AppendFiles appendFiles = transaction.newAppend();
         commit(appendFiles, session);
@@ -325,7 +353,7 @@ public abstract class AbstractTrinoCatalog
         return storageTable;
     }
 
-    private List<ColumnMetadata> columnsForMaterializedView(ConnectorMaterializedViewDefinition definition)
+    private List<ColumnMetadata> columnsForMaterializedView(ConnectorMaterializedViewDefinition definition, Map<String, Object> materializedViewProperties)
     {
         Schema schemaWithTimestampTzPreserved = schemaFromMetadata(mappedCopy(
                 definition.getColumns(),
@@ -340,7 +368,7 @@ public abstract class AbstractTrinoCatalog
                     }
                     return new ColumnMetadata(column.getName(), type);
                 }));
-        PartitionSpec partitionSpec = parsePartitionFields(schemaWithTimestampTzPreserved, getPartitioning(definition.getProperties()));
+        PartitionSpec partitionSpec = parsePartitionFields(schemaWithTimestampTzPreserved, getPartitioning(materializedViewProperties));
         Set<String> temporalPartitioningSources = partitionSpec.fields().stream()
                 .flatMap(partitionField -> {
                     Types.NestedField sourceField = schemaWithTimestampTzPreserved.findField(partitionField.sourceId());
@@ -422,7 +450,6 @@ public abstract class AbstractTrinoCatalog
     }
 
     protected ConnectorMaterializedViewDefinition getMaterializedViewDefinition(
-            Table icebergTable,
             Optional<String> owner,
             String viewOriginalText,
             SchemaTableName storageTableName)
@@ -437,11 +464,7 @@ public abstract class AbstractTrinoCatalog
                 definition.getGracePeriod(),
                 definition.getComment(),
                 owner,
-                definition.getPath(),
-                ImmutableMap.<String, Object>builder()
-                        .putAll(getIcebergTableProperties(icebergTable))
-                        .put(STORAGE_SCHEMA, storageTableName.getSchemaName())
-                        .buildOrThrow());
+                definition.getPath());
     }
 
     protected List<ConnectorMaterializedViewDefinition.Column> toSpiMaterializedViewColumns(List<IcebergMaterializedViewDefinition.Column> columns)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/TrinoCatalog.java
@@ -163,6 +163,7 @@ public interface TrinoCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             boolean replace,
             boolean ignoreExisting);
 
@@ -171,6 +172,8 @@ public interface TrinoCatalog
     void dropMaterializedView(ConnectorSession session, SchemaTableName viewName);
 
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName);
+
+    Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition);
 
     Optional<BaseTable> getMaterializedViewStorageTable(ConnectorSession session, SchemaTableName viewName);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -866,7 +866,7 @@ public class TrinoGlueCatalog
             try {
                 // Note: this is racy from cache invalidation perspective, but it should not matter here
                 uncheckedCacheGet(materializedViewCache, schemaTableName, () -> {
-                    ConnectorMaterializedViewDefinition materializedView = createMaterializedViewDefinition(session, schemaTableName, table);
+                    ConnectorMaterializedViewDefinition materializedView = createMaterializedViewDefinition(schemaTableName, table);
                     return new MaterializedViewData(
                             materializedView,
                             Optional.ofNullable(parameters.get(METADATA_LOCATION_PROP)));
@@ -1128,6 +1128,7 @@ public class TrinoGlueCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             boolean replace,
             boolean ignoreExisting)
     {
@@ -1146,7 +1147,7 @@ public class TrinoGlueCatalog
         }
 
         if (hideMaterializedViewStorageTable) {
-            Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition);
+            Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition, materializedViewProperties);
             TableInput materializedViewTableInput = getMaterializedViewTableInput(
                     viewName.getTableName(),
                     encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition)),
@@ -1160,7 +1161,7 @@ public class TrinoGlueCatalog
             }
         }
         else {
-            createMaterializedViewWithStorageTable(session, viewName, definition, existing);
+            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties, existing);
         }
     }
 
@@ -1168,10 +1169,11 @@ public class TrinoGlueCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             Optional<com.amazonaws.services.glue.model.Table> existing)
     {
         // Create the storage table
-        SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition);
+        SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition, materializedViewProperties);
         // Create a view indicating the storage table
         TableInput materializedViewTableInput = getMaterializedViewTableInput(
                 viewName.getTableName(),
@@ -1218,8 +1220,7 @@ public class TrinoGlueCatalog
                 definition.getGracePeriod(),
                 definition.getComment(),
                 definition.getOwner(),
-                definition.getPath(),
-                definition.getProperties());
+                definition.getPath());
 
         updateMaterializedView(viewName, newDefinition);
     }
@@ -1293,11 +1294,10 @@ public class TrinoGlueCatalog
             return Optional.empty();
         }
 
-        return Optional.of(createMaterializedViewDefinition(session, viewName, table));
+        return Optional.of(createMaterializedViewDefinition(viewName, table));
     }
 
     private ConnectorMaterializedViewDefinition createMaterializedViewDefinition(
-            ConnectorSession session,
             SchemaTableName viewName,
             com.amazonaws.services.glue.model.Table table)
     {
@@ -1315,54 +1315,18 @@ public class TrinoGlueCatalog
                     .orElse(viewName.getSchemaName());
             SchemaTableName storageTableName = new SchemaTableName(storageSchema, storageTable);
 
-            Table icebergTable;
-            try {
-                icebergTable = loadTable(session, storageTableName);
-            }
-            catch (RuntimeException e) {
-                // The materialized view could be removed concurrently. This may manifest in a number of ways, e.g.
-                // - io.trino.spi.connector.TableNotFoundException
-                // - org.apache.iceberg.exceptions.NotFoundException when accessing manifest file
-                // - other failures when reading storage table's metadata files
-                // Retry, as we're catching broadly.
-                throw new MaterializedViewMayBeBeingRemovedException(e);
-            }
-
             String viewOriginalText = table.getViewOriginalText();
             if (viewOriginalText == null) {
                 throw new TrinoException(ICEBERG_BAD_DATA, "Materialized view did not have original text " + viewName);
             }
             return getMaterializedViewDefinition(
-                    icebergTable,
                     Optional.ofNullable(table.getOwner()),
                     viewOriginalText,
                     storageTableName);
         }
 
         SchemaTableName storageTableName = new SchemaTableName(viewName.getSchemaName(), tableNameWithType(viewName.getTableName(), MATERIALIZED_VIEW_STORAGE));
-        Table icebergTable;
-        try {
-            TableMetadata metadata = getMaterializedViewTableMetadata(session, storageTableName, storageMetadataLocation);
-            IcebergTableOperations operations = tableOperationsProvider.createTableOperations(
-                    this,
-                    session,
-                    storageTableName.getSchemaName(),
-                    storageTableName.getTableName(),
-                    Optional.empty(),
-                    Optional.empty());
-            operations.initializeFromMetadata(metadata);
-            icebergTable = new BaseTable(operations, quotedTableName(storageTableName), TRINO_METRICS_REPORTER);
-        }
-        catch (RuntimeException e) {
-            // The materialized view could be removed concurrently. This may manifest in a number of ways, e.g.
-            // - org.apache.iceberg.exceptions.NotFoundException when accessing manifest file
-            // - other failures when reading storage table's metadata files
-            // Retry, as we're catching broadly.
-            throw new MaterializedViewMayBeBeingRemovedException(e);
-        }
-
         return getMaterializedViewDefinition(
-                icebergTable,
                 Optional.ofNullable(table.getOwner()),
                 table.getViewOriginalText(),
                 storageTableName);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -568,6 +568,7 @@ public class TrinoHiveCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             boolean replace,
             boolean ignoreExisting)
     {
@@ -586,7 +587,7 @@ public class TrinoHiveCatalog
         }
 
         if (hideMaterializedViewStorageTable) {
-            Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition);
+            Location storageMetadataLocation = createMaterializedViewStorage(session, viewName, definition, materializedViewProperties);
 
             Map<String, String> viewProperties = createMaterializedViewProperties(session, storageMetadataLocation);
             Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty(), ImmutableMap.of());
@@ -614,7 +615,7 @@ public class TrinoHiveCatalog
             }
         }
         else {
-            createMaterializedViewWithStorageTable(session, viewName, definition, existing);
+            createMaterializedViewWithStorageTable(session, viewName, definition, materializedViewProperties, existing);
         }
     }
 
@@ -622,9 +623,10 @@ public class TrinoHiveCatalog
             ConnectorSession session,
             SchemaTableName viewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             Optional<io.trino.plugin.hive.metastore.Table> existing)
     {
-        SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition);
+        SchemaTableName storageTable = createMaterializedViewStorageTable(session, viewName, definition, materializedViewProperties);
 
         // Create a view indicating the storage table
         Map<String, String> viewProperties = createMaterializedViewProperties(session, storageTable);
@@ -686,8 +688,7 @@ public class TrinoHiveCatalog
                 definition.getGracePeriod(),
                 definition.getComment(),
                 definition.getOwner(),
-                definition.getPath(),
-                definition.getProperties());
+                definition.getPath());
 
         replaceMaterializedView(session, viewName, existing, newDefinition);
     }
@@ -766,23 +767,7 @@ public class TrinoHiveCatalog
             String storageSchema = Optional.ofNullable(materializedView.getParameters().get(STORAGE_SCHEMA))
                     .orElse(viewName.getSchemaName());
             SchemaTableName storageTableName = new SchemaTableName(storageSchema, storageTable);
-
-            Table icebergTable;
-            try {
-                icebergTable = loadTable(session, storageTableName);
-            }
-            catch (RuntimeException e) {
-                // The materialized view could be removed concurrently. This may manifest in a number of ways, e.g.
-                // - io.trino.spi.connector.TableNotFoundException
-                // - org.apache.iceberg.exceptions.NotFoundException when accessing manifest file
-                // - other failures when reading storage table's metadata files
-                // Retry, as we're catching broadly.
-                metastore.invalidateTable(viewName.getSchemaName(), viewName.getTableName());
-                metastore.invalidateTable(storageSchema, storageTable);
-                throw new MaterializedViewMayBeBeingRemovedException(e);
-            }
             return Optional.of(getMaterializedViewDefinition(
-                    icebergTable,
                     materializedView.getOwner(),
                     materializedView.getViewOriginalText()
                             .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewName)),
@@ -790,33 +775,11 @@ public class TrinoHiveCatalog
         }
 
         SchemaTableName storageTableName = new SchemaTableName(viewName.getSchemaName(), IcebergTableName.tableNameWithType(viewName.getTableName(), MATERIALIZED_VIEW_STORAGE));
-        IcebergTableOperations operations = tableOperationsProvider.createTableOperations(
-                this,
-                session,
-                storageTableName.getSchemaName(),
-                storageTableName.getTableName(),
-                Optional.empty(),
-                Optional.empty());
-        try {
-            TableMetadata metadata = getMaterializedViewTableMetadata(session, storageTableName, materializedView);
-            operations.initializeFromMetadata(metadata);
-            Table icebergTable = new BaseTable(operations, quotedTableName(storageTableName), TRINO_METRICS_REPORTER);
-
-            return Optional.of(getMaterializedViewDefinition(
-                    icebergTable,
-                    materializedView.getOwner(),
-                    materializedView.getViewOriginalText()
-                            .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewName)),
-                    storageTableName));
-        }
-        catch (RuntimeException e) {
-            // The materialized view could be removed concurrently. This may manifest in a number of ways, e.g.
-            // - org.apache.iceberg.exceptions.NotFoundException when accessing manifest file
-            // - other failures when reading storage table's metadata files
-            // Retry, as we're catching broadly.
-            metastore.invalidateTable(viewName.getSchemaName(), viewName.getTableName());
-            throw new MaterializedViewMayBeBeingRemovedException(e);
-        }
+        return Optional.of(getMaterializedViewDefinition(
+                materializedView.getOwner(),
+                materializedView.getViewOriginalText()
+                        .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewName)),
+                storageTableName));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/TrinoJdbcCatalog.java
@@ -445,7 +445,13 @@ public class TrinoJdbcCatalog
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName schemaViewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName schemaViewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         throw new TrinoException(NOT_SUPPORTED, "createMaterializedView is not supported for Iceberg JDBC catalogs");
     }
@@ -466,6 +472,12 @@ public class TrinoJdbcCatalog
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName schemaViewName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "getMaterializedViewProperties is not supported for Iceberg JDBC catalogs");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -405,6 +405,7 @@ public class TrinoNessieCatalog
             ConnectorSession session,
             SchemaTableName schemaViewName,
             ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
             boolean replace,
             boolean ignoreExisting)
     {
@@ -427,6 +428,12 @@ public class TrinoNessieCatalog
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName schemaViewName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "The Iceberg Nessie catalog does not support materialized views");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -438,7 +438,13 @@ public class TrinoRestCatalog
     }
 
     @Override
-    public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(
+            ConnectorSession session,
+            SchemaTableName viewName,
+            ConnectorMaterializedViewDefinition definition,
+            Map<String, Object> materializedViewProperties,
+            boolean replace,
+            boolean ignoreExisting)
     {
         throw new TrinoException(NOT_SUPPORTED, "createMaterializedView is not supported for Iceberg REST catalog");
     }
@@ -459,6 +465,12 @@ public class TrinoRestCatalog
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Object> getMaterializedViewProperties(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "The Iceberg REST catalog does not support materialized views");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -785,6 +785,11 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
                         .build());
 
+        assertFileSystemAccesses(session, "SELECT * FROM iceberg.information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name = 'mv1'",
+                ImmutableMultiset.<FileOperation>builder()
+                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
+                        .build());
+
         assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -762,10 +762,10 @@ public class TestIcebergFileOperations
                         .build());
 
         // Bulk retrieval without selecting freshness
-        assertFileSystemAccesses(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
-                ImmutableMultiset.<FileOperation>builder()
-                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
-                        .build());
+        assertFileSystemAccesses(
+                session,
+                "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA",
+                ImmutableMultiset.of());
 
         // Bulk retrieval for two schemas
         assertFileSystemAccesses(session, "SELECT * FROM system.metadata.materialized_views WHERE schema_name IN (CURRENT_SCHEMA, 'non_existent')",
@@ -780,15 +780,15 @@ public class TestIcebergFileOperations
                         .build());
 
         // Pointed lookup without selecting freshness
-        assertFileSystemAccesses(session, "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
-                ImmutableMultiset.<FileOperation>builder()
-                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
-                        .build());
+        assertFileSystemAccesses(
+                session,
+                "SELECT schema_name, name FROM system.metadata.materialized_views WHERE schema_name = CURRENT_SCHEMA AND name = 'mv1'",
+                ImmutableMultiset.of());
 
-        assertFileSystemAccesses(session, "SELECT * FROM iceberg.information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name = 'mv1'",
-                ImmutableMultiset.<FileOperation>builder()
-                        .add(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM))
-                        .build());
+        assertFileSystemAccesses(
+                session,
+                "SELECT * FROM iceberg.information_schema.columns WHERE table_schema = CURRENT_SCHEMA AND table_name = 'mv1'",
+                ImmutableMultiset.of());
 
         assertUpdate("DROP SCHEMA " + schemaName + " CASCADE");
     }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -180,8 +180,7 @@ public class TestEventListenerBasic
                                     Optional.of(Duration.ZERO),
                                     Optional.empty(),
                                     Optional.of("alice"),
-                                    ImmutableList.of(),
-                                    ImmutableMap.of());
+                                    ImmutableList.of());
                             SchemaTableName materializedViewName = new SchemaTableName("default", "test_materialized_view");
                             return ImmutableMap.of(materializedViewName, definition);
                         })

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestRefreshMaterializedView.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestRefreshMaterializedView.java
@@ -109,8 +109,7 @@ public class TestRefreshMaterializedView
                                                 Optional.of(Duration.ZERO),
                                                 Optional.empty(),
                                                 Optional.of("alice"),
-                                                ImmutableList.of(),
-                                                ImmutableMap.of())))
+                                                ImmutableList.of())))
                                 .withDelegateMaterializedViewRefreshToConnector((connectorSession, schemaTableName) -> true)
                                 .withRefreshMaterializedView((connectorSession, schemaTableName) -> {
                                     startRefreshMaterializedView.set(null);

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -214,8 +214,7 @@ public class TestAccessControl
                                 Optional.of(Duration.ZERO),
                                 Optional.of("comment"),
                                 Optional.of("owner"),
-                                ImmutableList.of(),
-                                ImmutableMap.of());
+                                ImmutableList.of());
                         return ImmutableMap.of(
                                 new SchemaTableName("default", "test_materialized_view"), materializedViewDefinition);
                     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -106,8 +106,7 @@ public class TestMockConnector
                                                 Optional.of(Duration.ZERO),
                                                 Optional.empty(),
                                                 Optional.of("alice"),
-                                                ImmutableList.of(),
-                                                ImmutableMap.of())))
+                                                ImmutableList.of())))
                                 .withData(schemaTableName -> {
                                     if (schemaTableName.equals(new SchemaTableName("default", "nation"))) {
                                         return TPCH_NATION_DATA;


### PR DESCRIPTION
## Description

Materialized view properties can be more expensive to retrieve
and are unused except for SHOW CREATE queries. Splitting them
from the main definition reduces file system calls for metadata
queries against the Iceberg connector.

## Additional context and related issues



## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of metadata queries involving materialized views.
```
