### PR TITLE
Increase timeout for TestWindow.testManyFunctionsWithSameWindow

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindow.java
@@ -36,7 +36,7 @@ public class TestWindow
     }
 
     @Test
-    @Timeout(2)
+    @Timeout(5)
     public void testManyFunctionsWithSameWindow()
     {
         assertThat(assertions.query("""


### PR DESCRIPTION
The test sometimes failed due to a timeout on CI.


Fixes https://github.com/trinodb/trino/issues/20077