### PR TITLE
Revert "Allow differentiating materialized views from tables efficiently"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaTable.java
@@ -47,7 +47,6 @@ public enum InformationSchemaTable
             .column("table_schema", createUnboundedVarcharType())
             .column("table_name", createUnboundedVarcharType())
             .column("table_type", createUnboundedVarcharType())
-            .hiddenColumn("trino_relation_type", createUnboundedVarcharType())
             .hiddenColumn("table_comment", createUnboundedVarcharType()) // MySQL compatible
             .build()),
     VIEWS(table("views")

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -1052,15 +1052,15 @@ public abstract class BaseConnectorTest
                 .containsAll("VALUES '" + view.getObjectName() + "'");
         // information_schema.tables without table_name filter so that ConnectorMetadata.listViews is exercised
         assertThat(query(
-                "SELECT table_name, table_type, trino_relation_type FROM information_schema.tables " +
+                "SELECT table_name, table_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "'"))
                 .skippingTypesCheck()
-                .containsAll("VALUES ('" + view.getObjectName() + "', 'BASE TABLE', 'MATERIALIZED VIEW')");
+                .containsAll("VALUES ('" + view.getObjectName() + "', 'BASE TABLE')");
         // information_schema.tables with table_name filter
         assertQuery(
-                "SELECT table_name, table_type, trino_relation_type FROM information_schema.tables " +
+                "SELECT table_name, table_type FROM information_schema.tables " +
                         "WHERE table_schema = '" + view.getSchemaName() + "' and table_name = '" + view.getObjectName() + "'",
-                "VALUES ('" + view.getObjectName() + "', 'BASE TABLE', 'MATERIALIZED VIEW')");
+                "VALUES ('" + view.getObjectName() + "', 'BASE TABLE')");
 
         // system.jdbc.tables without filter
         assertThat(query("SELECT table_schem, table_name, table_type FROM system.jdbc.tables"))


### PR DESCRIPTION
Per https://github.com/trinodb/trino/pull/19947#issuecomment-1836496038, this needs more thought and a different approach that does not involve modifying the information_schema tables. Reverting it for now before the next release goes out.

This reverts commit 1c5e5eb0d3949ff5d6f6bfd42a72428b4a2d5668.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
