### PR TITLE
Ensure jq exists before executing the script

### DIFF
--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -47,6 +47,13 @@ while getopts ":a:h:r:j:" o; do
 done
 shift $((OPTIND - 1))
 
+function check_environment() {
+    if ! command -v jq &> /dev/null; then
+        echo >&2 "Please install jq"
+        exit 1
+    fi
+}
+
 function temurin_jdk_link() {
   local JDK_VERSION="${1}"
   local ARCH="${2}"
@@ -78,6 +85,8 @@ function temurin_jdk_link() {
     ;;
   esac
 }
+
+check_environment
 
 if [ -n "$TRINO_VERSION" ]; then
     echo "🎣 Downloading server and client artifacts for release version ${TRINO_VERSION}"


### PR DESCRIPTION
## Description
While running the docker image build on a new fresh laptop, I just noticed that `build.sh` script requires `jq` to be installed. Added a `jq` existence check in the earlier portion of the build script, so that the build fails faster and it is more obvious that it's required.

With the change the script outputs the following when `jq` doesn't exist.
```
+++ dirname ./build.sh
++ cd .
++ pwd
+ SCRIPT_DIR=<trino-base-dir>/trino/core/docker
+ cd <trino-base-dir>/trino/core/docker
+ SOURCE_DIR=<trino-base-dir>/trino/core/docker/../..
+ ARCHITECTURES=(amd64 arm64 ppc64le)
+ TRINO_VERSION=
++ cat <trino-base-dir>trino/core/docker/../../.java-version
+ JDK_VERSION=21.0
+ getopts :a:h:r:j: o
+ shift 0
+ check_environment
+ command -v jq
+ echo 'Please install jq'
Please install jq
+ exit 1
```

## Additional context and related issues
Before the change, if jq isn't there, the following error message was buried in the log and the docker build actually started.
```
... <omitted> ...
+++ jq -er '.releases[]'
+++ head -n 1
./build.sh: line 60: jq: command not found
++ RELEASE_NAME=
++ echo 'Failed to determine release name: '
Failed to determine release name: 
++ exit 1
... <omitted> ...
```

then the docker image build failed with the following error:
```
ERROR: failed to solve: process "/bin/sh -c set -xeuo pipefail &&     microdnf install -y tar gzip &&     echo \"Downloading JDK from ${JDK_DOWNLOAD_LINK}\" &&     mkdir -p \"${JAVA_HOME}\" &&     curl -#LfS \"${JDK_DOWNLOAD_LINK}\" | tar -zx --strip 1 -C \"${JAVA_HOME}\"" did not complete successfully: exit code: 2
```

## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
() Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

