### PR TITLE
Fix potential infinite loop at IterativeOptimizer with Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -2551,8 +2551,7 @@ public class IcebergMetadata
 
         if (newEnforcedConstraint.equals(table.getEnforcedPredicate())
                 && newUnenforcedConstraint.equals(table.getUnenforcedPredicate())
-                && newConstraintColumns.equals(table.getConstraintColumns())
-                && constraint.getPredicateColumns().isEmpty()) {
+                && newConstraintColumns.equals(table.getConstraintColumns())) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Remove a condition that can potentially lead to an infinite loop at `IterativeOptimizer`.
When this condition was added, `constraint.getPredicateColumns()` was always empty when the rule was running within iterative optimizer (see discussion at https://github.com/trinodb/trino/pull/17263/files#r1189575899) but this is not the case since https://github.com/trinodb/trino/pull/16019/files#diff-624ea155d75175ba8802d5f93af759bdb88c6f63f1ca9660d6704892e1033f1dR814-R825. According to my check, we don't see an infinite loop only because `io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan#arePlansSame` returns `true` and stops the iterative process. If in the future `io.trino.plugin.iceberg.IcebergTableHandle#equals` will return `false` when comparing 2 tables of 2 different iterations, then we'll see an infinite loop. That's while `io.trino.spi.connector.ConnectorTableHandle` is an empty interface that doesn't declare `equals()`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
[19876](https://github.com/trinodb/trino/issues/19876)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
```
