### PR TITLE
Require JDK 21 to run Trino

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 17 # Keep testing on JDK 17 to ensure basic backward compatibility
           - 21
     timeout-minutes: 45
     steps:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ information about reporting vulnerabilities.
 ## Build requirements
 
 * Mac OS X or Linux
-* Java 17.0.8+, 64-bit
+* Java 21.0.1+, 64-bit
 * Docker
   * Turn SELinux or other systems disabling write access to the local checkout
     off, to allow containers to mount parts of the Trino source tree
@@ -70,8 +70,8 @@ After opening the project in IntelliJ, double check that the Java SDK is
 properly configured for the project:
 
 * Open the File menu and select Project Structure
-* In the SDKs section, ensure that JDK 17 is selected (create one if none exist)
-* In the Project section, ensure the Project language level is set to 17
+* In the SDKs section, ensure that JDK 21 is selected (create one if none exist)
+* In the Project section, ensure the Project language level is set to 21
 
 ### Running a testing server
 

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -94,7 +94,7 @@ final class TrinoSystemRequirements
 
     private static void verifyJavaVersion()
     {
-        Version required = Version.parse("17.0.8");
+        Version required = Version.parse("21.0.1");
 
         if (Runtime.version().compareTo(required) < 0) {
             failRequirement("Trino requires Java %s at minimum (found %s)", required, Runtime.version());

--- a/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
+++ b/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
@@ -29,8 +29,8 @@ public final class TrinoServer
         String javaVersion = nullToEmpty(StandardSystemProperty.JAVA_VERSION.value());
         String majorVersion = javaVersion.split("\\D", 2)[0];
         Integer major = Ints.tryParse(majorVersion);
-        if (major == null || major < 17) {
-            System.err.println(format("ERROR: Trino requires Java 17+ (found %s)", javaVersion));
+        if (major == null || major < 21) {
+            System.err.println(format("ERROR: Trino requires Java 21+ (found %s)", javaVersion));
             System.exit(100);
         }
 

--- a/core/trino-server-rpm/src/main/rpm/preinstall
+++ b/core/trino-server-rpm/src/main/rpm/preinstall
@@ -22,7 +22,7 @@ check_if_correct_java_version() {
     # candidate for JAVA_HOME).
     JAVA_VERSION=$(java_version "$1")
     JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d'.' -f1)
-    if [ "$JAVA_MAJOR" -ge "17" ]; then
+    if [ "$JAVA_MAJOR" -ge "21" ]; then
         echo "$1" >/tmp/trino-rpm-install-java-home
         return 0
     else
@@ -34,10 +34,6 @@ check_if_correct_java_version() {
 if ! check_if_correct_java_version "$JAVA_HOME"; then
     java_found=false
     for candidate in \
-        /usr/lib/jvm/java-17-* \
-        /usr/lib/jvm/zulu-17 \
-        /usr/lib/jvm/temurin-17 \
-        /usr/lib/jvm/temurin-17-* \
         /usr/lib/jvm/java-21-* \
         /usr/lib/jvm/zulu-21 \
         /usr/lib/jvm/temurin-21 \
@@ -61,7 +57,7 @@ if [ "$java_found" = false ]; then
 +======================================================================+
 |            Error: Required Java version could not be found           |
 +----------------------------------------------------------------------+
-|                       JDK 17 was not detected.                       |
+|                       JDK 21 was not detected.                       |
 |           Recommended JDK distribution is Eclipse Temurin.           |
 |     Installation guide: https://adoptium.net/installation/linux/     |
 |                                                                      |

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -56,7 +56,6 @@ public class ServerIT
     @Test
     public void testInstall()
     {
-        testInstall("17");
         testInstall("21");
     }
 
@@ -107,7 +106,6 @@ public class ServerIT
     public void testUninstall()
             throws Exception
     {
-        testUninstall("17");
         testUninstall("21");
     }
 

--- a/docs/src/main/sphinx/functions/conversion.md
+++ b/docs/src/main/sphinx/functions/conversion.md
@@ -22,7 +22,7 @@ Like {func}`cast`, but returns null if the cast fails.
 ## Formatting
 
 :::{function} format(format, args...) -> varchar
-Returns a formatted string using the specified [format string](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Formatter.html#syntax)
+Returns a formatted string using the specified [format string](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Formatter.html#syntax)
 and arguments:
 
 ```

--- a/docs/src/main/sphinx/functions/regexp.md
+++ b/docs/src/main/sphinx/functions/regexp.md
@@ -184,6 +184,6 @@ SELECT regexp_split('1a 2b 14m', '\s*[a-z]+\s*'); -- [1, 2, 14, ]
 ```
 :::
 
-[capturing group number]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html#gnumber
-[capturing groups]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html#cg
-[java pattern]: https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html
+[capturing group number]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html#gnumber
+[capturing groups]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html#cg
+[java pattern]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/regex/Pattern.html

--- a/docs/src/main/sphinx/installation/deployment.md
+++ b/docs/src/main/sphinx/installation/deployment.md
@@ -35,18 +35,14 @@
 
 ### Java runtime environment
 
-Trino requires a 64-bit version of Java 17, with a minimum required version of 17.0.8.
-Earlier major versions such as Java 8 or Java 11 do not work.
-Newer major versions such as Java 18 or 19, are not supported -- they may work, but are not tested.
+Trino requires a 64-bit version of Java 21, with a minimum required version of 21.0.1.
+Earlier major versions such as Java 8, Java 11 or Java 17 do not work.
+Newer major versions such as Java 22 are not supported -- they may work, but are not tested.
 
 We recommend using the Eclipse Temurin OpenJDK distribution from
 [Adoptium](https://adoptium.net/) as the JDK for Trino, as Trino is tested
 against that distribution. Eclipse Temurin is also the JDK used by the [Trino
 Docker image](https://hub.docker.com/r/trinodb/trino).
-
-If you are using Java 17 or 18, the JVM must be configured to use UTF-8 as the default charset by
-adding `-Dfile.encoding=UTF-8` to `etc/jvm.config`. Starting with Java 19, the Java default 
-charset is UTF-8, so this configuration is not needed.
 
 (requirements-python)=
 

--- a/docs/src/main/sphinx/security/tls.md
+++ b/docs/src/main/sphinx/security/tls.md
@@ -26,8 +26,8 @@ using TLS 1.2 and TLS 1.3 certificates. The server rejects TLS 1.1, TLS 1.0, and
 all SSL format certificates.
 
 The Trino server does not specify a set of supported ciphers, instead deferring
-to the defaults set by the JVM version in use. The documentation for Java 17
-lists its [supported cipher suites](https://docs.oracle.com/en/java/javase/17/security/oracle-providers.html#GUID-7093246A-31A3-4304-AC5F-5FB6400405E2__SUNJSSE_CIPHER_SUITES).
+to the defaults set by the JVM version in use. The documentation for Java 21
+lists its [supported cipher suites](https://docs.oracle.com/en/java/javase/21/security/oracle-providers.html#GUID-7093246A-31A3-4304-AC5F-5FB6400405E2__SUNJSSE_CIPHER_SUITES).
 
 Run the following two-line code on the same JVM from the same vendor as
 configured on the coordinator to determine that JVM's default cipher list.
@@ -56,7 +56,7 @@ considered in conjunction with your organization's security managers. Using a
 different suite may require downloading and installing a different SunJCE
 implementation package. Some locales may have export restrictions on cipher
 suites. See the discussion in Java documentation that begins with [Customizing
-the Encryption Algorithm Providers](https://docs.oracle.com/en/java/javase/17/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-316FB978-7588-442E-B829-B4973DB3B584).
+the Encryption Algorithm Providers](https://docs.oracle.com/en/java/javase/21/security/java-secure-socket-extension-jsse-reference-guide.html#GUID-316FB978-7588-442E-B829-B4973DB3B584).
 
 :::{note}
 If you manage the coordinator's direct TLS implementatation, monitor the CPU

--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,12 @@
     </scm>
 
     <properties>
-        <project.build.targetJdk>17</project.build.targetJdk>
+        <project.build.targetJdk>21</project.build.targetJdk>
 
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
-        <air.java.version>17.0.8</air.java.version>
+        <air.java.version>21.0.1</air.java.version>
         <air.javadoc.lint>-missing</air.javadoc.lint>
         <air.main.basedir>${project.basedir}</air.main.basedir>
         <air.modernizer.java-version>8</air.modernizer.java-version>


### PR DESCRIPTION
Release notes needed:

```
Require JDK 21.0.1 to run Trino
```

Closes https://github.com/trinodb/trino/issues/17017