### PR TITLE
[pinot connector]Support pinot connector to read DataTableV4 bytes

### DIFF
--- a/plugin/trino-pinot/src/test/resources/pinot-server/pinot-server.conf
+++ b/plugin/trino-pinot/src/test/resources/pinot-server/pinot-server.conf
@@ -4,3 +4,4 @@ pinot.server.instance.dataDir=/var/pinot/server/data/index
 pinot.server.instance.segmentTarDir=/var/pinot/server/data/segment
 pinot.set.instance.id.to.hostname=true
 pinot.server.grpc.enable=true
+pinot.server.instance.currentDataTableVersion=4


### PR DESCRIPTION
## Description
Pinot DataTableV4 has a different implementation for reading Bytes:
- V2/V3 uses hex string to represent bytes,
- V4 directly uses var length bytes encoding.

This PR will check the implementation of DataTable then pick the right method to read it.


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
