### PR TITLE
Fix incorrect LIKE for patterns with repeating substrings

### DIFF
--- a/core/trino-main/src/main/java/io/trino/likematcher/FjsMatcher.java
+++ b/core/trino-main/src/main/java/io/trino/likematcher/FjsMatcher.java
@@ -146,7 +146,7 @@ public class FjsMatcher
                 j = kmpShifts[j];
 
                 // Continue to match the whole pattern using KMP
-                while (j > 0) {
+                while (j >= 0) {
                     int size = findLongestMatch(input, i, pattern, j, Math.min(inputLimit - i, pattern.length - j));
                     i += size;
                     j += size;

--- a/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/likematcher/TestLikeMatcher.java
@@ -96,6 +96,12 @@ public class TestLikeMatcher
 
         assertFalse(match("%abaaa%", "ababaa"));
 
+        assertTrue(match("%paya%", "papaya"));
+        assertTrue(match("%paya%", "papapaya"));
+        assertTrue(match("%paya%", "papapapaya"));
+        assertTrue(match("%paya%", "papapapapaya"));
+        assertTrue(match("%paya%", "papapapapapaya"));
+
         // utf-8
         LikeMatcher singleOptimized = LikePattern.compile("_", Optional.empty(), true).getMatcher();
         LikeMatcher multipleOptimized = LikePattern.compile("_a%b_", Optional.empty(), true).getMatcher(); // prefix and suffix with _a and b_ to avoid optimizations


### PR DESCRIPTION
After the initial KMP mismatch, the next match was being skipped at position i == longest match.

Fixes #20089

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix incorrect results for LIKE with some strings containing repeated substrings. ({issue}`20089`)
```
