### PR TITLE
Add resource group selector based on query text

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -199,7 +199,8 @@ public class DispatchManager
                     sessionContext.getSource(),
                     sessionContext.getClientTags(),
                     sessionContext.getResourceEstimates(),
-                    queryType));
+                    queryType,
+                    query));
 
             // apply system default session properties (does not override user set properties)
             session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType, selectionContext.getResourceGroupId());

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -212,6 +212,11 @@
                                 </item>
                                 <!-- Backwards incompatible changes since the previous release -->
                                 <!-- Any exclusions below can be deleted after each release -->
+                                <item>
+                                    <code>java.method.numberOfParametersChanged</code>
+                                    <old>method void io.trino.spi.resourcegroups.SelectionCriteria::&lt;init&gt;(boolean, java.lang.String, java.util.Set&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.session.ResourceEstimates, java.util.Optional&lt;java.lang.String&gt;)</old>
+                                    <new>method void io.trino.spi.resourcegroups.SelectionCriteria::&lt;init&gt;(boolean, java.lang.String, java.util.Set&lt;java.lang.String&gt;, java.util.Optional&lt;java.lang.String&gt;, java.util.Set&lt;java.lang.String&gt;, io.trino.spi.session.ResourceEstimates, java.util.Optional&lt;java.lang.String&gt;, java.lang.String)</new>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
@@ -30,6 +30,7 @@ public final class SelectionCriteria
     private final Set<String> clientTags;
     private final ResourceEstimates resourceEstimates;
     private final Optional<String> queryType;
+    private final String queryText;
 
     public SelectionCriteria(
             boolean authenticated,
@@ -38,7 +39,8 @@ public final class SelectionCriteria
             Optional<String> source,
             Set<String> clientTags,
             ResourceEstimates resourceEstimates,
-            Optional<String> queryType)
+            Optional<String> queryType,
+            String queryText)
     {
         this.authenticated = authenticated;
         this.user = requireNonNull(user, "user is null");
@@ -47,6 +49,7 @@ public final class SelectionCriteria
         this.clientTags = Set.copyOf(requireNonNull(clientTags, "clientTags is null"));
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
+        this.queryText = requireNonNull(queryText, "queryText is null");
     }
 
     public boolean isAuthenticated()
@@ -84,6 +87,11 @@ public final class SelectionCriteria
         return queryType;
     }
 
+    public String getQueryText()
+    {
+        return queryText;
+    }
+
     @Override
     public String toString()
     {
@@ -95,6 +103,7 @@ public final class SelectionCriteria
                 .add("clientTags=" + clientTags)
                 .add("resourceEstimates=" + resourceEstimates)
                 .add("queryType=" + queryType)
+                .add("queryText=" + queryText)
                 .toString();
     }
 }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/AbstractResourceConfigurationManager.java
@@ -97,6 +97,7 @@ public abstract class AbstractResourceConfigurationManager
                     spec.getUserRegex(),
                     spec.getUserGroupRegex(),
                     spec.getSourceRegex(),
+                    spec.getQueryTextRegex(),
                     spec.getClientTags(),
                     spec.getResourceEstimate(),
                     spec.getQueryType(),

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/SelectorSpec.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/SelectorSpec.java
@@ -29,6 +29,7 @@ public class SelectorSpec
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> userGroupRegex;
     private final Optional<Pattern> sourceRegex;
+    private final Optional<Pattern> queryTextRegex;
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
     private final Optional<SelectorResourceEstimate> selectorResourceEstimate;
@@ -39,6 +40,7 @@ public class SelectorSpec
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("userGroup") Optional<Pattern> userGroupRegex,
             @JsonProperty("source") Optional<Pattern> sourceRegex,
+            @JsonProperty("queryText") Optional<Pattern> queryTextRegex,
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("clientTags") Optional<List<String>> clientTags,
             @JsonProperty("selectorResourceEstimate") Optional<SelectorResourceEstimate> selectorResourceEstimate,
@@ -47,6 +49,7 @@ public class SelectorSpec
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.userGroupRegex = requireNonNull(userGroupRegex, "userGroupRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
+        this.queryTextRegex = requireNonNull(queryTextRegex, "queryTextRegex is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.clientTags = requireNonNull(clientTags, "clientTags is null");
         this.selectorResourceEstimate = requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
@@ -66,6 +69,11 @@ public class SelectorSpec
     public Optional<Pattern> getSourceRegex()
     {
         return sourceRegex;
+    }
+
+    public Optional<Pattern> getQueryTextRegex()
+    {
+        return queryTextRegex;
     }
 
     public Optional<String> getQueryType()
@@ -98,13 +106,15 @@ public class SelectorSpec
             return false;
         }
         SelectorSpec that = (SelectorSpec) other;
-        return (group.equals(that.group) &&
+        return group.equals(that.group) &&
                 userRegex.map(Pattern::pattern).equals(that.userRegex.map(Pattern::pattern)) &&
                 userRegex.map(Pattern::flags).equals(that.userRegex.map(Pattern::flags)) &&
                 userGroupRegex.map(Pattern::pattern).equals(that.userGroupRegex.map(Pattern::pattern)) &&
                 userGroupRegex.map(Pattern::flags).equals(that.userGroupRegex.map(Pattern::flags)) &&
-                sourceRegex.map(Pattern::pattern).equals(that.sourceRegex.map(Pattern::pattern))) &&
+                sourceRegex.map(Pattern::pattern).equals(that.sourceRegex.map(Pattern::pattern)) &&
                 sourceRegex.map(Pattern::flags).equals(that.sourceRegex.map(Pattern::flags)) &&
+                queryTextRegex.map(Pattern::pattern).equals(that.queryTextRegex.map(Pattern::pattern)) &&
+                queryTextRegex.map(Pattern::flags).equals(that.queryTextRegex.map(Pattern::flags)) &&
                 queryType.equals(that.queryType) &&
                 clientTags.equals(that.clientTags);
     }
@@ -120,6 +130,8 @@ public class SelectorSpec
                 userGroupRegex.map(Pattern::flags),
                 sourceRegex.map(Pattern::pattern),
                 sourceRegex.map(Pattern::flags),
+                queryTextRegex.map(Pattern::pattern),
+                queryTextRegex.map(Pattern::flags),
                 queryType,
                 clientTags);
     }
@@ -135,6 +147,8 @@ public class SelectorSpec
                 .add("userGroupFlags", userGroupRegex.map(Pattern::flags))
                 .add("sourceRegex", sourceRegex)
                 .add("sourceFlags", sourceRegex.map(Pattern::flags))
+                .add("queryTextRegex", queryTextRegex)
+                .add("queryTextFlags", queryTextRegex.map(Pattern::flags))
                 .add("queryType", queryType)
                 .add("clientTags", clientTags)
                 .toString();

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/DbResourceGroupConfigurationManager.java
@@ -314,6 +314,7 @@ public class DbResourceGroupConfigurationManager
                                 selectorRecord.getUserRegex(),
                                 selectorRecord.getUserGroupRegex(),
                                 selectorRecord.getSourceRegex(),
+                                selectorRecord.getQueryTextRegex(),
                                 selectorRecord.getQueryType(),
                                 selectorRecord.getClientTags(),
                                 selectorRecord.getSelectorResourceEstimate(),

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupsDao.java
@@ -60,7 +60,7 @@ public interface ResourceGroupsDao
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)
     List<ResourceGroupSpecBuilder> getResourceGroups(@Bind("environment") String environment);
 
-    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.user_group_regex\n" +
+    @SqlQuery("SELECT S.resource_group_id, S.priority, S.user_regex, S.source_regex, S.query_type, S.client_tags, S.selector_resource_estimate, S.user_group_regex, S.query_text_regex\n" +
             "FROM selectors S\n" +
             "JOIN resource_groups R ON (S.resource_group_id = R.resource_group_id)\n" +
             "WHERE R.environment = :environment\n" +
@@ -74,6 +74,7 @@ public interface ResourceGroupsDao
             "  user_regex VARCHAR(512),\n" +
             "  user_group_regex VARCHAR(512),\n" +
             "  source_regex VARCHAR(512),\n" +
+            "  query_text_regex VARCHAR(512),\n" +
             "  query_type VARCHAR(512),\n" +
             "  client_tags VARCHAR(512),\n" +
             "  selector_resource_estimate VARCHAR(1024),\n" +

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/SelectorRecord.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/SelectorRecord.java
@@ -36,6 +36,7 @@ public class SelectorRecord
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> userGroupRegex;
     private final Optional<Pattern> sourceRegex;
+    private final Optional<Pattern> queryTextRegex;
     private final Optional<String> queryType;
     private final Optional<List<String>> clientTags;
     private final Optional<SelectorResourceEstimate> selectorResourceEstimate;
@@ -46,6 +47,7 @@ public class SelectorRecord
             Optional<Pattern> userRegex,
             Optional<Pattern> userGroupRegex,
             Optional<Pattern> sourceRegex,
+            Optional<Pattern> queryTextRegex,
             Optional<String> queryType,
             Optional<List<String>> clientTags,
             Optional<SelectorResourceEstimate> selectorResourceEstimate)
@@ -55,6 +57,7 @@ public class SelectorRecord
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.userGroupRegex = requireNonNull(userGroupRegex, "userGroupRegex is null");
         this.sourceRegex = requireNonNull(sourceRegex, "sourceRegex is null");
+        this.queryTextRegex = requireNonNull(queryTextRegex, "queryTextRegex is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.clientTags = clientTags.map(ImmutableList::copyOf);
         this.selectorResourceEstimate = requireNonNull(selectorResourceEstimate, "selectorResourceEstimate is null");
@@ -83,6 +86,11 @@ public class SelectorRecord
     public Optional<Pattern> getSourceRegex()
     {
         return sourceRegex;
+    }
+
+    public Optional<Pattern> getQueryTextRegex()
+    {
+        return queryTextRegex;
     }
 
     public Optional<String> getQueryType()
@@ -116,6 +124,7 @@ public class SelectorRecord
                     Optional.ofNullable(resultSet.getString("user_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("user_group_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("source_regex")).map(Pattern::compile),
+                    Optional.ofNullable(resultSet.getString("query_text_regex")).map(Pattern::compile),
                     Optional.ofNullable(resultSet.getString("query_type")),
                     Optional.ofNullable(resultSet.getString("client_tags")).map(LIST_STRING_CODEC::fromJson),
                     Optional.ofNullable(resultSet.getString("selector_resource_estimate")).map(SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC::fromJson));

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V7__add_query_text_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/mysql/V7__add_query_text_to_selectors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE selectors ADD COLUMN query_text_regex VARCHAR(2048);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V7__add_query_text_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/oracle/V7__add_query_text_to_selectors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE selectors ADD query_text_regex VARCHAR(2048);

--- a/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V7__add_query_text_to_selectors.sql
+++ b/plugin/trino-resource-group-managers/src/main/resources/db/migration/postgresql/V7__add_query_text_to_selectors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE selectors ADD COLUMN query_text_regex VARCHAR(2048);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestFileResourceGroupConfigurationManager.java
@@ -198,7 +198,8 @@ public class TestFileResourceGroupConfigurationManager
                 Optional.of("jdbc#powerfulbi"),
                 ImmutableSet.of("hipri"),
                 EMPTY_RESOURCE_ESTIMATES,
-                Optional.of("select")));
+                Optional.of("select"),
+                "select 1"));
         assertThat(selectionContext.getResourceGroupId().toString()).isEqualTo("global.adhoc.bi-powerfulbi.Alice");
         TestingResourceGroup resourceGroup = new TestingResourceGroup(selectionContext.getResourceGroupId());
         manager.configure(resourceGroup, selectionContext);
@@ -254,7 +255,7 @@ public class TestFileResourceGroupConfigurationManager
 
     private static SelectionCriteria userAndSourceSelectionCriteria(String user, String source)
     {
-        return new SelectionCriteria(true, user, ImmutableSet.of(), Optional.of(source), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        return new SelectionCriteria(true, user, ImmutableSet.of(), Optional.of(source), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
     }
 
     private static SelectionCriteria userSelectionCriteria(String user)
@@ -264,12 +265,12 @@ public class TestFileResourceGroupConfigurationManager
 
     private static SelectionCriteria queryTypeSelectionCriteria(String queryType)
     {
-        return new SelectionCriteria(true, "test_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(queryType));
+        return new SelectionCriteria(true, "test_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(queryType), "");
     }
 
     private static SelectionCriteria userGroupsSelectionCriteria(String... groups)
     {
-        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
     }
 
     private static SelectionCriteria userAndUserGroupsSelectionCriteria(String user, String group, String... groups)
@@ -283,6 +284,7 @@ public class TestFileResourceGroupConfigurationManager
                 Optional.empty(),
                 ImmutableSet.of(),
                 EMPTY_RESOURCE_ESTIMATES,
-                Optional.empty());
+                Optional.empty(),
+                "");
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestResourceGroupIdTemplate.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestResourceGroupIdTemplate.java
@@ -48,8 +48,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "job_testpipeline_user:user"), "user");
 
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
 
         assertThat(selector.match(context).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(expected));
     }
@@ -61,8 +61,8 @@ public class TestResourceGroupIdTemplate
         ResourceGroupId expected = new ResourceGroupId(new ResourceGroupId(new ResourceGroupId(new ResourceGroupId("test"), "pipeline"), "testpipeline"), "_s");
 
         Pattern userPattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.of(userPattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "scheduler.important.testpipeline[5]", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
 
         assertThat(selector.match(context).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(expected));
     }
@@ -72,8 +72,8 @@ public class TestResourceGroupIdTemplate
     {
         ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
         Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+        SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
 
         assertThat(selector.match(context).isPresent()).isFalse();
     }
@@ -84,8 +84,8 @@ public class TestResourceGroupIdTemplate
         assertThatThrownBy(() -> {
             ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${user}");
             Pattern sourcePattern = Pattern.compile("scheduler.important.(?<pipeline>[^\\[]*).*");
-            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
             selector.match(context);
         })
                 .isInstanceOf(IllegalArgumentException.class)
@@ -98,8 +98,8 @@ public class TestResourceGroupIdTemplate
         assertThatThrownBy(() -> {
             ResourceGroupIdTemplate template = new ResourceGroupIdTemplate("test.pipeline.${pipeline}.${USER}");
             Pattern sourcePattern = Pattern.compile("scheduler.important.(testpipeline\\[|(?<pipeline>[^\\[]*)).*");
-            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), template);
-            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+            StaticSelector selector = new StaticSelector(Optional.empty(), Optional.empty(), Optional.of(sourcePattern), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), template);
+            SelectionCriteria context = new SelectionCriteria(true, "user", ImmutableSet.of(), Optional.of("scheduler.important.testpipeline[5]"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
             selector.match(context);
         })
                 .isInstanceOf(IllegalArgumentException.class)

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/TestingResourceGroups.java
@@ -78,6 +78,7 @@ final class TestingResourceGroups
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         groupIdTemplate));
     }
 
@@ -104,6 +105,7 @@ final class TestingResourceGroups
                             Optional.of(matchLiterals(users)),
                             spec.getUserGroupRegex(),
                             spec.getSourceRegex(),
+                            spec.getQueryTextRegex(),
                             spec.getQueryType(),
                             spec.getClientTags(),
                             spec.getResourceEstimate(),
@@ -117,6 +119,7 @@ final class TestingResourceGroups
                             spec.getUserRegex(),
                             Optional.of(matchLiterals(groups)),
                             spec.getSourceRegex(),
+                            spec.getQueryTextRegex(),
                             spec.getQueryType(),
                             spec.getClientTags(),
                             spec.getResourceEstimate(),

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/H2ResourceGroupsDao.java
@@ -80,14 +80,15 @@ public interface H2ResourceGroupsDao
     void deleteResourceGroup(@Bind("resource_group_id") long resourceGroupId);
 
     @SqlUpdate("INSERT INTO selectors\n" +
-            "(resource_group_id, priority, user_regex, user_group_regex, source_regex, query_type, client_tags, selector_resource_estimate)\n" +
-            "VALUES (:resource_group_id, :priority, :user_regex, :user_group_regex, :source_regex, :query_type, :client_tags, :selector_resource_estimate)")
+            "(resource_group_id, priority, user_regex, user_group_regex, source_regex, query_text_regex, query_type, client_tags, selector_resource_estimate)\n" +
+            "VALUES (:resource_group_id, :priority, :user_regex, :user_group_regex, :source_regex, :query_text_regex, :query_type, :client_tags, :selector_resource_estimate)")
     void insertSelector(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("priority") long priority,
             @Bind("user_regex") String userRegex,
             @Bind("user_group_regex") String userGroupRegex,
             @Bind("source_regex") String sourceRegex,
+            @Bind("query_text_regex") String queryTextRegex,
             @Bind("query_type") String queryType,
             @Bind("client_tags") String clientTags,
             @Bind("selector_resource_estimate") String selectorResourceEstimate);

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -73,8 +73,8 @@ public class TestDbResourceGroupConfigurationManager
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
         dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, prodEnvironment);
         dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, devEnvironment);
-        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null);
-        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null);
+        dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null, null, null);
+        dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null, null, null);
 
         // check the prod configuration
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), prodEnvironment);
@@ -85,7 +85,9 @@ public class TestDbResourceGroupConfigurationManager
         assertEqualsResourceGroup(prodGlobal, "10MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertThat(manager.getSelectors().size()).isEqualTo(1);
         ResourceGroupSelector prodSelector = manager.getSelectors().get(0);
-        ResourceGroupId prodResourceGroupId = prodSelector.match(new SelectionCriteria(true, "prod_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
+        ResourceGroupId prodResourceGroupId = prodSelector
+                .match(new SelectionCriteria(true, "prod_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "")).get()
+                .getResourceGroupId();
         assertThat(prodResourceGroupId.toString()).isEqualTo("prod_global");
 
         // check the dev configuration
@@ -96,7 +98,9 @@ public class TestDbResourceGroupConfigurationManager
         assertEqualsResourceGroup(devGlobal, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         assertThat(manager.getSelectors().size()).isEqualTo(1);
         ResourceGroupSelector devSelector = manager.getSelectors().get(0);
-        ResourceGroupId devResourceGroupId = devSelector.match(new SelectionCriteria(true, "dev_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty())).get().getResourceGroupId();
+        ResourceGroupId devResourceGroupId = devSelector
+                .match(new SelectionCriteria(true, "dev_user", ImmutableSet.of(), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "")).get()
+                .getResourceGroupId();
         assertThat(devResourceGroupId.toString()).isEqualTo("dev_global");
     }
 
@@ -111,7 +115,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup global = new InternalResourceGroup("global", (group, export) -> {}, directExecutor());
         manager.configure(global, new SelectionContext<>(global.getId(), new ResourceGroupIdTemplate("global")));
@@ -135,7 +139,7 @@ public class TestDbResourceGroupConfigurationManager
                     assertThat(ex.getCause() instanceof JdbcException).isTrue();
                     assertThat(ex.getCause().getMessage().startsWith("Unique index or primary key violation")).isTrue();
                 });
-        dao.insertSelector(1, 1, null, null, null, null, null, null);
+        dao.insertSelector(1, 1, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -153,7 +157,7 @@ public class TestDbResourceGroupConfigurationManager
                     assertThat(ex.getCause() instanceof JdbcException).isTrue();
                     assertThat(ex.getCause().getMessage().startsWith("Unique index or primary key violation")).isTrue();
                 });
-        dao.insertSelector(2, 2, null, null, null, null, null, null);
+        dao.insertSelector(2, 2, null, null, null, null, null, null, null);
     }
 
     @Test
@@ -167,7 +171,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null);
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         InternalResourceGroup missing = new InternalResourceGroup("missing", (group, export) -> {}, directExecutor());
 
@@ -188,7 +192,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(listener -> {}, new DbResourceGroupConfig(), daoProvider.get(), ENVIRONMENT);
         manager.start();
@@ -225,7 +229,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createExactMatchSelectorsTable();
         dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
         dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
-        dao.insertSelector(2, 1, null, null, null, null, null, null);
+        dao.insertSelector(2, 1, null, null, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbResourceGroupConfig config = new DbResourceGroupConfig();
         config.setExactMatchSelectorEnabled(true);
@@ -264,7 +268,7 @@ public class TestDbResourceGroupConfigurationManager
         for (int i = 0; i < numberOfUsers; i++) {
             int priority = randomPriorities[i];
             String user = String.valueOf(priority);
-            dao.insertSelector(1, priority, user, null, ".*", null, null, null);
+            dao.insertSelector(1, priority, user, null, ".*", null, null, null, null);
             expectedUsers.add(user);
         }
 
@@ -341,7 +345,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertSelector(1, 1, null, "first matching|second matching", null, null, null, null);
+        dao.insertSelector(1, 1, null, "first matching|second matching", null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 listener -> {},
@@ -364,7 +368,7 @@ public class TestDbResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroup(1, "group", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertSelector(1, 1, "Matching user", "Matching group", null, null, null, null);
+        dao.insertSelector(1, 1, "Matching user", "Matching group", null, null, null, null, null);
 
         DbResourceGroupConfigurationManager manager = new DbResourceGroupConfigurationManager(
                 listener -> {},
@@ -404,7 +408,7 @@ public class TestDbResourceGroupConfigurationManager
 
     private static SelectionCriteria userGroupsSelectionCriteria(String... groups)
     {
-        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty());
+        return new SelectionCriteria(true, "test_user", ImmutableSet.copyOf(groups), Optional.empty(), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), "");
     }
 
     private static SelectionCriteria userAndUserGroupsSelectionCriteria(String user, String group, String... groups)
@@ -418,6 +422,7 @@ public class TestDbResourceGroupConfigurationManager
                 Optional.empty(),
                 ImmutableSet.of(),
                 EMPTY_RESOURCE_ESTIMATES,
-                Optional.empty());
+                Optional.empty(),
+                "");
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbSourceExactMatchSelector.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbSourceExactMatchSelector.java
@@ -53,11 +53,11 @@ public class TestDbSourceExactMatchSelector
 
         DbSourceExactMatchSelector selector = new DbSourceExactMatchSelector("test", dao);
 
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty()))).isEqualTo(Optional.empty());
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId1));
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()))).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId2));
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name())))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty(), ""))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()), "")).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId1));
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()), "")).map(SelectionContext::getResourceGroupId)).isEqualTo(Optional.of(resourceGroupId2));
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name()), ""))).isEqualTo(Optional.empty());
 
-        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name())))).isEqualTo(Optional.empty());
+        assertThat(selector.match(new SelectionCriteria(true, "testuser", ImmutableSet.of(), Optional.of("@test@test_new"), ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()), ""))).isEqualTo(Optional.empty());
     }
 }

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestResourceGroupsDao.java
@@ -127,6 +127,7 @@ public class TestResourceGroupsDao
                         Optional.of(Pattern.compile("ping_user")),
                         Optional.of(Pattern.compile("ping_user_group")),
                         Optional.of(Pattern.compile(".*")),
+                        Optional.of(Pattern.compile(".*")),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()));
@@ -136,6 +137,7 @@ public class TestResourceGroupsDao
                         2L,
                         Optional.of(Pattern.compile("admin_user")),
                         Optional.of(Pattern.compile("admin_group")),
+                        Optional.of(Pattern.compile(".*")),
                         Optional.of(Pattern.compile(".*")),
                         Optional.of(EXPLAIN.name()),
                         Optional.of(ImmutableList.of("tag1", "tag2")),
@@ -149,6 +151,7 @@ public class TestResourceGroupsDao
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.of(SELECTOR_RESOURCE_ESTIMATE)));
 
         dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
@@ -156,9 +159,9 @@ public class TestResourceGroupsDao
         dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
 
-        dao.insertSelector(2, 1, "ping_user", null, ".*", null, null, null);
-        dao.insertSelector(3, 2, "admin_user", null, ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(4, 0, null, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE));
+        dao.insertSelector(2, 1, "ping_user", null, ".*", ".*", null, null, null);
+        dao.insertSelector(3, 2, "admin_user", null, ".*", ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
+        dao.insertSelector(4, 0, null, null, null, null, null, null, SELECTOR_RESOURCE_ESTIMATE_JSON_CODEC.toJson(SELECTOR_RESOURCE_ESTIMATE));
         List<SelectorRecord> records = dao.getSelectors(ENVIRONMENT);
         compareSelectors(map, records);
     }
@@ -173,6 +176,7 @@ public class TestResourceGroupsDao
                 Optional.empty(),
                 Optional.of(Pattern.compile("ping_source")),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(ImmutableList.of("tag1")),
                 Optional.empty());
         map.put(2L, updated);
@@ -181,7 +185,8 @@ public class TestResourceGroupsDao
 
     private static void testSelectorUpdateNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
-        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord updated = new SelectorRecord(2, 3L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty());
         map.put(2L, updated);
         dao.updateSelector(2, null, null, null, "ping.*", "ping_source", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1")));
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
@@ -191,6 +196,7 @@ public class TestResourceGroupsDao
                 Optional.of(Pattern.compile("ping.*")),
                 Optional.empty(),
                 Optional.of(Pattern.compile("ping_source")),
+                Optional.empty(),
                 Optional.of(EXPLAIN.name()),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
                 Optional.empty());
@@ -209,7 +215,8 @@ public class TestResourceGroupsDao
     private static void testSelectorDeleteNull(H2ResourceGroupsDao dao, Map<Long, SelectorRecord> map)
     {
         dao.updateSelector(3, null, null, null, "admin_user", ".*", LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")));
-        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+        SelectorRecord nullRegexes = new SelectorRecord(3L, 2L, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty());
         map.put(3L, nullRegexes);
         compareSelectors(map, dao.getSelectors(ENVIRONMENT));
         dao.deleteSelector(3, null, null, null);
@@ -223,13 +230,14 @@ public class TestResourceGroupsDao
             return;
         }
 
-        dao.insertSelector(3, 3L, "user1", null, "pipeline", null, null, null);
+        dao.insertSelector(3, 3L, "user1", null, "pipeline", null, null, null, null);
         map.put(3L, new SelectorRecord(
                 3L,
                 3L,
                 Optional.of(Pattern.compile("user1")),
                 Optional.empty(),
                 Optional.of(Pattern.compile("pipeline")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty()));

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
@@ -295,6 +295,23 @@ public class TestQueues
         }
     }
 
+    @Test
+    @Timeout(240)
+    public void testQueryTextBasedSelection()
+            throws Exception
+    {
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
+            queryRunner.installPlugin(new ResourceGroupManagerPlugin());
+            queryRunner.getCoordinator().getResourceGroupManager().get()
+                    .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_query_text_based_config.json")));
+            assertResourceGroup(queryRunner, newAdhocSession(), "SELECT * FROM nation LIMIT 1", createResourceGroupId("global", "nation"));
+            assertResourceGroup(queryRunner, newAdhocSession(), "SELECT * FROM region LIMIT 1", createResourceGroupId("global", "region"));
+            assertResourceGroup(queryRunner, newAdhocSession(), "SELECT partkey FROM part LIMIT 1", createResourceGroupId("global", "partkey"));
+            assertResourceGroup(queryRunner, newAdhocSession(), "SELECT * FROM part LIMIT 1", createResourceGroupId("global", "part"));
+            assertResourceGroup(queryRunner, newAdhocSession(), "SELECT * FROM supplier LIMIT 1", createResourceGroupId("global", "other"));
+        }
+    }
+
     private void assertResourceGroup(DistributedQueryRunner queryRunner, Session session, String query, ResourceGroupId expectedResourceGroup)
             throws InterruptedException
     {

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2TestUtil.java
@@ -165,13 +165,15 @@ final class H2TestUtil
         dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
         dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertSelector(2, 10_000, "user.*", null, "test", null, null, null);
-        dao.insertSelector(4, 1_000, "user.*", null, "(?i).*adhoc.*", null, null, null);
-        dao.insertSelector(5, 100, "user.*", null, "(?i).*dashboard.*", null, null, null);
-        dao.insertSelector(4, 10, "user.*", null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
-        dao.insertSelector(2, 1, "user.*", null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null);
-        dao.insertSelector(6, 6, ".*", null, ".*", null, null, null);
-        dao.insertSelector(7, 100_000, null, null, null, EXPLAIN.name(), null, null);
+        dao.insertResourceGroup(8, "select_partkey", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertSelector(2, 10_000, "user.*", null, "test", null, null, null, null);
+        dao.insertSelector(4, 1_000, "user.*", null, "(?i).*adhoc.*", null, null, null, null);
+        dao.insertSelector(5, 100, "user.*", null, "(?i).*dashboard.*", null, null, null, null);
+        dao.insertSelector(4, 10, "user.*", null, null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);
+        dao.insertSelector(2, 1, "user.*", null, null, null, null, CLIENT_TAGS_CODEC.toJson(ImmutableList.of("tag1")), null);
+        dao.insertSelector(6, 6, ".*", null, ".*", null, null, null, null);
+        dao.insertSelector(7, 100_000, null, null, null, null, EXPLAIN.name(), null, null);
+        dao.insertSelector(8, 10_00_000, null, null, null, "(?i).*partkey.*from part.*", null, null, null);
 
         int expectedSelectors = 6;
         if (environment.equals(TEST_ENVIRONMENT_2)) {

--- a/testing/trino-tests/src/test/resources/resource_groups_query_text_based_config.json
+++ b/testing/trino-tests/src/test/resources/resource_groups_query_text_based_config.json
@@ -1,0 +1,67 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "1MB",
+      "hardConcurrencyLimit": 100,
+      "maxQueued": 1000,
+      "softCpuLimit": "1h",
+      "hardCpuLimit": "1d",
+      "subGroups": [
+        {
+          "name": "nation",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "region",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "partkey",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "part",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        },
+        {
+          "name": "other",
+          "softMemoryLimit": "2MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 4
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "queryText" : "(?i).*from nation.*",
+      "group": "global.nation"
+    },
+    {
+      "queryText" : "(?i).*from region.*",
+      "group": "global.region"
+    },
+    {
+      "queryText" : "(?i).*partkey.*from part.*",
+      "group": "global.partkey"
+    },
+    {
+      "queryText" : "(?i).*from part.*",
+      "group": "global.part"
+    },
+    {
+      "group": "global.other"
+    }
+  ],
+  "cpuQuotaPeriod": "1h"
+}
+


### PR DESCRIPTION
Allows setting query-text regex based selector for resource groups in file and db configurations.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
