### PR TITLE
Use concurrent hash map for tracking query memory

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
+++ b/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
@@ -225,7 +225,7 @@ public class QueryContext
         return memoryPool;
     }
 
-    public synchronized long getUserMemoryReservation()
+    public long getUserMemoryReservation()
     {
         return memoryPool.getQueryMemoryReservation(queryId);
     }


### PR DESCRIPTION
This will increase the performance of `getQueryMemoryReservation(queryId)` method since that is called from every different local exchange thread.

Extracted from https://github.com/trinodb/trino/pull/19649

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
