### PR TITLE
Add handling for root bucket table location in sync_partition_metadata

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -191,7 +191,7 @@ public class SyncPartitionMetadataProcedure
     private static String listedDirectoryName(Location directory, Location location)
     {
         String prefix = directory.path();
-        if (!prefix.endsWith("/")) {
+        if (!prefix.isEmpty() && !prefix.endsWith("/")) {
             prefix += "/";
         }
         String path = location.path();


### PR DESCRIPTION
## Description
- Currently, `sync_partition_metadata()` procedure cannot handle the table located in the root bucket path, due to bug on the `listDirectoryName()` logic
- I know, using table mapped with the root bucket path is not the best practice, but we dumped some AWS logs(like cloudfront logs) into the root path of dedicated log bucket.
- the same strategy was already in use on [trino/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java](https://github.com/trinodb/trino/blob/f7369f674384b7cde8b5eb97931d679674930c2f/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java#L175-L177)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
