### PR TITLE
Fix negative cost estimated failure in testUnionAllAboveBroadcastJoin

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -715,6 +715,7 @@ public final class SystemSessionProperties
                         COST_ESTIMATION_WORKER_COUNT,
                         "Set the estimate count of workers while planning",
                         null,
+                        value -> validateIntegerValue(value, COST_ESTIMATION_WORKER_COUNT, 1, true),
                         true),
                 booleanProperty(
                         OMIT_DATETIME_TYPE_PRECISION,

--- a/core/trino-main/src/main/java/io/trino/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CostCalculatorWithEstimatedExchanges.java
@@ -32,6 +32,7 @@ import io.trino.sql.planner.plan.UnionNode;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.cost.LocalCostEstimate.addPartialComponents;
 import static java.util.Objects.requireNonNull;
 
@@ -206,6 +207,7 @@ public class CostCalculatorWithEstimatedExchanges
             boolean replicated,
             int estimatedSourceDistributedTaskCount)
     {
+        checkArgument(estimatedSourceDistributedTaskCount > 0, "estimatedSourceDistributedTaskCount must be positive: %s", estimatedSourceDistributedTaskCount);
         LocalCostEstimate exchangesCost = calculateJoinExchangeCost(
                 probe,
                 build,

--- a/core/trino-main/src/main/java/io/trino/cost/LocalCostEstimate.java
+++ b/core/trino-main/src/main/java/io/trino/cost/LocalCostEstimate.java
@@ -21,7 +21,9 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Double.NaN;
+import static java.lang.Double.isNaN;
 
 /**
  * Represents inherent cost of some plan node, not including cost of its sources.
@@ -63,6 +65,9 @@ public class LocalCostEstimate
             @JsonProperty("maxMemory") double maxMemory,
             @JsonProperty("networkCost") double networkCost)
     {
+        checkArgument(isNaN(cpuCost) || cpuCost >= 0, "cpuCost cannot be negative: %s", cpuCost);
+        checkArgument(isNaN(maxMemory) || maxMemory >= 0, "maxMemory cannot be negative: %s", maxMemory);
+        checkArgument(isNaN(networkCost) || networkCost >= 0, "networkCost cannot be negative: %s", networkCost);
         this.cpuCost = cpuCost;
         this.maxMemory = maxMemory;
         this.networkCost = networkCost;

--- a/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsAndCostSummary.java
+++ b/core/trino-main/src/main/java/io/trino/cost/PlanNodeStatsAndCostSummary.java
@@ -16,6 +16,9 @@ package io.trino.cost;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Double.isNaN;
+
 public class PlanNodeStatsAndCostSummary
 {
     private final double outputRowCount;
@@ -32,6 +35,11 @@ public class PlanNodeStatsAndCostSummary
             @JsonProperty("memoryCost") double memoryCost,
             @JsonProperty("networkCost") double networkCost)
     {
+        checkArgument(isNaN(outputRowCount) || outputRowCount >= 0, "outputRowCount cannot be negative: %s", outputRowCount);
+        checkArgument(isNaN(outputSizeInBytes) || outputSizeInBytes >= 0, "outputSizeInBytes cannot be negative: %s", outputSizeInBytes);
+        checkArgument(isNaN(cpuCost) || cpuCost >= 0, "cpuCost cannot be negative: %s", cpuCost);
+        checkArgument(isNaN(memoryCost) || memoryCost >= 0, "memoryCost cannot be negative: %s", memoryCost);
+        checkArgument(isNaN(networkCost) || networkCost >= 0, "networkCost cannot be negative: %s", networkCost);
         this.outputRowCount = outputRowCount;
         this.outputSizeInBytes = outputSizeInBytes;
         this.cpuCost = cpuCost;

--- a/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/TaskCountEstimator.java
@@ -23,6 +23,7 @@ import io.trino.operator.RetryPolicy;
 import java.util.Set;
 import java.util.function.IntSupplier;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.trino.SystemSessionProperties.getCostEstimationWorkerCount;
 import static io.trino.SystemSessionProperties.getFaultTolerantExecutionMaxPartitionCount;
 import static io.trino.SystemSessionProperties.getMaxHashPartitionCount;
@@ -42,12 +43,17 @@ public class TaskCountEstimator
         requireNonNull(nodeManager, "nodeManager is null");
         this.numberOfNodes = () -> {
             Set<InternalNode> activeNodes = nodeManager.getAllNodes().getActiveNodes();
+            int count;
             if (schedulerIncludeCoordinator) {
-                return activeNodes.size();
+                count = activeNodes.size();
             }
-            return toIntExact(activeNodes.stream()
-                    .filter(node -> !node.isCoordinator())
-                    .count());
+            else {
+                count = toIntExact(activeNodes.stream()
+                        .filter(node -> !node.isCoordinator())
+                        .count());
+            }
+            // At least 1 even if no worker nodes currently registered. This is to prevent underflow or other mis-estimations.
+            return Math.max(count, 1);
         };
     }
 
@@ -60,9 +66,12 @@ public class TaskCountEstimator
     {
         Integer costEstimationWorkerCount = getCostEstimationWorkerCount(session);
         if (costEstimationWorkerCount != null) {
+            // validated to be at least 1
             return costEstimationWorkerCount;
         }
-        return numberOfNodes.getAsInt();
+        int count = numberOfNodes.getAsInt();
+        checkState(count > 0, "%s should return positive number of nodes: %s", numberOfNodes, count);
+        return count;
     }
 
     public int estimateHashedTaskCount(Session session)

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -1204,7 +1204,6 @@ public class LocalQueryRunner
         private final Session defaultSession;
         private FeaturesConfig featuresConfig = new FeaturesConfig();
         private NodeSpillConfig nodeSpillConfig = new NodeSpillConfig();
-        private boolean initialTransaction;
         private boolean alwaysRevokeMemory;
         private Map<String, List<PropertyMetadata<?>>> defaultSessionProperties = ImmutableMap.of();
         private Set<SystemSessionPropertiesProvider> extraSessionProperties = ImmutableSet.of();

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -1208,7 +1208,7 @@ public class LocalQueryRunner
         private boolean alwaysRevokeMemory;
         private Map<String, List<PropertyMetadata<?>>> defaultSessionProperties = ImmutableMap.of();
         private Set<SystemSessionPropertiesProvider> extraSessionProperties = ImmutableSet.of();
-        private int nodeCountForStats;
+        private int nodeCountForStats = 1;
         private Function<Metadata, Metadata> metadataDecorator = Function.identity();
 
         private Builder(Session defaultSession)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -458,11 +458,11 @@ public abstract class AbstractPredicatePushdownTest
     {
         assertPlan(
                 """
-                WITH t(a) AS (VALUES 'a', 'b')
-                SELECT *
-                FROM t t1 JOIN t t2 ON true
-                WHERE t1.a = 'aa'
-                """,
+                        WITH t(a) AS (VALUES 'a', 'b')
+                        SELECT *
+                        FROM t t1 JOIN t t2 ON true
+                        WHERE t1.a = 'aa'
+                        """,
                 output(values("field", "field_0")));
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -40,6 +40,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 public abstract class AbstractPredicatePushdownTest
         extends BasePlanTest
@@ -424,33 +425,31 @@ public abstract class AbstractPredicatePushdownTest
     @Test
     public void testTablePredicateIsExtracted()
     {
+        PlanMatchPattern ordersTableScan = tableScan("orders", ImmutableMap.of("ORDERSTATUS", "orderstatus"));
+        if (enableDynamicFiltering) {
+            ordersTableScan = filter(TRUE_LITERAL, ordersTableScan);
+        }
         assertPlan(
                 "SELECT * FROM orders, nation WHERE orderstatus = CAST(nation.name AS varchar(1)) AND orderstatus BETWEEN 'A' AND 'O'",
                 anyTree(
                         node(JoinNode.class,
+                                ordersTableScan,
                                 anyTree(
                                         filter("CAST(NAME AS varchar(1)) IN ('F', 'O')",
                                                 tableScan(
                                                         "nation",
-                                                        ImmutableMap.of("NAME", "name")))),
-                                anyTree(
-                                        tableScan(
-                                                "orders",
-                                                ImmutableMap.of("ORDERSTATUS", "orderstatus"))))));
+                                                        ImmutableMap.of("NAME", "name")))))));
 
         assertPlan(
                 "SELECT * FROM orders JOIN nation ON orderstatus = CAST(nation.name AS varchar(1))",
                 anyTree(
                         node(JoinNode.class,
+                                ordersTableScan,
                                 anyTree(
                                         filter("CAST(NAME AS varchar(1)) IN ('F', 'O', 'P')",
                                                 tableScan(
                                                         "nation",
-                                                        ImmutableMap.of("NAME", "name")))),
-                                anyTree(
-                                        tableScan(
-                                                "orders",
-                                                ImmutableMap.of("ORDERSTATUS", "orderstatus"))))));
+                                                        ImmutableMap.of("NAME", "name")))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestAddDynamicFilterSource.java
@@ -225,24 +225,24 @@ public class TestAddDynamicFilterSource
                         filter("O_ORDERKEY BETWEEN L_ORDERKEY AND L_PARTKEY",
                                 join(INNER, builder -> builder
                                         .dynamicFilter(ImmutableList.of(
-                                                new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN_OR_EQUAL, "L_ORDERKEY"),
-                                                new DynamicFilterPattern("O_ORDERKEY", LESS_THAN_OR_EQUAL, "L_PARTKEY")))
+                                                new DynamicFilterPattern("L_ORDERKEY", LESS_THAN_OR_EQUAL, "O_ORDERKEY"),
+                                                new DynamicFilterPattern("L_PARTKEY", GREATER_THAN_OR_EQUAL, "O_ORDERKEY")))
                                         .left(
                                                 filter(
                                                         TRUE_LITERAL,
-                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))
+                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey"))))
                                         .right(
                                                 exchange(
                                                         LOCAL,
                                                         exchange(
                                                                 REMOTE,
-                                                                node(
-                                                                        DynamicFilterSourceNode.class,
-                                                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey", "L_PARTKEY", "partkey"))))))))));
+                                                                node(DynamicFilterSourceNode.class,
+                                                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))))))))));
 
         // TODO: Add support for dynamic filters in the below case
         assertDistributedPlan(
                 "SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey >= l.orderkey AND o.orderkey <= l.partkey - 1",
+                withJoinDistributionType(PARTITIONED),
                 anyTree(
                         filter("O_ORDERKEY >= L_ORDERKEY AND O_ORDERKEY <= expr",
                                 join(INNER, builder -> builder

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -1691,14 +1691,14 @@ public class TestLogicalPlanner
     {
         assertPlan(
                 """
-                SELECT col FROM (
-                    SELECT nationkey FROM nation
-                    UNION ALL
-                    SELECT nationkey FROM nation
-                    UNION ALL
-                    SELECT nationkey FROM nation
-                ) AS t(col)
-                LIMIT 2""",
+                        SELECT col FROM (
+                            SELECT nationkey FROM nation
+                            UNION ALL
+                            SELECT nationkey FROM nation
+                            UNION ALL
+                            SELECT nationkey FROM nation
+                        ) AS t(col)
+                        LIMIT 2""",
                 output(
                         limit(
                                 2,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -397,24 +397,24 @@ public class TestLogicalPlanner
                 anyTree(
                         anyNot(FilterNode.class,
                                 join(INNER, builder -> builder
-                                        .equiCriteria("O_SHIPPRIORITY", "L_LINENUMBER")
+                                        .equiCriteria("L_LINENUMBER", "O_SHIPPRIORITY")
                                         .filter("O_ORDERKEY < L_ORDERKEY")
                                         .dynamicFilter(
                                                 ImmutableList.of(
-                                                        new DynamicFilterPattern("O_SHIPPRIORITY", EQUAL, "L_LINENUMBER"),
-                                                        new DynamicFilterPattern("O_ORDERKEY", LESS_THAN, "L_ORDERKEY")))
+                                                        new DynamicFilterPattern("L_LINENUMBER", EQUAL, "O_SHIPPRIORITY"),
+                                                        new DynamicFilterPattern("L_ORDERKEY", GREATER_THAN, "O_ORDERKEY")))
                                         .left(
                                                 filter(TRUE_LITERAL,
-                                                        tableScan("orders",
-                                                                ImmutableMap.of(
-                                                                        "O_SHIPPRIORITY", "shippriority",
-                                                                        "O_ORDERKEY", "orderkey"))))
-                                        .right(
-                                                anyTree(
                                                         tableScan("lineitem",
                                                                 ImmutableMap.of(
                                                                         "L_LINENUMBER", "linenumber",
-                                                                        "L_ORDERKEY", "orderkey"))))))));
+                                                                        "L_ORDERKEY", "orderkey"))))
+                                        .right(
+                                                anyTree(
+                                                        tableScan("orders",
+                                                                ImmutableMap.of(
+                                                                        "O_SHIPPRIORITY", "shippriority",
+                                                                        "O_ORDERKEY", "orderkey"))))))));
     }
 
     @Test
@@ -439,13 +439,13 @@ public class TestLogicalPlanner
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
                                 .left(
                                         anyTree(
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))
                                 .right(
                                         anyTree(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
     }
 
     @Test
@@ -454,13 +454,13 @@ public class TestLogicalPlanner
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey ORDER BY l.orderkey ASC, o.orderkey ASC",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
                                 .left(
                                         anyTree(
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))
                                 .right(
                                         anyTree(
-                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
     }
 
     @Test
@@ -902,19 +902,19 @@ public class TestLogicalPlanner
         assertPlan("SELECT o.orderkey, count(*) FROM orders o, lineitem l WHERE o.orderkey=l.orderkey GROUP BY 1",
                 anyTree(
                         aggregation(
-                                singleGroupingSet("o_orderkey"),
+                                singleGroupingSet("l_orderkey"),
                                 ImmutableMap.of(Optional.empty(), functionCall("count", ImmutableList.of())),
-                                ImmutableList.of("o_orderkey"), // streaming
+                                ImmutableList.of("l_orderkey"), // streaming
                                 Optional.empty(),
                                 SINGLE,
                                 join(INNER, builder -> builder
-                                        .equiCriteria("o_orderkey", "l_orderkey")
+                                        .equiCriteria("l_orderkey", "o_orderkey")
                                         .left(
                                                 anyTree(
-                                                        tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey"))))
+                                                        tableScan("lineitem", ImmutableMap.of("l_orderkey", "orderkey"))))
                                         .right(
                                                 anyTree(
-                                                        tableScan("lineitem", ImmutableMap.of("l_orderkey", "orderkey"))))))));
+                                                        tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey"))))))));
 
         // left join -> streaming aggregation
         assertPlan("SELECT o.orderkey, count(*) FROM orders o LEFT JOIN lineitem l ON o.orderkey=l.orderkey GROUP BY 1",
@@ -1324,7 +1324,9 @@ public class TestLogicalPlanner
         // replicated join is preserved if probe side is single node
         assertPlanWithSession(
                 "SELECT * FROM (VALUES 1, 2, 3) t(a), region r WHERE r.regionkey = t.a",
-                broadcastJoin,
+                Session.builder(broadcastJoin)
+                        .setSystemProperty(JOIN_REORDERING_STRATEGY, JoinReorderingStrategy.NONE.name())
+                        .build(),
                 false,
                 anyTree(
                         node(JoinNode.class,
@@ -1433,18 +1435,18 @@ public class TestLogicalPlanner
                 "SELECT custkey FROM orders WHERE custkey IN (SELECT custkey FROM customer)",
                 any(
                         join(INNER, builder -> builder
-                                .equiCriteria("CUSTOMER_CUSTKEY", "ORDER_CUSTKEY")
+                                .equiCriteria("ORDER_CUSTKEY", "CUSTOMER_CUSTKEY")
                                 .left(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDER_CUSTKEY", "custkey"))))
+                                .right(
                                         aggregation(
                                                 singleGroupingSet("CUSTOMER_CUSTKEY"),
                                                 ImmutableMap.of(),
                                                 Optional.empty(),
                                                 FINAL,
                                                 anyTree(
-                                                        tableScan("customer", ImmutableMap.of("CUSTOMER_CUSTKEY", "custkey")))))
-                                .right(
-                                        anyTree(
-                                                tableScan("orders", ImmutableMap.of("ORDER_CUSTKEY", "custkey")))))));
+                                                        tableScan("customer", ImmutableMap.of("CUSTOMER_CUSTKEY", "custkey"))))))));
     }
 
     @Test
@@ -1861,13 +1863,19 @@ public class TestLogicalPlanner
                         "ON orders.orderstatus = t2.s",
                 any(
                         join(INNER, builder -> builder
-                                .equiCriteria("expr", "ORDER_STATUS")
-                                .left(anyTree(values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new StringLiteral("O")), ImmutableList.of(new StringLiteral("F"))))))
+                                .equiCriteria("ORDER_STATUS", "expr")
+                                .left(
+                                        filter(TRUE_LITERAL,
+                                                strictConstrainedTableScan(
+                                                        "orders",
+                                                        ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
+                                                        ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O")))))))
                                 .right(
-                                        exchange(strictConstrainedTableScan(
-                                                "orders",
-                                                ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
-                                                ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O"))))))))));
+                                        filter(
+                                                "expr IN ('F', 'O')",
+                                                values(
+                                                        ImmutableList.of("expr"),
+                                                        ImmutableList.of(ImmutableList.of(new StringLiteral("O")), ImmutableList.of(new StringLiteral("F")))))))));
     }
 
     @Test
@@ -1956,16 +1964,16 @@ public class TestLogicalPlanner
                         "ON orders.orderstatus = t2.s",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("expr", "ORDER_STATUS")
+                                .equiCriteria("ORDER_STATUS", "expr")
                                 .left(
-                                        filter("expr IN ('F', 'O')",
-                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new StringLiteral("O")), ImmutableList.of(new StringLiteral("F"))))))
-                                .right(
-                                        exchange(
+                                        filter(TRUE_LITERAL,
                                                 strictConstrainedTableScan(
                                                         "orders",
                                                         ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
-                                                        ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O"))))))))));
+                                                        ImmutableMap.of("orderstatus", multipleValues(createVarcharType(1), ImmutableList.of(utf8Slice("F"), utf8Slice("O")))))))
+                                .right(
+                                        filter("expr IN ('F', 'O')",
+                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new StringLiteral("O")), ImmutableList.of(new StringLiteral("F")))))))));
 
         // Constraint for the table is derived, based on constant values in the other branch of the join.
         // It is not accepted by the connector, and remains in form of a filter over TableScan.
@@ -1976,18 +1984,18 @@ public class TestLogicalPlanner
                         "ON orders.orderkey = t2.s",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("expr", "ORDER_KEY")
+                                .equiCriteria("ORDER_KEY", "expr")
                                 .left(
                                         filter(
-                                                "expr IN (BIGINT '1', BIGINT '2')",
-                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1")), ImmutableList.of(new GenericLiteral("BIGINT", "2"))))))
-                                .right(
-                                        anyTree(filter(
                                                 "ORDER_KEY IN (BIGINT '1', BIGINT '2')",
                                                 strictConstrainedTableScan(
                                                         "orders",
                                                         ImmutableMap.of("ORDER_STATUS", "orderstatus", "ORDER_KEY", "orderkey"),
-                                                        ImmutableMap.of())))))));
+                                                        ImmutableMap.of())))
+                                .right(
+                                        filter(
+                                                "expr IN (BIGINT '1', BIGINT '2')",
+                                                values(ImmutableList.of("expr"), ImmutableList.of(ImmutableList.of(new GenericLiteral("BIGINT", "1")), ImmutableList.of(new GenericLiteral("BIGINT", "2")))))))));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
@@ -155,7 +155,7 @@ public class TestPredicatePushdown
                         semiJoin("LINE_ORDER_KEY", "ORDERS_ORDER_KEY", "SEMI_JOIN_RESULT", true,
                                 anyTree(
                                         tableScan("lineitem", ImmutableMap.of(
-                                        "LINE_ORDER_KEY", "orderkey"))),
+                                                "LINE_ORDER_KEY", "orderkey"))),
                                 node(ExchangeNode.class,
                                         filter("ORDERS_ORDER_KEY = CAST(random(5) AS bigint)",
                                                 tableScan("orders", ImmutableMap.of("ORDERS_ORDER_KEY", "orderkey")))))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdown.java
@@ -168,15 +168,14 @@ public class TestPredicatePushdown
                 "SELECT * FROM orders JOIN lineitem ON orders.orderkey = lineitem.orderkey AND cast(lineitem.linenumber AS varchar) = '2'",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
                                 .left(
-                                        anyTree(
-                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))
+                                        filter("cast(LINEITEM_LINENUMBER as varchar) = VARCHAR '2'",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINEITEM_OK", "orderkey",
+                                                        "LINEITEM_LINENUMBER", "linenumber"))))
                                 .right(
                                         anyTree(
-                                                filter("cast(LINEITEM_LINENUMBER as varchar) = VARCHAR '2'",
-                                                        tableScan("lineitem", ImmutableMap.of(
-                                                                "LINEITEM_OK", "orderkey",
-                                                                "LINEITEM_LINENUMBER", "linenumber"))))))));
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestPredicatePushdownWithoutDynamicFilter.java
@@ -163,14 +163,14 @@ public class TestPredicatePushdownWithoutDynamicFilter
                 "SELECT * FROM orders JOIN lineitem ON orders.orderkey = lineitem.orderkey AND cast(lineitem.linenumber AS varchar) = '2'",
                 anyTree(
                         join(INNER, builder -> builder
-                                .equiCriteria("ORDERS_OK", "LINEITEM_OK")
+                                .equiCriteria("LINEITEM_OK", "ORDERS_OK")
                                 .left(
-                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))
+                                        filter("cast(LINEITEM_LINENUMBER as varchar) = VARCHAR '2'",
+                                                tableScan("lineitem", ImmutableMap.of(
+                                                        "LINEITEM_OK", "orderkey",
+                                                        "LINEITEM_LINENUMBER", "linenumber"))))
                                 .right(
                                         anyTree(
-                                                filter("cast(LINEITEM_LINENUMBER as varchar) = VARCHAR '2'",
-                                                        tableScan("lineitem", ImmutableMap.of(
-                                                                "LINEITEM_OK", "orderkey",
-                                                                "LINEITEM_LINENUMBER", "linenumber"))))))));
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestQuantifiedComparison.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestQuantifiedComparison.java
@@ -38,9 +38,9 @@ public class TestQuantifiedComparison
         String query = "SELECT orderkey, custkey FROM orders WHERE orderkey = ANY (VALUES ROW(CAST(5 as BIGINT)), ROW(CAST(3 as BIGINT)))";
         assertPlan(query, anyTree(
                 join(INNER, builder -> builder
-                        .equiCriteria("Y", "X")
-                        .left(anyTree(values(ImmutableMap.of("Y", 0))))
-                        .right(anyTree(tableScan("orders", ImmutableMap.of("X", "orderkey")))))));
+                        .equiCriteria("X", "Y")
+                        .left(anyTree(tableScan("orders", ImmutableMap.of("X", "orderkey"))))
+                        .right(anyTree(values(ImmutableMap.of("Y", 0)))))));
     }
 
     @Test

--- a/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableCache.java
+++ b/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableCache.java
@@ -360,7 +360,7 @@ public class TestEvictableCache
 
     /**
      * Test that the loader is invoked only once for concurrent invocations of {{@link LoadingCache#get(Object, Callable)} with equal keys.
-     * This is a behavior of Guava Cache as well. While this is necessarily desirable behavior (see
+     * This is a behavior of Guava Cache as well. While this is not necessarily desirable behavior (see
      * <a href="https://github.com/trinodb/trino/issues/11067">https://github.com/trinodb/trino/issues/11067</a>),
      * the test exists primarily to document current state and support discussion, should the current state change.
      */

--- a/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableLoadingCache.java
+++ b/lib/trino-cache/src/test/java/io/trino/cache/TestEvictableLoadingCache.java
@@ -411,7 +411,7 @@ public class TestEvictableLoadingCache
 
     /**
      * Test that the loader is invoked only once for concurrent invocations of {{@link LoadingCache#get(Object, Callable)} with equal keys.
-     * This is a behavior of Guava Cache as well. While this is necessarily desirable behavior (see
+     * This is a behavior of Guava Cache as well. While this is not necessarily desirable behavior (see
      * <a href="https://github.com/trinodb/trino/issues/11067">https://github.com/trinodb/trino/issues/11067</a>),
      * the test exists primarily to document current state and support discussion, should the current state change.
      */

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergProjectionPushdownPlans.java
@@ -218,8 +218,14 @@ public class TestIcebergProjectionPushdownPlans
                                         "expr_0", expression("expr_0"),
                                         "expr_0_y", expression("expr_0[2]")),
                                 join(INNER, builder -> builder
-                                        .equiCriteria("t_expr_1", "s_expr_1")
+                                        .equiCriteria("s_expr_1", "t_expr_1")
                                         .left(
+                                                anyTree(
+                                                        tableScan(
+                                                                equalTo(((IcebergTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(column1Handle))),
+                                                                TupleDomain.all(),
+                                                                ImmutableMap.of("s_expr_1", equalTo(column1Handle)))))
+                                        .right(
                                                 anyTree(
                                                         filter(
                                                                 "x = BIGINT '2'",
@@ -234,12 +240,6 @@ public class TestIcebergProjectionPushdownPlans
                                                                                     unenforcedConstraint.equals(expectedUnenforcedConstraint);
                                                                         },
                                                                         TupleDomain.all(),
-                                                                        ImmutableMap.of("x", equalTo(columnX), "expr_0", equalTo(column0Handle), "t_expr_1", equalTo(column1Handle))))))
-                                        .right(
-                                                anyTree(
-                                                        tableScan(
-                                                                equalTo(((IcebergTableHandle) tableHandle.get().getConnectorHandle()).withProjectedColumns(Set.of(column1Handle))),
-                                                                TupleDomain.all(),
-                                                                ImmutableMap.of("s_expr_1", equalTo(column1Handle)))))))));
+                                                                        ImmutableMap.of("x", equalTo(columnX), "expr_0", equalTo(column0Handle), "t_expr_1", equalTo(column1Handle))))))))));
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
@@ -274,14 +273,5 @@ public class TestQueryPlanDeterminism
     {
         // testLargeIn is expensive
         Assumptions.abort("Skipping testLargeIn");
-    }
-
-    @Test
-    @Override
-    public void testUnionAllAboveBroadcastJoin()
-    {
-        // TODO: https://github.com/trinodb/trino/issues/20043
-        assertThatThrownBy(super::testUnionAllAboveBroadcastJoin)
-                .hasMessageContaining("bytes is negative");
     }
 }


### PR DESCRIPTION
Assuming 0 node count, we were getting negative cost in the formula

        double cpuCost = buildSideSize * (estimatedSourceDistributedTaskCount - 1);

where `estimatedSourceDistributedTaskCount` is the node count.