### PR TITLE
Disable failing bigquery test

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BaseBigQueryConnectorTest.java
@@ -809,6 +809,13 @@ public abstract class BaseBigQueryConnectorTest
     }
 
     @Override
+    @Test
+    public void testCreateSchemaWithLongName()
+    {
+        abort("Dropping schema with long name causes BigQuery to return code 500");
+    }
+
+    @Override
     protected void verifySchemaNameLengthFailurePermissible(Throwable e)
     {
         assertThat(e).hasMessageContaining("Invalid dataset ID");


### PR DESCRIPTION
This behaviour fails even on the UI:

<img width="596" alt="Screenshot 2023-12-14 at 14 54 58" src="https://github.com/trinodb/trino/assets/66972/651ba56c-70af-4475-a60c-4d81ece95394">
