### PR TITLE
Add config to reject Iceberg queries without partition pruning

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -171,6 +171,12 @@ implementation is used:
     `query_partition_filter_required` catalog session property for temporary,
     catalog specific use.
   - `false`
+* - `iceberg.query-partition-pruning-required`
+  - Set to `true` to force a query to use a partition pruning in the query plan.
+    This can be enabled only with `iceberg.query-partition-filter-required=true`.
+    You can use the`query_partition_pruning_required` catalog session property,
+    for temporary catalog specific use.
+  - `false`
 :::
 
 ## Type mapping

--- a/docs/src/main/sphinx/connector/iceberg.md
+++ b/docs/src/main/sphinx/connector/iceberg.md
@@ -171,6 +171,10 @@ implementation is used:
     `query_partition_filter_required` catalog session property for temporary,
     catalog specific use.
   - `false`
+* - `iceberg.query-partition-filter-required-common-fields`
+  - Comma-separated list of field names to must be used in the filter of queries,
+    if those fields are the partition fields of each table.
+  - `null`
 * - `iceberg.query-partition-pruning-required`
   - Set to `true` to force a query to use a partition pruning in the query plan.
     This can be enabled only with `iceberg.query-partition-filter-required=true`.

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -80,6 +80,7 @@ public class IcebergConfig
     private boolean sortedWritingEnabled = true;
     private boolean queryPartitionFilterRequired;
     private boolean queryPartitionPruningRequired;
+    private Optional<String> queryPartitionFilterRequiredCommonFields = Optional.empty();
 
     public CatalogType getCatalogType()
     {
@@ -413,6 +414,19 @@ public class IcebergConfig
     public boolean isQueryPartitionFilterRequired()
     {
         return queryPartitionFilterRequired;
+    }
+
+    public Optional<String> getQueryPartitionFilterRequiredCommonFields()
+    {
+        return queryPartitionFilterRequiredCommonFields;
+    }
+
+    @Config("iceberg.query-partition-filter-required-common-fields")
+    @ConfigDescription("Require filter predicates on all the partition fields declared in this configuration")
+    public IcebergConfig setQueryPartitionFilterRequiredCommonFields(String queryPartitionFilterRequiredCommonFields)
+    {
+        this.queryPartitionFilterRequiredCommonFields = Optional.ofNullable(queryPartitionFilterRequiredCommonFields);
+        return this;
     }
 
     @Config("iceberg.query-partition-pruning-required")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -21,6 +21,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
@@ -78,6 +79,7 @@ public class IcebergConfig
     private Optional<String> materializedViewsStorageSchema = Optional.empty();
     private boolean sortedWritingEnabled = true;
     private boolean queryPartitionFilterRequired;
+    private boolean queryPartitionPruningRequired;
 
     public CatalogType getCatalogType()
     {
@@ -411,6 +413,25 @@ public class IcebergConfig
     public boolean isQueryPartitionFilterRequired()
     {
         return queryPartitionFilterRequired;
+    }
+
+    @Config("iceberg.query-partition-pruning-required")
+    @ConfigDescription("Require a partition pruning on at least one partition column in the query plan. This can be enabled only with iceberg.query-partition-filter-required=true")
+    public IcebergConfig setQueryPartitionFilterPruningRequired(boolean queryPartitionPruningRequired)
+    {
+        this.queryPartitionPruningRequired = queryPartitionPruningRequired;
+        return this;
+    }
+
+    public boolean isQueryPartitionPruningRequired()
+    {
+        return queryPartitionPruningRequired;
+    }
+
+    @AssertTrue(message = "iceberg.query-partition-pruning-required may only be enabled when iceberg.query-partition-filter-required is set to true")
+    public boolean isQueryPartitionPruningEnabledWhenPartitionFilterIsEnabled()
+    {
+        return !queryPartitionPruningRequired || queryPartitionFilterRequired;
     }
 
     @AssertFalse(message = "iceberg.materialized-views.storage-schema may only be set when iceberg.materialized-views.hide-storage-table is set to false")

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -417,7 +417,7 @@ public class IcebergConfig
 
     @Config("iceberg.query-partition-pruning-required")
     @ConfigDescription("Require a partition pruning on at least one partition column in the query plan. This can be enabled only with iceberg.query-partition-filter-required=true")
-    public IcebergConfig setQueryPartitionFilterPruningRequired(boolean queryPartitionPruningRequired)
+    public IcebergConfig setQueryPartitionPruningRequired(boolean queryPartitionPruningRequired)
     {
         this.queryPartitionPruningRequired = queryPartitionPruningRequired;
         return this;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -93,6 +93,7 @@ public final class IcebergSessionProperties
     private static final String MERGE_MANIFESTS_ON_WRITE = "merge_manifests_on_write";
     private static final String SORTED_WRITING_ENABLED = "sorted_writing_enabled";
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
+    private static final String QUERY_PARTITION_FILTER_REQUIRED_COMMON_FIELDS = "query-partition-filter-required-common-fields";
     private static final String QUERY_PARTITION_PRUNING_REQUIRED = "query_partition_pruning_required";
 
     private final List<PropertyMetadata<?>> sessionProperties;
@@ -328,6 +329,11 @@ public final class IcebergSessionProperties
                         "Require filter on partition column",
                         icebergConfig.isQueryPartitionFilterRequired(),
                         false))
+                .add(stringProperty(
+                        QUERY_PARTITION_FILTER_REQUIRED_COMMON_FIELDS,
+                        "Require filter predicates on all the partition fields declared in this configuration",
+                        icebergConfig.getQueryPartitionFilterRequiredCommonFields().orElse(null),
+                        false))
                 .add(booleanProperty(
                         QUERY_PARTITION_PRUNING_REQUIRED,
                         "Require pruning on partition column",
@@ -542,6 +548,11 @@ public final class IcebergSessionProperties
     public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
     {
         return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
+    }
+
+    public static Optional<String> getQueryPartitionFilterRequiredCommonFields(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(QUERY_PARTITION_FILTER_REQUIRED_COMMON_FIELDS, String.class));
     }
 
     public static boolean isQueryPartitionPruningRequired(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -93,6 +93,7 @@ public final class IcebergSessionProperties
     private static final String MERGE_MANIFESTS_ON_WRITE = "merge_manifests_on_write";
     private static final String SORTED_WRITING_ENABLED = "sorted_writing_enabled";
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
+    private static final String QUERY_PARTITION_PRUNING_REQUIRED = "query_partition_pruning_required";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -327,6 +328,11 @@ public final class IcebergSessionProperties
                         "Require filter on partition column",
                         icebergConfig.isQueryPartitionFilterRequired(),
                         false))
+                .add(booleanProperty(
+                        QUERY_PARTITION_PRUNING_REQUIRED,
+                        "Require pruning on partition column",
+                        icebergConfig.isQueryPartitionPruningRequired(),
+                        false))
                 .build();
     }
 
@@ -536,5 +542,10 @@ public final class IcebergSessionProperties
     public static boolean isQueryPartitionFilterRequired(ConnectorSession session)
     {
         return session.getProperty(QUERY_PARTITION_FILTER_REQUIRED, Boolean.class);
+    }
+
+    public static boolean isQueryPartitionPruningRequired(ConnectorSession session)
+    {
+        return session.getProperty(QUERY_PARTITION_PRUNING_REQUIRED, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -66,7 +66,8 @@ public class TestIcebergConfig
                 .setMaterializedViewsStorageSchema(null)
                 .setRegisterTableProcedureEnabled(false)
                 .setSortedWritingEnabled(true)
-                .setQueryPartitionFilterRequired(false));
+                .setQueryPartitionFilterRequired(false)
+                .setQueryPartitionPruningRequired(false));
     }
 
     @Test
@@ -97,6 +98,7 @@ public class TestIcebergConfig
                 .put("iceberg.register-table-procedure.enabled", "true")
                 .put("iceberg.sorted-writing-enabled", "false")
                 .put("iceberg.query-partition-filter-required", "true")
+                .put("iceberg.query-partition-pruning-required", "true")
                 .buildOrThrow();
 
         IcebergConfig expected = new IcebergConfig()
@@ -123,7 +125,8 @@ public class TestIcebergConfig
                 .setMaterializedViewsStorageSchema("mv_storage_schema")
                 .setRegisterTableProcedureEnabled(true)
                 .setSortedWritingEnabled(false)
-                .setQueryPartitionFilterRequired(true);
+                .setQueryPartitionFilterRequired(true)
+                .setQueryPartitionPruningRequired(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -67,6 +67,7 @@ public class TestIcebergConfig
                 .setRegisterTableProcedureEnabled(false)
                 .setSortedWritingEnabled(true)
                 .setQueryPartitionFilterRequired(false)
+                .setQueryPartitionFilterRequiredCommonFields(null)
                 .setQueryPartitionPruningRequired(false));
     }
 
@@ -98,6 +99,7 @@ public class TestIcebergConfig
                 .put("iceberg.register-table-procedure.enabled", "true")
                 .put("iceberg.sorted-writing-enabled", "false")
                 .put("iceberg.query-partition-filter-required", "true")
+                .put("iceberg.query-partition-filter-required-common-fields", "log_ts,timestamp")
                 .put("iceberg.query-partition-pruning-required", "true")
                 .buildOrThrow();
 
@@ -126,6 +128,7 @@ public class TestIcebergConfig
                 .setRegisterTableProcedureEnabled(true)
                 .setSortedWritingEnabled(false)
                 .setQueryPartitionFilterRequired(true)
+                .setQueryPartitionFilterRequiredCommonFields("log_ts,timestamp")
                 .setQueryPartitionPruningRequired(true);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
## Description
We adopt the new catalog option `iceberg.query-partition-filter-required` introduced by https://github.com/trinodb/trino/pull/17263 (since `v430`)
But, we realized this option cannot prevent all the full scan queries with some edge cases.

We migrated some tables from Hive format to Iceberg format, and Trino users in our company usually submit queries to those new Iceberg format tables, just simply ported with `cast(date(log_ts) as varchar)` from their existing queries to legacy Hive format table (w/ string-typed date partition field, ex: `log_dt="2023-12-14"`), like below.

```
select *
from iceberg.very_big_size_table_containing_many_years_data_migrated_from_hive_format
where cast(date(log_ts) as varchar) = '2023-12-14' 
limit 1000 
```

Although the queries like above end up with trying full-scan on the table, but those queries passed the validation-checks of `iceberg.query-partition-filter-required=true`. and I found that validation logic allow the case of partitioning field in just constraint columns of query plans.

How about adding more strict constraint option `iceberg.query-partition-pruning-required` to prevent those edge cases and ensure partition-pruning on the query plan..?

I tried some queries to test this new option working well, but honestly.. I cannot make sure, there is no side-effect.

@zhangminglei , Could you review this minor update to your nice contribution..?

This looks like just a reverse issue case of https://github.com/trinodb/trino/issues/12925, fixed with https://github.com/trinodb/trino/pull/13567 by @findepi 

If there is more fancy way to cover these edge cases, please fix it.. or tell me that alternative solution..!

## Related PR
- https://github.com/trinodb/trino/pull/17263
- https://github.com/trinodb/trino/pull/13567