### PR TITLE
Allow differentiating materialized views from tables efficiently

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTable.java
@@ -47,6 +47,7 @@ public enum InformationSchemaTable
             .column("table_schema", createUnboundedVarcharType())
             .column("table_name", createUnboundedVarcharType())
             .column("table_type", createUnboundedVarcharType())
+            .hiddenColumn("trino_relation_type", createUnboundedVarcharType())
             .hiddenColumn("table_comment", createUnboundedVarcharType()) // MySQL compatible
             .build()),
     VIEWS(table("views")

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1052,15 +1052,15 @@ public abstract class BaseConnectorTest
                 .containsAll("VALUES '" + view.getObjectName() + "'");
         // information_schema.tables without table_name filter so that ConnectorMetadata.listViews is exercised
         assertThat(query(
-                "SELECT table_name, table_type FROM information_schema.tables " +
+                "SELECT table_name, table_type, trino_relation_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "'"))
                 .skippingTypesCheck()
-                .containsAll("VALUES ('" + view.getObjectName() + "', 'BASE TABLE')");
+                .containsAll("VALUES ('" + view.getObjectName() + "', 'BASE TABLE', 'MATERIALIZED VIEW')");
         // information_schema.tables with table_name filter
         assertQuery(
-                "SELECT table_name, table_type FROM information_schema.tables " +
+                "SELECT table_name, table_type, trino_relation_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "' and table_name = '" + view.getObjectName() + "'",
-                "VALUES ('" + view.getObjectName() + "', 'BASE TABLE')");
+                "VALUES ('" + view.getObjectName() + "', 'BASE TABLE', 'MATERIALIZED VIEW')");
 
         // system.jdbc.tables without filter
         assertThat(query("SELECT table_schem, table_name, table_type FROM system.jdbc.tables"))


### PR DESCRIPTION
Tools often need to list tables/relations and know whether they are regular tables, views, or materialized views. For example, on a table one can `SHOW CREATE TABLE` or `DROP TABLE`, but syntax for views and materialized views is different. Before this change, to differentiate different relations types, tools need to join
`information_schema.tables` with `system.metadata.materialized_views`. This is effective, but not efficient:
`system.metadata.materialized_views` contains much more information. To address the inefficiency, this commit introduces a new column to `information_schema.tables`. To guarantee SQL spec future-compatibility, the column is hidden and prefixed with `trino_`
