### PR TITLE
Delta lake change predicate test order for split enumeration

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -123,8 +123,8 @@ public class DeltaLakeSplitSource
                             .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
                     List<ConnectorSplit> filteredSplits = splits.stream()
                             .map(DeltaLakeSplit.class::cast)
-                            .filter(split -> split.getStatisticsPredicate().overlaps(dynamicFilterPredicate) &&
-                                    partitionMatchesPredicate(split.getPartitionKeys(), partitionColumnDomains))
+                            .filter(split -> partitionMatchesPredicate(split.getPartitionKeys(), partitionColumnDomains) &&
+                                    split.getStatisticsPredicate().overlaps(dynamicFilterPredicate))
                             .collect(toImmutableList());
                     if (recordScannedFiles) {
                         filteredSplits.forEach(split -> scannedFilePaths.add(((DeltaLakeSplit) split).getPath()));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
With large dynamic filter, testing statistics predicate is a time-consuming operation which should be done after testing if partition predicate is fulfilled. For example q72:
![obraz](https://github.com/trinodb/trino/assets/6515994/d091f77e-7ff8-48c6-8aad-6f4a42ddeb4b)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
