### PR TITLE
Fix serialization failure when invoking json_table

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6694,6 +6694,22 @@ public abstract class AbstractTestEngineOnlyQueries
                 .hasMessage("line 3:8: Recursive language functions are not supported: a(integer):integer");
     }
 
+    // ensure that JSON_TABLE runs properly in distributed mode (i.e., serialization of handles works correctly, etc)
+    @Test
+    public void testJsonTable()
+    {
+        assertThat(query("""
+                         SELECT first, last
+                          FROM (SELECT '{"a" : [1, 2, 3], "b" : [4, 5, 6]}') t(json_col), JSON_TABLE(
+                              json_col,
+                              'lax $.a'
+                              COLUMNS(
+                                  first bigint PATH 'lax $[0]',
+                                  last bigint PATH 'lax $[last]'))
+                         """))
+                .matches("VALUES (BIGINT '1', BIGINT '3')");
+    }
+
     private static ZonedDateTime zonedDateTime(String value)
     {
         return ZONED_DATE_TIME_FORMAT.parse(value, ZonedDateTime::from);


### PR DESCRIPTION
The concrete type declared in the JsonTableFunctionHandle is not directly serializable. The deserializer binding is only declared for the Type class.


## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix query failure when invoking `json_table`. ({issue}`...`)
```
