### PR TITLE
Use correct class loader when loading catalogs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
+++ b/core/trino-main/src/main/java/io/trino/connector/DefaultCatalogFactory.java
@@ -220,7 +220,7 @@ public class DefaultCatalogFactory
                 pageIndexerFactory,
                 duplicatePluginClassLoaderFactory);
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(connectorFactory.getClass().getClassLoader())) {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(duplicatePluginClassLoaderFactory.get())) {
             return connectorFactory.create(catalogName, properties, context);
         }
     }


### PR DESCRIPTION
Use the plugin class loader instead of the one from the connector factory. This is not an issue (yet), as it should be the same class loader anyway, but it makes the code more consistent.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
