### PR TITLE
Add scheduler span under query that aggregates all stage spans

### DIFF
--- a/core/trino-main/src/main/java/io/trino/exchange/ExchangeContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/ExchangeContextInstance.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.exchange;
+
+import io.opentelemetry.api.trace.Span;
+import io.trino.spi.QueryId;
+import io.trino.spi.exchange.ExchangeContext;
+import io.trino.spi.exchange.ExchangeId;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class ExchangeContextInstance
+        implements ExchangeContext
+{
+    private final QueryId queryId;
+    private final ExchangeId exchangeId;
+    private final Span parentSpan;
+
+    public ExchangeContextInstance(QueryId queryId, ExchangeId exchangeId, Span parentSpan)
+    {
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.exchangeId = requireNonNull(exchangeId, "exchangeId is null");
+        this.parentSpan = requireNonNull(parentSpan, "parentSpan is null");
+    }
+
+    @Override
+    public QueryId getQueryId()
+    {
+        return queryId;
+    }
+
+    @Override
+    public ExchangeId getExchangeId()
+    {
+        return exchangeId;
+    }
+
+    @Override
+    public Span getParentSpan()
+    {
+        return parentSpan;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("queryId", queryId)
+                .add("exchangeId", exchangeId)
+                .add("parentSpan", parentSpan)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/exchange/ExchangeManagerContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/ExchangeManagerContextInstance.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.exchange;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.spi.exchange.ExchangeManagerContext;
+
+import static java.util.Objects.requireNonNull;
+
+public class ExchangeManagerContextInstance
+        implements ExchangeManagerContext
+{
+    private final OpenTelemetry openTelemetry;
+    private final Tracer tracer;
+
+    public ExchangeManagerContextInstance(
+            OpenTelemetry openTelemetry,
+            Tracer tracer)
+    {
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+    }
+
+    @Override
+    public OpenTelemetry getOpenTelemetry()
+    {
+        return openTelemetry;
+    }
+
+    @Override
+    public Tracer getTracer()
+    {
+        return tracer;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/exchange/ExchangeManagerRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/exchange/ExchangeManagerRegistry.java
@@ -13,7 +13,10 @@
  */
 package io.trino.exchange;
 
+import com.google.inject.Inject;
 import io.airlift.log.Logger;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.exchange.ExchangeManager;
@@ -42,9 +45,20 @@ public class ExchangeManagerRegistry
     private static final File CONFIG_FILE = new File("etc/exchange-manager.properties");
     private static final String EXCHANGE_MANAGER_NAME_PROPERTY = "exchange-manager.name";
 
+    private final OpenTelemetry openTelemetry;
+    private final Tracer tracer;
     private final Map<String, ExchangeManagerFactory> exchangeManagerFactories = new ConcurrentHashMap<>();
 
     private volatile ExchangeManager exchangeManager;
+
+    @Inject
+    public ExchangeManagerRegistry(
+            OpenTelemetry openTelemetry,
+            Tracer tracer)
+    {
+        this.openTelemetry = requireNonNull(openTelemetry, "openTelemetry is null");
+        this.tracer = requireNonNull(tracer, "tracer is null");
+    }
 
     public void addExchangeManagerFactory(ExchangeManagerFactory factory)
     {
@@ -78,7 +92,7 @@ public class ExchangeManagerRegistry
 
         ExchangeManager exchangeManager;
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
-            exchangeManager = factory.create(properties);
+            exchangeManager = factory.create(properties, new ExchangeManagerContextInstance(openTelemetry, tracer));
         }
 
         log.info("-- Loaded exchange manager %s --", name);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStage.java
@@ -85,6 +85,7 @@ public final class SqlStage
             NodeTaskMap nodeTaskMap,
             Executor stateMachineExecutor,
             Tracer tracer,
+            Span schedulerSpan,
             SplitSchedulerStats schedulerStats)
     {
         requireNonNull(stageId, "stageId is null");
@@ -104,7 +105,7 @@ public final class SqlStage
                 tables,
                 stateMachineExecutor,
                 tracer,
-                session.getQuerySpan(),
+                schedulerSpan,
                 schedulerStats);
 
         SqlStage sqlStage = new SqlStage(

--- a/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStateMachine.java
@@ -102,7 +102,7 @@ public class StageStateMachine
             Map<PlanNodeId, TableInfo> tables,
             Executor executor,
             Tracer tracer,
-            Span querySpan,
+            Span schedulerSpan,
             SplitSchedulerStats schedulerStats)
     {
         this.stageId = requireNonNull(stageId, "stageId is null");
@@ -116,7 +116,7 @@ public class StageStateMachine
         finalStageInfo = new StateMachine<>("final stage " + stageId, executor, Optional.empty());
 
         stageSpan = tracer.spanBuilder("stage")
-                .setParent(Context.current().with(querySpan))
+                .setParent(Context.current().with(schedulerSpan))
                 .setAttribute(TrinoAttributes.QUERY_ID, stageId.getQueryId().toString())
                 .setAttribute(TrinoAttributes.STAGE_ID, stageId.toString())
                 .startSpan();

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/PipelinedQueryScheduler.java
@@ -28,6 +28,7 @@ import io.airlift.stats.TimeStat;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
 import io.trino.Session;
 import io.trino.exchange.DirectExchangeInput;
 import io.trino.execution.BasicStageStats;
@@ -71,6 +72,7 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.RemoteSourceNode;
 import io.trino.sql.planner.plan.TableScanNode;
+import io.trino.tracing.TrinoAttributes;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -178,6 +180,7 @@ public class PipelinedQueryScheduler
     private final Duration retryInitialDelay;
     private final Duration retryMaxDelay;
     private final double retryDelayScaleFactor;
+    private final Span schedulerSpan;
 
     @GuardedBy("this")
     private boolean started;
@@ -220,6 +223,10 @@ public class PipelinedQueryScheduler
         this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
         this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
         this.splitSourceFactory = requireNonNull(splitSourceFactory, "splitSourceFactory is null");
+        this.schedulerSpan = tracer.spanBuilder("scheduler")
+                .setParent(Context.current().with(queryStateMachine.getSession().getQuerySpan()))
+                .setAttribute(TrinoAttributes.QUERY_ID, queryStateMachine.getQueryId().toString())
+                .startSpan();
 
         stageManager = StageManager.create(
                 queryStateMachine,
@@ -227,6 +234,7 @@ public class PipelinedQueryScheduler
                 remoteTaskFactory,
                 nodeTaskMap,
                 tracer,
+                schedulerSpan,
                 schedulerStats,
                 plan,
                 summarizeTaskInfo);
@@ -286,6 +294,7 @@ public class PipelinedQueryScheduler
                 }
                 stageManager.abort();
             }
+            schedulerSpan.end();
 
             queryStateMachine.updateQueryInfo(Optional.ofNullable(getStageInfo()));
         });

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/StageManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/StageManager.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.graph.Traverser;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.Session;
 import io.trino.execution.BasicStageStats;
@@ -67,6 +68,7 @@ class StageManager
             RemoteTaskFactory taskFactory,
             NodeTaskMap nodeTaskMap,
             Tracer tracer,
+            Span schedulerSpan,
             SplitSchedulerStats schedulerStats,
             SubPlan planTree,
             boolean summarizeTaskInfo)
@@ -91,6 +93,7 @@ class StageManager
                     nodeTaskMap,
                     queryStateMachine.getStateMachineExecutor(),
                     tracer,
+                    schedulerSpan,
                     schedulerStats);
             StageId stageId = stage.getStageId();
             stages.put(stageId, stage);

--- a/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DirectExchangeClientFactory.java
@@ -19,6 +19,7 @@ import io.airlift.http.client.HttpClient;
 import io.airlift.node.NodeInfo;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.FeaturesConfig;
 import io.trino.FeaturesConfig.DataIntegrityVerification;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -137,6 +138,7 @@ public class DirectExchangeClientFactory
     public DirectExchangeClient get(
             QueryId queryId,
             ExchangeId exchangeId,
+            Span parentSpan,
             LocalMemoryContext memoryContext,
             TaskFailureListener taskFailureListener,
             RetryPolicy retryPolicy)
@@ -144,7 +146,7 @@ public class DirectExchangeClientFactory
         @SuppressWarnings("resource")
         DirectExchangeBuffer buffer = switch (retryPolicy) {
             case TASK -> throw new UnsupportedOperationException();
-            case QUERY -> new DeduplicatingDirectExchangeBuffer(scheduler, deduplicationBufferSize, retryPolicy, exchangeManagerRegistry, queryId, exchangeId);
+            case QUERY -> new DeduplicatingDirectExchangeBuffer(scheduler, deduplicationBufferSize, retryPolicy, exchangeManagerRegistry, queryId, parentSpan, exchangeId);
             case NONE -> new StreamingDirectExchangeBuffer(scheduler, maxBufferedBytes);
         };
 

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
@@ -97,6 +97,7 @@ public class ExchangeOperator
                 exchangeDataSource = new LazyExchangeDataSource(
                         taskId.getQueryId(),
                         new ExchangeId(format("direct-exchange-%s-%s", taskId.getStageId().getId(), sourceId)),
+                        taskContext.getSession().getQuerySpan(),
                         directExchangeClientSupplier,
                         memoryContext,
                         taskContext::sourceTaskFailed,

--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -169,6 +169,7 @@ public class MergeOperator
         DirectExchangeClient client = closer.register(directExchangeClientSupplier.get(
                 taskContext.getTaskId().getQueryId(),
                 new ExchangeId(format("direct-exchange-merge-%s-%s", taskContext.getTaskId().getStageId().getId(), sourceId)),
+                taskContext.getSession().getQuerySpan(),
                 operatorContext.localUserMemoryContext(),
                 taskContext::sourceTaskFailed,
                 RetryPolicy.NONE));

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -186,6 +186,7 @@ class Query
         ExchangeDataSource exchangeDataSource = new LazyExchangeDataSource(
                 session.getQueryId(),
                 new ExchangeId("query-results-exchange-" + session.getQueryId()),
+                session.getQuerySpan(),
                 directExchangeClientSupplier,
                 new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), Query.class.getSimpleName()),
                 queryManager::outputTaskFailed,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Closer;
 import io.airlift.node.NodeInfo;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.opentelemetry.api.OpenTelemetry;
@@ -476,7 +477,7 @@ public class LocalQueryRunner
                 ImmutableSet.of(),
                 ImmutableSet.of(new ExcludeColumnsFunction()));
 
-        exchangeManagerRegistry = new ExchangeManagerRegistry();
+        exchangeManagerRegistry = new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer());
         this.pluginManager = new PluginManager(
                 (loader, createClassLoader) -> {},
                 catalogFactory,

--- a/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
+++ b/core/trino-main/src/main/java/io/trino/tracing/TrinoAttributes.java
@@ -60,4 +60,6 @@ public final class TrinoAttributes
     public static final AttributeKey<Boolean> SPLIT_BLOCKED = booleanKey("trino.split.blocked");
 
     public static final AttributeKey<String> EVENT_STATE = stringKey("state");
+
+    public static final AttributeKey<String> FAILURE_MESSAGE = stringKey("failure");
 }

--- a/core/trino-main/src/test/java/io/trino/execution/BaseTestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseTestSqlTaskManager.java
@@ -18,9 +18,11 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.node.NodeInfo;
 import io.airlift.stats.TestingGcMonitor;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.connector.CatalogProperties;
@@ -335,7 +337,7 @@ public abstract class BaseTestSqlTaskManager
                 new NodeSpillConfig(),
                 new TestingGcMonitor(),
                 noopTracer(),
-                new ExchangeManagerRegistry());
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()));
     }
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, ImmutableSet<ScheduledSplit> splits, OutputBuffers outputBuffers)
@@ -383,6 +385,7 @@ public abstract class BaseTestSqlTaskManager
         public DirectExchangeClient get(
                 QueryId queryId,
                 ExchangeId exchangeId,
+                Span parentSpan,
                 LocalMemoryContext memoryContext,
                 TaskFailureListener taskFailureListener,
                 RetryPolicy retryPolicy)

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -23,8 +23,10 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.stats.TestingGcMonitor;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
@@ -227,7 +229,7 @@ public class MockRemoteTaskFactory
                     DataSize.ofBytes(1),
                     () -> new SimpleLocalMemoryContext(newSimpleAggregatedMemoryContext(), "test"),
                     () -> {},
-                    new ExchangeManagerRegistry());
+                    new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()));
 
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.nodeId = requireNonNull(nodeId, "nodeId is null");

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -16,6 +16,8 @@ package io.trino.execution;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.ObjectMapperProvider;
+import io.airlift.tracing.Tracing;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogServiceProvider;
@@ -179,7 +181,7 @@ public final class TaskTestUtils
                 blockTypeOperators,
                 PLANNER_CONTEXT.getTypeOperators(),
                 new TableExecuteContextManager(),
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new NodeVersion("test"),
                 new CompilerConfig());
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -20,7 +20,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.TestingGcMonitor;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.buffer.PipelinedOutputBuffers;
 import io.trino.execution.executor.TaskExecutor;
@@ -280,7 +282,7 @@ public class TestMemoryRevokingScheduler
                 sqlTask -> {},
                 DataSize.of(32, MEGABYTE),
                 DataSize.of(200, MEGABYTE),
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new CounterStat());
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlStage.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
+import io.opentelemetry.api.trace.Span;
 import io.trino.client.NodeVersion;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.buffer.PipelinedOutputBuffers;
@@ -124,6 +125,7 @@ public class TestSqlStage
                 nodeTaskMap,
                 executor,
                 noopTracer(),
+                Span.getInvalid(),
                 new SplitSchedulerStats());
 
         // add listener that fetches stage info when the final status is available

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -21,8 +21,10 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.CounterStat;
 import io.airlift.stats.TestingGcMonitor;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.buffer.BufferResult;
@@ -454,7 +456,7 @@ public class TestSqlTask
                 sqlTask -> {},
                 DataSize.of(32, MEGABYTE),
                 DataSize.of(200, MEGABYTE),
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new CounterStat());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerRaceWithCatalogPrune.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerRaceWithCatalogPrune.java
@@ -22,6 +22,7 @@ import io.airlift.node.NodeInfo;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.tracing.Tracing;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.connector.CatalogConnector;
@@ -263,7 +264,7 @@ public class TestSqlTaskManagerRaceWithCatalogPrune
                 new NodeSpillConfig(),
                 new TestingGcMonitor(),
                 noopTracer(),
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 ignore -> true);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestTaskExecutorStuckSplits.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestTaskExecutorStuckSplits.java
@@ -20,7 +20,9 @@ import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.airlift.node.NodeInfo;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.testing.TestingTicker;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.connector.CatalogProperties;
@@ -135,7 +137,7 @@ public class TestTaskExecutorStuckSplits
                 new NodeSpillConfig(),
                 new TestingGcMonitor(),
                 noopTracer(),
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 stuckSplitStackTracePredicate);
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestMultiSourcePartitionedScheduler.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.client.NodeVersion;
 import io.trino.cost.StatsAndCosts;
@@ -624,6 +625,7 @@ public class TestMultiSourcePartitionedScheduler
                 nodeTaskMap,
                 queryExecutor,
                 noopTracer(),
+                Span.getInvalid(),
                 new SplitSchedulerStats());
         ImmutableMap.Builder<PlanFragmentId, PipelinedOutputBufferManager> outputBuffers = ImmutableMap.builder();
         outputBuffers.put(fragment.getId(), new PartitionedPipelinedOutputBufferManager(FIXED_HASH_DISTRIBUTION, 1));

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.trace.Span;
 import io.trino.Session;
 import io.trino.client.NodeVersion;
 import io.trino.cost.StatsAndCosts;
@@ -764,6 +765,7 @@ public class TestSourcePartitionedScheduler
                 nodeTaskMap,
                 queryExecutor,
                 noopTracer(),
+                Span.getInvalid(),
                 new SplitSchedulerStats());
         ImmutableMap.Builder<PlanFragmentId, PipelinedOutputBufferManager> outputBuffers = ImmutableMap.builder();
         outputBuffers.put(fragment.getId(), new PartitionedPipelinedOutputBufferManager(FIXED_HASH_DISTRIBUTION, 1));

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingExchangeSourceHandle.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestingExchangeSourceHandle.java
@@ -13,6 +13,8 @@
  */
 package io.trino.execution.scheduler;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.exchange.ExchangeSourceHandle;
 
 import java.util.Objects;
@@ -29,25 +31,32 @@ public class TestingExchangeSourceHandle
     private final int partitionId;
     private final long sizeInBytes;
 
-    public TestingExchangeSourceHandle(int id, int partitionId, long sizeInBytes)
+    @JsonCreator
+    public TestingExchangeSourceHandle(
+            @JsonProperty("id") int id,
+            @JsonProperty("partitionId") int partitionId,
+            @JsonProperty("sizeInBytes") long sizeInBytes)
     {
         this.id = id;
         this.partitionId = partitionId;
         this.sizeInBytes = sizeInBytes;
     }
 
+    @JsonProperty
     public int getId()
     {
         return id;
     }
 
     @Override
+    @JsonProperty
     public int getPartitionId()
     {
         return partitionId;
     }
 
     @Override
+    @JsonProperty("sizeInBytes")
     public long getDataSizeInBytes()
     {
         return sizeInBytes;

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/faulttolerant/TestTaskDescriptorStorage.java
@@ -13,6 +13,8 @@
  */
 package io.trino.execution.scheduler.faulttolerant;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
@@ -223,12 +225,13 @@ public class TestTaskDescriptorStorage
         return DataSize.of(size, unit).toBytes();
     }
 
-    private static class TestingExchangeSourceHandle
+    public static class TestingExchangeSourceHandle
             implements ExchangeSourceHandle
     {
         private final long retainedSizeInBytes;
 
-        private TestingExchangeSourceHandle(long retainedSizeInBytes)
+        @JsonCreator
+        public TestingExchangeSourceHandle(@JsonProperty("retainedSizeInBytes") long retainedSizeInBytes)
         {
             this.retainedSizeInBytes = retainedSizeInBytes;
         }
@@ -246,6 +249,7 @@ public class TestTaskDescriptorStorage
         }
 
         @Override
+        @JsonProperty
         public long getRetainedSizeInBytes()
         {
             return retainedSizeInBytes;

--- a/core/trino-main/src/test/java/io/trino/operator/TestDeduplicatingDirectExchangeBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDeduplicatingDirectExchangeBuffer.java
@@ -21,7 +21,10 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
 import io.trino.exchange.ExchangeManagerRegistry;
 import io.trino.execution.StageId;
 import io.trino.execution.TaskId;
@@ -64,7 +67,7 @@ public class TestDeduplicatingDirectExchangeBuffer
     @BeforeAll
     public void beforeClass()
     {
-        exchangeManagerRegistry = new ExchangeManagerRegistry();
+        exchangeManagerRegistry = new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer());
         exchangeManagerRegistry.addExchangeManagerFactory(new FileSystemExchangeManagerFactory());
         exchangeManagerRegistry.loadExchangeManager("filesystem", ImmutableMap.of(
                 "exchange.base-directories", System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager"));
@@ -445,8 +448,9 @@ public class TestDeduplicatingDirectExchangeBuffer
                 directExecutor(),
                 DataSize.of(100, BYTE),
                 RetryPolicy.QUERY,
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new QueryId("query"),
+                Span.getInvalid(),
                 createRandomExchangeId())) {
             TaskId task = createTaskId(0, 0);
             Slice page = createPage("1234", DataSize.of(10, BYTE));
@@ -468,8 +472,9 @@ public class TestDeduplicatingDirectExchangeBuffer
                 directExecutor(),
                 DataSize.of(100, BYTE),
                 RetryPolicy.QUERY,
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new QueryId("query"),
+                Span.getInvalid(),
                 createRandomExchangeId())) {
             TaskId task = createTaskId(0, 0);
 
@@ -690,6 +695,7 @@ public class TestDeduplicatingDirectExchangeBuffer
                 retryPolicy,
                 exchangeManagerRegistry,
                 new QueryId("query"),
+                Span.getInvalid(),
                 createRandomExchangeId());
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDirectExchangeClient.java
@@ -25,9 +25,12 @@ import io.airlift.http.client.Response;
 import io.airlift.http.client.testing.TestingHttpClient;
 import io.airlift.http.client.testing.TestingResponse;
 import io.airlift.slice.Slice;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Span;
 import io.trino.FeaturesConfig.DataIntegrityVerification;
 import io.trino.block.BlockAssertions;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -489,8 +492,9 @@ public class TestDirectExchangeClient
                 scheduler,
                 DataSize.of(1, Unit.MEGABYTE),
                 RetryPolicy.QUERY,
-                new ExchangeManagerRegistry(),
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                 new QueryId("query"),
+                Span.getInvalid(),
                 createRandomExchangeId());
 
         DirectExchangeClient exchangeClient = new DirectExchangeClient(
@@ -549,8 +553,9 @@ public class TestDirectExchangeClient
                         scheduler,
                         DataSize.of(1, Unit.KILOBYTE),
                         RetryPolicy.QUERY,
-                        new ExchangeManagerRegistry(),
+                        new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()),
                         new QueryId("query"),
+                        Span.getInvalid(),
                         createRandomExchangeId()),
                 maxResponseSize,
                 1,

--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -19,8 +19,10 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.testing.TestingHttpClient;
+import io.airlift.tracing.Tracing;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.FeaturesConfig.DataIntegrityVerification;
 import io.trino.exchange.DirectExchangeInput;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -91,7 +93,7 @@ public class TestExchangeOperator
         pageBufferClientCallbackExecutor = Executors.newSingleThreadExecutor();
         httpClient = new TestingHttpClient(new TestingExchangeHttpClientHandler(taskBuffers, SERDE_FACTORY), scheduler);
 
-        directExchangeClientSupplier = (queryId, exchangeId, memoryContext, taskFailureListener, retryPolicy) -> new DirectExchangeClient(
+        directExchangeClientSupplier = (queryId, exchangeId, span, memoryContext, taskFailureListener, retryPolicy) -> new DirectExchangeClient(
                 "localhost",
                 DataIntegrityVerification.ABORT,
                 new StreamingDirectExchangeBuffer(scheduler, DataSize.of(32, MEGABYTE)),
@@ -266,7 +268,7 @@ public class TestExchangeOperator
                 directExchangeClientSupplier,
                 SERDE_FACTORY,
                 RetryPolicy.NONE,
-                new ExchangeManagerRegistry());
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()));
 
         DriverContext driverContext = createTaskContext(scheduler, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/core/trino-main/src/test/java/io/trino/operator/TestMergeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestMergeOperator.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.http.client.HttpClient;
 import io.airlift.http.client.testing.TestingHttpClient;
 import io.airlift.node.NodeInfo;
+import io.airlift.tracing.Tracing;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.FeaturesConfig;
 import io.trino.exchange.DirectExchangeInput;
 import io.trino.exchange.ExchangeManagerRegistry;
@@ -94,7 +96,7 @@ public class TestMergeOperator
                 new DirectExchangeClientConfig(),
                 httpClient,
                 executor,
-                new ExchangeManagerRegistry());
+                new ExchangeManagerRegistry(OpenTelemetry.noop(), Tracing.noopTracer()));
         orderingCompiler = new OrderingCompiler(new TypeOperators());
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
@@ -13,41 +13,16 @@
  */
 package io.trino.spi.exchange;
 
+import io.opentelemetry.api.trace.Span;
 import io.trino.spi.Experimental;
 import io.trino.spi.QueryId;
 
-import java.util.StringJoiner;
-
-import static java.util.Objects.requireNonNull;
-
 @Experimental(eta = "2023-09-01")
-public class ExchangeContext
+public interface ExchangeContext
 {
-    private final QueryId queryId;
-    private final ExchangeId exchangeId;
+    QueryId getQueryId();
 
-    public ExchangeContext(QueryId queryId, ExchangeId exchangeId)
-    {
-        this.queryId = requireNonNull(queryId, "queryId is null");
-        this.exchangeId = requireNonNull(exchangeId, "exchangeId is null");
-    }
+    ExchangeId getExchangeId();
 
-    public QueryId getQueryId()
-    {
-        return queryId;
-    }
-
-    public ExchangeId getExchangeId()
-    {
-        return exchangeId;
-    }
-
-    @Override
-    public String toString()
-    {
-        return new StringJoiner(", ", ExchangeContext.class.getSimpleName() + "[", "]")
-                .add("queryId=" + queryId)
-                .add("exchangeId=" + exchangeId)
-                .toString();
-    }
+    Span getParentSpan();
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeContext.java
@@ -14,10 +14,8 @@
 package io.trino.spi.exchange;
 
 import io.opentelemetry.api.trace.Span;
-import io.trino.spi.Experimental;
 import io.trino.spi.QueryId;
 
-@Experimental(eta = "2023-09-01")
 public interface ExchangeContext
 {
     QueryId getQueryId();

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeId.java
@@ -15,7 +15,6 @@ package io.trino.spi.exchange;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import io.trino.spi.Experimental;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
@@ -25,7 +24,6 @@ import static io.airlift.slice.SizeOf.instanceSize;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 
-@Experimental(eta = "2023-09-01")
 public class ExchangeId
 {
     private static final long INSTANCE_SIZE = instanceSize(ExchangeId.class);

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManager.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManager.java
@@ -15,7 +15,6 @@ package io.trino.spi.exchange;
 
 import com.google.errorprone.annotations.ThreadSafe;
 import io.airlift.slice.Slice;
-import io.trino.spi.Experimental;
 
 /**
  * Service provider interface for an external exchange
@@ -37,7 +36,6 @@ import io.trino.spi.Experimental;
  * data written by other instances must be safely discarded
  */
 @ThreadSafe
-@Experimental(eta = "2023-09-01")
 public interface ExchangeManager
 {
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerContext.java
@@ -11,21 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator;
+package io.trino.spi.exchange;
 
-import io.opentelemetry.api.trace.Span;
-import io.trino.execution.TaskFailureListener;
-import io.trino.memory.context.LocalMemoryContext;
-import io.trino.spi.QueryId;
-import io.trino.spi.exchange.ExchangeId;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 
-public interface DirectExchangeClientSupplier
+public interface ExchangeManagerContext
 {
-    DirectExchangeClient get(
-            QueryId queryId,
-            ExchangeId exchangeId,
-            Span parentSpan,
-            LocalMemoryContext memoryContext,
-            TaskFailureListener taskFailureListener,
-            RetryPolicy retryPolicy);
+    default OpenTelemetry getOpenTelemetry()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default Tracer getTracer()
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerFactory.java
@@ -13,11 +13,8 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
 import java.util.Map;
 
-@Experimental(eta = "2023-09-01")
 public interface ExchangeManagerFactory
 {
     String getName();

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerFactory.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerFactory.java
@@ -22,5 +22,5 @@ public interface ExchangeManagerFactory
 {
     String getName();
 
-    ExchangeManager create(Map<String, String> config);
+    ExchangeManager create(Map<String, String> config, ExchangeManagerContext context);
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerHandleResolver.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeManagerHandleResolver.java
@@ -13,9 +13,6 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
-@Experimental(eta = "2023-09-01")
 public interface ExchangeManagerHandleResolver
 {
     Class<? extends ExchangeSinkInstanceHandle> getExchangeSinkInstanceHandleClass();

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSink.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSink.java
@@ -15,12 +15,10 @@ package io.trino.spi.exchange;
 
 import com.google.errorprone.annotations.ThreadSafe;
 import io.airlift.slice.Slice;
-import io.trino.spi.Experimental;
 
 import java.util.concurrent.CompletableFuture;
 
 @ThreadSafe
-@Experimental(eta = "2023-09-01")
 public interface ExchangeSink
 {
     CompletableFuture<Void> NOT_BLOCKED = CompletableFuture.completedFuture(null);

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSinkHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSinkHandle.java
@@ -13,12 +13,9 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
 /*
  * Implementation is expected to be Jackson serializable
  */
-@Experimental(eta = "2023-09-01")
 public interface ExchangeSinkHandle
 {
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSinkInstanceHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSinkInstanceHandle.java
@@ -13,9 +13,6 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
-@Experimental(eta = "2023-09-01")
 public interface ExchangeSinkInstanceHandle
 {
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSource.java
@@ -15,7 +15,6 @@ package io.trino.spi.exchange;
 
 import com.google.errorprone.annotations.ThreadSafe;
 import io.airlift.slice.Slice;
-import io.trino.spi.Experimental;
 import jakarta.annotation.Nullable;
 
 import java.io.Closeable;
@@ -23,7 +22,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @ThreadSafe
-@Experimental(eta = "2023-09-01")
 public interface ExchangeSource
         extends Closeable
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceHandle.java
@@ -13,12 +13,9 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
 /*
  * Implementation is expected to be Jackson serializable
  */
-@Experimental(eta = "2023-09-01")
 public interface ExchangeSourceHandle
 {
     int getPartitionId();

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceStatistics.java
@@ -13,9 +13,6 @@
  */
 package io.trino.spi.exchange;
 
-import io.trino.spi.Experimental;
-
-@Experimental(eta = "2023-09-01")
 public class ExchangeSourceStatistics
 {
     private final long sizeInBytes;

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -341,6 +341,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>tracing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing-containers</artifactId>
             <scope>test</scope>

--- a/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/main/java/io/trino/plugin/exchange/filesystem/FileSystemExchangeManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.exchange.filesystem;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import io.opentelemetry.api.trace.Tracer;
 import io.trino.spi.TrinoException;
 import io.trino.spi.exchange.Exchange;
 import io.trino.spi.exchange.ExchangeContext;
@@ -41,6 +42,7 @@ public class FileSystemExchangeManager
 
     private final FileSystemExchangeStorage exchangeStorage;
     private final FileSystemExchangeStats stats;
+    private final Tracer tracer;
     private final List<URI> baseDirectories;
     private final int maxPageStorageSizeInBytes;
     private final int exchangeSinkBufferPoolMinSize;
@@ -57,12 +59,14 @@ public class FileSystemExchangeManager
     public FileSystemExchangeManager(
             FileSystemExchangeStorage exchangeStorage,
             FileSystemExchangeStats stats,
-            FileSystemExchangeConfig fileSystemExchangeConfig)
+            FileSystemExchangeConfig fileSystemExchangeConfig,
+            Tracer tracer)
     {
         this.exchangeStorage = requireNonNull(exchangeStorage, "exchangeStorage is null");
         this.stats = requireNonNull(stats, "stats is null");
         this.baseDirectories = ImmutableList.copyOf(requireNonNull(fileSystemExchangeConfig.getBaseDirectories(), "baseDirectories is null"));
         this.maxPageStorageSizeInBytes = toIntExact(fileSystemExchangeConfig.getMaxPageStorageSize().toBytes());
+        this.tracer = requireNonNull(tracer, "tracer is null");
         this.exchangeSinkBufferPoolMinSize = fileSystemExchangeConfig.getExchangeSinkBufferPoolMinSize();
         this.exchangeSinkBuffersPerPartition = fileSystemExchangeConfig.getExchangeSinkBuffersPerPartition();
         this.exchangeSinkMaxFileSizeInBytes = fileSystemExchangeConfig.getExchangeSinkMaxFileSize().toBytes();
@@ -87,6 +91,7 @@ public class FileSystemExchangeManager
                 baseDirectories,
                 exchangeStorage,
                 stats,
+                tracer,
                 context,
                 outputPartitionCount,
                 preserveOrderWithinPartition,

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestExchangeManagerContext.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/TestExchangeManagerContext.java
@@ -11,21 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.operator;
+package io.trino.plugin.exchange.filesystem;
 
-import io.opentelemetry.api.trace.Span;
-import io.trino.execution.TaskFailureListener;
-import io.trino.memory.context.LocalMemoryContext;
-import io.trino.spi.QueryId;
-import io.trino.spi.exchange.ExchangeId;
+import io.airlift.tracing.Tracing;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+import io.trino.spi.exchange.ExchangeManagerContext;
 
-public interface DirectExchangeClientSupplier
+public class TestExchangeManagerContext
+        implements ExchangeManagerContext
 {
-    DirectExchangeClient get(
-            QueryId queryId,
-            ExchangeId exchangeId,
-            Span parentSpan,
-            LocalMemoryContext memoryContext,
-            TaskFailureListener taskFailureListener,
-            RetryPolicy retryPolicy);
+    @Override
+    public OpenTelemetry getOpenTelemetry()
+    {
+        return OpenTelemetry.noop();
+    }
+
+    @Override
+    public Tracer getTracer()
+    {
+        return Tracing.noopTracer();
+    }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/local/TestLocalFileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/local/TestLocalFileSystemExchangeManager.java
@@ -16,6 +16,7 @@ package io.trino.plugin.exchange.filesystem.local;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.exchange.filesystem.AbstractTestExchangeManager;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeManagerFactory;
+import io.trino.plugin.exchange.filesystem.TestExchangeManagerContext;
 import io.trino.spi.exchange.ExchangeManager;
 
 public class TestLocalFileSystemExchangeManager
@@ -26,10 +27,12 @@ public class TestLocalFileSystemExchangeManager
     {
         String baseDirectory1 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-1";
         String baseDirectory2 = System.getProperty("java.io.tmpdir") + "/trino-local-file-system-exchange-manager-2";
-        return new FileSystemExchangeManagerFactory().create(ImmutableMap.of(
-                "exchange.base-directories", baseDirectory1 + "," + baseDirectory2,
-                // to trigger file split in some tests
-                "exchange.sink-max-file-size", "16MB",
-                "exchange.source-handle-target-data-size", "1MB"));
+        return new FileSystemExchangeManagerFactory().create(
+                ImmutableMap.of(
+                        "exchange.base-directories", baseDirectory1 + "," + baseDirectory2,
+                        // to trigger file split in some tests
+                        "exchange.sink-max-file-size", "16MB",
+                        "exchange.source-handle-target-data-size", "1MB"),
+                new TestExchangeManagerContext());
     }
 }

--- a/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestS3FileSystemExchangeManager.java
+++ b/plugin/trino-exchange-filesystem/src/test/java/io/trino/plugin/exchange/filesystem/s3/TestS3FileSystemExchangeManager.java
@@ -15,6 +15,7 @@ package io.trino.plugin.exchange.filesystem.s3;
 
 import io.trino.plugin.exchange.filesystem.AbstractTestExchangeManager;
 import io.trino.plugin.exchange.filesystem.FileSystemExchangeManagerFactory;
+import io.trino.plugin.exchange.filesystem.TestExchangeManagerContext;
 import io.trino.plugin.exchange.filesystem.containers.MinioStorage;
 import io.trino.spi.exchange.ExchangeManager;
 import org.junit.jupiter.api.AfterAll;
@@ -33,7 +34,9 @@ public class TestS3FileSystemExchangeManager
         this.minioStorage = new MinioStorage("test-exchange-spooling-" + randomUUID());
         minioStorage.start();
 
-        return new FileSystemExchangeManagerFactory().create(getExchangeManagerProperties(minioStorage));
+        return new FileSystemExchangeManagerFactory().create(
+                getExchangeManagerProperties(minioStorage),
+                new TestExchangeManagerContext());
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The Trino spans below the the Query span are Dispatch, Analyzer, Planner and then a sequence of Stage spans. Placing the set of Stage spans under a new Scheduler span allows all execution spans to be grouped together. In
addition, new Exchange spans are also being added to instrument the exchanges that operate across stages.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
