### PR TITLE
Remove unused property

### DIFF
--- a/docs/src/main/sphinx/admin/properties-http-client.md
+++ b/docs/src/main/sphinx/admin/properties-http-client.md
@@ -28,13 +28,6 @@ The following prefixes are supported:
 
 Timeout value for establishing the connection to the external service.
 
-### `http-client.max-connections`
-
-- **Type:** {ref}`prop-type-integer`
-- **Default value:** `200`
-
-Maximum connections allowed to the service.
-
 ### `http-client.request-timeout`
 
 - **Type:** {ref}`prop-type-duration`


### PR DESCRIPTION
## Description

See https://trinodb.slack.com/archives/CP1MUNEUX/p1701464071442409

According to @electrum the property is not used.

Maybe we should also list all the subsystems where these properties are used .. wdyt @electrum ?

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
