### PR TITLE
Seal SplitWeight API

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestArbitraryDistributionSplitAssigner.java
@@ -683,7 +683,7 @@ public class TestArbitraryDistributionSplitAssigner
                                 hostRequirement = Optional.of(hostAddress);
                                 break;
                             }
-                            else if (currentAssignment.getSplits().size() < splitCount) {
+                            if (currentAssignment.getSplits().size() < splitCount) {
                                 splitCount = currentAssignment.getSplits().size();
                                 hostRequirement = Optional.of(hostAddress);
                             }

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
@@ -16,7 +16,6 @@ package io.trino.execution.scheduler.faulttolerant;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.Split;
 import io.trino.spi.HostAddress;
-import io.trino.spi.SplitWeight;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
@@ -38,19 +37,12 @@ class TestingConnectorSplit
     private final int id;
     private final OptionalInt bucket;
     private final Optional<List<HostAddress>> addresses;
-    private final SplitWeight weight;
 
     public TestingConnectorSplit(int id, OptionalInt bucket, Optional<List<HostAddress>> addresses)
-    {
-        this(id, bucket, addresses, SplitWeight.standard().getRawValue());
-    }
-
-    public TestingConnectorSplit(int id, OptionalInt bucket, Optional<List<HostAddress>> addresses, long weight)
     {
         this.id = id;
         this.bucket = requireNonNull(bucket, "bucket is null");
         this.addresses = addresses.map(ImmutableList::copyOf);
-        this.weight = SplitWeight.fromRawValue(weight);
     }
 
     public int getId()
@@ -73,12 +65,6 @@ class TestingConnectorSplit
     public List<HostAddress> getAddresses()
     {
         return addresses.orElse(ImmutableList.of());
-    }
-
-    @Override
-    public SplitWeight getSplitWeight()
-    {
-        return weight;
     }
 
     @Override
@@ -105,13 +91,13 @@ class TestingConnectorSplit
             return false;
         }
         TestingConnectorSplit that = (TestingConnectorSplit) o;
-        return id == that.id && weight.equals(that.weight) && Objects.equals(bucket, that.bucket) && Objects.equals(addresses, that.addresses);
+        return id == that.id && Objects.equals(bucket, that.bucket) && Objects.equals(addresses, that.addresses);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(id, bucket, addresses, weight);
+        return Objects.hash(id, bucket, addresses);
     }
 
     @Override
@@ -121,7 +107,6 @@ class TestingConnectorSplit
                 .add("id", id)
                 .add("bucket", bucket)
                 .add("addresses", addresses)
-                .add("weight", weight)
                 .toString();
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestingConnectorSplit.java
@@ -105,7 +105,7 @@ class TestingConnectorSplit
             return false;
         }
         TestingConnectorSplit that = (TestingConnectorSplit) o;
-        return id == that.id && weight == that.weight && Objects.equals(bucket, that.bucket) && Objects.equals(addresses, that.addresses);
+        return id == that.id && weight.equals(that.weight) && Objects.equals(bucket, that.bucket) && Objects.equals(addresses, that.addresses);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/SplitWeight.java
@@ -15,6 +15,7 @@ package io.trino.spi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.errorprone.annotations.DoNotCall;
 
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -82,10 +83,10 @@ public final class SplitWeight
      * to avoid breakages that could arise if {@link SplitWeight#UNIT_VALUE} changes in the future.
      */
     @JsonCreator
-    // TODO Mark with @DoNotCall
+    @DoNotCall // For JSON serialization only
     public static SplitWeight fromRawValue(long value)
     {
-        return value == UNIT_VALUE ? STANDARD_WEIGHT : new SplitWeight(value);
+        return fromRawValueInternal(value);
     }
 
     /**
@@ -105,7 +106,12 @@ public final class SplitWeight
             throw new IllegalArgumentException("Invalid weight: " + weight);
         }
         // Must round up to avoid small weights rounding to 0
-        return fromRawValue((long) Math.ceil(weight * UNIT_VALUE));
+        return fromRawValueInternal((long) Math.ceil(weight * UNIT_VALUE));
+    }
+
+    private static SplitWeight fromRawValueInternal(long value)
+    {
+        return value == UNIT_VALUE ? STANDARD_WEIGHT : new SplitWeight(value);
     }
 
     public static SplitWeight standard()


### PR DESCRIPTION
Prevent calls to a non-API method that exists for JSON serialization only.
