### PR TITLE
Support for 0 length dictionary copyRegion

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -420,6 +420,9 @@ public final class DictionaryBlock
     public Block copyRegion(int position, int length)
     {
         checkValidRegion(positionCount, position, length);
+        if (length == 0) {
+            return dictionary.copyRegion(0, 0);
+        }
         // Avoid repeated volatile reads to the uniqueIds field
         int uniqueIds = this.uniqueIds;
         if (length <= 1 || (uniqueIds == dictionary.getPositionCount() && isSequentialIds)) {


### PR DESCRIPTION
checkValidRegion already validates that
region is correct. Therefore copyRegion
for postiion 42 and length 0 shoudn't
fail for dictionary with 42 positions.
