### PR TITLE
Convert the retrieval of the active data files to streaming

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitManager.java
@@ -153,7 +153,7 @@ public class DeltaLakeSplitManager
     {
         TableSnapshot tableSnapshot = deltaLakeTransactionManager.get(transaction, session.getIdentity())
                 .getSnapshot(session, tableHandle.getSchemaTableName(), tableHandle.getLocation(), tableHandle.getReadVersion());
-        List<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(
+        Stream<AddFileEntry> validDataFiles = transactionLogAccess.getActiveFiles(
                 tableSnapshot,
                 tableHandle.getMetadataEntry(),
                 tableHandle.getProtocolEntry(),
@@ -191,7 +191,7 @@ public class DeltaLakeSplitManager
         List<DeltaLakeColumnMetadata> predicatedColumns = schema.stream()
                 .filter(column -> predicatedColumnNames.contains(column.getName()))
                 .collect(toImmutableList());
-        return validDataFiles.stream()
+        return validDataFiles
                 .flatMap(addAction -> {
                     if (tableHandle.getAnalyzeHandle().isPresent() &&
                             !(tableHandle.getAnalyzeHandle().get().getAnalyzeMode() == FULL_REFRESH) && !addAction.isDataChange()) {
@@ -250,12 +250,12 @@ public class DeltaLakeSplitManager
                 });
     }
 
-    private static List<AddFileEntry> filterValidDataFilesForOptimize(List<AddFileEntry> validDataFiles, long maxScannedFileSizeInBytes)
+    private static Stream<AddFileEntry> filterValidDataFilesForOptimize(Stream<AddFileEntry> validDataFiles, long maxScannedFileSizeInBytes)
     {
         // Value being present is a pending file (potentially the only one) for a given partition.
         // Value being empty is a tombstone, indicates that there were in the stream previously at least 2 files selected for processing for a given partition.
         Map<Map<String, Optional<String>>, Optional<AddFileEntry>> pendingAddFileEntriesMap = new HashMap<>();
-        return validDataFiles.stream()
+        return validDataFiles
                 .filter(addFileEntry -> addFileEntry.getSize() < maxScannedFileSizeInBytes)
                 .flatMap(addFileEntry -> {
                     Map<String, Optional<String>> canonicalPartitionValues = addFileEntry.getCanonicalPartitionValues();
@@ -270,8 +270,7 @@ public class DeltaLakeSplitManager
 
                     pendingAddFileEntriesMap.put(canonicalPartitionValues, Optional.of(addFileEntry));
                     return Stream.empty();
-                })
-                .collect(toImmutableList());
+                });
     }
 
     private static boolean mayAnyDataColumnProjected(DeltaLakeTableHandle tableHandle)

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -16,6 +16,7 @@ package io.trino.plugin.deltalake;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
 import com.google.common.util.concurrent.Futures;
 import io.airlift.concurrent.MoreFutures;
 import io.airlift.log.Logger;
@@ -30,6 +31,8 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -61,6 +64,8 @@ public class DeltaLakeSplitSource
     private final DynamicFilter dynamicFilter;
     private final long dynamicFilteringWaitTimeoutMillis;
     private final Stopwatch dynamicFilterWaitStopwatch;
+    private final Closer closer = Closer.create();
+
     private volatile TrinoException trinoException;
 
     public DeltaLakeSplitSource(
@@ -75,10 +80,12 @@ public class DeltaLakeSplitSource
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.queue = new ThrottledAsyncQueue<>(maxSplitsPerSecond, maxOutstandingSplits, executor);
+        closer.register(queue::finish);
         this.recordScannedFiles = recordScannedFiles;
         this.dynamicFilter = requireNonNull(dynamicFilter, "dynamicFilter is null");
         this.dynamicFilteringWaitTimeoutMillis = dynamicFilteringWaitTimeout.toMillis();
         this.dynamicFilterWaitStopwatch = Stopwatch.createStarted();
+        closer.register(splits::close);
         queueSplits(splits, queue, executor)
                 .exceptionally(throwable -> {
                     // set trinoException before finishing the queue to ensure failure is observed instead of successful completion
@@ -147,7 +154,12 @@ public class DeltaLakeSplitSource
     @Override
     public void close()
     {
-        queue.finish();
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/statistics/FileBasedTableStatisticsProvider.java
@@ -33,11 +33,13 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -110,72 +112,76 @@ public class FileBasedTableStatisticsProvider
                 .filter(column -> predicatedColumnNames.contains(column.getName()))
                 .collect(toImmutableList());
 
-        for (AddFileEntry addEntry : transactionLogAccess.getActiveFiles(
+        try (Stream<AddFileEntry> addEntries = transactionLogAccess.getActiveFiles(
                 tableSnapshot,
                 tableHandle.getMetadataEntry(),
                 tableHandle.getProtocolEntry(),
                 tableHandle.getEnforcedPartitionConstraint(),
                 tableHandle.getProjectedColumns(),
                 session)) {
-            Optional<? extends DeltaLakeFileStatistics> fileStatistics = addEntry.getStats();
-            if (fileStatistics.isEmpty()) {
-                // Open source Delta Lake does not collect stats
-                return TableStatistics.empty();
-            }
-            DeltaLakeFileStatistics stats = fileStatistics.get();
-            if (!partitionMatchesPredicate(addEntry.getCanonicalPartitionValues(), tableHandle.getEnforcedPartitionConstraint().getDomains().orElseThrow())) {
-                continue;
-            }
-
-            TupleDomain<DeltaLakeColumnHandle> statisticsPredicate = createStatisticsPredicate(
-                    addEntry,
-                    predicatedColumns,
-                    tableHandle.getMetadataEntry().getLowercasePartitionColumns());
-            if (!tableHandle.getNonPartitionConstraint().overlaps(statisticsPredicate)) {
-                continue;
-            }
-
-            if (stats.getNumRecords().isEmpty()) {
-                // Not clear if it's possible for stats to be present with no row count, but bail out if that happens
-                return TableStatistics.empty();
-            }
-            numRecords += stats.getNumRecords().get();
-            for (DeltaLakeColumnHandle column : columns) {
-                if (column.getColumnType() == PARTITION_KEY) {
-                    Optional<String> partitionValue = addEntry.getCanonicalPartitionValues().get(column.getBasePhysicalColumnName());
-                    if (partitionValue.isEmpty()) {
-                        nullCounts.merge(column, (double) stats.getNumRecords().get(), Double::sum);
-                    }
-                    else {
-                        // NULL is not counted as a distinct value
-                        // Code below assumes that values returned by addEntry.getCanonicalPartitionValues() are normalized,
-                        // it may not be true in case of real, doubles, timestamps etc
-                        partitioningColumnsDistinctValues.get(column).add(partitionValue.get());
-                    }
+            Iterator<AddFileEntry> addEntryIterator = addEntries.iterator();
+            while (addEntryIterator.hasNext()) {
+                AddFileEntry addEntry = addEntryIterator.next();
+                Optional<? extends DeltaLakeFileStatistics> fileStatistics = addEntry.getStats();
+                if (fileStatistics.isEmpty()) {
+                    // Open source Delta Lake does not collect stats
+                    return TableStatistics.empty();
                 }
-                else {
-                    Optional<Long> maybeNullCount = column.isBaseColumn() ? stats.getNullCount(column.getBasePhysicalColumnName()) : Optional.empty();
-                    if (maybeNullCount.isPresent()) {
-                        nullCounts.put(column, nullCounts.get(column) + maybeNullCount.get());
-                    }
-                    else {
-                        // If any individual file fails to report null counts, fail to calculate the total for the table
-                        nullCounts.put(column, NaN);
-                    }
+                DeltaLakeFileStatistics stats = fileStatistics.get();
+                if (!partitionMatchesPredicate(addEntry.getCanonicalPartitionValues(), tableHandle.getEnforcedPartitionConstraint().getDomains().orElseThrow())) {
+                    continue;
                 }
 
-                // Math.min returns NaN if any operand is NaN
-                stats.getMinColumnValue(column)
-                        .map(parsedValue -> toStatsRepresentation(column.getBaseType(), parsedValue))
-                        .filter(OptionalDouble::isPresent)
-                        .map(OptionalDouble::getAsDouble)
-                        .ifPresent(parsedValueAsDouble -> minValues.merge(column, parsedValueAsDouble, Math::min));
+                TupleDomain<DeltaLakeColumnHandle> statisticsPredicate = createStatisticsPredicate(
+                        addEntry,
+                        predicatedColumns,
+                        tableHandle.getMetadataEntry().getLowercasePartitionColumns());
+                if (!tableHandle.getNonPartitionConstraint().overlaps(statisticsPredicate)) {
+                    continue;
+                }
 
-                stats.getMaxColumnValue(column)
-                        .map(parsedValue -> toStatsRepresentation(column.getBaseType(), parsedValue))
-                        .filter(OptionalDouble::isPresent)
-                        .map(OptionalDouble::getAsDouble)
-                        .ifPresent(parsedValueAsDouble -> maxValues.merge(column, parsedValueAsDouble, Math::max));
+                if (stats.getNumRecords().isEmpty()) {
+                    // Not clear if it's possible for stats to be present with no row count, but bail out if that happens
+                    return TableStatistics.empty();
+                }
+                numRecords += stats.getNumRecords().get();
+                for (DeltaLakeColumnHandle column : columns) {
+                    if (column.getColumnType() == PARTITION_KEY) {
+                        Optional<String> partitionValue = addEntry.getCanonicalPartitionValues().get(column.getBasePhysicalColumnName());
+                        if (partitionValue.isEmpty()) {
+                            nullCounts.merge(column, (double) stats.getNumRecords().get(), Double::sum);
+                        }
+                        else {
+                            // NULL is not counted as a distinct value
+                            // Code below assumes that values returned by addEntry.getCanonicalPartitionValues() are normalized,
+                            // it may not be true in case of real, doubles, timestamps etc
+                            partitioningColumnsDistinctValues.get(column).add(partitionValue.get());
+                        }
+                    }
+                    else {
+                        Optional<Long> maybeNullCount = column.isBaseColumn() ? stats.getNullCount(column.getBasePhysicalColumnName()) : Optional.empty();
+                        if (maybeNullCount.isPresent()) {
+                            nullCounts.put(column, nullCounts.get(column) + maybeNullCount.get());
+                        }
+                        else {
+                            // If any individual file fails to report null counts, fail to calculate the total for the table
+                            nullCounts.put(column, NaN);
+                        }
+                    }
+
+                    // Math.min returns NaN if any operand is NaN
+                    stats.getMinColumnValue(column)
+                            .map(parsedValue -> toStatsRepresentation(column.getBaseType(), parsedValue))
+                            .filter(OptionalDouble::isPresent)
+                            .map(OptionalDouble::getAsDouble)
+                            .ifPresent(parsedValueAsDouble -> minValues.merge(column, parsedValueAsDouble, Math::min));
+
+                    stats.getMaxColumnValue(column)
+                            .map(parsedValue -> toStatsRepresentation(column.getBaseType(), parsedValue))
+                            .filter(OptionalDouble::isPresent)
+                            .map(OptionalDouble::getAsDouble)
+                            .ifPresent(parsedValueAsDouble -> maxValues.merge(column, parsedValueAsDouble, Math::max));
+                }
             }
         }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -774,6 +774,11 @@ public class CheckpointEntryIterator
         return true;
     }
 
+    public void close()
+    {
+        pageSource.close();
+    }
+
     private void fillNextEntries()
     {
         while (nextEntries.isEmpty()) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriterManager.java
@@ -37,6 +37,7 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.alwaysTrue;
@@ -97,19 +98,20 @@ public class CheckpointWriterManager
             CheckpointBuilder checkpointBuilder = new CheckpointBuilder();
 
             TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-            List<DeltaLakeTransactionLogEntry> checkpointLogEntries = snapshot
-                    .getCheckpointTransactionLogEntries(
-                            session,
-                            ImmutableSet.of(METADATA, PROTOCOL),
-                            checkpointSchemaManager,
-                            typeManager,
-                            fileSystem,
-                            fileFormatDataSourceStats,
-                            Optional.empty(),
-                            TupleDomain.all(),
-                            Optional.empty())
-                    .filter(entry -> entry.getMetaData() != null || entry.getProtocol() != null)
-                    .collect(toImmutableList());
+            List<DeltaLakeTransactionLogEntry> checkpointLogEntries;
+            try (Stream<DeltaLakeTransactionLogEntry> checkpointLogEntriesStream = snapshot.getCheckpointTransactionLogEntries(
+                    session,
+                    ImmutableSet.of(METADATA, PROTOCOL),
+                    checkpointSchemaManager,
+                    typeManager,
+                    fileSystem,
+                    fileFormatDataSourceStats,
+                    Optional.empty(),
+                    TupleDomain.all(),
+                    Optional.empty())) {
+                checkpointLogEntries = checkpointLogEntriesStream.filter(entry -> entry.getMetaData() != null || entry.getProtocol() != null)
+                        .collect(toImmutableList());
+            }
 
             if (!checkpointLogEntries.isEmpty()) {
                 // TODO HACK: this call is required only to ensure that cachedMetadataEntry is set in snapshot (https://github.com/trinodb/trino/issues/12032),
@@ -132,17 +134,18 @@ public class CheckpointWriterManager
                 checkpointBuilder.addLogEntry(protocolLogEntry);
 
                 // read remaining entries from checkpoint register them in writer
-                snapshot.getCheckpointTransactionLogEntries(
-                                session,
-                                ImmutableSet.of(TRANSACTION, ADD, REMOVE, COMMIT),
-                                checkpointSchemaManager,
-                                typeManager,
-                                fileSystem,
-                                fileFormatDataSourceStats,
-                                Optional.of(new MetadataAndProtocolEntry(metadataLogEntry.getMetaData(), protocolLogEntry.getProtocol())),
-                                TupleDomain.all(),
-                                Optional.of(alwaysTrue()))
-                        .forEach(checkpointBuilder::addLogEntry);
+                try (Stream<DeltaLakeTransactionLogEntry> checkpointLogEntriesStream = snapshot.getCheckpointTransactionLogEntries(
+                        session,
+                        ImmutableSet.of(TRANSACTION, ADD, REMOVE, COMMIT),
+                        checkpointSchemaManager,
+                        typeManager,
+                        fileSystem,
+                        fileFormatDataSourceStats,
+                        Optional.of(new MetadataAndProtocolEntry(metadataLogEntry.getMetaData(), protocolLogEntry.getProtocol())),
+                        TupleDomain.all(),
+                        Optional.of(alwaysTrue()))) {
+                    checkpointLogEntriesStream.forEach(checkpointBuilder::addLogEntry);
+                }
             }
 
             snapshot.getJsonTransactionLogEntries()

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSplitManager.java
@@ -60,6 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
@@ -188,7 +189,7 @@ public class TestDeltaLakeSplitManager
                 new ParquetReaderConfig())
         {
             @Override
-            public List<AddFileEntry> getActiveFiles(
+            public Stream<AddFileEntry> getActiveFiles(
                     TableSnapshot tableSnapshot,
                     MetadataEntry metadataEntry,
                     ProtocolEntry protocolEntry,
@@ -196,7 +197,7 @@ public class TestDeltaLakeSplitManager
                     Optional<Set<DeltaLakeColumnHandle>> projectedColumns,
                     ConnectorSession session)
             {
-                return addFileEntries;
+                return addFileEntries.stream();
             }
         };
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakeUtils.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestingDeltaLakeUtils.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.deltalake.DeltaLakeQueryRunner.DELTA_CATALOG;
 import static io.trino.plugin.deltalake.DeltaTestingConnectorSession.SESSION;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -57,7 +58,9 @@ public final class TestingDeltaLakeUtils
         TableSnapshot snapshot = transactionLogAccess.loadSnapshot(SESSION, dummyTable, tableLocation);
         MetadataEntry metadataEntry = transactionLogAccess.getMetadataEntry(snapshot, SESSION);
         ProtocolEntry protocolEntry = transactionLogAccess.getProtocolEntry(SESSION, snapshot);
-        return transactionLogAccess.getActiveFiles(snapshot, metadataEntry, protocolEntry, SESSION);
+        try (Stream<AddFileEntry> addFileEntries = transactionLogAccess.getActiveFiles(snapshot, metadataEntry, protocolEntry, SESSION)) {
+            return addFileEntries.collect(toImmutableList());
+        }
     }
 
     public static void copyDirectoryContents(Path source, Path destination)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Instead of waiting to get in bulk the collection of all
the active data files of a table relevant to a query, 
provide a stream of active add entries so that the 
split manager can start providing to the engine splits right away.

The active add entries stream is closeable in order to ensure that
the underlying checkpoint parquet page source gets closed
even when not all the entries from the checkpoint are consumed.

These changes should provide visible improvements in terms of reduced memory requirements when dealing with Delta Lake tables having many active `add` files, because as of now these files will not be held anymore in memory within `DeltaLakeSplitManager` due to the fact that the `add` files are processed as a consequence of the current changes now one by one.

**Potential downside** The checkpoint entry iterator will keep _open_ the parquet page source corresponding to the checkpoint (multipart) file until all the `add` entries are processed by the `DeltaLakeSplitSource`. 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The access to the active add stream needs to be done within a try-with-resources statement to make sure that the checkpoint iterator does indeed release the opened resources.

The key output of these changes is that in the `DeltaLakeSplitManager` & `DeltaLakeSplitSource` don't block anymore until all the `add` entries relevant to the query are collected, but instead the splits are provided gradually (in parallel with the query execution).

This change should particularly speed up the _planning_ of the queries involving Delta Lake tables where the table statistics are not required because the split generation can start right away.

Fixes https://github.com/trinodb/trino/issues/20088

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Speed up the beginning of the query execution for queries which don't involve table statitstics. ({issue}`issuenumber`)
```
