### PR TITLE
Added TrinoException for millis overflow in from_unixtime

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -127,7 +127,12 @@ public final class DateTimeFunctions
     public static long fromUnixTime(ConnectorSession session, @SqlType(StandardTypes.DOUBLE) double unixTime)
     {
         // TODO (https://github.com/trinodb/trino/issues/5781)
-        return packDateTimeWithZone(Math.round(unixTime * 1000), session.getTimeZoneKey());
+        try {
+            return packDateTimeWithZone(Math.round(unixTime * 1000), session.getTimeZoneKey());
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
     }
 
     @ScalarFunction("from_unixtime")
@@ -137,11 +142,11 @@ public final class DateTimeFunctions
         TimeZoneKey timeZoneKey;
         try {
             timeZoneKey = getTimeZoneKeyForOffset(toIntExact(hoursOffset * 60 + minutesOffset));
+            return packDateTimeWithZone(Math.round(unixTime * 1000), timeZoneKey);
         }
         catch (IllegalArgumentException e) {
             throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
         }
-        return packDateTimeWithZone(Math.round(unixTime * 1000), timeZoneKey);
     }
 
     @ScalarFunction("from_unixtime")
@@ -149,7 +154,12 @@ public final class DateTimeFunctions
     @SqlType("timestamp(3) with time zone")
     public static long fromUnixTime(@SqlType(StandardTypes.DOUBLE) double unixTime, @SqlType("varchar(x)") Slice zoneId)
     {
-        return packDateTimeWithZone(Math.round(unixTime * 1000), zoneId.toStringUtf8());
+        try {
+            return packDateTimeWithZone(Math.round(unixTime * 1000), zoneId.toStringUtf8());
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
     }
 
     @ScalarFunction("from_unixtime_nanos")
@@ -172,7 +182,12 @@ public final class DateTimeFunctions
                 epochSeconds -= 1;
                 picosOfSecond += PICOSECONDS_PER_SECOND;
             }
-            return DateTimes.longTimestampWithTimeZone(epochSeconds, picosOfSecond, session.getTimeZoneKey().getZoneId());
+            try {
+                return DateTimes.longTimestampWithTimeZone(epochSeconds, picosOfSecond, session.getTimeZoneKey().getZoneId());
+            }
+            catch (ArithmeticException e) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
+            }
         }
 
         @LiteralParameters({"p", "s"})
@@ -216,7 +231,12 @@ public final class DateTimeFunctions
         DateTimeFormatter formatter = ISODateTimeFormat.dateTimeParser()
                 .withChronology(getChronology(session.getTimeZoneKey()))
                 .withOffsetParsed();
-        return packDateTimeWithZone(parseDateTimeHelper(formatter, iso8601DateTime.toStringUtf8()));
+        try {
+            return packDateTimeWithZone(parseDateTimeHelper(formatter, iso8601DateTime.toStringUtf8()));
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
     }
 
     @ScalarFunction("from_iso8601_timestamp_nanos")

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -130,6 +130,10 @@ public class TestDateTimeFunctions
 
         assertThat(assertions.function("from_unixtime", "980172245.888"))
                 .matches("TIMESTAMP '2001-01-22 03:04:05.888 Pacific/Apia'");
+
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "123456789123456789")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Millis overflow: 9223372036854775807");
     }
 
     @Test
@@ -197,6 +201,10 @@ public class TestDateTimeFunctions
 
         assertThat(assertions.function("from_unixtime_nanos", "DECIMAL '-12345678900123456789.500'"))
                 .matches("TIMESTAMP '1578-10-13 17:18:03.876543210 Pacific/Apia'");
+
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime_nanos", "DECIMAL '123456789123456789000000000'")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("long overflow");
     }
 
     @Test
@@ -214,6 +222,11 @@ public class TestDateTimeFunctions
 
         assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "0", "-100", "100")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+
+        // test millisecond overflow
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "123456789123456789", "1", "1")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Millis overflow: 9223372036854775807");
     }
 
     @Test
@@ -236,6 +249,10 @@ public class TestDateTimeFunctions
 
         assertThat(assertions.function("from_unixtime", "7200", "'America/Los_Angeles'"))
                 .matches("TIMESTAMP '1969-12-31 18:00:00.000 America/Los_Angeles'");
+
+        assertTrinoExceptionThrownBy(assertions.function("from_unixtime", "123456789123456789", "'Asia/Kolkata'")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Millis overflow: 9223372036854775807");
     }
 
     @Test
@@ -262,6 +279,10 @@ public class TestDateTimeFunctions
 
         assertThat(assertions.function("from_iso8601_date", "'2001-08-22'"))
                 .matches("DATE '2001-08-22'");
+
+        assertTrinoExceptionThrownBy(assertions.function("from_iso8601_timestamp", "'115023-03-21T10:45:30.00Z'")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT)
+                .hasMessage("Millis overflow: 3567614928330000");
     }
 
     @Test


### PR DESCRIPTION
The exception is due to the value user entered hence should be reported as a TrinoException rather than a GENERIC_INTERNAL_ERROR

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
As per #20085, the error in `from_unixtime` is due to an invalid function argument passed by the user. Hence, it should be reported as such for statistics purposes. Currently, it is reported as a `GENERIC_INTERNAL_ERROR`. This PR fixes this by catching and throwing a `TrinoException` with the error code `INVALID_FUNCTION_ARGUMENT`.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
