### PR TITLE
Avoid concatenation in checkArgument messages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -585,7 +585,7 @@ public class PipelinedQueryScheduler
         private static PipelinedOutputBufferManager createSingleStreamOutputBuffer(SqlStage stage)
         {
             PartitioningHandle partitioningHandle = stage.getFragment().getOutputPartitioningScheme().getPartitioning().getHandle();
-            checkArgument(partitioningHandle.isSingleNode(), "partitioning is expected to be single node: " + partitioningHandle);
+            checkArgument(partitioningHandle.isSingleNode(), "partitioning is expected to be single node: %s", partitioningHandle);
             return new PartitionedPipelinedOutputBufferManager(partitioningHandle, 1);
         }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/GlobalFunctionCatalog.java
@@ -272,14 +272,14 @@ public class GlobalFunctionCatalog
         public FunctionMetadata get(FunctionId functionId)
         {
             FunctionMetadata functionMetadata = functionsById.get(functionId);
-            checkArgument(functionMetadata != null, "Unknown function implementation: " + functionId);
+            checkArgument(functionMetadata != null, "Unknown function implementation: %s", functionId);
             return functionMetadata;
         }
 
         public FunctionBundle getFunctionBundle(FunctionId functionId)
         {
             FunctionBundle functionBundle = functionBundlesById.get(functionId);
-            checkArgument(functionBundle != null, "Unknown function implementation: " + functionId);
+            checkArgument(functionBundle != null, "Unknown function implementation: %s", functionId);
             return functionBundle;
         }
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InternalFunctionBundle.java
@@ -184,7 +184,7 @@ public class InternalFunctionBundle
     private SqlFunction getSqlFunction(FunctionId functionId)
     {
         SqlFunction function = functions.get(functionId);
-        checkArgument(function != null, "Unknown function implementation: " + functionId);
+        checkArgument(function != null, "Unknown function implementation: %s", functionId);
         return function;
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/LanguageFunctionManager.java
@@ -269,7 +269,7 @@ public class LanguageFunctionManager
         public FunctionDependencyDeclaration getDependencies(FunctionId functionId, AccessControl accessControl)
         {
             LanguageFunctionImplementation function = implementationsById.get(functionId);
-            checkArgument(function != null, "Unknown function implementation: " + functionId);
+            checkArgument(function != null, "Unknown function implementation: %s", functionId);
             return function.getFunctionDependencies(accessControl);
         }
 
@@ -285,7 +285,7 @@ public class LanguageFunctionManager
         public FunctionMetadata getFunctionMetadata(FunctionId functionId)
         {
             LanguageFunctionImplementation function = implementationsById.get(functionId);
-            checkArgument(function != null, "Unknown function implementation: " + functionId);
+            checkArgument(function != null, "Unknown function implementation: %s", functionId);
             return function.getFunctionMetadata();
         }
 
@@ -293,7 +293,7 @@ public class LanguageFunctionManager
         {
             FunctionId functionId = resolvedFunction.getFunctionId();
             LanguageFunctionImplementation function = implementationsById.get(functionId);
-            checkArgument(function != null, "Unknown function implementation: " + functionId);
+            checkArgument(function != null, "Unknown function implementation: %s", functionId);
             implementationsByResolvedFunction.put(resolvedFunction, function);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -379,7 +379,7 @@ public class TaskContext
         checkArgument(maxWriterCount > 0, "maxWriterCount must be > 0");
 
         int oldMaxWriterCount = this.maxWriterCount.getAndSet(maxWriterCount);
-        checkArgument(oldMaxWriterCount == -1 || oldMaxWriterCount == maxWriterCount, "maxWriterCount already set to " + oldMaxWriterCount);
+        checkArgument(oldMaxWriterCount == -1 || oldMaxWriterCount == maxWriterCount, "maxWriterCount already set to %s", oldMaxWriterCount);
     }
 
     public Optional<Integer> getMaxWriterCount()

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IrRowPatternToProgramRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IrRowPatternToProgramRewriter.java
@@ -33,7 +33,6 @@ import java.util.stream.IntStream;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Collections2.orderedPermutations;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class IrRowPatternToProgramRewriter
@@ -200,7 +199,7 @@ public class IrRowPatternToProgramRewriter
 
         private void loopingQuantified(IrRowPattern pattern, boolean greedy, int min)
         {
-            checkArgument(min >= 0, "invalid min value: " + min);
+            checkArgument(min >= 0, "invalid min value: %s", min);
 
             if (min == 0) {
                 int startSplitPosition = instructions.size();
@@ -243,7 +242,7 @@ public class IrRowPatternToProgramRewriter
 
         private void rangeQuantified(IrRowPattern pattern, boolean greedy, int min, int max)
         {
-            checkArgument(min <= max, format("invalid range: (%s, %s)", min, max));
+            checkArgument(min <= max, "invalid range: (%s, %s)", min, max);
 
             for (int i = 0; i < min; i++) {
                 process(pattern);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -364,7 +364,7 @@ public class ExpressionInterpreter
         @Override
         protected Object visitDereferenceExpression(DereferenceExpression node, Object context)
         {
-            checkArgument(!isQualifiedAllFieldsReference(node), "unexpected expression: all fields labeled reference " + node);
+            checkArgument(!isQualifiedAllFieldsReference(node), "unexpected expression: all fields labeled reference %s", node);
             Identifier fieldIdentifier = node.getField().orElseThrow();
 
             Type type = type(node.getBase());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -906,7 +906,7 @@ public class LocalExecutionPlanner
         private PhysicalOperation createMergeSource(RemoteSourceNode node, LocalExecutionPlanContext context)
         {
             checkArgument(node.getOrderingScheme().isPresent(), "orderingScheme is absent");
-            checkArgument(node.getRetryPolicy() == RetryPolicy.NONE, "unexpected retry policy: " + node.getRetryPolicy());
+            checkArgument(node.getRetryPolicy() == RetryPolicy.NONE, "unexpected retry policy: %s", node.getRetryPolicy());
 
             // merging remote source must have a single driver
             context.setDriverInstanceCount(1);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithProjection.java
@@ -150,7 +150,7 @@ public class TransformCorrelatedGlobalAggregationWithProjection
     @Override
     public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
-        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: " + correlatedJoinNode.getType());
+        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: %s", correlatedJoinNode.getType());
 
         // if there is another aggregation below the AggregationNode, handle both
         PlanNode source = captures.get(SOURCE);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedGlobalAggregationWithoutProjection.java
@@ -143,7 +143,7 @@ public class TransformCorrelatedGlobalAggregationWithoutProjection
     @Override
     public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
-        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: " + correlatedJoinNode.getType());
+        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: %s", correlatedJoinNode.getType());
 
         PlanNode source = captures.get(SOURCE);
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -103,7 +103,7 @@ public class TransformCorrelatedScalarSubquery
     public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
         // lateral references are only allowed for INNER or LEFT correlated join
-        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: " + correlatedJoinNode.getType());
+        checkArgument(correlatedJoinNode.getType() == INNER || correlatedJoinNode.getType() == LEFT, "unexpected correlated join type: %s", correlatedJoinNode.getType());
         PlanNode subquery = context.getLookup().resolve(correlatedJoinNode.getSubquery());
 
         if (!searchFrom(subquery, context.getLookup())

--- a/core/trino-main/src/main/java/io/trino/sql/planner/rowpattern/LogicalIndexPointer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/rowpattern/LogicalIndexPointer.java
@@ -53,7 +53,7 @@ public class LogicalIndexPointer
         this.labels = requireNonNull(labels, "labels is null");
         this.last = last;
         this.running = running;
-        checkArgument(logicalOffset >= 0, "logical offset must be >= 0, actual: " + logicalOffset);
+        checkArgument(logicalOffset >= 0, "logical offset must be >= 0, actual: %s", logicalOffset);
         this.logicalOffset = logicalOffset;
         this.physicalOffset = physicalOffset;
     }

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -317,10 +317,10 @@ public final class StatementUtils
             this.queryType = requireNonNull(queryType, "queryType is null");
             this.taskType = requireNonNull(taskType, "taskType is null");
             if (queryType == DATA_DEFINITION) {
-                checkArgument(taskType.isPresent(), "taskType is required for " + DATA_DEFINITION);
+                checkArgument(taskType.isPresent(), "taskType is required for %s", DATA_DEFINITION);
             }
             else {
-                checkArgument(taskType.isEmpty(), "taskType is not allowed for " + queryType);
+                checkArgument(taskType.isEmpty(), "taskType is not allowed for %s", queryType);
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -139,7 +139,7 @@ public final class BlockAssertions
 
     public static RunLengthEncodedBlock createRandomRleBlock(Block block, int positionCount)
     {
-        checkArgument(block.getPositionCount() >= 2, format("block positions %d is less 2", block.getPositionCount()));
+        checkArgument(block.getPositionCount() >= 2, "block positions %s is less than 2", block.getPositionCount());
         return (RunLengthEncodedBlock) RunLengthEncodedBlock.create(block.getSingleValueBlock(random().nextInt(block.getPositionCount())), positionCount);
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
@@ -58,7 +58,7 @@ public class FunctionCall
         super(location);
         requireNonNull(name, "name is null");
         requireNonNull(window, "window is null");
-        window.ifPresent(node -> checkArgument(node instanceof WindowReference || node instanceof WindowSpecification, "unexpected window: " + node.getClass().getSimpleName()));
+        window.ifPresent(node -> checkArgument(node instanceof WindowReference || node instanceof WindowSpecification, "unexpected window: %s", node.getClass().getSimpleName()));
         requireNonNull(filter, "filter is null");
         requireNonNull(orderBy, "orderBy is null");
         requireNonNull(nullTreatment, "nullTreatment is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/PlanSiblings.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/PlanSiblings.java
@@ -33,7 +33,7 @@ public class PlanSiblings
         super(location);
         this.type = requireNonNull(type, "type is null");
         this.siblings = ImmutableList.copyOf(siblings);
-        checkArgument(siblings.size() >= 2, "sibling plan must contain at least two siblings, actual: " + siblings.size());
+        checkArgument(siblings.size() >= 2, "sibling plan must contain at least two siblings, actual: %s", siblings.size());
     }
 
     public SiblingsPlanType getType()

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SkipTo.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SkipTo.java
@@ -107,8 +107,8 @@ public class SkipTo
         super(location);
         requireNonNull(position, "position is null");
         requireNonNull(identifier, "identifier is null");
-        checkArgument(identifier.isPresent() || (position == PAST_LAST || position == NEXT), "missing identifier in SKIP TO " + position.name());
-        checkArgument(!identifier.isPresent() || (position == FIRST || position == LAST), "unexpected identifier in SKIP TO " + position.name());
+        checkArgument(identifier.isPresent() || (position == PAST_LAST || position == NEXT), "missing identifier in SKIP TO %s", position.name());
+        checkArgument(!identifier.isPresent() || (position == FIRST || position == LAST), "unexpected identifier in SKIP TO %s", position.name());
         this.position = position;
         this.identifier = identifier;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/WindowOperation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/WindowOperation.java
@@ -55,7 +55,7 @@ public class WindowOperation
         super(location);
         requireNonNull(name, "name is null");
         requireNonNull(window, "window is null");
-        checkArgument(window instanceof WindowReference || window instanceof WindowSpecification, "unexpected window: " + window.getClass().getSimpleName());
+        checkArgument(window instanceof WindowReference || window instanceof WindowSpecification, "unexpected window: %s", window.getClass().getSimpleName());
 
         this.name = name;
         this.window = window;

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
@@ -54,7 +54,7 @@ public final class ColumnReaders
             return new TimeColumnReader(type, column, memoryContext.newLocalMemoryContext(ColumnReaders.class.getSimpleName()));
         }
         if (type instanceof UuidType) {
-            checkArgument(column.getColumnType() == BINARY, "UUID type can only be read from BINARY column but got " + column);
+            checkArgument(column.getColumnType() == BINARY, "UUID type can only be read from BINARY column but got %s", column);
             checkArgument(
                     "UUID".equals(column.getAttributes().get(ICEBERG_BINARY_TYPE)),
                     "Expected ORC column for UUID data to be annotated with %s=UUID: %s",

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/NestedColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/NestedColumnReader.java
@@ -507,8 +507,8 @@ public class NestedColumnReader<BufferType>
         int maxDefinitionLevel = field.getDefinitionLevel();
         int maxRepetitionLevel = field.getRepetitionLevel();
 
-        checkArgument(maxDefinitionLevel == 0 || definitionEncoding == RLE, "Invalid definition level encoding: " + definitionEncoding);
-        checkArgument(maxRepetitionLevel == 0 || repetitionEncoding == RLE, "Invalid repetition level encoding: " + definitionEncoding);
+        checkArgument(maxDefinitionLevel == 0 || definitionEncoding == RLE, "Invalid definition level encoding: %s", definitionEncoding);
+        checkArgument(maxRepetitionLevel == 0 || repetitionEncoding == RLE, "Invalid repetition level encoding: %s", repetitionEncoding);
 
         repetitionLevelDecoder = levelsDecoderProvider.create(maxRepetitionLevel);
         if (maxRepetitionLevel > 0) {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatColumnReader.java
@@ -280,7 +280,7 @@ public class FlatColumnReader<BufferType>
         Slice buffer = page.getSlice();
         ParquetEncoding definitionEncoding = page.getDefinitionLevelEncoding();
 
-        checkArgument(isNonNull() || definitionEncoding == RLE, "Invalid definition level encoding: " + definitionEncoding);
+        checkArgument(isNonNull() || definitionEncoding == RLE, "Invalid definition level encoding: %s", definitionEncoding);
         int alreadyRead = 0;
         if (definitionEncoding == RLE) {
             // Definition levels are skipped from file when the max definition level is 0 as the bit-width required to store them is 0.

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatDefinitionLevelDecoder.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/flat/FlatDefinitionLevelDecoder.java
@@ -39,7 +39,7 @@ public interface FlatDefinitionLevelDecoder
 
     static FlatDefinitionLevelDecoder getFlatDefinitionLevelDecoder(int maxDefinitionLevel)
     {
-        checkArgument(maxDefinitionLevel >= 0 && maxDefinitionLevel <= 1, "Invalid max definition level: " + maxDefinitionLevel);
+        checkArgument(maxDefinitionLevel >= 0 && maxDefinitionLevel <= 1, "Invalid max definition level: %s", maxDefinitionLevel);
         if (maxDefinitionLevel == 0) {
             return new ZeroDefinitionLevelDecoder();
         }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeVisitor.java
@@ -44,15 +44,15 @@ public class ParquetTypeVisitor<T>
         LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
         if (LogicalTypeAnnotation.listType().equals(annotation)) {
             checkArgument(!group.isRepetition(REPEATED),
-                    "Invalid list: top-level group is repeated: " + group);
+                    "Invalid list: top-level group is repeated: %s", group);
             checkArgument(group.getFieldCount() == 1,
-                    "Invalid list: does not contain single repeated field: " + group);
+                    "Invalid list: does not contain single repeated field: %s", group);
 
             GroupType repeatedElement = group.getFields().get(0).asGroupType();
             checkArgument(repeatedElement.isRepetition(REPEATED),
                     "Invalid list: inner group is not repeated");
             checkArgument(repeatedElement.getFieldCount() <= 1,
-                    "Invalid list: repeated group is not a single field: " + group);
+                    "Invalid list: repeated group is not a single field: %s", group);
 
             visitor.fieldNames.push(repeatedElement.getName());
             try {
@@ -69,9 +69,9 @@ public class ParquetTypeVisitor<T>
         }
         if (LogicalTypeAnnotation.mapType().equals(annotation)) {
             checkArgument(!group.isRepetition(REPEATED),
-                    "Invalid map: top-level group is repeated: " + group);
+                    "Invalid map: top-level group is repeated: %s", group);
             checkArgument(group.getFieldCount() == 1,
-                    "Invalid map: does not contain single repeated field: " + group);
+                    "Invalid map: does not contain single repeated field: %s", group);
 
             GroupType repeatedKeyValue = group.getType(0).asGroupType();
             checkArgument(repeatedKeyValue.isRepetition(REPEATED),

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -411,7 +411,7 @@ public class MongoPageSource
         if (columnHandle.getType() instanceof RowType) {
             return dbRefValue;
         }
-        checkArgument(columnHandle.isDbRefField(), "columnHandle is not a dbRef field: " + columnHandle);
+        checkArgument(columnHandle.isDbRefField(), "columnHandle is not a dbRef field: %s", columnHandle);
         List<String> dereferenceNames = columnHandle.getDereferenceNames();
         checkState(!dereferenceNames.isEmpty(), "dereferenceNames is empty");
         String leafColumnName = dereferenceNames.get(dereferenceNames.size() - 1);

--- a/testing/trino-testing/src/main/java/io/trino/testing/statistics/StatsContext.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/statistics/StatsContext.java
@@ -36,7 +36,7 @@ public class StatsContext
 
     public Symbol getSymbolForColumn(String columnName)
     {
-        checkArgument(columnSymbols.containsKey(columnName), "no symbol found for column '" + columnName + "'");
+        checkArgument(columnSymbols.containsKey(columnName), "no symbol found for column '%s'", columnName);
         return columnSymbols.get(columnName);
     }
 


### PR DESCRIPTION
## Description
Replaces string concatenation with message formatting for usages of `checkArgument` throughout the codebase.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
