### PR TITLE
Turn off SELinux in doc build container

### DIFF
--- a/docs/build
+++ b/docs/build
@@ -8,5 +8,5 @@ test -t 1 && OPTS='-it' || OPTS=''
 
 SPHINX_IMAGE=${SPHINX_IMAGE:-ghcr.io/trinodb/build/sphinx:7}
 
-docker run --rm $OPTS -e TRINO_VERSION -u $(id -u):$(id -g) -v "$PWD":/docs $SPHINX_IMAGE \
+docker run --security-opt label:disable --rm $OPTS -e TRINO_VERSION -u $(id -u):$(id -g) -v "$PWD":/docs $SPHINX_IMAGE \
   sphinx-build -q -j auto -b html -W -d target/doctrees src/main/sphinx target/html


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

If SELinux is protecting the host directory where trino/docs resides, the build container cannot mount it, and we get this error:
```
Configuration error:
config directory doesn't contain a conf.py file (/docs/src/main/sphinx)
```
This patch makes Docker explicitly disable security policies that protect the host, eliminating the error.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/19938#issuecomment-1830864510

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
