### PR TITLE
Iceberg Rest Catalog: Fix bug where listing namespaces was performed but non-existing namespace was provided

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -183,16 +183,7 @@ public class TrinoRestCatalog
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> namespace)
     {
         SessionContext sessionContext = convert(session);
-        List<Namespace> namespaces;
-
-        if (namespace.isPresent() && namespaceExists(session, namespace.get())) {
-            namespaces = ImmutableList.of(Namespace.of(namespace.get()));
-        }
-        else {
-            namespaces = listNamespaces(session).stream()
-                    .map(Namespace::of)
-                    .collect(toImmutableList());
-        }
+        List<Namespace> namespaces = listNamespaces(session, namespace);
 
         ImmutableList.Builder<SchemaTableName> tables = ImmutableList.builder();
         for (Namespace restNamespace : namespaces) {
@@ -554,5 +545,16 @@ public class TrinoRestCatalog
     private static TableIdentifier toIdentifier(SchemaTableName schemaTableName)
     {
         return TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+    }
+
+    private List<Namespace> listNamespaces(ConnectorSession session, Optional<String> namespace)
+    {
+        if (namespace.isEmpty()) {
+            return listNamespaces(session).stream()
+                    .map(Namespace::of)
+                    .collect(toImmutableList());
+        }
+
+        return ImmutableList.of(Namespace.of(namespace.get()));
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/BaseTrinoCatalogTest.java
@@ -385,6 +385,47 @@ public abstract class BaseTrinoCatalogTest
         }
     }
 
+    @Test
+    public void testListTables()
+            throws Exception
+    {
+        TrinoCatalog catalog = createTrinoCatalog(false);
+        TrinoPrincipal principal = new TrinoPrincipal(PrincipalType.USER, SESSION.getUser());
+        String ns1 = "ns1";
+        String ns2 = "ns2";
+
+        catalog.createNamespace(SESSION, ns1, defaultNamespaceProperties(ns1), principal);
+        catalog.createNamespace(SESSION, ns2, defaultNamespaceProperties(ns2), principal);
+        SchemaTableName table1 = new SchemaTableName(ns1, "t1");
+        SchemaTableName table2 = new SchemaTableName(ns2, "t2");
+        catalog.newCreateTableTransaction(
+                        SESSION,
+                        table1,
+                        new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
+                        PartitionSpec.unpartitioned(),
+                        SortOrder.unsorted(),
+                        arbitraryTableLocation(catalog, SESSION, table1),
+                        ImmutableMap.of())
+                .commitTransaction();
+
+        catalog.newCreateTableTransaction(
+                        SESSION,
+                        table2,
+                        new Schema(Types.NestedField.of(1, true, "col1", Types.LongType.get())),
+                        PartitionSpec.unpartitioned(),
+                        SortOrder.unsorted(),
+                        arbitraryTableLocation(catalog, SESSION, table2),
+                        ImmutableMap.of())
+                .commitTransaction();
+
+        // No namespace provided, all tables across all namespaces should be returned
+        assertThat(catalog.listTables(SESSION, Optional.empty())).containsAll(ImmutableList.of(table1, table2));
+        // Namespace is provided and exists
+        assertThat(catalog.listTables(SESSION, Optional.of(ns1))).isEqualTo(ImmutableList.of(table1));
+        // Namespace is provided and does not exist
+        assertThat(catalog.listTables(SESSION, Optional.of("non_existing"))).isEmpty();
+    }
+
     private String arbitraryTableLocation(TrinoCatalog catalog, ConnectorSession session, SchemaTableName schemaTableName)
             throws Exception
     {


### PR DESCRIPTION
Fix bug where listing namespaces was performed but non-existing namespace was provided. This is coming from discussion on #19818 https://github.com/trinodb/trino/pull/19818#discussion_r1400214440 

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This change fixes a bug where if an explicit namespace was provided the listTables implementation would do a full listing of the all the namespaces even if the namespace does not exist at the time. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( X) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix bug where listing namespaces was performed but non-existing namespace was provided.  This applies when listing tables.
```
