### PR TITLE
Increase GCLocker retries for Maven

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -9,3 +9,5 @@
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+-XX:+UnlockDiagnosticVMOptions
+-XX:GCLockerRetryAllocationCount=100


### PR DESCRIPTION
The build was observed failing with

    Warning: [325.033s][warning][gc,alloc] mvn-builder-trino-parquet: Retried waiting for GCLocker too often allocating 4194306 words

on CI (https://github.com/trinodb/trino/actions/runs/7221312204/job/19676023973?pr=20134)
