### PR TITLE
Support for pseudo impersonation for glue metastore and s3 using  AWS Session Credentials.

### DIFF
--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -76,6 +76,16 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <scope>test</scope>

--- a/client/trino-client/src/main/java/io/trino/client/ClientExternalCredentialProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientExternalCredentialProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import java.util.Map;
+
+public interface ClientExternalCredentialProvider
+{
+    Map<String, String> getExternalCredentials();
+}

--- a/client/trino-client/src/main/java/io/trino/client/DefaultAwsChainClientExternalCredentialProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/DefaultAwsChainClientExternalCredentialProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_ACCESS_KEY_ID;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_SECRET_ACCESS_KEY;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_SESSION_TOKEN;
+
+public class DefaultAwsChainClientExternalCredentialProvider
+        implements ClientExternalCredentialProvider
+{
+    private static final DefaultCredentialsProvider defaultAWSCredentialsProvider = DefaultCredentialsProvider.create();
+
+    @Override
+    public Map<String, String> getExternalCredentials()
+    {
+        Map<String, String> externalAwsCredentials = new HashMap<>();
+        try {
+            AwsSessionCredentials credentials = (AwsSessionCredentials) defaultAWSCredentialsProvider.resolveCredentials();
+            externalAwsCredentials.put(AWS_ACCESS_KEY_ID, credentials.accessKeyId());
+            externalAwsCredentials.put(AWS_SECRET_ACCESS_KEY, credentials.secretAccessKey());
+            externalAwsCredentials.put(AWS_SESSION_TOKEN, credentials.sessionToken());
+        }
+        catch (Throwable e) {
+            throw new RuntimeException("Unable to fetch aws external credentials", e);
+        }
+        return externalAwsCredentials;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/ExternalCredentialProviderEnum.java
+++ b/client/trino-client/src/main/java/io/trino/client/ExternalCredentialProviderEnum.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client;
+
+import java.util.function.Supplier;
+
+public enum ExternalCredentialProviderEnum
+{
+    AWS_DEFAULT_CHAIN(DefaultAwsChainClientExternalCredentialProvider::new);
+    private final ClientExternalCredentialProvider instance;
+
+    ExternalCredentialProviderEnum(Supplier<ClientExternalCredentialProvider> instance)
+    {
+        this.instance = instance.get();
+    }
+
+    public ClientExternalCredentialProvider getInstance()
+    {
+        return instance;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -18,8 +18,10 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
+import io.trino.client.ClientExternalCredentialProvider;
 import io.trino.client.ClientSelectedRole;
 import io.trino.client.DnsResolver;
+import io.trino.client.ExternalCredentialProviderEnum;
 import io.trino.client.auth.external.ExternalRedirectStrategy;
 import org.ietf.jgss.GSSCredential;
 
@@ -89,6 +91,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
     public static final ConnectionProperty<String, List<ExternalRedirectStrategy>> EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS = new ExternalAuthenticationRedirectHandlers();
     public static final ConnectionProperty<String, KnownTokenCache> EXTERNAL_AUTHENTICATION_TOKEN_CACHE = new ExternalAuthenticationTokenCache();
+    public static final ConnectionProperty<String, ClientExternalCredentialProvider> EXTERNAL_CREDENTIAL_PROVIDER = new ExternalCredentialProvider();
     public static final ConnectionProperty<String, Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<String, String> CLIENT_INFO = new ClientInfo();
     public static final ConnectionProperty<String, String> CLIENT_TAGS = new ClientTags();
@@ -131,6 +134,7 @@ final class ConnectionProperties
             .add(KERBEROS_DELEGATION)
             .add(KERBEROS_CONSTRAINED_DELEGATION)
             .add(ACCESS_TOKEN)
+            .add(EXTERNAL_CREDENTIAL_PROVIDER)
             .add(EXTRA_CREDENTIALS)
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
@@ -622,6 +626,25 @@ final class ConnectionProperties
         public ExternalAuthenticationTokenCache()
         {
             super(PropertyName.EXTERNAL_AUTHENTICATION_TOKEN_CACHE, Optional.of(KnownTokenCache.NONE), NOT_REQUIRED, ALLOWED, KnownTokenCache::valueOf);
+        }
+    }
+
+    private static class ExternalCredentialProvider
+            extends AbstractConnectionProperty<String, ClientExternalCredentialProvider>
+    {
+        public ExternalCredentialProvider()
+        {
+            super(PropertyName.EXTERNAL_CREDENTIAL_PROVIDER, NOT_REQUIRED, ALLOWED, ExternalCredentialProvider::parse);
+        }
+
+        public static ClientExternalCredentialProvider parse(String value)
+        {
+            try {
+                return ExternalCredentialProviderEnum.valueOf(value).getInstance();
+            }
+            catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid external credential provider: " + value);
+            }
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -55,6 +55,7 @@ public enum PropertyName
     EXTERNAL_AUTHENTICATION_TIMEOUT("externalAuthenticationTimeout"),
     EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS("externalAuthenticationRedirectHandlers"),
     EXTERNAL_AUTHENTICATION_TOKEN_CACHE("externalAuthenticationTokenCache"),
+    EXTERNAL_CREDENTIAL_PROVIDER("externalCredentialProvider"),
     EXTRA_CREDENTIALS("extraCredentials"),
     CLIENT_INFO("clientInfo"),
     CLIENT_TAGS("clientTags"),

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -375,6 +375,37 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>auth</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>http-client-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>profiles</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>provided</scope>

--- a/core/trino-main/src/main/java/com/yahoo/trino/server/security/AwsSessionCredentialsAuthenticator.java
+++ b/core/trino-main/src/main/java/com/yahoo/trino/server/security/AwsSessionCredentialsAuthenticator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.trino.server.security;
+
+import com.google.inject.Inject;
+import io.trino.client.ProtocolDetectionException;
+import io.trino.client.ProtocolHeaders;
+import io.trino.server.HttpRequestSessionContextFactory;
+import io.trino.server.ProtocolConfig;
+import io.trino.server.security.AuthenticationException;
+import io.trino.server.security.Authenticator;
+import io.trino.spi.security.BasicPrincipal;
+import io.trino.spi.security.Identity;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest;
+import software.amazon.awssdk.services.sts.model.GetCallerIdentityResponse;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Strings.emptyToNull;
+import static io.trino.client.ProtocolHeaders.detectProtocol;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_ACCESS_KEY_ID;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_SECRET_ACCESS_KEY;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_SESSION_TOKEN;
+
+public class AwsSessionCredentialsAuthenticator
+        implements Authenticator
+{
+    private final Optional<String> alternateHeaderName;
+    private final Set<String> allowedAwsAccounts;
+
+    @Inject
+    public AwsSessionCredentialsAuthenticator(ProtocolConfig protocolConfig, AwsSessionCredentialsAuthenticatorConfig awsSessionCredentialsAuthenticatorConfig)
+    {
+        this.alternateHeaderName = protocolConfig.getAlternateHeaderName();
+        this.allowedAwsAccounts = awsSessionCredentialsAuthenticatorConfig.getAllowedAwsAccounts();
+    }
+
+    @Override
+    public Identity authenticate(ContainerRequestContext request)
+            throws AuthenticationException
+    {
+        try {
+            ProtocolHeaders protocolHeaders = detectProtocol(alternateHeaderName, request.getHeaders().keySet());
+            Map<String, String> extraCredentials = HttpRequestSessionContextFactory.parseExtraCredentials(protocolHeaders, request.getHeaders());
+
+            AwsSessionCredentials sessionCredentials = new AwsSessionCredentials.Builder().accessKeyId(extraCredentials.get(AWS_ACCESS_KEY_ID))
+                    .secretAccessKey(extraCredentials.get(AWS_SECRET_ACCESS_KEY))
+                    .sessionToken(extraCredentials.get(AWS_SESSION_TOKEN))
+                    .build();
+
+            AwsCredentialsProvider credentialsProvider = StaticCredentialsProvider.create(sessionCredentials);
+            StsClient stsClient = StsClient.builder()
+                    .credentialsProvider(credentialsProvider)
+                    .build();
+
+            GetCallerIdentityRequest getCallerIdentityRequest = GetCallerIdentityRequest.builder().build();
+            GetCallerIdentityResponse getCallerIdentityResponse = stsClient.getCallerIdentity(getCallerIdentityRequest);
+
+            if (getCallerIdentityResponse.sdkHttpResponse().isSuccessful()) {
+                String requestAccountId = emptyToNull(getCallerIdentityResponse.account());
+
+                if (requestAccountId == null || !allowedAwsAccounts.contains(requestAccountId)) {
+                    throw new AuthenticationException("Requested account is not allowed to access the Trino cluster");
+                }
+
+                String principal = emptyToNull(getCallerIdentityResponse.arn());
+                if (principal != null) {
+                    String user;
+                    String userId = emptyToNull(getCallerIdentityResponse.userId());
+                    if (userId != null) {
+                        // Hardcoding userId to index 1 ref https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable
+                        user = userId.contains(":") ? userId.split(":")[1] : userId;
+                    }
+                    else {
+                        user = principal.substring(principal.lastIndexOf("/") + 1);
+                    }
+                    return Identity.forUser(user)
+                            .withPrincipal(new BasicPrincipal(principal))
+                            .withExtraCredentials(extraCredentials)
+                            .build();
+                }
+            }
+            else {
+                throw new AuthenticationException("Error while authentication the sesion credentials: " + getCallerIdentityResponse.sdkHttpResponse().statusText().orElse("UNKNOWN"));
+            }
+        }
+        catch (ProtocolDetectionException | RuntimeException e) {
+            throw new AuthenticationException(e.getMessage());
+        }
+        throw new AuthenticationException(null);
+    }
+}

--- a/core/trino-main/src/main/java/com/yahoo/trino/server/security/AwsSessionCredentialsAuthenticatorConfig.java
+++ b/core/trino-main/src/main/java/com/yahoo/trino/server/security/AwsSessionCredentialsAuthenticatorConfig.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.trino.server.security;
+
+import com.google.common.base.Splitter;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AwsSessionCredentialsAuthenticatorConfig
+{
+    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private Set<String> allowedAwsAccounts;
+
+    public Set<String> getAllowedAwsAccounts()
+    {
+        return allowedAwsAccounts;
+    }
+
+    @Config("http-server.authentication.aws-session-creds.allowed-accounts")
+    @ConfigDescription("Comma seperated AWS accounts allowed to access this Trino cluster")
+    public AwsSessionCredentialsAuthenticatorConfig setAllowedAwsAccounts(String allowedAwsAccounts)
+    {
+        this.allowedAwsAccounts = SPLITTER.splitToStream(allowedAwsAccounts).collect(Collectors.toSet());
+        return this;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContextFactory.java
@@ -332,7 +332,7 @@ public class HttpRequestSessionContextFactory
         return role;
     }
 
-    private static Map<String, String> parseExtraCredentials(ProtocolHeaders protocolHeaders, MultivaluedMap<String, String> headers)
+    public static Map<String, String> parseExtraCredentials(ProtocolHeaders protocolHeaders, MultivaluedMap<String, String> headers)
     {
         return parseProperty(headers, protocolHeaders.requestExtraCredential());
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
@@ -19,6 +19,8 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
+import com.yahoo.trino.server.security.AwsSessionCredentialsAuthenticator;
+import com.yahoo.trino.server.security.AwsSessionCredentialsAuthenticatorConfig;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.discovery.server.DynamicAnnouncementResource;
 import io.airlift.discovery.server.ServiceResource;
@@ -27,6 +29,7 @@ import io.airlift.http.server.HttpServer.ClientCertificate;
 import io.airlift.http.server.HttpServerConfig;
 import io.airlift.jmx.MBeanResource;
 import io.airlift.openmetrics.MetricsResource;
+import io.trino.server.ProtocolConfig;
 import io.trino.server.security.jwt.JwtAuthenticator;
 import io.trino.server.security.jwt.JwtAuthenticatorSupportModule;
 import io.trino.server.security.oauth2.OAuth2AuthenticationSupportModule;
@@ -87,6 +90,11 @@ public class ServerSecurityModule
         install(authenticatorModule("jwt", JwtAuthenticator.class, new JwtAuthenticatorSupportModule()));
         install(authenticatorModule("oauth2", OAuth2Authenticator.class, new OAuth2AuthenticationSupportModule()));
         newOptionalBinder(binder, OAuth2Client.class);
+
+        install(authenticatorModule("aws-session-creds", AwsSessionCredentialsAuthenticator.class, awsSessionCredentialsBinder -> {
+            configBinder(awsSessionCredentialsBinder).bindConfig(ProtocolConfig.class);
+            configBinder(awsSessionCredentialsBinder).bindConfig(AwsSessionCredentialsAuthenticatorConfig.class);
+        }));
 
         configBinder(binder).bindConfig(InsecureAuthenticatorConfig.class);
         binder.bind(InsecureAuthenticator.class).in(Scopes.SINGLETON);

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/HiveS3Config.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/HiveS3Config.java
@@ -82,6 +82,7 @@ public class HiveS3Config
     private boolean s3preemptiveBasicProxyAuth;
     private String s3StsEndpoint;
     private String s3StsRegion;
+    private boolean useS3SessionCredentials;
 
     public String getS3AwsAccessKey()
     {
@@ -640,6 +641,18 @@ public class HiveS3Config
     public HiveS3Config setS3StsRegion(String s3StsRegion)
     {
         this.s3StsRegion = s3StsRegion;
+        return this;
+    }
+
+    public boolean isUseS3SessionCredentials()
+    {
+        return useS3SessionCredentials;
+    }
+
+    @Config("hive.s3.use-session-credentials")
+    public HiveS3Config setUseS3SessionCredentials(boolean useS3SessionCredentials)
+    {
+        this.useS3SessionCredentials = useS3SessionCredentials;
         return this;
     }
 }

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/S3SecurityMappingConfigurationProvider.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/S3SecurityMappingConfigurationProvider.java
@@ -46,7 +46,7 @@ public class S3SecurityMappingConfigurationProvider
 {
     private static final Logger log = Logger.get(S3SecurityMappingConfigurationProvider.class);
 
-    private static final Set<String> SCHEMES = ImmutableSet.of("s3", "s3a", "s3n");
+    static final Set<String> SCHEMES = ImmutableSet.of("s3", "s3a", "s3n");
     private static final String ANY_KMS_KEY_ID = "*";
 
     private final Supplier<S3SecurityMappings> mappings;

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/S3SessionCredentialConfigurationProvider.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/s3/S3SessionCredentialConfigurationProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hdfs.s3;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import io.trino.hdfs.DynamicConfigurationProvider;
+import io.trino.hdfs.HdfsContext;
+import org.apache.hadoop.conf.Configuration;
+
+import java.net.URI;
+import java.util.Map;
+
+import static com.amazonaws.auth.profile.internal.ProfileKeyConstants.AWS_ACCESS_KEY_ID;
+import static com.amazonaws.auth.profile.internal.ProfileKeyConstants.AWS_SECRET_ACCESS_KEY;
+import static com.amazonaws.auth.profile.internal.ProfileKeyConstants.AWS_SESSION_TOKEN;
+import static io.trino.hdfs.DynamicConfigurationProvider.setCacheKey;
+import static io.trino.hdfs.s3.S3SecurityMappingConfigurationProvider.SCHEMES;
+import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_ACCESS_KEY;
+import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SECRET_KEY;
+import static io.trino.hdfs.s3.TrinoS3FileSystem.S3_SESSION_TOKEN;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class S3SessionCredentialConfigurationProvider
+        implements DynamicConfigurationProvider
+{
+    @Override
+    public void updateConfiguration(Configuration configuration, HdfsContext context, URI uri)
+    {
+        if (!SCHEMES.contains(uri.getScheme())) {
+            return;
+        }
+
+        Hasher hasher = Hashing.sha256().newHasher();
+
+        Map<String, String> extraCredentials = context.getIdentity().getExtraCredentials();
+
+        if (extraCredentials.containsKey(AWS_ACCESS_KEY_ID)) {
+            configuration.set(S3_ACCESS_KEY, extraCredentials.get(AWS_ACCESS_KEY_ID));
+            hasher.putString(extraCredentials.get(AWS_ACCESS_KEY_ID), UTF_8);
+        }
+
+        if (extraCredentials.containsKey(AWS_SECRET_ACCESS_KEY)) {
+            configuration.set(S3_SECRET_KEY, extraCredentials.get(AWS_SECRET_ACCESS_KEY));
+            hasher.putString(extraCredentials.get(AWS_SECRET_ACCESS_KEY), UTF_8);
+        }
+
+        if (extraCredentials.containsKey(AWS_SESSION_TOKEN)) {
+            configuration.set(S3_SESSION_TOKEN, extraCredentials.get(AWS_SESSION_TOKEN));
+            hasher.putString(extraCredentials.get(AWS_SESSION_TOKEN), UTF_8);
+        }
+
+        setCacheKey(configuration, hasher.hash().toString());
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -49,6 +49,8 @@ public class GlueHiveMetastoreConfig
     private int writeStatisticsThreads = 20;
     private boolean assumeCanonicalPartitionKeys;
 
+    private boolean impersonationEnabled;
+
     public Optional<String> getGlueRegion()
     {
         return glueRegion;
@@ -314,6 +316,19 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setWriteStatisticsThreads(int writeStatisticsThreads)
     {
         this.writeStatisticsThreads = writeStatisticsThreads;
+        return this;
+    }
+
+    public boolean isImpersonationEnabled()
+    {
+        return impersonationEnabled;
+    }
+
+    @Config("hive.metastore.glue.impersonation.enabled")
+    @ConfigDescription("Should end user be impersonated when communicating with metastore")
+    public GlueHiveMetastoreConfig setImpersonationEnabled(boolean impersonationEnabled)
+    {
+        this.impersonationEnabled = impersonationEnabled;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreFactory.java
@@ -13,36 +13,79 @@
  */
 package io.trino.plugin.hive.metastore.glue;
 
-import com.google.inject.Inject;
+import com.amazonaws.services.glue.AWSGlueAsync;
+import com.amazonaws.services.glue.model.Table;
 import io.opentelemetry.api.trace.Tracer;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.tracing.TracingHiveMetastore;
 import io.trino.spi.security.ConnectorIdentity;
 
 import java.util.Optional;
+import java.util.concurrent.Executor;
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
 
 public class GlueHiveMetastoreFactory
         implements HiveMetastoreFactory
 {
-    private final HiveMetastore metastore;
+    public static final String DEFAULT_METASTORE_USER = "presto";
+    private final TrinoFileSystem fileSystem;
+    private final AWSGlueAsync glueClient;
+    private final Optional<String> defaultDir;
+    private final int partitionSegments;
+    private final Executor partitionsReadExecutor;
+    private final GlueMetastoreStats stats;
+    private final GlueColumnStatisticsProvider columnStatisticsProvider;
+    private final boolean assumeCanonicalPartitionKeys;
+    private final Predicate<com.amazonaws.services.glue.model.Table> tableFilter;
+    private final boolean impersonationEnabled;
+    private final Tracer tracer;
 
-    // Glue metastore does not support impersonation, so just use single shared instance
-    @Inject
-    public GlueHiveMetastoreFactory(GlueHiveMetastore metastore, Tracer tracer)
+    public GlueHiveMetastoreFactory(
+            TrinoFileSystemFactory fileSystemFactory,
+            GlueHiveMetastoreConfig glueConfig,
+            @ForGlueHiveMetastore Executor partitionsReadExecutor,
+            GlueColumnStatisticsProviderFactory columnStatisticsProviderFactory,
+            AWSGlueAsync glueClient,
+            @ForGlueHiveMetastore GlueMetastoreStats stats,
+            @ForGlueHiveMetastore Predicate<Table> tableFilter,
+            Tracer tracer)
     {
-        this.metastore = new TracingHiveMetastore(tracer, metastore);
+        this.fileSystem = fileSystemFactory.create(ConnectorIdentity.ofUser(DEFAULT_METASTORE_USER));
+        this.glueClient = glueClient;
+        this.defaultDir = glueConfig.getDefaultWarehouseDir();
+        this.partitionSegments = glueConfig.getPartitionSegments();
+        this.partitionsReadExecutor = partitionsReadExecutor;
+        this.assumeCanonicalPartitionKeys = glueConfig.isAssumeCanonicalPartitionKeys();
+        this.tableFilter = tableFilter;
+        this.stats = stats;
+        this.columnStatisticsProvider = columnStatisticsProviderFactory.createGlueColumnStatisticsProvider(glueClient, stats);
+        this.impersonationEnabled = glueConfig.isImpersonationEnabled();
+        this.tracer = requireNonNull(tracer, "tracer is null");
     }
 
     @Override
     public boolean isImpersonationEnabled()
     {
-        return false;
+        return impersonationEnabled;
     }
 
     @Override
     public HiveMetastore createMetastore(Optional<ConnectorIdentity> identity)
     {
-        return metastore;
+        return new TracingHiveMetastore(tracer, new GlueHiveMetastore(identity,
+                fileSystem,
+                glueClient,
+                defaultDir,
+                partitionSegments,
+                partitionsReadExecutor,
+                assumeCanonicalPartitionKeys,
+                columnStatisticsProvider,
+                stats,
+                tableFilter));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -59,7 +59,6 @@ public class GlueMetastoreModule
         newOptionalBinder(binder, Key.get(new TypeLiteral<Predicate<Table>>() {}, ForGlueHiveMetastore.class))
                 .setDefault().toProvider(DefaultGlueMetastoreTableFilterProvider.class).in(Scopes.SINGLETON);
 
-        binder.bind(GlueHiveMetastore.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, Key.get(HiveMetastoreFactory.class, RawHiveMetastoreFactory.class))
                 .setDefault()
                 .to(GlueHiveMetastoreFactory.class)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingGlueHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingGlueHiveMetastore.java
@@ -16,28 +16,44 @@ package io.trino.plugin.hive.metastore.glue;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.glue.AWSGlueAsync;
 import com.google.common.collect.ImmutableSet;
+import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
+import io.trino.hdfs.DynamicHdfsConfiguration;
+import io.trino.hdfs.HdfsConfig;
+import io.trino.hdfs.HdfsConfiguration;
+import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.hdfs.TrinoHdfsFileSystemStats;
+import io.trino.hdfs.authentication.NoHdfsAuthentication;
+import io.trino.spi.security.ConnectorIdentity;
 
-import java.nio.file.Path;
+import java.util.Optional;
 
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
 import static io.trino.plugin.hive.metastore.glue.GlueClientUtil.createAsyncGlueClient;
+import static io.trino.plugin.hive.metastore.glue.GlueHiveMetastoreFactory.DEFAULT_METASTORE_USER;
 
 public final class TestingGlueHiveMetastore
 {
     private TestingGlueHiveMetastore() {}
 
-    public static GlueHiveMetastore createTestingGlueHiveMetastore(Path defaultWarehouseDir)
+    public static GlueHiveMetastore createTestingGlueHiveMetastore(java.nio.file.Path defaultWarehouseDir)
     {
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+        GlueMetastoreStats stats = new GlueMetastoreStats();
         GlueHiveMetastoreConfig glueConfig = new GlueHiveMetastoreConfig()
                 .setDefaultWarehouseDir(defaultWarehouseDir.toUri().toString());
-        GlueMetastoreStats stats = new GlueMetastoreStats();
+        AWSGlueAsync glueClient = createTestingAsyncGlueClient(glueConfig, stats);
         return new GlueHiveMetastore(
-                HDFS_FILE_SYSTEM_FACTORY,
-                glueConfig,
+                Optional.empty(),
+                new HdfsFileSystemFactory(hdfsEnvironment, new TrinoHdfsFileSystemStats()).create(ConnectorIdentity.ofUser(DEFAULT_METASTORE_USER)),
+                glueClient,
+                glueConfig.getDefaultWarehouseDir(),
+                glueConfig.getPartitionSegments(),
                 directExecutor(),
-                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()),
-                createTestingAsyncGlueClient(glueConfig, stats),
+                glueConfig.isAssumeCanonicalPartitionKeys(),
+                new DefaultGlueColumnStatisticsProviderFactory(directExecutor(), directExecutor()).createGlueColumnStatisticsProvider(glueClient, stats),
                 stats,
                 table -> true);
     }


### PR DESCRIPTION
Use-case:
Submit Trino jobs from managed services like Airflow (MWAA in AWS).

Changes:
Fetch Trino session credentials from the client (credentials for the service role with which the EC2 instance is associated in the AWS case) and use those credentials to authenticate and authorize Glue and S3 operations.

I came across some threads with a similar use case as ours and also noticed a few people looking for a similar feature after the Pinterest talk on FGAC (Fine Grain Access Control) in today's Trino Summit. Perhaps it will be useful for them as well.

Material referred: https://github.com/trinodb/trino/issues/966
https://github.com/trinodb/trino/issues/7581
https://github.com/trinodb/trino/pull/8009


Adding @electrum as I discussed the initial approach for this with him and @dain as I saw most of the code by him around impersonation for thrift hive metastore.

Please let me know if this will be helpful for the community and is worth contributing.
Also, do let me know if you think there is a better approach to doing it.

I can take up writing test cases and documentation if this approach looks good.

TODO: Testcases and documentation
