### PR TITLE
Do not fail stage after already done

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/EventDrivenFaultTolerantQueryScheduler.java
@@ -2415,6 +2415,10 @@ public class EventDrivenFaultTolerantQueryScheduler
 
         public void fail(Throwable t)
         {
+            if (stage.getState().isDone()) {
+                // stage already done; ignore
+                return;
+            }
             Closer closer = createStageExecutionCloser();
             closer.register(() -> stage.fail(t));
             try {


### PR DESCRIPTION
Ignore failure within stage execution if it already done. This is to work around the problem which was introduced with https://github.com/trinodb/trino/commit/39b04491c05. With that change we close EventDrivenTaskSource when stage completes, and as a result of that it may emit an failure event due to internall processes being cancelled.
Handling of event in `StageExecution.fail()` did close a number of objects needed for query completion (see createStageExecutionCloser()). As a result the query could hang.



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

