### PR TITLE
Minor refactoring of the bin-packing allocator's candidate logic

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/faulttolerant/BinPackingNodeAllocatorService.java
@@ -575,6 +575,11 @@ public class BinPackingNodeAllocatorService
             }
         }
 
+        private List<InternalNode> dropCoordinatorsIfNecessary(List<InternalNode> candidates)
+        {
+            return scheduleOnCoordinator ? candidates : candidates.stream().filter(node -> !node.isCoordinator()).collect(toImmutableList());
+        }
+
         public ReserveResult tryReserve(PendingAcquire acquire)
         {
             NodeRequirements requirements = acquire.getNodeRequirements();
@@ -586,8 +591,8 @@ public class BinPackingNodeAllocatorService
             if (!addresses.isEmpty()) {
                 candidates = candidates.stream().filter(node -> addresses.contains(node.getHostAndPort())).collect(toImmutableList());
             }
-            else if (!scheduleOnCoordinator) {
-                candidates = candidates.stream().filter(node -> !node.isCoordinator()).collect(toImmutableList());
+            else {
+                candidates = dropCoordinatorsIfNecessary(candidates);
             }
 
             if (candidates.isEmpty()) {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Just a small refactoring.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

The BinPackingSimulation class reserves nodes for splits by matching available nodes against a NodeRequirements object.  This PR rewrites that logic in an equivalent but shorter and more extensible way.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
