### PR TITLE
Fix writing Constant integer value to a block

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/DereferenceCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/DereferenceCodeGenerator.java
@@ -44,7 +44,7 @@ public class DereferenceCodeGenerator
         returnType = specialForm.getType();
         checkArgument(specialForm.getArguments().size() == 2);
         base = specialForm.getArguments().get(0);
-        index = (int) ((ConstantExpression) specialForm.getArguments().get(1)).getValue();
+        index = toIntValue(((ConstantExpression) specialForm.getArguments().get(1)).getValue());
     }
 
     @Override
@@ -92,5 +92,14 @@ public class DereferenceCodeGenerator
                 .visitLabel(end);
 
         return block;
+    }
+
+    private static int toIntValue(Object value)
+    {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+
+        return (int) value;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
@@ -83,7 +83,7 @@ public final class TypeUtils
             type.writeDouble(blockBuilder, ((double) value));
         }
         else if (type.getJavaType() == long.class) {
-            type.writeLong(blockBuilder, ((long) value));
+            type.writeLong(blockBuilder, castToLong(value));
         }
         else if (type.getJavaType() == Slice.class) {
             Slice slice;
@@ -115,6 +115,15 @@ public final class TypeUtils
             return Float.isNaN(intBitsToFloat(toIntExact((long) value)));
         }
         return false;
+    }
+
+    private static long castToLong(Object value)
+    {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+
+        return (long) value;
     }
 
     static void checkElementNotNull(boolean isNull, String errorMsg)


### PR DESCRIPTION
`SqlToRowExpressionTranslator.visitSubscriptExpression` creates a constant with integer index that gets assigned to a Object field which makes it boxed `Integer` class instance.

Then when serialized, Integer is casted to a primitive long, which fails at runtime.

Fixes https://github.com/trinodb/trino/issues/19997
