### PR TITLE
Cleanup outputTaskFailureListeners on query complete

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -1523,6 +1523,7 @@ public class QueryStateMachine
             }
             queryCompleted = true;
             inputsQueue.clear();
+            outputTaskFailureListeners.clear();
             noMoreInputs = true;
         }
 
@@ -1530,7 +1531,9 @@ public class QueryStateMachine
         {
             Map<TaskId, Throwable> failures;
             synchronized (this) {
-                outputTaskFailureListeners.add(listener);
+                if (!queryCompleted) {
+                    outputTaskFailureListeners.add(listener);
+                }
                 failures = ImmutableMap.copyOf(outputTaskFailures);
             }
             if (!failures.isEmpty()) {
@@ -1542,6 +1545,10 @@ public class QueryStateMachine
         {
             List<TaskFailureListener> listeners;
             synchronized (this) {
+                if (queryCompleted) {
+                    // ignore late task failed events after query is completed
+                    return;
+                }
                 outputTaskFailures.putIfAbsent(taskId, failure);
                 listeners = ImmutableList.copyOf(outputTaskFailureListeners);
             }


### PR DESCRIPTION
outputTaskFailureListeners were referencing QueryScheduler which are retaining references to HttpRemoteTask instances and other query runtime objects. This was considered a memory leak.

Before:

![Zrzut ekranu 2023-12-5 o 11 51 15](https://github.com/trinodb/trino/assets/5989165/bf10da91-d03a-477e-b970-4a59d7c10ae6)
![Zrzut ekranu 2023-12-5 o 12 04 43](https://github.com/trinodb/trino/assets/5989165/00cc65a8-8e6c-4f5d-a73b-7c6f14846520)

After this PR references to `HttpRemoteTask` are gone