### PR TITLE
Produce a more actionable error on wrong JDBC URL

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/TracingDataSource.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/TracingDataSource.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class TracingDataSource
@@ -70,7 +71,9 @@ public class TracingDataSource
         public Connection getConnection()
                 throws SQLException
         {
-            return driver.connect(connectionUrl, properties);
+            Connection connection = driver.connect(connectionUrl, properties);
+            checkState(connection != null, "Driver returned null connection, make sure the connection URL '%s' is valid for the driver %s", connectionUrl, driver);
+            return connection;
         }
 
         @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Currently, when using a JDBC URL with an invalid schema, a vague error like this is produced:
> io.trino.spi.TrinoException: Error listing schemas for catalog xxx: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException: Cannot invoke "java.sql.Connection.getMetaData()" because "this.delegate" is null

After #18735, the connection is wrapped in `io.opentelemetry.instrumentation.jdbc.internal.OpenTelemetryConnection` so it's not null when checking in https://github.com/trinodb/trino/blob/master/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DriverConnectionFactory.java#L79, but the delegate inside this wrapper is null. The underlying `JdbcDataSource` should never return a null connection, since it's always used with a specific JDBC driver.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
