### PR TITLE
Ensure taskInfo finalized on permanent worker failure

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -1057,6 +1057,14 @@ public final class HttpRemoteTask
                     taskStatusFetcher.updateTaskStatus(taskStatus);
                 }
             }
+            else {
+                // Even though state in taskStatus is Done already it could not be the case for task info.
+                // We could have received valid response from taskStatusFetcher just before the worker went
+                // down, but taskInfoFetcher still holds old state.
+                // Update taskInfo so task is not stuck in FTE execution mode which depends on final task info
+                // being delivered.
+                updateTaskInfo(getTaskInfo().withTaskStatus(taskStatus));
+            }
         }
     }
 


### PR DESCRIPTION
## Description

Even though state in taskStatus is Done already it could not be the case for task info.
We could have received valid response from taskStatusFetcher just before the worker went
down, but taskInfoFetcher still holds old state.
Update taskInfo so task is not stuck in FTE execution mode which depends on final task info
being delivered.

#fixes #18603

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix bug when query could hang with `retry.policy` set to `TASK` when Trino worker node died. ({issue}`18603 `)
```
