### PR TITLE
Upgrading spring boot maven plugin to resolve multiple CVE

### DIFF
--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>1.2.5.RELEASE</version>
+                <version>3.2.0</version>
                 <configuration>
                     <classifier>executable</classifier>
                     <mainClass>io.trino.benchto.driver.DriverApp</mainClass>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Module trino-benchto-benchmarks dependency: spring boot maven plugin version 1.2.5.RELEASE has multiple CVE's reported mentioned below so to resolve these upgrading to the latest version.

Vulnerabilities:

- [CVE-2023-37460](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-37460)
- [CVE-2022-4245](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4245)
- [CVE-2022-4244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4244)
- [CVE-2021-26291](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-26291)
- [CVE-2018-1002200](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1002200)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

```markdown
No release notes needed
```
