### PR TITLE
Convert PTL tests to JUnit

### DIFF
--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -200,6 +200,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-jdbc</artifactId>
             <scope>test</scope>
@@ -212,8 +218,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/cli/TestInvocations.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/cli/TestInvocations.java
@@ -14,7 +14,8 @@
 package io.trino.tests.product.launcher.cli;
 
 import com.google.common.base.Splitter;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,8 +25,9 @@ import java.util.List;
 import static io.trino.tests.product.launcher.cli.Launcher.execute;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@Test(singleThreaded = true)
+@Execution(SAME_THREAD)
 public class TestInvocations
 {
     @Test

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/cli/TestOptionsPrinter.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/cli/TestOptionsPrinter.java
@@ -14,7 +14,7 @@
 package io.trino.tests.product.launcher.cli;
 
 import com.google.common.collect.ImmutableList;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/env/TestConfigurations.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/env/TestConfigurations.java
@@ -17,7 +17,7 @@ import io.trino.tests.product.launcher.env.environment.EnvMultinodeSqlserver;
 import io.trino.tests.product.launcher.suite.suites.Suite1;
 import io.trino.tests.product.launcher.suite.suites.Suite6NonGeneric;
 import io.trino.tests.product.launcher.suite.suites.SuiteTpcds;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.trino.tests.product.launcher.Configurations.canonicalEnvironmentName;
 import static io.trino.tests.product.launcher.Configurations.nameForSuiteClass;

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
@@ -13,8 +13,8 @@
  */
 package io.trino.tests.product.launcher.local;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.Socket;
@@ -23,7 +23,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Properties;
 
 import static java.lang.String.format;
@@ -32,8 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class TestManuallyJdbcOauth2
 {
-    @BeforeClass(alwaysRun = true)
-    public void verifyEtcHostsEntries()
+    private static void verifyEtcHostsEntries()
             throws UnknownHostException
     {
         assertThat(InetAddress.getByName("presto-master").isLoopbackAddress()).isTrue();
@@ -53,10 +51,13 @@ public class TestManuallyJdbcOauth2
      * 127.0.0.1 hydra
      * 127.0.0.1 hydra-consent
      */
-    @Test(enabled = false)
+    @Test
+    @Disabled
     public void shouldAuthenticateAndExecuteQuery()
-            throws SQLException
+            throws Exception
     {
+        verifyEtcHostsEntries();
+
         Properties properties = new Properties();
         String jdbcUrl = format("jdbc:trino://presto-master:7778?"
                 + "SSL=true&"

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/util/TestConsoleTable.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/util/TestConsoleTable.java
@@ -13,7 +13,7 @@
  */
 package io.trino.tests.product.launcher.util;
 
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
Convert product tests launcher's test to JUnit. This does not change product tests themselves.
