### PR TITLE
Implement CREATE OR REPLACE TABLE for delta lake connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeOutputTableHandle.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeColumnType.PARTITION_KEY;
@@ -38,6 +39,8 @@ public record DeltaLakeOutputTableHandle(
         String schemaString,
         ColumnMappingMode columnMappingMode,
         OptionalInt maxColumnId,
+        boolean replace,
+        OptionalLong readVersion,
         ProtocolEntry protocolEntry)
         implements ConnectorOutputTableHandle
 {
@@ -53,6 +56,7 @@ public record DeltaLakeOutputTableHandle(
         requireNonNull(schemaString, "schemaString is null");
         requireNonNull(columnMappingMode, "columnMappingMode is null");
         requireNonNull(maxColumnId, "maxColumnId is null");
+        requireNonNull(readVersion, "readVersion is null");
         requireNonNull(protocolEntry, "protocolEntry is null");
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/DeltaLakeMetastore.java
@@ -39,6 +39,8 @@ public interface DeltaLakeMetastore
 
     void createTable(Table table, PrincipalPrivileges principalPrivileges);
 
+    void replaceTable(Table table, PrincipalPrivileges principalPrivileges);
+
     void dropTable(SchemaTableName schemaTableName, String tableLocation, boolean deleteData);
 
     void renameTable(SchemaTableName from, SchemaTableName to);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/metastore/HiveMetastoreBackedDeltaLakeMetastore.java
@@ -113,6 +113,12 @@ public class HiveMetastoreBackedDeltaLakeMetastore
     }
 
     @Override
+    public void replaceTable(Table table, PrincipalPrivileges principalPrivileges)
+    {
+        delegate.replaceTable(table.getDatabaseName(), table.getTableName(), table, principalPrivileges);
+    }
+
+    @Override
     public void dropTable(SchemaTableName schemaTableName, String tableLocation, boolean deleteData)
     {
         delegate.dropTable(schemaTableName.getSchemaName(), schemaTableName.getTableName(), deleteData);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -17,6 +17,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,6 +69,8 @@ import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.CREATE_OR_REPLACE_TABLE_AS_OPERATION;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.CREATE_OR_REPLACE_TABLE_OPERATION;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.createDockerizedDeltaLakeQueryRunner;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.EXTENDED_STATISTICS_COLLECT_ON_WRITE;
@@ -74,6 +78,7 @@ import static io.trino.plugin.deltalake.TestingDeltaLakeUtils.getConnectorServic
 import static io.trino.plugin.deltalake.TestingDeltaLakeUtils.getTableActiveFiles;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
 import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
+import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.QueryAssertions.getTrinoExceptionCause;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DELETE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_TABLE;
@@ -2292,6 +2297,140 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     {
         testConcurrentInsertsReconciliationForBlindInserts(false);
         testConcurrentInsertsReconciliationForBlindInserts(true);
+    }
+
+    @Test
+    public void testCreateOrReplaceTable()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_table", " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b")) {
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', -385e-1)");
+
+            assertUpdate("CREATE OR REPLACE TABLE %s (a bigint, b double)".formatted(table.getName()));
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+
+            assertTableVersion(table.getName(), 1L);
+            assertTableOperation(table.getName(), 1, CREATE_OR_REPLACE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAs()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_table", " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b")) {
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', -385e-1)");
+
+            assertUpdate("CREATE OR REPLACE TABLE %s AS SELECT BIGINT '-53' a, DOUBLE '49.6' b".formatted(table.getName()), 1);
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '-53', 496e-1)");
+
+            assertTableVersion(table.getName(), 1L);
+            assertTableOperation(table.getName(), 1, CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableChangeColumnNamesAndTypes()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_table", " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b")) {
+            assertThat(query("SELECT CAST(a AS bigint), b FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', -385e-1)");
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT VARCHAR 'test' c, VARCHAR 'test2' d", 1);
+            assertThat(query("SELECT c, d FROM " + table.getName()))
+                    .matches("VALUES (VARCHAR 'test', VARCHAR 'test2')");
+
+            assertTableVersion(table.getName(), 1L);
+            assertTableOperation(table.getName(), 1, CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+        }
+    }
+
+    @RepeatedTest(3)
+    // Test from BaseConnectorTest
+    public void testCreateOrReplaceTableConcurrently()
+            throws Exception
+    {
+        int threads = 4;
+        int numOfCreateOrReplaceStatements = 4;
+        int numOfReads = 16;
+        CyclicBarrier barrier = new CyclicBarrier(threads + 1);
+        ExecutorService executor = newFixedThreadPool(threads + 1);
+        List<Future<?>> futures = new ArrayList<>();
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace", "(col integer)")) {
+            String tableName = table.getName();
+
+            getQueryRunner().execute("CREATE OR REPLACE TABLE " + tableName + " AS SELECT 1 a");
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1");
+
+            // One thread submits some CREATE OR REPLACE statements
+            futures.add(executor.submit(() -> {
+                barrier.await(30, SECONDS);
+                IntStream.range(0, numOfCreateOrReplaceStatements).forEach(index -> {
+                    try {
+                        getQueryRunner().execute("CREATE OR REPLACE TABLE " + tableName + " AS SELECT * FROM (VALUES (1), (2)) AS t(a) ");
+                    } catch (Exception e) {
+                        RuntimeException trinoException = getTrinoExceptionCause(e);
+                        try {
+                            throw new AssertionError("Unexpected concurrent CREATE OR REPLACE failure", trinoException);
+                        } catch (Throwable verifyFailure) {
+                            if (verifyFailure != e) {
+                                verifyFailure.addSuppressed(e);
+                            }
+                            throw verifyFailure;
+                        }
+                    }
+                });
+                return null;
+            }));
+            // Other 4 threads continue try to read the same table, none of the reads should fail.
+            IntStream.range(0, threads)
+                    .forEach(threadNumber -> futures.add(executor.submit(() -> {
+                        barrier.await(30, SECONDS);
+                        IntStream.range(0, numOfReads).forEach(readIndex -> {
+                            try {
+                                MaterializedResult result = computeActual("SELECT * FROM " + tableName);
+                                if (result.getRowCount() == 1) {
+                                    assertEqualsIgnoreOrder(result.getMaterializedRows(), List.of(new MaterializedRow(List.of(1))));
+                                }
+                                else {
+                                    assertEqualsIgnoreOrder(result.getMaterializedRows(), List.of(new MaterializedRow(List.of(1)), new MaterializedRow(List.of(2))));
+                                }
+                            }
+                            catch (Exception e) {
+                                RuntimeException trinoException = getTrinoExceptionCause(e);
+                                try {
+                                    throw new AssertionError("Unexpected concurrent CREATE OR REPLACE failure", trinoException);
+                                }
+                                catch (Throwable verifyFailure) {
+                                    if (verifyFailure != e) {
+                                        verifyFailure.addSuppressed(e);
+                                    }
+                                    throw verifyFailure;
+                                }
+                            }
+                        });
+                        return null;
+                    })));
+            futures.forEach(Futures::getUnchecked);
+            getQueryRunner().execute("CREATE OR REPLACE TABLE " + tableName + " AS SELECT * FROM (VALUES (1), (2), (3)) AS t(a)");
+            assertThat(query("SELECT * FROM " + tableName)).matches("VALUES 1, 2, 3");
+        }
+        finally {
+            executor.shutdownNow();
+            executor.awaitTermination(30, SECONDS);
+        }
+    }
+
+    private void assertTableVersion(String tableName, long version)
+    {
+        assertThat(computeScalar(format("SELECT max(version) FROM \"%s$history\"", tableName))).isEqualTo(version);
+    }
+
+    private void assertTableOperation(String tableName, long version, String operation)
+    {
+        assertQuery("SELECT operation FROM \"%s$history\" WHERE version = %s".formatted(tableName, version),
+                "VALUES '%s'".formatted(operation));
     }
 
     private void testConcurrentInsertsReconciliationForBlindInserts(boolean partitioned)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeAlluxioCacheFileOperations.java
@@ -421,6 +421,37 @@ public class TestDeltaLakeAlluxioCacheFileOperations
                         .build());
     }
 
+    @Test
+    public void testCreateOrReplaceTable()
+    {
+        assertFileSystemAccesses("CREATE OR REPLACE TABLE test_create_or_replace (id VARCHAR, age INT)", ImmutableMultiset.of());
+
+        assertFileSystemAccesses("CREATE OR REPLACE TABLE test_create_or_replace (id VARCHAR, age INT)",
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 762))
+                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 762))
+                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 762))
+                        .build());
+        assertUpdate("DROP TABLE test_create_or_replace");
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsSelect()
+    {
+        assertFileSystemAccesses(
+                "CREATE OR REPLACE TABLE test_create_or_replace_as_select AS SELECT 1 col_name", ImmutableMultiset.of());
+
+        assertFileSystemAccesses(
+                "CREATE OR REPLACE TABLE test_create_or_replace_as_select AS SELECT 1 col_name",
+                ImmutableMultiset.<CacheOperation>builder()
+                        .add(new CacheOperation("Alluxio.readCached", "00000000000000000000.json", 0, 1004))
+                        .add(new CacheOperation("Alluxio.readExternal", "00000000000000000000.json", 0, 1004))
+                        .add(new CacheOperation("Alluxio.writeCache", "00000000000000000000.json", 0, 1004))
+                        .build());
+
+        assertUpdate("DROP TABLE test_create_or_replace_as_select");
+    }
+
     private void assertFileSystemAccesses(@Language("SQL") String query, Multiset<CacheOperation> expectedCacheAccesses)
     {
         assertUpdate("CALL system.flush_metadata_cache()");

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeBasic.java
@@ -1001,6 +1001,7 @@ public class TestDeltaLakeBasic
         assertQueryFails("COMMENT ON COLUMN " + tableName + ".foo IS NULL", "Metadata not found in transaction log for tpch." + tableName);
         assertQueryFails("CALL system.vacuum(CURRENT_SCHEMA, '" + tableName + "', '7d')", "Metadata not found in transaction log for tpch." + tableName);
         assertQueryFails("SELECT * FROM TABLE(system.table_changes('tpch', '" + tableName + "'))", "Metadata not found in transaction log for tpch." + tableName);
+        assertQueryFails("CREATE OR REPLACE TABLE " + tableName + " (id INTEGER)", "Metadata not found in transaction log for tpch." + tableName);
         assertQuerySucceeds("CALL system.drop_extended_stats(CURRENT_SCHEMA, '" + tableName + "')");
 
         // Avoid failing metadata queries

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -59,8 +59,13 @@ import static com.google.common.collect.Sets.union;
 import static io.trino.plugin.base.util.Closables.closeAllSuppress;
 import static io.trino.plugin.deltalake.DeltaLakeCdfPageSink.CHANGE_DATA_FOLDER_NAME;
 import static io.trino.plugin.deltalake.DeltaLakeMetadata.CHANGE_DATA_FEED_COLUMN_NAMES;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.CREATE_OR_REPLACE_TABLE_AS_OPERATION;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.CREATE_OR_REPLACE_TABLE_OPERATION;
+import static io.trino.plugin.deltalake.DeltaLakeMetadata.CREATE_TABLE_OPERATION;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogUtil.TRANSACTION_LOG_DIRECTORY;
+import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
+import static io.trino.plugin.hive.TableType.MANAGED_TABLE;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -137,7 +142,8 @@ public class TestDeltaLakeConnectorTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         return switch (connectorBehavior) {
-            case SUPPORTS_REPORTING_WRITTEN_BYTES -> true;
+            case SUPPORTS_CREATE_OR_REPLACE_TABLE,
+                    SUPPORTS_REPORTING_WRITTEN_BYTES -> true;
             case SUPPORTS_ADD_FIELD,
                     SUPPORTS_AGGREGATION_PUSHDOWN,
                     SUPPORTS_CREATE_MATERIALIZED_VIEW,
@@ -1769,6 +1775,410 @@ public class TestDeltaLakeConnectorTest
         testSupportedNonPartitionedColumnMappingWrites("write_stats_as_json_column_mapping_none", false);
     }
 
+    @Test
+    public void testCreateOrReplaceTableOnNonExistingTable()
+    {
+        String tableName = "create_or_replace_table" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE OR REPLACE TABLE " + tableName + " (id BIGINT)");
+            assertLatestTableOperation(tableName, CREATE_OR_REPLACE_TABLE_OPERATION);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsSelectOnNonExistingTable()
+    {
+        String tableName = "create_or_replace_table_as_select_" + randomNameSuffix();
+        try {
+            assertUpdate("CREATE OR REPLACE TABLE " + tableName + " AS SELECT 1 as colA", 1);
+            assertLatestTableOperation(tableName, CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+        }
+        finally {
+            assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsSelectWithSwappedColumns()
+    {
+        testCreateOrReplaceTableAsSelectWithSwappedColumns(ColumnMappingMode.ID);
+        testCreateOrReplaceTableAsSelectWithSwappedColumns(ColumnMappingMode.NAME);
+        testCreateOrReplaceTableAsSelectWithSwappedColumns(ColumnMappingMode.NONE);
+    }
+
+    private void testCreateOrReplaceTableAsSelectWithSwappedColumns(ColumnMappingMode columnMappingMode)
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_with_column",
+                "AS SELECT 'abc' colA, BIGINT '1' colB")) {
+            assertThat(query("SELECT colA, colB FROM " + table.getName()))
+                    .matches("VALUES (CAST('abc' AS VARCHAR), BIGINT '1')");
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (column_mapping_mode='" + columnMappingMode.name() + "') AS SELECT BIGINT '42' colA, 'def' colB", 1);
+
+            assertThat(query("SELECT colA, colB FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', CAST('def' AS VARCHAR))");
+
+            assertLatestTableOperation(table.getName(), CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableChangeUnpartitionedTableIntoPartitioned()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_", " AS SELECT BIGINT '22' a, CAST('some data' AS VARCHAR) b")) {
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (partitioned_by=ARRAY['a']) AS SELECT BIGINT '42' a, 'some data' b UNION ALL SELECT BIGINT '43' a, 'another data' b", 2);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', CAST('some data' AS VARCHAR)), (BIGINT '43', CAST('another data' AS VARCHAR))");
+
+            assertLatestTableOperation(table.getName(), CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("partitioned_by = ARRAY['a']");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableChangePartitionedTableIntoUnpartitioned()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_",
+                "  WITH (partitioned_by=ARRAY['a']) AS SELECT BIGINT '42' a, 'some data' b UNION ALL SELECT BIGINT '43' a, 'another data' b")) {
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT BIGINT '42' a, 'some data' b UNION ALL SELECT BIGINT '43' a, 'another data' b", 2);
+            assertThat(query("SELECT * FROM " + table.getName()))
+                    .matches("VALUES (BIGINT '42', CAST('some data' AS VARCHAR)), (BIGINT '43', CAST('another data' AS VARCHAR))");
+
+            assertLatestTableOperation(table.getName(), CREATE_OR_REPLACE_TABLE_AS_OPERATION);
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .matches("CREATE TABLE delta.test_schema.%s \\(\n".formatted(table.getName()) +
+                            "   a bigint,\n" +
+                            "   b varchar\n" +
+                            "\\)\n" +
+                            "WITH \\(\n" +
+                            "   location = '.*'\n" +
+                            "\\)");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableTableCommentIsRemoved()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_", " (a BIGINT) COMMENT 'This is a table'")) {
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (a BIGINT COMMENT 'This is a column')");
+            assertQueryReturnsEmptyResult("SELECT * FROM " + table.getName());
+
+            assertThat(getColumnComment(table.getName(), "a"))
+                    .isEqualTo("This is a column");
+            assertThat(getTableComment(getSession().getCatalog().orElseThrow(), getSession().getSchema().orElseThrow(), table.getName()))
+                    .isNull();
+            assertLatestTableOperation(table.getName(), CREATE_OR_REPLACE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithEnablingCdcProperty()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_with_cdc", " (a BIGINT)")) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " (c BIGINT) WITH (change_data_feed_enabled = true)",
+                    "CREATE OR REPLACE is not supported for tables with change data feed enabled");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithEnablingCdcProperty()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_with_cdc", " (a BIGINT)")) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " WITH (change_data_feed_enabled = true) AS SELECT 1 new_column",
+                    "CREATE OR REPLACE is not supported for tables with change data feed enabled");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceOnCdcEnabledTables()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_with_cdc", " (a BIGINT) WITH (change_data_feed_enabled = true)")) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " (d BIGINT)",
+                    "CREATE OR REPLACE is not supported for tables with change data feed enabled");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsOnCdcEnabledTables()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_with_cdc", " (a BIGINT) WITH (change_data_feed_enabled = true)")) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT 1 new_column",
+                    "CREATE OR REPLACE is not supported for tables with change data feed enabled");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithSameLocationForManagedTable()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_with_same_location_",
+                " (a BIGINT)")) {
+            HiveMetastore metastore = TestingDeltaLakeUtils.getConnectorService(getDistributedQueryRunner(), HiveMetastoreFactory.class)
+                    .createMetastore(Optional.empty());
+            String location = metastore.getTable("test_schema", table.getName()).orElseThrow().getStorage().getLocation();
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (d BIGINT) WITH (location = '" + location + "')");
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (d BIGINT) WITH (location = '" + location + "/')");
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithSameLocationForManagedTable()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_with_same_location_",
+                " (a BIGINT)")) {
+            HiveMetastore metastore = TestingDeltaLakeUtils.getConnectorService(getDistributedQueryRunner(), HiveMetastoreFactory.class)
+                    .createMetastore(Optional.empty());
+            String location = metastore.getTable("test_schema", table.getName()).orElseThrow().getStorage().getLocation();
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (location = '" + location + "') AS SELECT 'abc' as colA", 1);
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (location = '" + location + "/') AS SELECT 'abc' as colA", 1);
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithChangeInLocationForManagedTable()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_change_location_", " (a BIGINT) ")) {
+            String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " (a BIGINT) WITH (location = '%s')".formatted(location),
+                    "The provided location '%s' does not match the existing table location '.*'".formatted(location));
+
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " (a BIGINT) WITH (location = '%s/')".formatted(location),
+                    "The provided location '%s/' does not match the existing table location '.*'".formatted(location));
+
+            assertLatestTableOperation(table.getName(), CREATE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceAsTableWithChangeInLocationForManagedTable()
+    {
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_or_replace_change_location_", " (a BIGINT) ")) {
+            String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " WITH (location = '%s') AS SELECT 'a' colA".formatted(location),
+                    "The provided location '%s' does not match the existing table location '.*'".formatted(location));
+
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " WITH (location = '%s/')  AS SELECT 'a' colA".formatted(location),
+                    "The provided location '%s/' does not match the existing table location '.*'".formatted(location));
+
+            assertLatestTableOperation(table.getName(), CREATE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithChangeInLocationForExternalTable()
+    {
+        String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_change_location_",
+                " (a BIGINT) WITH (location = '%s')".formatted(location))) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " (a BIGINT) WITH (location = '%s_2')".formatted(location),
+                    "The provided location '%1$s_2' does not match the existing table location '%1$s'".formatted(location));
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("location = '%s'".formatted(location));
+            assertLatestTableOperation(table.getName(), CREATE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithChangeInLocationForExternalTable()
+    {
+        String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "test_create_or_replace_change_location_",
+                " (a BIGINT) WITH (location = '%s')".formatted(location))) {
+            assertQueryFails(
+                    "CREATE OR REPLACE TABLE " + table.getName() + " WITH (location = '%s_2') AS SELECT 'a' colA".formatted(location),
+                    "The provided location '%1$s_2' does not match the existing table location '%1$s'".formatted(location));
+
+            assertThat((String) computeScalar("SHOW CREATE TABLE " + table.getName()))
+                    .contains("location = '%s'".formatted(location));
+            assertLatestTableOperation(table.getName(), CREATE_TABLE_OPERATION);
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithNoLocationSpecifiedForExternalTable()
+    {
+        String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_with_no_location_",
+                " (a BIGINT) WITH (location = '%s')".formatted(location))) {
+            assertTableType("test_schema", table.getName(), EXTERNAL_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (colA VARCHAR)");
+            assertTableType("test_schema", table.getName(), EXTERNAL_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithNoLocationSpecifiedForExternalTable()
+    {
+        String location = "s3://%s/%s".formatted(bucketName, randomNameSuffix());
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_with_no_location_",
+                " (a BIGINT) WITH (location = '%s')".formatted(location))) {
+            assertTableType("test_schema", table.getName(), EXTERNAL_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT 'abc' as colA", 1);
+            assertTableType("test_schema", table.getName(), EXTERNAL_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithNoLocationSpecifiedForManagedTable()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_with_no_location_",
+                " (a BIGINT)")) {
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (colA VARCHAR)");
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithNoLocationSpecifiedForManagedTable()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_with_no_location_",
+                " (a BIGINT)")) {
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT 'abc' as colA", 1);
+            assertTableType("test_schema", table.getName(), MANAGED_TABLE.name());
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithStatsUpdated()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_for_stats_",
+                " AS SELECT 1 as colA")) {
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES" +
+                            "('cola', null, 1.0, 0.0, null, '1', '1')," +
+                            "(null, null, null, null, 1.0, null, null)");
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " (colA BIGINT) ");
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES" +
+                            "('cola', 0.0, 0.0, 1.0, null, null, null)," +
+                            "(null, null, null, null, 0.0, null, null)");
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES null", 1);
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES" +
+                            "('cola', 0.0, 0.0, 1.0, null, null, null)," +
+                            "(null, null, null, null, 1.0, null, null)");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsWithStatsUpdated()
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_for_stats_",
+                " AS SELECT 1 as colA")) {
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES" +
+                            "('cola', null, 1.0, 0.0, null, '1', '1')," +
+                            "(null, null, null, null, 1.0, null, null)");
+
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " AS SELECT 25 colb ", 1);
+            assertUpdate("INSERT INTO " + table.getName() + " VALUES (null)", 1);
+            assertQuery(
+                    "SHOW STATS FOR " + table.getName(),
+                    "VALUES" +
+                            "('colb', null, 1.0, 0.5, null, '25', '25')," +
+                            "(null, null, null, null, 2.0, null, null)");
+        }
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithChangeInColumnMappingToId()
+    {
+        testTableOperationWithChangeInColumnMappingMode("id");
+    }
+
+    @Test
+    public void testCreateOrReplaceTableWithChangeInColumnMappingToName()
+    {
+        testTableOperationWithChangeInColumnMappingMode("name");
+    }
+
+    public void testTableOperationWithChangeInColumnMappingMode(String columnMappingMode)
+    {
+        try (TestTable table = new TestTable(
+                getQueryRunner()::execute,
+                "create_or_replace_with_change_column_mapping_",
+                " AS SELECT 1 as colA, 'B' as colB")) {
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " DROP COLUMN colA",
+                    "Cannot drop column from table using column mapping mode NONE");
+            assertQueryFails(
+                    "ALTER TABLE " + table.getName() + " RENAME COLUMN colA TO renamed_column",
+                    "Cannot rename column in table using column mapping mode NONE");
+            assertUpdate("CREATE OR REPLACE TABLE " + table.getName() + " WITH (column_mapping_mode = '" + columnMappingMode + "') AS SELECT 25 colc, 'D' cold ", 1);
+            assertQuery("SELECT colc FROM " + table.getName(), "VALUES 25");
+            assertUpdate("ALTER TABLE " + table.getName() + " DROP COLUMN colc");
+            assertUpdate("ALTER TABLE " + table.getName() + " RENAME COLUMN cold TO colc");
+            assertQuery("SELECT colc FROM " + table.getName(), "VALUES 'D'");
+        }
+    }
+
+    private void assertLatestTableOperation(String tableName, String operation)
+    {
+        assertQuery("SELECT operation FROM \"%s$history\" ORDER BY version DESC LIMIT 1".formatted(tableName),
+                "VALUES '%s'".formatted(operation));
+    }
+
+    private void assertTableType(String schemaName, String tableName, String tableType)
+    {
+        HiveMetastore metastore = TestingDeltaLakeUtils.getConnectorService(getDistributedQueryRunner(), HiveMetastoreFactory.class)
+                .createMetastore(Optional.empty());
+        assertThat(metastore.getTable(schemaName, tableName).orElseThrow().getTableType()).isEqualTo(tableType);
+    }
+
     private void testSupportedNonPartitionedColumnMappingWrites(String resourceName, boolean statsAsJsonEnabled)
             throws Exception
     {
@@ -2126,7 +2536,7 @@ public class TestDeltaLakeConnectorTest
         assertUpdate("CALL system.unregister_table(CURRENT_SCHEMA, '" + tableName + "')");
 
         assertQueryFails(format("CREATE TABLE %s (dummy int) with (location = '%s')", tableName, tableLocation),
-                ".*Using CREATE TABLE with an existing table content is disallowed.*");
+                ".*Using CREATE \\[OR REPLACE] TABLE with an existing table content is disallowed.*");
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -92,6 +92,7 @@ import static io.trino.plugin.deltalake.DeltaLakeTableProperties.PARTITIONED_BY_
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
+import static io.trino.spi.connector.SaveMode.FAIL;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -309,7 +310,7 @@ public class TestDeltaLakeMetadata
                 ImmutableList.of(BIGINT_COLUMN_1, BIGINT_COLUMN_2),
                 ImmutableList.of(BIGINT_COLUMN_1));
 
-        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, FAIL);
 
         Optional<ConnectorTableLayout> insertLayout = deltaLakeMetadata
                 .getInsertLayout(
@@ -347,7 +348,7 @@ public class TestDeltaLakeMetadata
                 ImmutableList.of(BIGINT_COLUMN_1),
                 ImmutableList.of());
 
-        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, FAIL);
 
         // should return empty insert layout since table exists but is unpartitioned
         assertThat(deltaLakeMetadata.getInsertLayout(
@@ -476,7 +477,7 @@ public class TestDeltaLakeMetadata
         ConnectorTableMetadata tableMetadata = newTableMetadata(
                 ImmutableList.of(BIGINT_COLUMN_1, BIGINT_COLUMN_2),
                 ImmutableList.of(BIGINT_COLUMN_1));
-        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, FAIL);
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable(), Optional.empty(), Optional.empty());
         assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(true, 0)));
         deltaLakeMetadata.cleanupQuery(SESSION);
@@ -489,7 +490,7 @@ public class TestDeltaLakeMetadata
         ConnectorTableMetadata tableMetadata = newTableMetadata(
                 ImmutableList.of(BIGINT_COLUMN_1, BIGINT_COLUMN_2),
                 ImmutableList.of());
-        deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
+        deltaLakeMetadata.createTable(SESSION, tableMetadata, FAIL);
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable(), Optional.empty(), Optional.empty());
         assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(false, 0)));
         deltaLakeMetadata.cleanupQuery(SESSION);

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePageSink.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -174,6 +175,8 @@ public class TestDeltaLakePageSink
                 schemaString,
                 NONE,
                 OptionalInt.empty(),
+                false,
+                OptionalLong.empty(),
                 new ProtocolEntry(DEFAULT_READER_VERSION, DEFAULT_WRITER_VERSION, Optional.empty(), Optional.empty()));
 
         DeltaLakePageSinkProvider provider = new DeltaLakePageSinkProvider(

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/metastore/TestDeltaLakeMetastoreAccessOperations.java
@@ -34,6 +34,7 @@ import static io.trino.plugin.hive.metastore.MetastoreMethod.GET_ALL_DATABASES;
 import static io.trino.plugin.hive.metastore.MetastoreMethod.GET_DATABASE;
 import static io.trino.plugin.hive.metastore.MetastoreMethod.GET_TABLE;
 import static io.trino.plugin.hive.metastore.MetastoreMethod.GET_TABLES;
+import static io.trino.plugin.hive.metastore.MetastoreMethod.REPLACE_TABLE;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @Execution(SAME_THREAD) // metastore invocation counters shares mutable state so can't be run from many threads simultaneously
@@ -61,6 +62,23 @@ public class TestDeltaLakeMetastoreAccessOperations
     }
 
     @Test
+    public void testCreateOrReplaceTable()
+    {
+        assertMetastoreInvocations("CREATE OR REPLACE TABLE test_create_or_replace (id VARCHAR, age INT)",
+                ImmutableMultiset.<MetastoreMethod>builder()
+                        .add(GET_DATABASE)
+                        .add(GET_TABLE)
+                        .add(CREATE_TABLE)
+                        .build());
+        assertMetastoreInvocations("CREATE OR REPLACE TABLE test_create_or_replace (id VARCHAR, age INT)",
+                ImmutableMultiset.<MetastoreMethod>builder()
+                        .add(GET_DATABASE)
+                        .add(GET_TABLE)
+                        .add(REPLACE_TABLE)
+                        .build());
+    }
+
+    @Test
     public void testCreateTableAsSelect()
     {
         assertMetastoreInvocations("CREATE TABLE test_ctas AS SELECT 1 AS age",
@@ -68,6 +86,26 @@ public class TestDeltaLakeMetastoreAccessOperations
                         .add(GET_DATABASE)
                         .add(CREATE_TABLE)
                         .add(GET_TABLE)
+                        .build());
+    }
+
+    @Test
+    public void testCreateOrReplaceTableAsSelect()
+    {
+        assertMetastoreInvocations(
+                "CREATE OR REPLACE TABLE test_cortas AS SELECT 1 AS age",
+                ImmutableMultiset.<MetastoreMethod>builder()
+                        .add(GET_DATABASE)
+                        .add(GET_TABLE)
+                        .add(CREATE_TABLE)
+                        .build());
+
+        assertMetastoreInvocations(
+                "CREATE OR REPLACE TABLE test_cortas AS SELECT 1 AS age",
+                ImmutableMultiset.<MetastoreMethod>builder()
+                        .add(GET_DATABASE)
+                        .add(GET_TABLE)
+                        .add(REPLACE_TABLE)
                         .build());
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.assertions.QueryAssert;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DELTA_LAKE_OSS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertLastEntryIsCheckpointed;
+import static io.trino.tests.product.deltalake.TransactionLogAssertions.assertTransactionLogVersion;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.dropDeltaTableWithRetry;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility
+        extends BaseTestDeltaLakeS3Storage
+{
+    @Inject
+    @Named("s3.server_type")
+    private String s3ServerType;
+
+    private AmazonS3 s3;
+
+    @BeforeMethodWithContext
+    public void setup()
+    {
+        super.setUp();
+        s3 = new S3ClientFactory().createS3Client(s3ServerType);
+    }
+
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testReplaceTableWithSchemaChange()
+    {
+        String tableName = "test_replace_table_with_schema_change_" + randomNameSuffix();
+
+        onTrino().executeQuery("CREATE TABLE delta.default." + tableName + " (ts VARCHAR) " +
+                "with (location = 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "', checkpoint_interval = 10)");
+        try {
+            ImmutableList.Builder<QueryAssert.Row> expected = ImmutableList.builder();
+            // Write to the table until a checkpoint file is written
+            for (int i = 0; i < 12; i++) {
+                onDelta().executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
+                expected.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
+            }
+
+            assertTransactionLogVersion(s3, bucketName, tableName, 12);
+            onDelta().executeQuery("CREATE OR REPLACE TABLE " + tableName + " USING DELTA AS SELECT CAST(ts AS TIMESTAMP) FROM " + tableName);
+            assertThat(onTrino().executeQuery("SELECT to_iso8601(ts) FROM delta.default." + tableName)).containsOnly(expected.build());
+        }
+        finally {
+            dropDeltaTableWithRetry(tableName);
+        }
+    }
+
+    @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
+    public void testReplaceTableWithSchemaChangeOnCheckpoint()
+    {
+        String tableName = "test_replace_table_with_schema_change_" + randomNameSuffix();
+        onTrino().executeQuery("CREATE TABLE delta.default." + tableName + " (ts VARCHAR) " +
+                "with (location = 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "', checkpoint_interval = 10)");
+        try {
+            ImmutableList.Builder<QueryAssert.Row> expected = ImmutableList.builder();
+            // Write to the table until a checkpoint file is written
+            for (int i = 0; i < 9; i++) {
+                onDelta().executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
+                expected.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
+            }
+            onDelta().executeQuery("CREATE OR REPLACE TABLE " + tableName + " USING DELTA AS SELECT CAST(ts AS TIMESTAMP) FROM " + tableName);
+            assertLastEntryIsCheckpointed(s3, bucketName, tableName);
+
+            onDelta().executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
+            expected.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
+            assertTransactionLogVersion(s3, bucketName, tableName, 11);
+
+            assertThat(onTrino().executeQuery("SELECT to_iso8601(ts) FROM delta.default." + tableName)).containsOnly(expected.build());
+        }
+        finally {
+            dropDeltaTableWithRetry(tableName);
+        }
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility.java
@@ -18,8 +18,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.trino.tempto.BeforeMethodWithContext;
-import io.trino.tempto.assertions.QueryAssert;
+import io.trino.tempto.assertions.QueryAssert.Row;
+import io.trino.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -49,23 +52,18 @@ public class TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility
     }
 
     @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
-    public void testReplaceTableWithSchemaChange()
+    public void testCreateOrReplaceTableWithSchemaChange()
     {
         String tableName = "test_replace_table_with_schema_change_" + randomNameSuffix();
 
         onTrino().executeQuery("CREATE TABLE delta.default." + tableName + " (ts VARCHAR) " +
                 "with (location = 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "', checkpoint_interval = 10)");
         try {
-            ImmutableList.Builder<QueryAssert.Row> expected = ImmutableList.builder();
-            // Write to the table until a checkpoint file is written
-            for (int i = 0; i < 12; i++) {
-                onDelta().executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
-                expected.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
-            }
+            List<Row> expectedRows = performInsert(onDelta(), tableName, 12);
 
             assertTransactionLogVersion(s3, bucketName, tableName, 12);
             onDelta().executeQuery("CREATE OR REPLACE TABLE " + tableName + " USING DELTA AS SELECT CAST(ts AS TIMESTAMP) FROM " + tableName);
-            assertThat(onTrino().executeQuery("SELECT to_iso8601(ts) FROM delta.default." + tableName)).containsOnly(expected.build());
+            assertThat(onTrino().executeQuery("SELECT to_iso8601(ts) FROM delta.default." + tableName)).containsOnly(expectedRows);
         }
         finally {
             dropDeltaTableWithRetry(tableName);
@@ -73,18 +71,15 @@ public class TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility
     }
 
     @Test(groups = {DELTA_LAKE_OSS, PROFILE_SPECIFIC_TESTS})
-    public void testReplaceTableWithSchemaChangeOnCheckpoint()
+    public void testCreateOrReplaceTableWithSchemaChangeOnCheckpoint()
     {
         String tableName = "test_replace_table_with_schema_change_" + randomNameSuffix();
         onTrino().executeQuery("CREATE TABLE delta.default." + tableName + " (ts VARCHAR) " +
                 "with (location = 's3://" + bucketName + "/databricks-compatibility-test-" + tableName + "', checkpoint_interval = 10)");
         try {
-            ImmutableList.Builder<QueryAssert.Row> expected = ImmutableList.builder();
-            // Write to the table until a checkpoint file is written
-            for (int i = 0; i < 9; i++) {
-                onDelta().executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
-                expected.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
-            }
+            ImmutableList.Builder<Row> expected = ImmutableList.builder();
+            expected.addAll(performInsert(onDelta(), tableName, 9));
+
             onDelta().executeQuery("CREATE OR REPLACE TABLE " + tableName + " USING DELTA AS SELECT CAST(ts AS TIMESTAMP) FROM " + tableName);
             assertLastEntryIsCheckpointed(s3, bucketName, tableName);
 
@@ -97,5 +92,16 @@ public class TestDeltaLakeCreateOrReplaceTableAsSelectCompatibility
         finally {
             dropDeltaTableWithRetry(tableName);
         }
+    }
+
+    private static List<Row> performInsert(QueryExecutor queryExecutor, String tableName, int numberOfRows)
+    {
+        ImmutableList.Builder<Row> expectedRowBuilder = ImmutableList.builder();
+        // Write to the table until a checkpoint file is written
+        for (int i = 0; i < numberOfRows; i++) {
+            queryExecutor.executeQuery("INSERT INTO " + tableName + " VALUES \"1960-01-01 01:02:03\", \"1961-01-01 01:02:03\", \"1962-01-01 01:02:03\"");
+            expectedRowBuilder.add(row("1960-01-01T01:02:03.000Z"), row("1961-01-01T01:02:03.000Z"), row("1962-01-01T01:02:03.000Z"));
+        }
+        return expectedRowBuilder.build();
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Introduces `CREATE OR REPLACE TABLE` operation for Delta lake connector.  It comes with some restrictions like we can't run CORTAS on table with cdc enabled or on cdc enabled roles.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake Connector
* Add support for CREATE OR REPLACE TABLE statements. ({issue}`issuenumber`)
```
