### PR TITLE
Do not shade opentelemetry-extension-incubator

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-extension-incubator</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>test</scope>
@@ -420,10 +426,6 @@
                                 <relocation>
                                     <pattern>okhttp3</pattern>
                                     <shadedPattern>${shadeBase}.okhttp3</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>io.opentelemetry.extension</pattern>
-                                    <shadedPattern>${shadeBase}.opentelemetry.extension</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.opentelemetry.instrumentation</pattern>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Solves #19958

Otherwise, OTEL's HttpMetricsAdvice class checks don't work, resulting in many harmful labels being exposed in OkHttp metrics like the `http_response_content_length` and `http_url`.

I've tested the change against the reproduction repository at https://github.com/gaeljw/otel9972 and it does fix the issue.

Behavior before:
- more than 1000 different metrics rows exported
- example of such rows (Prometheus format): `http_client_duration_milliseconds_bucket{otel_scope_name="io.opentelemetry.okhttp-3.0",http_method="GET",http_response_content_length="313",http_status_code="200",http_url="http://localhost:32769/v1/statement/queued/20231210_161430_00046_fhxz7/y1e8d019656c9d40982bc8bc8acd01931a65d7162/1",net_peer_name="localhost",net_peer_port="32769",net_protocol_name="http",net_protocol_version="1.1",user_agent_original="Trino JDBC Driver/434",le="0.0"} 0.0 1702224879638`

Behavior with this change:
- 80 different metrics rows exported
- example of such rows: `http_client_duration_milliseconds_bucket{otel_scope_name="io.opentelemetry.okhttp-3.0",http_method="GET",http_status_code="200",net_peer_name="localhost",net_peer_port="32771",net_protocol_name="http",net_protocol_version="1.1",le="0.0"} 0.0 1702225905514`
- there's no more the `http_response_content_length`, `http_url` and `user_agent_original` labels


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino/issues/19958
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/9972 (read the comments, thanks @laurit for the investigations)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix OpenTelemetry metrics containing harmful labels (`http_response_content_length`, `http_url` and `user_agent_original`). ({issue}`19958`)
```
