### PR TITLE
Fix hudi connector gets stuck #19506

### DIFF
--- a/docs/src/main/sphinx/connector/hudi.md
+++ b/docs/src/main/sphinx/connector/hudi.md
@@ -96,6 +96,11 @@ Additionally, following configuration properties can be set depending on the use
     or `CAST(part_key AS INTEGER) % 2 = 0` are not recognized as partition filters,
     and queries using such expressions fail if the property is set to `true`.
   - `false`
+* - `hudi.ignore-absent-partitions`
+  - Ignore partitions when the file system location does not exist rather than
+    failing the query. This skips data that may be expected to be part of the
+    table.
+  - `false`
 
 :::
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiConfig.java
@@ -47,6 +47,7 @@ public class HudiConfig
     private int splitGeneratorParallelism = 4;
     private long perTransactionMetastoreCacheMaximumSize = 2000;
     private boolean queryPartitionFilterRequired;
+    private boolean ignoreAbsentPartitions;
 
     public List<String> getColumnsToHide()
     {
@@ -202,5 +203,17 @@ public class HudiConfig
     public boolean isQueryPartitionFilterRequired()
     {
         return queryPartitionFilterRequired;
+    }
+
+    @Config("hudi.ignore-absent-partitions")
+    public HudiConfig setIgnoreAbsentPartitions(boolean ignoreAbsentPartitions)
+    {
+        this.ignoreAbsentPartitions = ignoreAbsentPartitions;
+        return this;
+    }
+
+    public boolean isIgnoreAbsentPartitions()
+    {
+        return ignoreAbsentPartitions;
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSessionProperties.java
@@ -52,6 +52,7 @@ public class HudiSessionProperties
     private static final String MAX_OUTSTANDING_SPLITS = "max_outstanding_splits";
     private static final String SPLIT_GENERATOR_PARALLELISM = "split_generator_parallelism";
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
+    private static final String IGNORE_ABSENT_PARTITIONS = "ignore_absent_partitions";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -125,6 +126,11 @@ public class HudiSessionProperties
                         QUERY_PARTITION_FILTER_REQUIRED,
                         "Require a filter on at least one partition column",
                         hudiConfig.isQueryPartitionFilterRequired(),
+                        false),
+                booleanProperty(
+                        IGNORE_ABSENT_PARTITIONS,
+                        "Ignore absent partitions",
+                        hudiConfig.isIgnoreAbsentPartitions(),
                         false));
     }
 
@@ -188,5 +194,10 @@ public class HudiSessionProperties
     public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
     {
         return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
+    }
+
+    public static boolean isIgnoreAbsentPartitions(ConnectorSession session)
+    {
+        return session.getProperty(IGNORE_ABSENT_PARTITIONS, Boolean.class);
     }
 }

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -48,6 +48,7 @@ import static io.trino.plugin.hudi.HudiErrorCode.HUDI_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hudi.HudiSessionProperties.getMinimumAssignedSplitWeight;
 import static io.trino.plugin.hudi.HudiSessionProperties.getSplitGeneratorParallelism;
 import static io.trino.plugin.hudi.HudiSessionProperties.getStandardSplitWeightSize;
+import static io.trino.plugin.hudi.HudiSessionProperties.isIgnoreAbsentPartitions;
 import static io.trino.plugin.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
 import static io.trino.plugin.hudi.HudiUtil.buildTableMetaClient;
 import static java.util.stream.Collectors.toList;
@@ -82,7 +83,8 @@ public class HudiSplitSource
                 metastore,
                 table,
                 partitionColumnHandles,
-                partitions);
+                partitions,
+                !tableHandle.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session));
 
         this.queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
         HudiBackgroundSplitLoader splitLoader = new HudiBackgroundSplitLoader(

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/query/HudiReadOptimizedDirectoryLister.java
@@ -54,9 +54,10 @@ public class HudiReadOptimizedDirectoryLister
             HiveMetastore hiveMetastore,
             Table hiveTable,
             List<HiveColumnHandle> partitionColumnHandles,
-            List<String> hivePartitionNames)
+            List<String> hivePartitionNames,
+            boolean ignoreAbsentPartitions)
     {
-        this.fileSystemView = new HudiTableFileSystemView(metaClient, metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants());
+        this.fileSystemView = new HudiTableFileSystemView(metaClient, metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(), ignoreAbsentPartitions);
         this.partitionColumns = hiveTable.getPartitionColumns();
         this.allPartitionInfoMap = hivePartitionNames.stream()
                 .collect(Collectors.toMap(

--- a/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
+++ b/plugin/trino-hudi/src/test/java/io/trino/plugin/hudi/TestHudiConfig.java
@@ -41,7 +41,8 @@ public class TestHudiConfig
                 .setSplitLoaderParallelism(4)
                 .setSplitGeneratorParallelism(4)
                 .setPerTransactionMetastoreCacheMaximumSize(2000)
-                .setQueryPartitionFilterRequired(false));
+                .setQueryPartitionFilterRequired(false)
+                .setIgnoreAbsentPartitions(false));
     }
 
     @Test
@@ -59,6 +60,7 @@ public class TestHudiConfig
                 .put("hudi.split-generator-parallelism", "32")
                 .put("hudi.per-transaction-metastore-cache-maximum-size", "1000")
                 .put("hudi.query-partition-filter-required", "true")
+                .put("hudi.ignore-absent-partitions", "true")
                 .buildOrThrow();
 
         HudiConfig expected = new HudiConfig()
@@ -72,7 +74,8 @@ public class TestHudiConfig
                 .setSplitLoaderParallelism(16)
                 .setSplitGeneratorParallelism(32)
                 .setPerTransactionMetastoreCacheMaximumSize(1000)
-                .setQueryPartitionFilterRequired(true);
+                .setQueryPartitionFilterRequired(true)
+                .setIgnoreAbsentPartitions(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- Fix HUDI connector gets stuck when an exception occurs
    - Solve HUDI connector stuck by using ExceptionCallback to ensure the asyncQueue is closed when an exception occurs.
    - Optimize the handling of multiple Futures with Futures.whenAllComplete instead of for_loop.
- Add a new HUDI session property: `ignore_absent_partitions`
    - Boolean property.
    - When set to false, the Trino HUDI connector will report an error if the partition does not exist; when set to true, non-existing partitions will be ignored.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- #19506


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix: Trino Hudi connector gets stuck while attempting to read empty partitions of a partitioned Hudi table. ({issue}`19506 `)
* New HUDI session property: ignore_absent_partitions
```
