### PR TITLE
Add limit pushdown for Kafka connectors, and further refactor and enhance predicate pushdown in Kafka connector

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/ColumnTypeProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/ColumnTypeProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import io.trino.spi.type.Type;
+
+import java.util.Optional;
+
+/**
+ * The ColumnTypeProvider interface is responsible for providing type information
+ * for columns represented by ColumnHandle instances. It plays a crucial role in the
+ * ConstraintExtractor class for extracting TupleDomain from constraints.
+ *
+ * <p>Implementations of this interface should be capable of mapping a ColumnHandle
+ * to its corresponding Type. This information is essential for handling expressions
+ * and constraints involving columns in a connector.
+ *
+ * @param <C> The type of ColumnHandle or its subclass that this provider supports.
+ *            It ensures that the ColumnHandle passed to the methods is of the correct
+ *            type or its subclasses.
+ */
+public interface ColumnTypeProvider<C>
+{
+    /**
+     * Retrieves the Type information for the given column represented by the provided
+     * ColumnHandle.
+     *
+     * @param column The handle representing a column.
+     * @return The Type of the specified column.
+     * @throws UnsupportedOperationException if the type information for the column
+     *         represented by the provided handle is not supported.
+     */
+    Optional<Type> getType(C column)
+            throws UnsupportedOperationException;
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/ConstraintExtractor.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/ConstraintExtractor.java
@@ -1,0 +1,762 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.math.LongMath;
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.Call;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.expression.FunctionName;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.base.expression.ConnectorExpressions.and;
+import static io.trino.plugin.base.expression.ConnectorExpressions.extractConjuncts;
+import static io.trino.spi.expression.StandardFunctions.CAST_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.expression.StandardFunctions.NOT_EQUAL_OPERATOR_FUNCTION_NAME;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.toIntExact;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class is used to extract and manipulate constraint related data.
+ * It provides static functions to handle different operations,
+ * including transforming constraints and expressions, managing conjuncts,
+ * converting and intersecting tuple domains, and handling different types of calls.
+ * <p>
+ * It has several private static helper methods for dealing with various cases
+ * of comparisons and conversions, such as timestamp to date casts and date truncations.
+ * Specialized handling for processing Connector specific timestamp handling is also included.
+ * <p>
+ * This class ends with a nested record ExtractionResult,
+ * which groups a TupleDomain with a remaining ConnnectorExpression,
+ * representing the result of an extraction process.
+ * <p>
+ * This class is declared as final, and it also has a private constructor,
+ * which means it cannot be instantiated or sub-classed.
+ * All of its methods are static and can be accessed directly from the class.
+ * <p>
+ * we should do some unit-tests here.
+ */
+public final class ConstraintExtractor
+{
+    private ConstraintExtractor() {}
+
+    /**
+     * Extracts the tuple domain and remaining expressions from a constraint.
+     *
+     * @param <C> the type of the column handle
+     * @param constraint the constraint to extract from
+     * @param columnTypeProvider provides the column types for the given column handles
+     * @return an ExtractionResult object containing the extracted tuple domain and remaining expressions
+     */
+    public static <C extends ColumnHandle> ExtractionResult<C> extractTupleDomain(Constraint constraint, ColumnTypeProvider<C> columnTypeProvider)
+    {
+        TupleDomain<C> result = constraint.getSummary()
+                .transformKeys(key -> (C) key);
+        ImmutableList.Builder<ConnectorExpression> remainingExpressions = ImmutableList.builder();
+        for (ConnectorExpression conjunct : extractConjuncts(constraint.getExpression())) {
+            Optional<TupleDomain<C>> converted = toTupleDomain(conjunct, constraint.getAssignments(), columnTypeProvider);
+            if (converted.isEmpty()) {
+                remainingExpressions.add(conjunct);
+            }
+            else {
+                result = result.intersect(converted.get());
+                if (result.isNone()) {
+                    return new ExtractionResult(TupleDomain.none(), Constant.TRUE);
+                }
+            }
+        }
+        return new ExtractionResult(result, and(remainingExpressions.build()));
+    }
+
+    /**
+     * Converts a ConnectorExpression to TupleDomain.
+     *
+     * @param <C> the type of the column handle
+     * @param expression the ConnectorExpression to convert
+     * @param assignments a map of column assignments
+     * @param columnTypeProvider provides the column types for the given column handles
+     * @return an Optional containing the converted TupleDomain if the expression is a Call,
+     *         otherwise an empty Optional
+     */
+    private static <C> Optional<TupleDomain<C>> toTupleDomain(ConnectorExpression expression, Map<String, ColumnHandle> assignments, ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (expression instanceof Call call) {
+            return toTupleDomain(call, assignments, columnTypeProvider);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Attempts to convert a 'Call' expression into a 'TupleDomain', if applicable. This method handles
+     * specific patterns of 'Call' expressions, particularly those involving 'cast', 'date_trunc', and 'year'
+     * functions, and attempts to transform them into a 'TupleDomain' representation.
+     *
+     * @param <C> the generic type parameter representing the column handle type.
+     * @param call the 'Call' expression to be converted. It represents a function call in the query.
+     * @param assignments a mapping of string identifiers to 'ColumnHandle' objects, used to resolve column references.
+     * @param columnTypeProvider a provider for column types based on column handles, used to determine data types for columns.
+     * @return an 'Optional' containing the 'TupleDomain' if conversion is applicable and successful, otherwise an empty 'Optional'.
+     *
+     * The method first checks if the 'Call' expression has exactly two arguments, a pattern common in binary functions
+     * like comparisons. It then examines the type and nature of these arguments:
+     *
+     * - If the first argument is a 'cast' function call and the second is a constant, and both arguments have the same type,
+     *   it attempts to unwrap this cast comparison into a 'TupleDomain'.
+     * - If the first argument is a 'date_trunc' function call and the second is a constant, with both having the same type,
+     *   it tries to unwrap this date truncation comparison.
+     * - If the first argument is a 'year' function call on a 'TimestampWithTimeZoneType' and the second is a constant,
+     *   with both having the same type, it unwraps this year comparison.
+     *
+     * If none of these patterns match, or if the arguments' types do not align in a way that permits meaningful comparison,
+     * the method returns an empty 'Optional', indicating that no 'TupleDomain' representation is applicable for the given 'Call'.
+     */
+    private static <C> Optional<TupleDomain<C>> toTupleDomain(Call call, Map<String, ColumnHandle> assignments, ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (call.getArguments().size() == 2) {
+            ConnectorExpression firstArgument = call.getArguments().get(0);
+            ConnectorExpression secondArgument = call.getArguments().get(1);
+
+            // Note: CanonicalizeExpressionRewriter ensures that constants are the second comparison argument.
+
+            if (firstArgument instanceof Call firstAsCall && firstAsCall.getFunctionName().equals(CAST_FUNCTION_NAME) &&
+                    secondArgument instanceof Constant constant &&
+                    // if type do no match, this cannot be a comparison function
+                    firstArgument.getType().equals(secondArgument.getType())) {
+                return unwrapCastInComparison(
+                        call.getFunctionName(),
+                        getOnlyElement(firstAsCall.getArguments()),
+                        constant,
+                        assignments,
+                        columnTypeProvider);
+            }
+
+            if (firstArgument instanceof Call firstAsCall &&
+                    firstAsCall.getFunctionName().equals(new FunctionName("date_trunc")) && firstAsCall.getArguments().size() == 2 &&
+                    firstAsCall.getArguments().get(0) instanceof Constant unit &&
+                    secondArgument instanceof Constant constant &&
+                    // if type do no match, this cannot be a comparison function
+                    firstArgument.getType().equals(secondArgument.getType())) {
+                return unwrapDateTruncInComparison(
+                        call.getFunctionName(),
+                        unit,
+                        firstAsCall.getArguments().get(1),
+                        constant,
+                        assignments,
+                        columnTypeProvider);
+            }
+
+            if (firstArgument instanceof Call firstAsCall &&
+                    firstAsCall.getFunctionName().equals(new FunctionName("year")) &&
+                    firstAsCall.getArguments().size() == 1 &&
+                    (getOnlyElement(firstAsCall.getArguments()).getType() instanceof TimestampWithTimeZoneType ||
+                            getOnlyElement(firstAsCall.getArguments()).getType() instanceof TimestampType) &&
+                    secondArgument instanceof Constant constant &&
+                    // if types do no match, this cannot be a comparison function
+                    firstArgument.getType().equals(secondArgument.getType())) {
+                return unwrapYearInTimestampTzComparison(
+                        call.getFunctionName(),
+                        getOnlyElement(firstAsCall.getArguments()),
+                        constant,
+                        assignments,
+                        columnTypeProvider);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Attempts to unwrap a cast operation within a comparison expression and convert it into a TupleDomain.
+     * This method is specifically designed to handle cases where a column is cast to a different type and then compared against a constant value.
+     *
+     * @param <C> The generic type parameter representing the column handle type.
+     * @param functionName The name of the function representing the comparison operation.
+     * @param castSource The expression that is being cast, typically a column or a variable in the query.
+     * @param constant The constant value being compared against after the cast operation.
+     * @param assignments A map of string identifiers to column handles, used for resolving column references in expressions.
+     * @param columnTypeProvider A provider for column types based on column handles, used to determine data types for columns.
+     * @return An Optional containing the TupleDomain if the cast can be successfully unwrapped into a meaningful comparison, otherwise an empty Optional.
+     *
+     * The method first checks if the castSource is a variable and the constant is not null, as the method is designed to work primarily with source columns and non-null constants.
+     * It then delegates to the processCastComparison method for further processing based on the column type.
+     */
+    private static <C> Optional<TupleDomain<C>> unwrapCastInComparison(
+            // upon invocation, we don't know if this really is a comparison
+            FunctionName functionName,
+            ConnectorExpression castSource,
+            Constant constant,
+            Map<String, ColumnHandle> assignments,
+            ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (!(castSource instanceof Variable sourceVariable)) {
+            // Engine unwraps casts in comparisons in UnwrapCastInComparison. Within a connector we can do more than
+            // engine only for source columns. We cannot draw many conclusions for intermediate expressions without
+            // knowing them well.
+            return Optional.empty();
+        }
+
+        if (constant.getValue() == null) {
+            // Comparisons with NULL should be simplified by the engine
+            return Optional.empty();
+        }
+
+        C column = resolve(sourceVariable, assignments);
+        return processCastComparison(column, functionName, constant, columnTypeProvider);
+    }
+
+    /**
+     * Processes the cast comparison by determining the type of the column and performing the appropriate unwrapping logic.
+     *
+     * @param <C> The generic type parameter representing the column handle type.
+     * @param column The column handle, representing a column in the query.
+     * @param functionName The name of the comparison function being used in the expression.
+     * @param constant The constant value being compared.
+     * @param columnTypeProvider A provider for column types based on column handles.
+     * @return An Optional containing the TupleDomain if the comparison can be successfully unwrapped, otherwise an empty Optional.
+     *
+     * The method checks the type of the column (TimestampWithTimeZoneType or TimestampType) and calls the respective unwrapping method.
+     * It handles specific precision requirements for timestamps (6 for with timezone and 3 for without timezone).
+     * If the column type does not match these specific types or if other checks fail, the method returns an empty Optional.
+     */
+    private static <C> Optional<TupleDomain<C>> processCastComparison(
+            C column,
+            FunctionName functionName,
+            Constant constant,
+            ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (constant.getValue() == null || constant.getType() != DateType.DATE) {
+            return Optional.empty();
+        }
+
+        return columnTypeProvider.getType(column)
+                .flatMap(type -> {
+                    // Connector supports timestamp(6) with time zone
+                    if (type instanceof TimestampWithTimeZoneType tztType && tztType.getPrecision() == 6) {
+                        return unwrapTimestampTzToDateCast(column, functionName, (long) constant.getValue(), columnTypeProvider)
+                                .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                    }
+                    else if (type instanceof TimestampType tsType && tsType.getPrecision() == 3) {
+                        return unwrapTimestampToDateCast(column, functionName, (long) constant.getValue(), columnTypeProvider)
+                                .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                    }
+                    return Optional.<TupleDomain<C>>empty();
+                });
+    }
+
+    /**
+     * Unwraps a cast operation from timestamp with timezone to date within a comparison expression and converts it into a Domain.
+     * This method specifically handles cases where a timestamp with timezone column is cast to a date and then compared against
+     * a constant date value.
+     *
+     * @param <C> Generic type representing the column handle.
+     * @param column The column handle, representing a column that is cast from timestamp with timezone to date.
+     * @param functionName The name of the comparison function being used.
+     * @param date The date value in epoch days.
+     * @param columnTypeProvider A provider for column types based on column handles.
+     * @return An Optional containing the Domain if the cast and comparison can be successfully unwrapped, otherwise an empty Optional.
+     */
+    private static <C> Optional<Domain> unwrapTimestampTzToDateCast(
+            C column, FunctionName functionName, long date, ColumnTypeProvider<C> columnTypeProvider)
+    {
+        return unwrapTimestampCastToDomain(
+                column,
+                functionName,
+                date,
+                columnTypeProvider,
+                d -> LongTimestampWithTimeZone.fromEpochMillisAndFraction(d * MILLISECONDS_PER_DAY, 0, UTC_KEY),
+                type -> type.equals(TIMESTAMP_TZ_MICROS));
+    }
+
+    /**
+     * Unwraps a cast operation from timestamp to date within a comparison expression and converts it into a Domain.
+     * This method specifically handles cases where a timestamp column (without timezone) is cast to a date and then compared against
+     * a constant date value.
+     *
+     * @param <C> Generic type representing the column handle.
+     * @param column The column handle, representing a column that is cast from timestamp to date.
+     * @param functionName The name of the comparison function being used.
+     * @param date The date value in epoch days.
+     * @param columnTypeProvider A provider for column types based on column handles.
+     * @return An Optional containing the Domain if the cast and comparison can be successfully unwrapped, otherwise an empty Optional.
+     */
+    private static <C> Optional<Domain> unwrapTimestampToDateCast(
+            C column, FunctionName functionName, long date, ColumnTypeProvider<C> columnTypeProvider)
+    {
+        return unwrapTimestampCastToDomain(
+                column,
+                functionName,
+                date,
+                columnTypeProvider,
+                d -> d * MICROSECONDS_PER_DAY,
+                type -> type.equals(TIMESTAMP_MILLIS));
+    }
+
+    /**
+     * Generalized method for unwrapping a timestamp cast to a domain. This method is used to create a domain
+     * from a timestamp value, taking into account different types of timestamp representations.
+     *
+     * @param <C> Generic type representing the column handle.
+     * @param <T> Generic type representing the timestamp type.
+     * @param column The column handle involved in the comparison.
+     * @param functionName The name of the function representing the comparison operation.
+     * @param date The date value in epoch days to be used in the comparison.
+     * @param columnTypeProvider Provides the column types based on column handles.
+     * @param timestampCreator A function to create a timestamp object from epoch milliseconds.
+     * @param typeValidator A predicate to validate if the provided type is acceptable for the operation.
+     * @return An Optional containing the Domain if it can be successfully created, otherwise an empty Optional.
+     */
+    private static <C, T> Optional<Domain> unwrapTimestampCastToDomain(
+            C column,
+            FunctionName functionName,
+            long date,
+            ColumnTypeProvider<C> columnTypeProvider,
+            Function<Long, T> timestampCreator,
+            Predicate<Type> typeValidator)
+    {
+        Type type = columnTypeProvider.getType(column).orElseThrow();
+        checkArgument(typeValidator.test(type), "Column of unexpected type %s: %s", type, column);
+
+        // Verify no overflow. Date values must be in integer range.
+        verify(date <= Integer.MAX_VALUE, "Date value out of range: %s", date);
+
+        T startOfDate = timestampCreator.apply(date);
+        T startOfNextDate = timestampCreator.apply((date + 1));
+
+        return createDomain(functionName, type, startOfDate, startOfNextDate);
+    }
+
+    /**
+     * Unwraps the year component from a given timestamp with timezone comparison.
+     *
+     * @param functionName The name of the function being executed.
+     * @param type The type of the comparison.
+     * @param constant The constant value being compared.
+     * @param timestampCalculator The function to calculate the timestamp from the year component.
+     * @param typeValidator The predicate to validate the type.
+     * @param <T> The type of the timestamp.
+     * @return An Optional containing the Domain object created from the calculated start and end timestamps.
+     * @throws IllegalArgumentException if the constant value is null or if the type is not valid.
+     */
+    private static <T> Optional<Domain> unwrapYearInTimestampTzComparison(FunctionName functionName, Type type, Constant constant, Function<ZonedDateTime, T> timestampCalculator, Predicate<Type> typeValidator)
+    {
+        checkArgument(constant.getValue() != null, "Unexpected constant: %s", constant);
+        checkArgument(typeValidator.test(type), "Unexpected type: %s", type);
+
+        int year = toIntExact((Long) constant.getValue());
+        ZonedDateTime periodStart = ZonedDateTime.of(year, 1, 1, 0, 0, 0, 0, UTC);
+        ZonedDateTime periodEnd = periodStart.plusYears(1);
+
+        T start = timestampCalculator.apply(periodStart);
+        T end = timestampCalculator.apply(periodEnd);
+
+        return createDomain(functionName, type, start, end);
+    }
+
+    /**
+     * Creates a Domain based on the given parameters.
+     *
+     * @param functionName      the name of the function
+     * @param type              the Type object representing the type of the Domain
+     * @param startOfDate       the start of the date range
+     * @param startOfNextDate   the start of the next date range
+     * @param <T>               the type of the startOfDate and startOfNextDate parameters
+     * @return an Optional object containing the created Domain, or an empty Optional if the function name is not supported
+     */
+    private static <T> Optional<Domain> createDomain(FunctionName functionName, Type type, T startOfDate, T startOfNextDate)
+    {
+        Map<FunctionName, DomainCreator<T>> domainCreators = Map.of(
+                EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.range(t, s, true, e, false)), false)),
+                NOT_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, s), Range.greaterThanOrEqual(t, e)), false)),
+                LESS_THAN_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, s)), false)),
+                LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, e)), false)),
+                GREATER_THAN_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(t, e)), false)),
+                GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(t, s)), false)),
+                IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME, (t, s, e) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, s), Range.greaterThanOrEqual(t, e)), true)));
+
+        return Optional.ofNullable(domainCreators.get(functionName))
+                .map(creator -> creator.create(type, startOfDate, startOfNextDate))
+                .orElse(Optional.empty());
+    }
+
+    /**
+     * This functional interface represents a domain creator which is used to create a domain object.
+     *
+     * @param <T> the type of the start and end values
+     */
+    @FunctionalInterface
+    private interface DomainCreator<T>
+    {
+        Optional<Domain> create(Type type, T start, T end);
+    }
+
+    /**
+     * Unwraps the date_trunc function in a comparison operation.
+     *
+     * @param functionName The name of the function.
+     * @param unit The unit of time used in the truncation.
+     * @param dateTruncSource The source of the date_trunc function.
+     * @param constant The constant value being compared.
+     * @param assignments A map of column assignments.
+     * @param columnTypeProvider A provider for column types.
+     * @param <C> The column type.
+     * @return An Optional TupleDomain that represents the unwrapped comparison. Returns Optional.empty() if unable to unwrap the date_trunc function.
+     */
+    private static <C> Optional<TupleDomain<C>> unwrapDateTruncInComparison(
+            // upon invocation, we don't know if this really is a comparison
+            FunctionName functionName,
+            Constant unit,
+            ConnectorExpression dateTruncSource,
+            Constant constant,
+            Map<String, ColumnHandle> assignments,
+            ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (!(dateTruncSource instanceof Variable sourceVariable)) {
+            // Engine unwraps date_trunc in comparisons in UnwrapDateTruncInComparison. Within a connector we can do more than
+            // engine only for source columns. We cannot draw many conclusions for intermediate expressions without
+            // knowing them well.
+            return Optional.empty();
+        }
+
+        if (unit.getValue() == null) {
+            return Optional.empty();
+        }
+
+        if (constant.getValue() == null) {
+            // Comparisons with NULL should be simplified by the engine
+            return Optional.empty();
+        }
+
+        C column = resolve(sourceVariable, assignments);
+        return columnTypeProvider.getType(column)
+                .flatMap(
+                        columnType -> {
+                            // Connector supports only timestamp(6) with time zone
+                            if (columnType instanceof TimestampWithTimeZoneType tztType && tztType.getPrecision() == 6 && constant.getType().equals(tztType)) {
+                                //checkArgument(tztType.getPrecision() == 6, "Unexpected type: %s", columnType);
+                                //verify(constant.getType().equals(tztType), "This method should not be invoked when type mismatch (i.e. surely not a comparison)");
+
+                                return unwrapDateTruncInComparison(((Slice) unit.getValue()).toStringUtf8(),
+                                        functionName,
+                                        constant,
+                                        ConstraintExtractor::convertToLongTimestampWithTimeZone)
+                                        .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                            }
+                            else if (columnType instanceof TimestampType tsType && tsType.getPrecision() == 3 && constant.getType().equals(tsType)) {
+                                return unwrapDateTruncInComparison(((Slice) unit.getValue()).toStringUtf8(),
+                                        functionName,
+                                        constant,
+                                        zonedDateTime -> zonedDateTime.toEpochSecond() * MICROSECONDS_PER_SECOND)
+                                        .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                            }
+                            return Optional.<TupleDomain<C>>empty();
+                        });
+    }
+
+    /**
+     * Unwraps a date truncation comparison to create a domain.
+     * This method processes a comparison where a date-time value has been truncated to a specific unit
+     * (e.g., hour, day, month, year) and then compared to a constant value.
+     *
+     * @param unit The unit of date truncation (e.g., "hour", "day", "month", "year").
+     * @param functionName The name of the function representing the comparison operation.
+     * @param constant The constant value used in the comparison.
+     * @param timestampCalculator A function to convert ZonedDateTime to a specific timestamp type.
+     * @param <T> The type of the timestamp (e.g., LongTimestampWithTimeZone, Long).
+     * @return An Optional containing the created Domain if the comparison can be unwrapped successfully, otherwise an empty Optional.
+     *
+     * The method first validates the constant for the specified timestamp type.
+     * Then, it converts the constant to a ZonedDateTime and calculates the start and end of the period based on the truncation unit.
+     * The start and end times are converted to the required timestamp type using the provided timestampCalculator.
+     * Finally, it invokes 'createDomainBasedOnFunction' to create the appropriate domain for the comparison function,
+     * considering whether the constant corresponds to the start of the calculated period.
+     */
+    private static <T> Optional<Domain> unwrapDateTruncInComparison(String unit,
+                                                                    FunctionName functionName,
+                                                                    Constant constant,
+                                                                    Function<ZonedDateTime, T> timestampCalculator)
+    {
+        // Validate constant for specified timestamp type
+        if (!isValidConstant(constant)) {
+            return Optional.empty();
+        }
+
+        // Convert constant to ZonedDateTime
+        Optional<ZonedDateTime> dateTime = getZonedDateTimeFromConstant(constant);
+        if (dateTime.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Calculate period interval based on the unit
+        Optional<PeriodInterval> periodInterval = calculatePeriodInterval(unit, dateTime.get());
+        if (periodInterval.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // Convert start and end of period to the required timestamp type
+        T startTimestamp = timestampCalculator.apply(periodInterval.orElseThrow().start);
+        T endTimestamp = timestampCalculator.apply(periodInterval.orElseThrow().end);
+        boolean isConstantAtPeriodStart = dateTime.get().equals(periodInterval.get().start);
+
+        // Create the domain based on the function and the type of comparison
+        return createDomainBasedOnFunction(functionName, constant.getType(),
+                startTimestamp, endTimestamp, isConstantAtPeriodStart);
+    }
+
+    private static Optional<ZonedDateTime> getZonedDateTimeFromConstant(Constant constant)
+    {
+        final Map<Type, Function<Constant, ZonedDateTime>> typeToConverter = Map.of(
+                TIMESTAMP_TZ_MICROS, c -> {
+                    LongTimestampWithTimeZone timestamp = (LongTimestampWithTimeZone) c.getValue();
+                    return Instant.ofEpochMilli(timestamp.getEpochMillis())
+                            .plusNanos(LongMath.divide(timestamp.getPicosOfMilli(), PICOSECONDS_PER_NANOSECOND, UNNECESSARY))
+                            .atZone(UTC);
+                },
+                TIMESTAMP_MILLIS, c -> {
+                    Long timestamp = (Long) c.getValue();
+                    return Instant.ofEpochMilli(timestamp / MICROSECONDS_PER_MILLISECOND)
+                            .plusNanos(timestamp % MICROSECONDS_PER_MILLISECOND * NANOSECONDS_PER_MICROSECOND)
+                            .atZone(UTC);
+                });
+        // add more converter functions
+        return Optional.ofNullable(typeToConverter.get(constant.getType()))
+                .map(converter -> converter.apply(constant));
+    }
+
+    /**
+     * Validates if the constant is a valid timestamp of the specified type.
+     *
+     * @param constant The constant to be validated.
+     * @return True if the constant is a valid timestamp of the specified type, otherwise false.
+     */
+    private static boolean isValidConstant(Constant constant)
+    {
+        //checkArgument(constant.getValue() != null, "Unexpected constant: %s", constant);
+        //checkArgument(constant.getType().equals(TIMESTAMP_TZ_MICROS), "Unexpected type: %s", constant.getType());
+        Map<Type, Predicate<Object>> typeValidators = Map.of(
+                TIMESTAMP_TZ_MICROS, value -> value instanceof LongTimestampWithTimeZone,
+                TIMESTAMP_MILLIS, value -> value instanceof Long);
+        // Add more timestamp types and their corresponding validation logic here
+        return Optional.ofNullable(typeValidators.get(constant.getType()))
+                .map(validator -> validator.test(constant.getValue()))
+                .orElse(false);
+    }
+
+    private static Optional<PeriodInterval> calculatePeriodInterval(String unit, ZonedDateTime dateTime)
+    {
+        return switch (unit.toLowerCase(ENGLISH)) {
+            case "hour" -> Optional.of(new PeriodInterval(dateTime, dateTime.plusHours(1)));
+            case "day" -> Optional.of(new PeriodInterval(dateTime.toLocalDate().atStartOfDay(UTC), dateTime.plusDays(1)));
+            case "month" -> Optional.of(new PeriodInterval(dateTime.toLocalDate().withDayOfMonth(1).atStartOfDay(UTC), dateTime.plusMonths(1)));
+            case "year" -> Optional.of(new PeriodInterval(dateTime.toLocalDate().withDayOfMonth(1).withMonth(1).atStartOfDay(UTC), dateTime.plusYears(1)));
+            default -> Optional.empty();
+        };
+    }
+
+    private static LongTimestampWithTimeZone convertToLongTimestampWithTimeZone(ZonedDateTime zonedDateTime)
+    {
+        return LongTimestampWithTimeZone.fromEpochSecondsAndFraction(zonedDateTime.toEpochSecond(), 0, UTC_KEY);
+    }
+
+    /**
+     * Creates a domain for a given comparison function based on the type, start, end, and a boolean flag.
+     * This method utilizes a map of function names to domain creators, selecting the appropriate domain logic
+     * based on the specified comparison function.
+     *
+     * @param functionName The name of the comparison function to be used.
+     * @param type The data type of the domain.
+     * @param start The start timestamp of the domain.
+     * @param end The end timestamp of the domain.
+     * @param isConstantAtPeriodStart A boolean flag indicating if the constant is at the start of the period.
+     * @return An Optional containing the created Domain if a matching domain creator is found; otherwise, an empty Optional.
+     */
+    private static <T> Optional<Domain> createDomainBasedOnFunction(FunctionName functionName, Type type,
+                                                                T start, T end,
+                                                                boolean isConstantAtPeriodStart)
+    {
+        Map<FunctionName, ComparisonDomainCreator<T>> domainCreators = Map.of(
+                EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> atStart
+                        ? Optional.of(Domain.create(ValueSet.ofRanges(Range.range(t, s, true, e, false)), false))
+                        : Optional.of(Domain.none(t)),
+                NOT_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> atStart
+                        ? Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, s), Range.greaterThanOrEqual(t, e)), false))
+                        : Optional.of(Domain.notNull(t)),
+                IS_DISTINCT_FROM_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> atStart
+                        ? Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, s), Range.greaterThanOrEqual(t, e)), true))
+                        : Optional.of(Domain.all(t)),
+                LESS_THAN_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, atStart ? s : e)), false)),
+                LESS_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.lessThan(t, e)), false)),
+                GREATER_THAN_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(t, e)), false)),
+                GREATER_THAN_OR_EQUAL_OPERATOR_FUNCTION_NAME, (t, s, e, atStart) -> Optional.of(Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(t, atStart ? s : e)), false)));
+
+        return Optional.ofNullable(domainCreators.get(functionName))
+                .map(creator -> creator.create(type, start, end, isConstantAtPeriodStart))
+                .orElse(Optional.empty());
+    }
+
+    /**
+     * Represents a functional interface for creating a comparison domain.
+     */
+    @FunctionalInterface
+    private interface ComparisonDomainCreator<T>
+    {
+        Optional<Domain> create(Type type, T start, T end, boolean isConstantAtPeriodStart);
+    }
+
+    /**
+     * Represents a time interval defined by a start and end {@link ZonedDateTime}.
+     */
+    private static class PeriodInterval
+    {
+        ZonedDateTime start;
+        ZonedDateTime end;
+
+        PeriodInterval(ZonedDateTime start, ZonedDateTime end)
+        {
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    /**
+     * Unwraps the year in a comparison of TIMESTAMP WITH TIME ZONE type column with a constant year value.
+     *
+     * @param functionName     The name of the function that is invoking this method
+     * @param yearSource       The expression representing the year source column
+     * @param constant         The constant year value
+     * @param assignments      The assignments for the columns
+     * @param columnTypeProvider The provider for the column types
+     * @param <C>              The column handle type
+     * @return An Optional containing the unwrapped year in the comparison, or an empty Optional if the year cannot be unwrapped
+     */
+    private static <C> Optional<TupleDomain<C>> unwrapYearInTimestampTzComparison(
+            // upon invocation, we don't know if this really is a comparison
+            FunctionName functionName,
+            ConnectorExpression yearSource,
+            Constant constant,
+            Map<String, ColumnHandle> assignments,
+            ColumnTypeProvider<C> columnTypeProvider)
+    {
+        if (!(yearSource instanceof Variable sourceVariable)) {
+            // Engine unwraps year in comparisons in UnwrapYearInComparison. Within a connector we can do more than
+            // engine only for source columns. We cannot draw many conclusions for intermediate expressions without
+            // knowing them well.
+            return Optional.empty();
+        }
+
+        if (constant.getValue() == null) {
+            // Comparisons with NULL should be simplified by the engine
+            return Optional.empty();
+        }
+
+        C column = resolve(sourceVariable, assignments);
+
+        return columnTypeProvider.getType(column)
+                .flatMap(type -> {
+                    if (type instanceof TimestampWithTimeZoneType ttzType && ttzType.getPrecision() == 6) {
+                        // Connector supports only timestamp(6) with time zone
+                        //checkArgument(ttzType.getPrecision() == 6, "Unexpected type: %s", type);
+                        return unwrapYearInTimestampTzComparison(functionName, type, constant, ConstraintExtractor::convertToLongTimestampWithTimeZone, t -> t.equals(TIMESTAMP_TZ_MICROS))
+                                .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                    }
+                    else if (type instanceof TimestampType tsType && tsType.getPrecision() == 3) {
+                        return unwrapYearInTimestampTzComparison(functionName, type, constant, zonedDateTime -> zonedDateTime.toEpochSecond() * MICROSECONDS_PER_SECOND, t -> t.equals(TIMESTAMP_MILLIS))
+                                .map(domain -> TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)));
+                    }
+                    return Optional.<TupleDomain<C>>empty();
+                });
+    }
+
+    /**
+     * Resolves a Variable to its corresponding ColumnHandle assignment.
+     *
+     * @param <C> the type of the ColumnHandle
+     * @param variable the Variable to resolve
+     * @param assignments the map of assignments where the Variable must be present
+     * @return the corresponding ColumnHandle assignment for the Variable
+     * @throws IllegalArgumentException if no assignment is found for the Variable
+     */
+    private static <C> C resolve(Variable variable, Map<String, ColumnHandle> assignments)
+    {
+        ColumnHandle columnHandle = assignments.get(variable.getName());
+        checkArgument(columnHandle != null, "No assignment for %s", variable);
+        return (C) columnHandle;
+    }
+
+    /**
+     * This record class, `ExtractionResult`, represents the result of an operation
+     * that extracts a tuple domain and the remaining expressions from some particular constraint.
+     * It encapsulates both the tuple domain and the remaining connector expression after the extraction.
+     *
+     * @param <C> A generic type that extends `ColumnHandle`.
+     *           It represents the type of the column handle that the `TupleDomain` consists of.
+     *
+     * @record
+     */
+    public record ExtractionResult<C extends ColumnHandle>(TupleDomain<C> tupleDomain, ConnectorExpression remainingExpression)
+    {
+        /**
+         * This is a constructor for the `ExtractionResult`. It checks that both `tupleDomain` and
+         * `remainingExpression` are not null before initializing.
+         *
+         * If either `tupleDomain` or `remainingExpression` is null, it throws a `NullPointerException`.
+         */
+        public ExtractionResult
+        {
+            requireNonNull(tupleDomain, "tupleDomain is null");
+            requireNonNull(remainingExpression, "remainingExpression is null");
+        }
+    }
+}

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaColumnHandle.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaColumnHandle.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -141,6 +142,16 @@ public final class KafkaColumnHandle
     public boolean isInternal()
     {
         return internal;
+    }
+
+    /**
+     * Returns the type of the column if it is internal.
+     *
+     * @return An Optional containing the column's type if it's internal, or an empty Optional otherwise.
+     */
+    public Optional<Type> getColumnTypeIfInternal()
+    {
+        return isInternal() ? Optional.of(getType()) : Optional.empty();
     }
 
     ColumnMetadata getColumnMetadata()

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConfig.java
@@ -48,6 +48,24 @@ public class KafkaConfig
     private boolean hideInternalColumns = true;
     private int messagesPerSplit = 100_000;
     private boolean timestampUpperBoundPushDownEnabled;
+    /**
+     * The domainCompactionThreshold variable represents the maximum number of ranges allowed in a tuple domain
+     * without compacting it. When the number of ranges exceeds this threshold, the tuple domain is compacted to reduce
+     * its size.
+     *
+     * The default value for domainCompactionThreshold is 1,000.
+     */
+    private int domainCompactionThreshold = 1_000;
+    /**
+     * Indicates whether the predicate force push down feature is enabled or disabled.
+     * When predicate force push down is enabled, the Kafka connector attempts to push down
+     * predicate filters to the Kafka broker for filtering messages at the broker level.
+     * If predicate force push down is disabled, the filtering happens at the Trino
+     * (formerly PrestoSQL) engine level.
+     *
+     * By default, the predicate force push down is enabled.
+     */
+    private boolean predicateForcePushDownEnabled = true;
     private String tableDescriptionSupplier = FileTableDescriptionSupplier.NAME;
     private List<File> resourceConfigFiles = ImmutableList.of();
     private String internalFieldPrefix = "_";
@@ -158,6 +176,31 @@ public class KafkaConfig
     {
         this.timestampUpperBoundPushDownEnabled = timestampUpperBoundPushDownEnabled;
         return this;
+    }
+
+    @Min(1)
+    public int getDomainCompactionThreshold()
+    {
+        return domainCompactionThreshold;
+    }
+
+    @Config("kafka.domain-compaction-threshold")
+    @ConfigDescription("Maximum ranges to allow in a tuple domain without compacting it")
+    public void setDomainCompactionThreshold(int domainCompactionThreshold)
+    {
+        this.domainCompactionThreshold = domainCompactionThreshold;
+    }
+
+    public boolean isPredicateForcePushDownEnabled()
+    {
+        return predicateForcePushDownEnabled;
+    }
+
+    @Config("kafka.predicate-force-push-down-enabled")
+    @ConfigDescription("predicate force pushing down enabled")
+    public void setPredicateForcePushDownEnabled(boolean predicateForcePushDownEnabled)
+    {
+        this.predicateForcePushDownEnabled = predicateForcePushDownEnabled;
     }
 
     @NotNull

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -37,11 +37,14 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -57,6 +60,7 @@ import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.Math.floorDiv;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 
 public class KafkaFilterManager
 {
@@ -90,58 +94,96 @@ public class KafkaFilterManager
         requireNonNull(partitionEndOffsets, "partitionEndOffsets is null");
 
         TupleDomain<ColumnHandle> constraint = kafkaTableHandle.getConstraint();
-        verify(!constraint.isNone(), "constraint is none");
+        TupleDomain<KafkaColumnHandle> effectivePredicate = kafkaTableHandle.getCompactEffectivePredicate();
+        verify(!effectivePredicate.isNone(), "effectivePredicate is none");
 
-        if (!constraint.isAll()) {
-            Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
+        if (kafkaTableHandle.isRightForPush() && !effectivePredicate.isAll()) {
+            KafkaFilteringResult filteringResult = buildFilterResult(session, kafkaTableHandle, effectivePredicate, partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+            partitionInfos = filteringResult.getPartitionInfos();
+            partitionBeginOffsets = filteringResult.getPartitionBeginOffsets();
+            partitionEndOffsets = filteringResult.getPartitionEndOffsets();
+        }
 
-            Map<String, Domain> domains = constraint.getDomains().orElseThrow()
-                    .entrySet().stream()
-                    .collect(toImmutableMap(
-                            entry -> ((KafkaColumnHandle) entry.getKey()).getName(),
-                            Map.Entry::getValue));
+        OptionalLong limit = kafkaTableHandle.getLimit();
+        // here push down limit at the very end of the scenario
+        if (limit.isPresent()) {
+            Map<TopicPartition, Long> finalPartitionBeginOffsets = partitionBeginOffsets;
+            partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                    partition -> (finalPartitionBeginOffsets.get(partition) != INVALID_KAFKA_RANGE_INDEX)
+                            ? Optional.of(finalPartitionBeginOffsets.get(partition) + limit.getAsLong()) : Optional.empty());
+        }
+        return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
 
-            Optional<Range> offsetRanged = getDomain(PARTITION_OFFSET_FIELD, domains)
-                    .flatMap(KafkaFilterManager::filterRangeByDomain);
-            Set<Long> partitionIdsFiltered = getDomain(PARTITION_ID_FIELD, domains)
-                    .map(domain -> filterValuesByDomain(domain, partitionIds))
-                    .orElse(partitionIds);
-            Optional<Range> offsetTimestampRanged = getDomain(OFFSET_TIMESTAMP_FIELD, domains)
-                    .flatMap(KafkaFilterManager::filterRangeByDomain);
+    /**
+     * Builds the filtering result for Kafka based on the given parameters and the predicate.
+     *
+     * @param session The connector session.
+     * @param kafkaTableHandle The Kafka table handle.
+     * @param predicate The predicate in the form of TupleDomain.
+     * @param partitionInfos The list of partition information.
+     * @param partitionBeginOffsets The map of partition begin offsets.
+     * @param partitionEndOffsets The map of partition end offsets.
+     *
+     * @return The filtering result for Kafka.
+     */
+    private KafkaFilteringResult buildFilterResult(ConnectorSession session,
+                                                   KafkaTableHandle kafkaTableHandle,
+                                                   TupleDomain<KafkaColumnHandle> predicate,
+                                                   List<PartitionInfo> partitionInfos,
+                                                   Map<TopicPartition, Long> partitionBeginOffsets,
+                                                   Map<TopicPartition, Long> partitionEndOffsets)
+    {
+        Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
 
-            // push down offset
-            if (offsetRanged.isPresent()) {
-                Range range = offsetRanged.get();
-                partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
-                        partition -> (range.getBegin() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getBegin()) : Optional.empty());
-                partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
-                        partition -> (range.getEnd() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getEnd()) : Optional.empty());
-            }
+        Map<TopicPartition, Long> partitionFilteredEndOffsets = partitionEndOffsets;
+        Map<TopicPartition, Long> partitionFilteredBeginOffsets = partitionBeginOffsets;
 
-            // push down timestamp if possible
-            if (offsetTimestampRanged.isPresent()) {
-                try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
-                    // filter negative value to avoid java.lang.IllegalArgumentException when using KafkaConsumer offsetsForTimes
-                    if (offsetTimestampRanged.get().getBegin() > INVALID_KAFKA_RANGE_INDEX) {
-                        partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
-                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getBegin()));
-                    }
-                    if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
-                        if (offsetTimestampRanged.get().getEnd() > INVALID_KAFKA_RANGE_INDEX) {
-                            partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
-                                    partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getEnd()));
-                        }
+        Map<String, Domain> domains = predicate.getDomains().orElseThrow()
+                .entrySet().stream()
+                .collect(toImmutableMap(
+                        entry -> ((KafkaColumnHandle) entry.getKey()).getName(),
+                        Map.Entry::getValue));
+
+        Optional<Range> offsetRanged = getDomain(PARTITION_OFFSET_FIELD, domains)
+                .flatMap(KafkaFilterManager::filterRangeByDomain);
+        Set<Long> partitionIdsFiltered = getDomain(PARTITION_ID_FIELD, domains)
+                .map(domain -> filterValuesByDomain(domain, partitionIds))
+                .orElse(partitionIds);
+        Optional<Range> offsetTimestampRanged = getDomain(OFFSET_TIMESTAMP_FIELD, domains)
+                .flatMap(KafkaFilterManager::filterRangeByDomain);
+
+        // push down offset
+        if (offsetRanged.isPresent()) {
+            Range range = offsetRanged.get();
+            partitionFilteredBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                    partition -> (range.getBegin() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getBegin()) : Optional.empty());
+            partitionFilteredEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                    partition -> (range.getEnd() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getEnd()) : Optional.empty());
+        }
+
+        // push down timestamp if possible
+        if (offsetTimestampRanged.isPresent()) {
+            try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
+                // filter negative value to avoid java.lang.IllegalArgumentException when using KafkaConsumer offsetsForTimes
+                if (offsetTimestampRanged.get().getBegin() > INVALID_KAFKA_RANGE_INDEX) {
+                    partitionFilteredBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                            partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getBegin()));
+                }
+                if (isTimestampUpperBoundPushdownEnabled(session, kafkaTableHandle.getTopicName())) {
+                    if (offsetTimestampRanged.get().getEnd() > INVALID_KAFKA_RANGE_INDEX) {
+                        partitionFilteredEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                                partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, offsetTimestampRanged.get().getEnd()));
                     }
                 }
             }
-
-            // push down partitions
-            List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
-                    .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
-                    .collect(toImmutableList());
-            return new KafkaFilteringResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
         }
-        return new KafkaFilteringResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+
+        // push down partitions
+        List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
+                .filter(partitionInfo -> partitionIdsFiltered.contains((long) partitionInfo.partition()))
+                .collect(toImmutableList());
+        return new KafkaFilteringResult(partitionFilteredInfos, partitionFilteredBeginOffsets, partitionFilteredEndOffsets);
     }
 
     private Optional<Domain> getDomain(InternalFieldId internalFieldId, Map<String, Domain> columnNameToDomain)
@@ -213,9 +255,9 @@ public class KafkaFilterManager
         }
         else {
             ValueSet valueSet = domain.getValues();
-            if (valueSet instanceof SortedRangeSet) {
+            if (valueSet instanceof SortedRangeSet rangeSet) {
                 // still return range for single value case like (_partition_offset in (XXX1,XXX2) or _timestamp in XXX1, XXX2)
-                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                Ranges ranges = rangeSet.getRanges();
                 List<io.trino.spi.predicate.Range> rangeList = ranges.getOrderedRanges();
                 if (rangeList.stream().allMatch(io.trino.spi.predicate.Range::isSingleValue)) {
                     List<Long> values = rangeList.stream()
@@ -237,33 +279,64 @@ public class KafkaFilterManager
         return Optional.of(new Range(low, high));
     }
 
+    /**
+     * Filters a set of source values based on a given domain.
+     * This method is used for testing purposes to ensure that only values
+     * that fall within a specified domain are retained.
+     *
+     * @param domain The domain against which the source values are to be filtered.
+     * @param sourceValues The set of values to be filtered.
+     * @return A set containing only those values from the source that are within the domain.
+     */
     @VisibleForTesting
     public static Set<Long> filterValuesByDomain(Domain domain, Set<Long> sourceValues)
     {
         requireNonNull(sourceValues, "sourceValues is none");
+        // If the domain represents a single value, filter the source values to this single value.
         if (domain.isSingleValue()) {
             long singleValue = (long) domain.getSingleValue();
             return sourceValues.stream().filter(sourceValue -> sourceValue == singleValue).collect(toImmutableSet());
         }
+
+        // Handle the case where the domain is a set of ranges.
         ValueSet valueSet = domain.getValues();
-        if (valueSet instanceof SortedRangeSet) {
-            Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+        if (valueSet instanceof SortedRangeSet rangeSet) {
+            Ranges ranges = rangeSet.getRanges();
             List<io.trino.spi.predicate.Range> rangeList = ranges.getOrderedRanges();
-            if (rangeList.stream().allMatch(io.trino.spi.predicate.Range::isSingleValue)) {
-                return rangeList.stream()
-                        .map(range -> (Long) range.getSingleValue())
-                        .filter(sourceValues::contains)
-                        .collect(toImmutableSet());
-            }
-            // still return values for range case like (_partition_id > 1)
-            io.trino.spi.predicate.Range span = ranges.getSpan();
-            long low = getLowIncludedValue(span).orElse(0L);
-            long high = getHighIncludedValue(span).orElse(Long.MAX_VALUE);
-            return sourceValues.stream()
-                    .filter(item -> item >= low && item <= high)
-                    .collect(toImmutableSet());
+            return filterValuesWithinRanges(sourceValues, rangeList);
         }
+        // If the domain does not match any of the above cases, return the original source values.
         return sourceValues;
+    }
+
+    /**
+     * Filters the provided source values to include only those that fall within the specified ranges.
+     * This method is used to handle cases where the domain is represented by multiple ranges,
+     * each potentially encompassing a set of values.
+     *
+     * @param sourceValues The source values to be filtered.
+     * @param rangeList A list of ranges used to filter the source values.
+     * @return A set of values from the source that are within the specified ranges.
+     */
+    private static Set<Long> filterValuesWithinRanges(Set<Long> sourceValues, List<io.trino.spi.predicate.Range> rangeList)
+    {
+        // Process each range in the range list.
+        return rangeList.stream()
+                .flatMap(range -> {
+                    // Handle the case where the range represents a single value.
+                    if (range.isSingleValue()) {
+                        return Stream.of((Long) range.getSingleValue());
+                    }
+                    else {
+                        // Handle the case where the range is a span (e.g., greater than a particular value).
+                        // still return values for range case like (_partition_id > 1)
+                        long low = getLowIncludedValue(range).orElse(0L);
+                        long high = getHighIncludedValue(range).orElse(Long.MAX_VALUE);
+                        return sourceValues.stream().filter(item -> item >= low && item <= high);
+                    }
+                })
+                .filter(sourceValues::contains)
+                .collect(toCollection(LinkedHashSet::new));
     }
 
     private static Optional<Long> getLowIncludedValue(io.trino.spi.predicate.Range range)
@@ -287,7 +360,7 @@ public class KafkaFilterManager
         if (type == BIGINT) {
             return 1;
         }
-        if (type instanceof TimestampType && ((TimestampType) type).getPrecision() == 3) {
+        if (type instanceof TimestampType tsType && tsType.getPrecision() == 3) {
             // native representation is in microseconds
             return 1000;
         }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaInternalFieldManager.java
@@ -238,4 +238,15 @@ public class KafkaInternalFieldManager
     {
         return fieldsByIds.get(id);
     }
+
+    /**
+     * Retrieves the internal field ID of a KafkaColumnHandle based on the name.
+     *
+     * @param columnHandle The KafkaColumnHandle object for which to retrieve the internal field ID
+     * @return The InternalFieldId associated with the column handle
+     */
+    public InternalFieldId getInternalFieldId(KafkaColumnHandle columnHandle)
+    {
+        return getFieldByName(columnHandle.getName()).getInternalFieldId();
+    }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -28,20 +28,26 @@ import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.RetryMode;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
+import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.ComputedStatistics;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -50,8 +56,12 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.StandardErrorCode.DUPLICATE_COLUMN_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
+import static io.trino.spi.predicate.TupleDomain.all;
+import static io.trino.spi.predicate.TupleDomain.none;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.concat;
 
@@ -66,6 +76,7 @@ public class KafkaMetadata
     private final boolean hideInternalColumns;
     private final TableDescriptionSupplier tableDescriptionSupplier;
     private final KafkaInternalFieldManager kafkaInternalFieldManager;
+    private final int domainCompactionThreshold;
 
     @Inject
     public KafkaMetadata(
@@ -76,6 +87,7 @@ public class KafkaMetadata
         this.hideInternalColumns = kafkaConfig.isHideInternalColumns();
         this.tableDescriptionSupplier = requireNonNull(tableDescriptionSupplier, "tableDescriptionSupplier is null");
         this.kafkaInternalFieldManager = requireNonNull(kafkaInternalFieldManager, "kafkaInternalFieldManager is null");
+        this.domainCompactionThreshold = kafkaConfig.getDomainCompactionThreshold();
     }
 
     @Override
@@ -103,7 +115,8 @@ public class KafkaMetadata
                         getColumnHandles(session, schemaTableName).values().stream()
                                 .map(KafkaColumnHandle.class::cast)
                                 .collect(toImmutableList()),
-                        TupleDomain.all()))
+                        all(),
+                        OptionalLong.empty()))
                 .orElse(null);
     }
 
@@ -116,6 +129,37 @@ public class KafkaMetadata
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return getTableMetadata(session, ((KafkaTableHandle) tableHandle).toSchemaTableName());
+    }
+
+    private static TupleDomain<KafkaColumnHandle> toCompactTupleDomain(TupleDomain<ColumnHandle> predicate, int threshold)
+    {
+        ImmutableMap.Builder<KafkaColumnHandle, Domain> builder = ImmutableMap.builder();
+        predicate.getDomains().ifPresent(domains -> {
+            domains.forEach((columnHandle, domain) -> {
+                builder.put((KafkaColumnHandle) columnHandle, domain.simplify(threshold));
+            });
+        });
+        return withColumnDomains(builder.build());
+    }
+
+    public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        KafkaTableHandle table = (KafkaTableHandle) tableHandle;
+
+        TupleDomain<ColumnHandle> predicate = all();
+        if (table.isRightForPush()) {
+            ImmutableMap.Builder<ColumnHandle, Domain> pushedDown = ImmutableMap.builder();
+            pushedDown.putAll(table.getEnforcedPredicate(kafkaInternalFieldManager).getDomains()
+                    .get().entrySet().stream()
+                    .collect(Collectors.toMap(e -> (KafkaColumnHandle) e.getKey(), e -> e.getValue())));
+            predicate = predicate.intersect(withColumnDomains(pushedDown.build()));
+        }
+
+        return new ConnectorTableProperties(
+                predicate,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     @Override
@@ -233,9 +277,94 @@ public class KafkaMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
     {
         KafkaTableHandle handle = (KafkaTableHandle) table;
-        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
-        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
-        if (oldDomain.equals(newDomain)) {
+        // some effective/unforced tuple sitting in the table handle included, and it does work
+        TupleDomain<ColumnHandle> effectivePredicate = constraint.getSummary().intersect(handle.getConstraint());
+        TupleDomain<KafkaColumnHandle> compactEffectivePredicate = toCompactTupleDomain(effectivePredicate, domainCompactionThreshold);
+        KafkaTableHandle newHandle = new KafkaTableHandle(
+                handle.getSchemaName(),
+                handle.getTableName(),
+                handle.getTopicName(),
+                handle.getKeyDataFormat(),
+                handle.getMessageDataFormat(),
+                handle.getKeyDataSchemaLocation(),
+                handle.getMessageDataSchemaLocation(),
+                handle.getKeySubject(),
+                handle.getMessageSubject(),
+                handle.getColumns(),
+                compactEffectivePredicate,
+                effectivePredicate,
+                handle.getPredicateColumns(),
+                handle.isRightForPush(),
+                handle.getLimit());
+
+        ImmutableMap.Builder<KafkaColumnHandle, Domain> pushedDown = ImmutableMap.builder();
+        pushedDown.putAll(effectivePredicate.getDomains().get().entrySet().stream()
+                .collect(toMap(e -> (KafkaColumnHandle) e.getKey(), e -> e.getValue())));
+
+        TupleDomain<KafkaColumnHandle> newEffectivePredicate = newHandle.getCompactEffectivePredicate()
+                .intersect(handle.getCompactEffectivePredicate())
+                .intersect(withColumnDomains(pushedDown.build()));
+
+        // Get list of all columns involved in predicate
+        Set<String> predicateColumnNames = new HashSet<>();
+        newEffectivePredicate.getDomains().get().keySet().stream()
+                .map(KafkaColumnHandle::getName)
+                .forEach(predicateColumnNames::add);
+
+        boolean isRightForPush = false;
+        if (KafkaSessionProperties.isPredicatePushDownEnabled(session)){
+            isRightForPush = checkIfPossibleToPush(newEffectivePredicate.getDomains().get().keySet());
+        }
+        // Get the column handle
+        Map<String, ColumnHandle> columnHandles = getColumnHandles(session, table);
+
+        //map predicate columns to kafka column handles
+        Map<String, KafkaColumnHandle> predicateColumns = predicateColumnNames.stream()
+                .map(columnHandles::get)
+                .map(KafkaColumnHandle.class::cast)
+                .collect(toImmutableMap(KafkaColumnHandle::getName, identity()));
+
+        newHandle = new KafkaTableHandle(
+                newHandle.getSchemaName(),
+                newHandle.getTableName(),
+                newHandle.getTopicName(),
+                newHandle.getKeyDataFormat(),
+                newHandle.getMessageDataFormat(),
+                newHandle.getKeyDataSchemaLocation(),
+                newHandle.getMessageDataSchemaLocation(),
+                newHandle.getKeySubject(),
+                newHandle.getMessageSubject(),
+                newHandle.getColumns(),
+                compactEffectivePredicate,
+                effectivePredicate,
+                predicateColumns,
+                isRightForPush,
+                newHandle.getLimit());
+
+        if (handle.getCompactEffectivePredicate().equals(newHandle.getCompactEffectivePredicate())) {
+            return Optional.empty();
+        }
+
+        boolean isFullPushDown;
+        if (isRightForPush) {
+            // Filter some unnecessary columns
+            TupleDomain<ColumnHandle> remainingFilter = newHandle.getRemainingFilter(kafkaInternalFieldManager);
+            isFullPushDown = remainingFilter.isAll();
+            // All predicates might be pushed down at this time, except for the special columns that don't support at right now.
+            // e.g. _message*
+            // discrete range matching for a query like: where x in (1, 6)
+            return Optional.of(new ConstraintApplicationResult<>(newHandle, isFullPushDown ? all() : remainingFilter, false));
+        }
+
+        return Optional.of(new ConstraintApplicationResult<>(handle, effectivePredicate, false));
+    }
+
+    @Override
+    public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
+    {
+        KafkaTableHandle handle = (KafkaTableHandle) table;
+
+        if (handle.getLimit().isPresent() && handle.getLimit().getAsLong() <= limit) {
             return Optional.empty();
         }
 
@@ -250,9 +379,18 @@ public class KafkaMetadata
                 handle.getKeySubject(),
                 handle.getMessageSubject(),
                 handle.getColumns(),
-                newDomain);
+                handle.getCompactEffectivePredicate(),
+                handle.getConstraint(),
+                handle.getPredicateColumns(),
+                handle.isRightForPush(),
+                OptionalLong.of(limit));
 
-        return Optional.of(new ConstraintApplicationResult<>(handle, constraint.getSummary(), constraint.getExpression(), false));
+        return Optional.of(new LimitApplicationResult<>(handle, true,true));
+    }
+
+    private boolean checkIfPossibleToPush(Set<KafkaColumnHandle> columnHandles) {
+        // Check if possible to push-down.
+        return columnHandles.stream().allMatch(KafkaColumnHandle::isInternal);
     }
 
     private KafkaTopicDescription getRequiredTopicDescription(ConnectorSession session, SchemaTableName schemaTableName)
@@ -290,7 +428,8 @@ public class KafkaMetadata
                 table.getKeySubject(),
                 table.getMessageSubject(),
                 actualColumns,
-                TupleDomain.none());
+                none(),
+                table.getLimit());
     }
 
     @Override

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSessionProperties.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSessionProperties.java
@@ -21,19 +21,47 @@ import io.trino.spi.session.PropertyMetadata;
 
 import java.util.List;
 
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
 public final class KafkaSessionProperties
         implements SessionPropertiesProvider
 {
+    /**
+     * The session property name for enabling or disabling timestamp upper bound push down for topics using "CreateTime" mode.
+     * The upper bound predicate is pushed down only for topics using "LogAppendTime" mode.
+     * By default, this property is set to false.
+     * To enable timestamp upper bound push down, set this property to true.
+     *
+     * @see KafkaSessionProperties#isTimestampUpperBoundPushdownEnabled(ConnectorSession)
+     */
     private static final String TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED = "timestamp_upper_bound_force_push_down_enabled";
+    /**
+     * Represents the session property name for enabling or disabling predicate force push down.
+     *
+     * By default, predicate push down is enabled. This means that predicate push down is attempted for all queries.
+     *
+     * Predicate push down can be disabled via the "kafka.predicate_force_push_down_enabled" config property
+     * or the "predicate_force_push_down_enabled" session property.
+     *
+     * @see KafkaSessionProperties#isPredicatePushDownEnabled(ConnectorSession)
+     */
+    private static final String PREDICATE_FORCE_PUSH_DOWN_ENABLED = "predicate_force_push_down_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public KafkaSessionProperties(KafkaConfig kafkaConfig)
     {
-        sessionProperties = ImmutableList.of(PropertyMetadata.booleanProperty(
-                TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
-                "Enable or disable timestamp upper bound push down for topic createTime mode",
-                kafkaConfig.isTimestampUpperBoundPushDownEnabled(), false));
+        sessionProperties = ImmutableList.of(
+                booleanProperty(
+                        TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
+                        "Enable or disable timestamp upper bound push down for topic createTime mode",
+                        kafkaConfig.isTimestampUpperBoundPushDownEnabled(),
+                        false),
+                booleanProperty(
+                        PREDICATE_FORCE_PUSH_DOWN_ENABLED,
+                        "Enable or disable timestamp upper bound push down for topic createTime mode",
+                        kafkaConfig.isPredicateForcePushDownEnabled(),
+                        false));
     }
 
     @Override
@@ -52,5 +80,15 @@ public final class KafkaSessionProperties
     public static boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED, Boolean.class);
+    }
+
+    /**
+     * By default, it supports predicate push-down.
+     * Push-down can be disabled via ``kafka.predicate-force-push-down-enabled`` config prop
+     * or ``kafka.predicate_force_push_down_enabled`` session prop.
+     */
+    public static boolean isPredicatePushDownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(PREDICATE_FORCE_PUSH_DOWN_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.SizeOf.estimatedSizeOf;
@@ -42,6 +43,7 @@ public class KafkaSplit
     private final int partitionId;
     private final Range messagesRange;
     private final HostAddress leader;
+    private final OptionalLong limit;
 
     @JsonCreator
     public KafkaSplit(
@@ -52,7 +54,8 @@ public class KafkaSplit
             @JsonProperty("messageDataSchemaContents") Optional<String> messageDataSchemaContents,
             @JsonProperty("partitionId") int partitionId,
             @JsonProperty("messagesRange") Range messagesRange,
-            @JsonProperty("leader") HostAddress leader)
+            @JsonProperty("leader") HostAddress leader,
+            @JsonProperty("limit") OptionalLong limit)
     {
         this.topicName = requireNonNull(topicName, "topicName is null");
         this.keyDataFormat = requireNonNull(keyDataFormat, "keyDataFormat is null");
@@ -62,6 +65,27 @@ public class KafkaSplit
         this.partitionId = partitionId;
         this.messagesRange = requireNonNull(messagesRange, "messagesRange is null");
         this.leader = requireNonNull(leader, "leader is null");
+        this.limit = requireNonNull(limit, "limit is null");
+    }
+
+    /**
+     * Returns a KafkaSplit object for the given messagesRange.
+     *
+     * @param messagesRange The range of messages for the split.
+     * @return A KafkaSplit object initialized with the appropriate properties.
+     */
+    public KafkaSplit getSplitByRange(Range messagesRange)
+    {
+        return new KafkaSplit(
+                getTopicName(),
+                getKeyDataFormat(),
+                getMessageDataFormat(),
+                getKeyDataSchemaContents(),
+                getMessageDataSchemaContents(),
+                getPartitionId(),
+                messagesRange,
+                getLeader(),
+                getLimit());
     }
 
     @JsonProperty
@@ -135,6 +159,11 @@ public class KafkaSplit
                 + sizeOf(messageDataSchemaContents, SizeOf::estimatedSizeOf)
                 + messagesRange.getRetainedSizeInBytes()
                 + leader.getRetainedSizeInBytes();
+    }
+
+    public OptionalLong getLimit()
+    {
+        return limit;
     }
 
     @Override

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
@@ -33,9 +33,13 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -56,6 +60,25 @@ public class KafkaSplitManager
         this.contentSchemaProvider = requireNonNull(contentSchemaProvider, "contentSchemaProvider is null");
     }
 
+    /**
+     * Calculates and returns the splits for a given Kafka table based on the specified constraints.
+     *
+     * @param transaction The transaction handle.
+     * @param session The session providing information about the current query.
+     * @param table The table handle for which to calculate splits.
+     * @param dynamicFilter The dynamic filter applied to the table.
+     * @param constraint The constraints applied to the table.
+     * @return A ConnectorSplitSource representing the calculated splits.
+     *
+     * This method creates a Kafka consumer to fetch partition information for the specified topic.
+     * It then calculates the starting and ending offsets for each partition and applies filtering based on
+     * the given constraints. The method divides each partition into smaller splits, considering the
+     * messagesPerSplit setting, and creates a KafkaSplit for each partition segment.
+     *
+     * The method also handles scenarios where the query includes a limit clause, ensuring that the total number
+     * of messages fetched does not exceed the specified limit. It uses range partitioning to divide the data
+     * into manageable chunks that can be processed in parallel.
+     */
     @Override
     public ConnectorSplitSource getSplits(
             ConnectorTransactionHandle transaction,
@@ -66,40 +89,207 @@ public class KafkaSplitManager
     {
         KafkaTableHandle kafkaTableHandle = (KafkaTableHandle) table;
         try (KafkaConsumer<byte[], byte[]> kafkaConsumer = consumerFactory.create(session)) {
+            // Fetch partition information for the specified Kafka topic using the consumer.
             List<PartitionInfo> partitionInfos = kafkaConsumer.partitionsFor(kafkaTableHandle.getTopicName());
 
+            // Convert PartitionInfo objects to TopicPartition objects.
             List<TopicPartition> topicPartitions = partitionInfos.stream()
                     .map(KafkaSplitManager::toTopicPartition)
                     .collect(toImmutableList());
 
+            // Fetch beginning and end offsets for each topic partition.
             Map<TopicPartition, Long> partitionBeginOffsets = kafkaConsumer.beginningOffsets(topicPartitions);
             Map<TopicPartition, Long> partitionEndOffsets = kafkaConsumer.endOffsets(topicPartitions);
+            // Apply filtering based on session and table handle to refine partition information.
             KafkaFilteringResult kafkaFilteringResult = kafkaFilterManager.getKafkaFilterResult(session, kafkaTableHandle,
                     partitionInfos, partitionBeginOffsets, partitionEndOffsets);
             partitionInfos = kafkaFilteringResult.getPartitionInfos();
             partitionBeginOffsets = kafkaFilteringResult.getPartitionBeginOffsets();
             partitionEndOffsets = kafkaFilteringResult.getPartitionEndOffsets();
 
+            int totalRows = 0;
+
+            // Builder to collect the calculated splits.
             ImmutableList.Builder<KafkaSplit> splits = ImmutableList.builder();
             Optional<String> keyDataSchemaContents = contentSchemaProvider.getKey(kafkaTableHandle);
             Optional<String> messageDataSchemaContents = contentSchemaProvider.getMessage(kafkaTableHandle);
 
+            Map<TopicPartition, Long> finalPartitionBeginOffsets = partitionBeginOffsets;
+            Map<TopicPartition, Long> finalPartitionEndOffsets = partitionEndOffsets;
+            // Iterate over each partition info to create splits.
             for (PartitionInfo partitionInfo : partitionInfos) {
                 TopicPartition topicPartition = toTopicPartition(partitionInfo);
                 HostAddress leader = HostAddress.fromParts(partitionInfo.leader().host(), partitionInfo.leader().port());
-                new Range(partitionBeginOffsets.get(topicPartition), partitionEndOffsets.get(topicPartition))
-                        .partition(messagesPerSplit).stream()
-                        .map(range -> new KafkaSplit(
-                                kafkaTableHandle.getTopicName(),
-                                kafkaTableHandle.getKeyDataFormat(),
-                                kafkaTableHandle.getMessageDataFormat(),
-                                keyDataSchemaContents,
-                                messageDataSchemaContents,
-                                partitionInfo.partition(),
-                                range,
-                                leader))
-                        .forEach(splits::add);
+
+                //Here class to handle the range repartition for each partition.
+                class RangeToRepartition
+                {
+                    private int partitionSize;
+                    private OptionalLong limit;
+
+                    {
+                        this.partitionSize = messagesPerSplit;
+                        this.limit = kafkaTableHandle.getLimit().isPresent() ? kafkaTableHandle.getLimit() : OptionalLong.empty();
+                    }
+
+                    public RangeToRepartition() {}
+
+                    public RangeToRepartition(int partitionSize)
+                    {
+                        this.partitionSize = partitionSize;
+                    }
+
+                    private List<Range> getParts()
+                    {
+                        return new Range(finalPartitionBeginOffsets.get(topicPartition), finalPartitionEndOffsets.get(topicPartition)).partition(partitionSize);
+                    }
+
+                    public long size()
+                    {
+                        return getParts().size();
+                    }
+
+                    private Stream<Range> rangeStream()
+                    {
+                        return getParts().stream();
+                    }
+
+                    public Stream<KafkaSplit> stream()
+                    {
+                        return rangeStream().map(range ->
+                           new KafkaSplit(
+                                   kafkaTableHandle.getTopicName(),
+                                   kafkaTableHandle.getKeyDataFormat(),
+                                   kafkaTableHandle.getMessageDataFormat(),
+                                   keyDataSchemaContents,
+                                   messageDataSchemaContents,
+                                   partitionInfo.partition(),
+                                   range,
+                                   leader,
+                                   limit));
+                    }
+
+                    public int getPartitionSize()
+                    {
+                        return partitionSize;
+                    }
+
+                    public RangeToRepartition setPartitionSize(int partitionSize)
+                    {
+                        this.partitionSize = partitionSize;
+                        return this;
+                    }
+                }
+
+                RangeToRepartition repartition = new RangeToRepartition();
+                // Check if there's a limit set in the Kafka table handle.
+                if (kafkaTableHandle.getLimit().isPresent()) {
+                    // Handle the logic for calculating splits when a limit is present.
+                    long limit = kafkaTableHandle.getLimit().getAsLong();
+                    if (limit > messagesPerSplit && messagesPerSplit > 0) {
+                        // It's very true for: round > 0
+                        long round = floorDiv(limit, messagesPerSplit);
+                        int remainder = (int) (limit % (long) messagesPerSplit);
+
+                        // Check if there are enough partitions to cover the requested limit.
+                        // probably: size == 0
+                        long size = repartition.size();
+                        if (size == 0) {
+                            continue;
+                        }
+                        final Stream<KafkaSplit> splitStream = repartition.stream();
+
+                        // Calculate the number of rows covered by the full rounds.
+                        long rowsInRound = splitStream.limit(round)
+                                .map(KafkaSplit::getMessagesRange)
+                                .mapToLong(r -> r.getEnd() - r.getBegin())
+                                .sum();
+                        // Calculate the number of rows covered by the remainder.
+                        long rowsInReminder = splitStream.skip(round).limit(1L)
+                                .map(split ->
+                                    split.getSplitByRange(split.getMessagesRange()
+                                            .slice(split.getMessagesRange().getBegin(), remainder)))
+                                .findFirst()
+                                .map(KafkaSplit::getMessagesRange)
+                                .map(r -> r.getEnd() - r.getBegin())
+                                .orElse(0L);
+
+                        long rows = rowsInRound + rowsInReminder;
+                        totalRows += rows;
+
+                        // Check if total rows exceed the limit and adjust accordingly.
+                        if (totalRows > limit) {
+                            rows -= totalRows - limit;
+                            // in fact, the finalRows exists
+                            long finalRows = rows;
+                            if (finalRows > 0) {
+                                // Stream and collect splits within the final rows limit.
+                                long round2 = floorDiv(finalRows, messagesPerSplit);
+                                int remainder2 = (int) (finalRows % (long) messagesPerSplit);
+                                splitStream.limit(round2).forEach(splits::add);
+                                // Handle the final partial split if the remainder is non-zero.
+                                if (remainder2 > 0) {
+                                    splitStream.skip(round2).limit(1L)
+                                            .map(split ->
+                                                    split.getSplitByRange(split.getMessagesRange()
+                                                            .slice(split.getMessagesRange().getBegin(), remainder2)))
+                                            .peek(splits::add);
+                                }
+                            }
+                            break;
+                        }
+                        // we can fetch all the splits if the constraint is size > limit
+                        splitStream.limit(round).forEach(splits::add);
+                        // Handle the case where the limit exceeds the partition size.
+                        // the limit-bound is more than the partitionSize
+                        if (remainder > 0 && size >= round) {
+                            splitStream.skip(round).limit(1L)
+                                    .map(split ->
+                                            split.getSplitByRange(split.getMessagesRange()
+                                                    .slice(split.getMessagesRange().getBegin(), remainder)))
+                                    .findFirst()
+                                    .ifPresent(splits::add);
+                        }
+                    }
+                    else {
+                        // Handle the case where the limit is less than or equal to the partition size.
+                        final Optional<KafkaSplit> first = repartition.setPartitionSize((int) limit)
+                                .stream()
+                                .findFirst();
+                        if (first.isEmpty()) {
+                            continue;
+                        }
+
+                        // Calculate the number of rows in the first split.
+                        long rows = first.map(KafkaSplit::getMessagesRange)
+                                .map(r -> r.getEnd() - r.getBegin())
+                                .orElse(0L);
+                        totalRows += rows;
+                        // Adjust if total rows exceed the limit.
+                        if (totalRows > limit) {
+                            rows -= totalRows - limit;
+                            long finalRows = rows;
+                            if (finalRows > 0) {
+                                first.map(split ->
+                                        // evidently, here the finalRows must be no more than rows
+                                        // since we can fetch what we need
+                                                split.getSplitByRange(split.getMessagesRange()
+                                                        .slice(split.getMessagesRange().getBegin(), toIntExact(finalRows))))
+                                        .ifPresent(splits::add);
+                            }
+                            break;
+                        }
+                        // Add the first split to the splits list.
+                        // there should be no more rows to be shown if the stuff of variable FIRST is not enough
+                        first.ifPresent(splits::add);
+                    }
+                }
+                else {
+                    // Generate splits for the entire range of each partition if no limit is set.
+                    repartition.stream().forEach(splits::add);
+                }
             }
+            // Return a fixed split source with the collected splits.
             return new FixedSplitSource(splits.build());
         }
         catch (Exception e) { // Catch all exceptions because Kafka library is written in scala and checked exceptions are not declared in method signature.

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
@@ -20,14 +20,25 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.SortedRangeSet;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Maps.filterKeys;
+import static io.trino.spi.predicate.TupleDomain.withColumnDomains;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 
 public final class KafkaTableHandle
         implements ConnectorTableHandle, ConnectorInsertTableHandle
@@ -55,7 +66,18 @@ public final class KafkaTableHandle
     private final Optional<String> keySubject;
     private final Optional<String> messageSubject;
     private final List<KafkaColumnHandle> columns;
+    private final TupleDomain<KafkaColumnHandle> compactEffectivePredicate;
     private final TupleDomain<ColumnHandle> constraint;
+    private final Map<String, KafkaColumnHandle> predicateColumns;
+    /**
+     * Represents the flag indicating whether the table is right for pushdown.
+     */
+    private final boolean rightForPush;
+    /**
+     * Represents a handle to a limit value in a Kafka table.
+     * The limit is an optional value indicating the maximum number of records to return in a query.
+     */
+    private final OptionalLong limit;
 
     @JsonCreator
     public KafkaTableHandle(
@@ -69,7 +91,11 @@ public final class KafkaTableHandle
             @JsonProperty("keySubject") Optional<String> keySubject,
             @JsonProperty("messageSubject") Optional<String> messageSubject,
             @JsonProperty("columns") List<KafkaColumnHandle> columns,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("compactEffectivePredicate") TupleDomain<KafkaColumnHandle> compactEffectivePredicate,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
+            @JsonProperty("predicateColumns") Map<String, KafkaColumnHandle> predicateColumns,
+            @JsonProperty("rightForPush") boolean rightForPush,
+            @JsonProperty("limit") OptionalLong limit)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -81,7 +107,43 @@ public final class KafkaTableHandle
         this.keySubject = requireNonNull(keySubject, "keySubject is null");
         this.messageSubject = requireNonNull(messageSubject, "messageSubject is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.compactEffectivePredicate = requireNonNull(compactEffectivePredicate, "constraint is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
+        this.predicateColumns = predicateColumns;
+        this.rightForPush = rightForPush;
+        this.limit = requireNonNull(limit, "constraint is null");
+    }
+
+    public KafkaTableHandle(
+            String schemaName,
+            String tableName,
+            String topicName,
+            String keyDataFormat,
+            String messageDataFormat,
+            Optional<String> keyDataSchemaLocation,
+            Optional<String> messageDataSchemaLocation,
+            Optional<String> keySubject,
+            Optional<String> messageSubject,
+            List<KafkaColumnHandle> columns,
+            TupleDomain<ColumnHandle> constraint,
+            OptionalLong limit)
+    {
+        this(
+                schemaName,
+                tableName,
+                topicName,
+                keyDataFormat,
+                messageDataFormat,
+                keyDataSchemaLocation,
+                messageDataSchemaLocation,
+                keySubject,
+                messageSubject,
+                columns,
+                TupleDomain.all(),
+                constraint,
+                null,
+                false,
+                limit);
     }
 
     @JsonProperty
@@ -150,6 +212,30 @@ public final class KafkaTableHandle
         return constraint;
     }
 
+    @JsonProperty
+    public TupleDomain<KafkaColumnHandle> getCompactEffectivePredicate()
+    {
+        return compactEffectivePredicate;
+    }
+
+    @JsonProperty
+    public Map<String, KafkaColumnHandle> getPredicateColumns()
+    {
+        return predicateColumns;
+    }
+
+    @JsonProperty
+    public boolean isRightForPush()
+    {
+        return rightForPush;
+    }
+
+    @JsonProperty
+    public OptionalLong getLimit()
+    {
+        return limit;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -169,7 +255,8 @@ public final class KafkaTableHandle
                 keySubject,
                 messageSubject,
                 columns,
-                constraint);
+                constraint,
+                limit);
     }
 
     @Override
@@ -193,7 +280,11 @@ public final class KafkaTableHandle
                 && Objects.equals(this.keySubject, other.keySubject)
                 && Objects.equals(this.messageSubject, other.messageSubject)
                 && Objects.equals(this.columns, other.columns)
-                && Objects.equals(this.constraint, other.constraint);
+                && Objects.equals(this.compactEffectivePredicate, other.compactEffectivePredicate)
+                && Objects.equals(this.constraint, other.constraint)
+                && Objects.equals(this.predicateColumns, other.predicateColumns)
+                && this.rightForPush == other.rightForPush
+                && Objects.equals(this.limit, other.limit);
     }
 
     @Override
@@ -211,6 +302,72 @@ public final class KafkaTableHandle
                 .add("messageSubject", messageSubject)
                 .add("columns", columns)
                 .add("constraint", constraint)
+                .add("limit", limit)
                 .toString();
+    }
+
+    /**
+     * Returns the list of KafkaColumnHandles that represent the remaining predicate columns.
+     * The method filters out the columns that are not compatible with the Kafka connector,
+     * such as columns that are not part of the supported types or columns associated with unsupported operations.
+     *
+     * @param internalFieldManager The KafkaInternalFieldManager used to retrieve the internal field ID of a column
+     * @return The list of remaining predicate columns that can be used for filtering
+     */
+    public List<KafkaColumnHandle> getRemainingPredicateColumn(final KafkaInternalFieldManager internalFieldManager)
+    {
+        // the connector for database does not support discrete range matching(or multiple ranges) at right now
+        // such as a query with the clause "where condition" like "where x in (2, 6) and (y > 7 or y = 7)"
+        return constraint.getDomains()
+                .orElseGet(HashMap::new)
+                .entrySet().stream()
+                .collect(toMap(e -> (KafkaColumnHandle) e.getKey(), e -> e.getValue()))
+                .entrySet().stream()
+                .filter(kafkaColumnHandleDomainEntry -> {
+                    switch (internalFieldManager.getInternalFieldId(kafkaColumnHandleDomainEntry.getKey())) {
+                        case PARTITION_OFFSET_FIELD -> {
+                            ValueSet valueSet = kafkaColumnHandleDomainEntry.getValue().getValues();
+                            if (valueSet instanceof SortedRangeSet sortedSet
+                                    && sortedSet.getRanges().getRangeCount() == 1) {
+                                return true;
+                            }
+                        }
+                        case PARTITION_ID_FIELD -> {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .map(entity -> entity.getKey())
+                .collect(toImmutableList());
+    }
+
+    /**
+     * Returns the remaining filter for the Kafka table.
+     *
+     * This method filters out unnecessary predicates and returns the remaining filter as a TupleDomain of ColumnHandles.
+     * The remaining filter includes only the predicate columns that are compatible with the Kafka connector, such as
+     * columns that are part of the supported types and are associated with supported operations.
+     *
+     * @param internalFieldManager The KafkaInternalFieldManager used to retrieve the internal field ID of a column.
+     * @return The remaining filter as a TupleDomain of ColumnHandles that can be used for filtering.
+     */
+    public TupleDomain<ColumnHandle> getRemainingFilter(final KafkaInternalFieldManager internalFieldManager)
+    {
+        // filter some unnecessary predicates
+        return TupleDomain.<ColumnHandle>all()
+                .intersect(withColumnDomains(filterKeys(constraint.getDomains().get(), not(in(getRemainingPredicateColumn(internalFieldManager))))));
+    }
+
+    /**
+     * Returns the enforced predicate for the Kafka table.
+     *
+     * @param internalFieldManager The KafkaInternalFieldManager used to retrieve the internal field ID of a column
+     * @return The enforced predicate for the Kafka table
+     */
+    public TupleDomain<ColumnHandle> getEnforcedPredicate(final KafkaInternalFieldManager internalFieldManager)
+    {
+        return TupleDomain.<ColumnHandle>all()
+                .intersect(withColumnDomains(filterKeys(constraint.getDomains().get(), in(getRemainingPredicateColumn(internalFieldManager)))));
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/Range.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/Range.java
@@ -60,6 +60,18 @@ public class Range
         return partitions.build();
     }
 
+    /**
+     * Returns a new Range object that represents a slice of the current Range object.
+     *
+     * @param startPos The starting position of the slice (inclusive)
+     * @param rangeSize The size of the slice
+     * @return A new Range object representing the slice of the current Range object
+     */
+    public Range slice(long startPos, int rangeSize)
+    {
+        return new Range(startPos, min(rangeSize + startPos, end));
+    }
+
     @Override
     public String toString()
     {

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestConstraintExtractor.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestConstraintExtractor.java
@@ -1,0 +1,759 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kafka;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.Constraint;
+import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.ConnectorExpressionTranslator;
+import io.trino.sql.planner.LiteralEncoder;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
+import io.trino.sql.planner.iterative.rule.UnwrapDateTruncInComparison;
+import io.trino.sql.planner.iterative.rule.UnwrapYearInComparison;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.SymbolReference;
+import io.trino.transaction.NoOpTransactionManager;
+import io.trino.transaction.TransactionId;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.plugin.kafka.ConstraintExtractor.extractTupleDomain;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_DAY;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
+import static io.trino.sql.planner.TypeAnalyzer.createTestingTypeAnalyzer;
+import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
+import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.IS_DISTINCT_FROM;
+import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN;
+import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+import static io.trino.sql.tree.ComparisonExpression.Operator.NOT_EQUAL;
+import static java.time.ZoneOffset.UTC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestConstraintExtractor
+{
+    private static final LiteralEncoder LITERAL_ENCODER = new LiteralEncoder(PLANNER_CONTEXT);
+
+    private static final AtomicInteger nextColumnId = new AtomicInteger(1);
+
+    private static final KafkaColumnHandle A_BIGINT = newPrimitiveColumn(BIGINT);
+    private static final KafkaColumnHandle A_TIMESTAMP_TZ = newPrimitiveColumn(TIMESTAMP_TZ_MICROS);
+    private static final KafkaColumnHandle A_TIMESTAMP_MILL = newPrimitiveColumn(TIMESTAMP_MILLIS);
+
+    /**
+     * Tests the extraction of a summary from a given constraint.
+     * This test checks that the extraction process correctly identifies and isolates the tuple domain from a constraint,
+     * which represents a set of conditions applied on the query.
+     *
+     * The test involves creating a constraint with a predefined tuple domain and ensuring
+     * that the extracted tuple domain matches the one defined in the constraint.
+     *
+     * @implNote This test assumes that the constraint's tuple domain is simple and consists of a single domain for a BIGINT column.
+     *           The test validates that the extraction process accurately retrieves this domain without invoking any additional value filtering logic.
+     */
+    @Test
+    public void testExtractSummary()
+    {
+        // Creating a constraint with a single-value domain for a BIGINT column
+        assertThat(extract(
+                new Constraint(
+                        // Tuple domain with a single value for the BIGINT column
+                        TupleDomain.withColumnDomains(Map.of(A_BIGINT, Domain.singleValue(BIGINT, 1L))),
+                        // The constant expression indicating no additional filtering
+                        Constant.TRUE,
+                        // Empty map for column assignments
+                        Map.of(),
+                        // A function that should not be called during the test
+                        values -> {
+                            throw new AssertionError("should not be called");
+                        },
+                        // The set of columns involved in the constraint
+                        Set.of(A_BIGINT))))
+                // Verifying that the extracted tuple domain matches the predefined domain
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_BIGINT, Domain.singleValue(BIGINT, 1L))));
+    }
+
+    /**
+     * Test equivalent of {@link UnwrapCastInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@link UnwrapCastInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Connector, we know
+     * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
+     * so we can unwrap.
+     */
+    @Test
+    public void testExtractTimestampTzDateComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        Cast castOfColumn = new Cast(new SymbolReference(timestampTzColumnSymbol), toSqlType(DATE));
+
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        Expression someDateExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay(), DATE);
+
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone startOfDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis);
+        LongTimestampWithTimeZone startOfNextDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis + MILLISECONDS_PER_DAY);
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.range(TIMESTAMP_TZ_MICROS, startOfDateUtc, true, startOfNextDateUtc, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(
+                        Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                        Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                                Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)),
+                        true))));
+    }
+
+    /**
+     * Tests the extraction process for comparisons involving a timestamp and a date.
+     * This test focuses on verifying the correct handling of scenarios where a timestamp (represented in milliseconds) is compared against a specific date.
+     *
+     * Different comparison expressions like equal, not equal, less than, etc., are evaluated
+     * to ensure accurate processing of timestamp to date comparisons.
+     *
+     * @implNote The timestamp is represented in milliseconds, and comparisons are made against a date cast from the timestamp.
+     */
+    @Test
+    public void testExtractTimestampDateComparison()
+    {
+        // Symbol representing the timestamp column in the query
+        String timestampColumnSymbol = "timestamp_symbol";
+        // Casting the timestamp column to a date type
+        Cast castOfColumn = new Cast(new SymbolReference(timestampColumnSymbol), toSqlType(DATE));
+
+        // Specific date for comparison
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        // Expression representing the specific date
+        Expression someDateExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay(), DATE);
+
+        // Calculating the start of the date and the start of the next day in microseconds
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MICROSECONDS_PER_SECOND;
+        Long startOfDate = startOfDateUtcEpochMillis;
+        Long startOfNextDate = (startOfDateUtcEpochMillis + MICROSECONDS_PER_DAY);
+
+        // Testing EQUAL comparison
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.range(TIMESTAMP_MILLIS, startOfDate, true, startOfNextDate, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(
+                        Range.lessThan(TIMESTAMP_MILLIS, startOfDate),
+                        Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDate)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfDate)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfNextDate)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDate)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfDate)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_MILLIS, startOfDate),
+                                Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDate)),
+                        true))));
+    }
+
+    /**
+     * Test equivalent of {@link UnwrapDateTruncInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@link UnwrapDateTruncInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Connector, we know
+     * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
+     * so we can unwrap.
+     */
+    @Test
+    public void testExtractDateTruncTimestampTzComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        FunctionCall truncateToDay = new FunctionCall(
+                PLANNER_CONTEXT.getMetadata().resolveBuiltinFunction("date_trunc", fromTypes(VARCHAR, TIMESTAMP_TZ_MICROS)).toQualifiedName(),
+                List.of(
+                        LITERAL_ENCODER.toExpression(utf8Slice("day"), createVarcharType(17)),
+                        new SymbolReference(timestampTzColumnSymbol)));
+
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        Expression someMidnightExpression = LITERAL_ENCODER.toExpression(
+                LongTimestampWithTimeZone.fromEpochMillisAndFraction(someDate.toEpochDay() * MILLISECONDS_PER_DAY, 0, UTC_KEY),
+                TIMESTAMP_TZ_MICROS);
+        Expression someMiddayExpression = LITERAL_ENCODER.toExpression(
+                LongTimestampWithTimeZone.fromEpochMillisAndFraction(someDate.toEpochDay() * MILLISECONDS_PER_DAY, PICOSECONDS_PER_MICROSECOND, UTC_KEY),
+                TIMESTAMP_TZ_MICROS);
+
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone startOfDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis);
+        LongTimestampWithTimeZone startOfNextDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis + MILLISECONDS_PER_DAY);
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.range(TIMESTAMP_TZ_MICROS, startOfDateUtc, true, startOfNextDateUtc, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, truncateToDay, someMiddayExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.none());
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(
+                        Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                        Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, truncateToDay, someMidnightExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                                Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)),
+                        true))));
+    }
+
+    /**
+     * Tests the extraction process for comparisons involving date truncation on a timestamp.
+     * This test verifies the handling of scenarios where a timestamp (represented in milliseconds) is truncated to a specific date unit (e.g., day)
+     * and then compared against a specific timestamp value.
+     *
+     * Different comparison expressions like equal, not equal, less than, etc., are evaluated
+     * to ensure correct processing of date truncation logic in timestamp comparisons.
+     *
+     * @implNote The timestamp is represented in milliseconds, and the date truncation is simulated using the 'date_trunc' function.
+     */
+    @Test
+    public void testExtractDateTruncTimestampComparison()
+    {
+        // Symbol representing the timestamp column in the query
+        String timestampColumnSymbol = "timestamp_symbol";
+        // Truncating the timestamp column to the day
+        FunctionCall truncateToDay = new FunctionCall(
+                PLANNER_CONTEXT.getMetadata().resolveBuiltinFunction("date_trunc", fromTypes(VARCHAR, TIMESTAMP_MILLIS)).toQualifiedName(),
+                List.of(
+                        LITERAL_ENCODER.toExpression(utf8Slice("day"), createVarcharType(17)),
+                        new SymbolReference(timestampColumnSymbol)));
+
+        // Specific date for comparison
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        // Expressions representing midnight and midday timestamps for the specific date
+        Expression someMidnightExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay() * MICROSECONDS_PER_DAY, TIMESTAMP_MILLIS);
+        Expression someMiddayExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay() * MICROSECONDS_PER_DAY + PICOSECONDS_PER_MICROSECOND, TIMESTAMP_MILLIS);
+
+        // Calculating start of the day and the start of the next day in microseconds
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MICROSECONDS_PER_SECOND;
+        Long startOfDateUtc = startOfDateUtcEpochMillis;
+        Long startOfNextDateUtc = (startOfDateUtcEpochMillis + MICROSECONDS_PER_DAY);
+
+        // Testing EQUAL comparison with exact midnight
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.range(TIMESTAMP_MILLIS, startOfDateUtc, true, startOfNextDateUtc, false)))));
+
+        // Testing EQUAL comparison with midday, expecting no matches
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, truncateToDay, someMiddayExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.none());
+
+        // Other comparison scenarios...
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(
+                        Range.lessThan(TIMESTAMP_MILLIS, startOfDateUtc),
+                        Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, truncateToDay, someMidnightExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_MILLIS, startOfDateUtc),
+                                Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextDateUtc)),
+                        true))));
+    }
+
+    /**
+     * Test equivalent of {@link UnwrapYearInComparison} for {@link TimestampWithTimeZoneType}.
+     * {@link UnwrapYearInComparison} handles {@link DateType} and {@link TimestampType}, but cannot handle
+     * {@link TimestampWithTimeZoneType}. Such unwrap would not be monotonic. Within Connector, we know
+     * that {@link TimestampWithTimeZoneType} is always in UTC zone (point in time, with no time zone information),
+     * so we can unwrap.
+     */
+    @Test
+    public void testExtractYearTimestampTzComparison()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        FunctionCall extractYear = new FunctionCall(
+                PLANNER_CONTEXT.getMetadata().resolveBuiltinFunction("year", fromTypes(TIMESTAMP_TZ_MICROS)).toQualifiedName(),
+                List.of(new SymbolReference(timestampTzColumnSymbol)));
+
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        Expression yearExpression = LITERAL_ENCODER.toExpression(2005L, BIGINT);
+
+        long startOfYearUtcEpochMillis = someDate.withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone startOfYearUtc = timestampTzFromEpochMillis(startOfYearUtcEpochMillis);
+        LongTimestampWithTimeZone startOfNextDateUtc = timestampTzFromEpochMillis(someDate.plusYears(1).withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND);
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.range(TIMESTAMP_TZ_MICROS, startOfYearUtc, true, startOfNextDateUtc, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(
+                        Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc),
+                        Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfYearUtc)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, extractYear, yearExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_TZ_MICROS, startOfYearUtc),
+                                Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)),
+                        true))));
+    }
+
+    /**
+     * Tests the extraction process for comparisons involving the extraction of the year from a timestamp.
+     * This test simulates the scenario where the year part of a timestamp (represented in milliseconds)
+     * is extracted and compared against a constant year value.
+     *
+     * The test evaluates various comparison expressions, such as equal, not equal, less than, etc.,
+     * to ensure that the extraction logic correctly interprets and processes these expressions.
+     *
+     * @implNote The timestamp is represented in milliseconds, and the year extraction is simulated using the 'year' function.
+     */
+    @Test
+    public void testExtractYearTimestampComparison()
+    {
+        // Symbol representing the timestamp column in the query
+        String timestampColumnSymbol = "timestamp_symbol";
+        // Extracting the year part from the timestamp column
+        FunctionCall extractYear = new FunctionCall(
+                PLANNER_CONTEXT.getMetadata().resolveBuiltinFunction("year", fromTypes(TIMESTAMP_MILLIS)).toQualifiedName(),
+                List.of(new SymbolReference(timestampColumnSymbol)));
+
+        // A specific year for comparison
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        // Expression representing the specific year
+        Expression yearExpression = LITERAL_ENCODER.toExpression(2005L, BIGINT);
+
+        // Calculating start of the year and the start of the next year in microseconds
+        Long startOfYear = someDate.withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MICROSECONDS_PER_SECOND;
+        Long startOfNextYear = someDate.plusYears(1).withDayOfYear(1).atStartOfDay().toEpochSecond(UTC) * MICROSECONDS_PER_SECOND;
+
+        // Testing EQUAL comparison
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(EQUAL, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.range(TIMESTAMP_MILLIS, startOfYear, true, startOfNextYear, false)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(NOT_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(
+                        Range.lessThan(TIMESTAMP_MILLIS, startOfYear),
+                        Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextYear)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfYear)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(LESS_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfNextYear)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextYear)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfYear)))));
+
+        assertThat(extract(
+                constraint(
+                        new ComparisonExpression(IS_DISTINCT_FROM, extractYear, yearExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, Domain.create(
+                        ValueSet.ofRanges(
+                                Range.lessThan(TIMESTAMP_MILLIS, startOfYear),
+                                Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfNextYear)),
+                        true))));
+    }
+
+    @Test
+    public void testIntersectSummaryAndExpressionExtraction()
+    {
+        String timestampTzColumnSymbol = "timestamp_tz_symbol";
+        Cast castOfColumn = new Cast(new SymbolReference(timestampTzColumnSymbol), toSqlType(DATE));
+
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        Expression someDateExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay(), DATE);
+
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MILLISECONDS_PER_SECOND;
+        LongTimestampWithTimeZone startOfDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis);
+        LongTimestampWithTimeZone startOfNextDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis + MILLISECONDS_PER_DAY);
+        LongTimestampWithTimeZone startOfNextNextDateUtc = timestampTzFromEpochMillis(startOfDateUtcEpochMillis + MILLISECONDS_PER_DAY * 2);
+
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextNextDateUtc)))),
+                        new ComparisonExpression(NOT_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(
+                        A_TIMESTAMP_TZ, domain(
+                                Range.lessThan(TIMESTAMP_TZ_MICROS, startOfDateUtc),
+                                Range.range(TIMESTAMP_TZ_MICROS, startOfNextDateUtc, true, startOfNextNextDateUtc, false)))));
+
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_TZ, domain(Range.lessThan(TIMESTAMP_TZ_MICROS, startOfNextDateUtc)))),
+                        new ComparisonExpression(GREATER_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.none());
+
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_BIGINT, Domain.singleValue(BIGINT, 1L))),
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampTzColumnSymbol, A_TIMESTAMP_TZ))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(
+                        A_BIGINT, Domain.singleValue(BIGINT, 1L),
+                        A_TIMESTAMP_TZ, domain(Range.greaterThanOrEqual(TIMESTAMP_TZ_MICROS, startOfDateUtc)))));
+    }
+
+    /**
+     * Tests the intersection of summary and expression for timestamp comparisons.
+     * This method evaluates how the extraction process handles various comparison expressions
+     * involving a timestamp column and a constant date.
+     *
+     * The test scenarios include:
+     * - Comparing a timestamp column not equal to a specific date
+     * - Comparing a timestamp column greater than a specific date
+     * - Comparing a timestamp column greater than or equal to a specific date
+     *
+     * The method simulates different conditions using the TupleDomain summary and a ComparisonExpression.
+     * It ensures that the TupleDomain extracted from these conditions correctly represents the expected result.
+     *
+     * @implNote This test uses a timestamp column represented in milliseconds.
+     */
+    @Test
+    public void testIntersectSummaryAndExpressionTimestampExtraction()
+    {
+        // Symbol representing the timestamp column in the query
+        String timestampColumnSymbol = "timestamp_symbol";
+        // Casting the timestamp column to DATE type for comparison
+        Cast castOfColumn = new Cast(new SymbolReference(timestampColumnSymbol), toSqlType(DATE));
+
+        // A specific date for comparison
+        LocalDate someDate = LocalDate.of(2005, 9, 10);
+        // Expression representing the specific date
+        Expression someDateExpression = LITERAL_ENCODER.toExpression(someDate.toEpochDay(), DATE);
+
+        // Calculating start of the date, next date, and the date after in microseconds
+        long startOfDateUtcEpochMillis = someDate.atStartOfDay().toEpochSecond(UTC) * MICROSECONDS_PER_SECOND;
+        Long startOfDate = startOfDateUtcEpochMillis;
+        Long startOfNextDate = startOfDateUtcEpochMillis + MICROSECONDS_PER_DAY;
+        Long startOfNextNextDate = startOfDateUtcEpochMillis + MICROSECONDS_PER_DAY * 2;
+
+        // Testing NOT_EQUAL comparison
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfNextNextDate)))),
+                        new ComparisonExpression(NOT_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(
+                        A_TIMESTAMP_MILL, domain(
+                                Range.lessThan(TIMESTAMP_MILLIS, startOfDate),
+                                Range.range(TIMESTAMP_MILLIS, startOfNextDate, true, startOfNextNextDate, false)))));
+
+        // Testing GREATER_THAN comparison
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_TIMESTAMP_MILL, domain(Range.lessThan(TIMESTAMP_MILLIS, startOfNextDate)))),
+                        new ComparisonExpression(GREATER_THAN, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.none());
+
+        // Testing GREATER_THAN_OR_EQUAL comparison
+        assertThat(extract(
+                constraint(
+                        TupleDomain.withColumnDomains(Map.of(A_BIGINT, Domain.singleValue(BIGINT, 1L))),
+                        new ComparisonExpression(GREATER_THAN_OR_EQUAL, castOfColumn, someDateExpression),
+                        Map.of(timestampColumnSymbol, A_TIMESTAMP_MILL))))
+                .isEqualTo(TupleDomain.withColumnDomains(Map.of(
+                        A_BIGINT, Domain.singleValue(BIGINT, 1L),
+                        A_TIMESTAMP_MILL, domain(Range.greaterThanOrEqual(TIMESTAMP_MILLIS, startOfDate)))));
+    }
+
+    private static KafkaColumnHandle newPrimitiveColumn(Type type)
+    {
+        //
+        int id = nextColumnId.getAndIncrement();
+        return new KafkaColumnHandle(
+                "column_" + id,
+                type,
+                null,
+                null,
+                null,
+                false,
+                false,
+                true);
+    }
+
+    private static TupleDomain<KafkaColumnHandle> extract(Constraint constraint)
+    {
+        ConstraintExtractor.ExtractionResult result = extractTupleDomain(constraint, KafkaColumnHandle::getColumnTypeIfInternal);
+        assertThat(result.remainingExpression())
+                .isEqualTo(Constant.TRUE);
+        return result.tupleDomain();
+    }
+
+    private static Constraint constraint(Expression expression, Map<String, KafkaColumnHandle> assignments)
+    {
+        return constraint(TupleDomain.all(), expression, assignments);
+    }
+
+    private static Constraint constraint(TupleDomain<ColumnHandle> summary, Expression expression, Map<String, KafkaColumnHandle> assignments)
+    {
+        Map<String, Type> symbolTypes = assignments.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getType()));
+        ConnectorExpression connectorExpression = connectorExpression(expression, symbolTypes);
+        return new Constraint(summary, connectorExpression, ImmutableMap.copyOf(assignments));
+    }
+
+    private static ConnectorExpression connectorExpression(Expression expression, Map<String, Type> symbolTypes)
+    {
+        return ConnectorExpressionTranslator.translate(
+                        TEST_SESSION.beginTransactionId(TransactionId.create(), new NoOpTransactionManager(), new AllowAllAccessControl()),
+                        expression,
+                        TypeProvider.viewOf(symbolTypes.entrySet().stream()
+                                .collect(toImmutableMap(entry -> new Symbol(entry.getKey()), Map.Entry::getValue))),
+                        PLANNER_CONTEXT,
+                        createTestingTypeAnalyzer(PLANNER_CONTEXT))
+                .orElseThrow(() -> new RuntimeException("Translation to ConnectorExpression failed for: " + expression));
+    }
+
+    private static LongTimestampWithTimeZone timestampTzFromEpochMillis(long epochMillis)
+    {
+        return LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, 0, UTC_KEY);
+    }
+
+    private static Domain domain(Range first, Range... rest)
+    {
+        return Domain.create(ValueSet.ofRanges(first, rest), false);
+    }
+}

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentContentSchemaProvider.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/schema/confluent/TestAvroConfluentContentSchemaProvider.java
@@ -28,6 +28,7 @@ import org.apache.avro.SchemaBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,10 +47,10 @@ public class TestAvroConfluentContentSchemaProvider
         Schema schema = getAvroSchema();
         mockSchemaRegistryClient.register(SUBJECT_NAME, schema);
         AvroConfluentContentSchemaProvider avroConfluentSchemaProvider = new AvroConfluentContentSchemaProvider(mockSchemaRegistryClient);
-        KafkaTableHandle tableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(SUBJECT_NAME), ImmutableList.of(), TupleDomain.all());
+        KafkaTableHandle tableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(SUBJECT_NAME), ImmutableList.of(), TupleDomain.all(), OptionalLong.empty());
         assertThat(avroConfluentSchemaProvider.getMessage(tableHandle)).isEqualTo(Optional.of(schema).map(Schema::toString));
         assertThat(avroConfluentSchemaProvider.getKey(tableHandle)).isEqualTo(Optional.empty());
-        KafkaTableHandle invalidTableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("another-schema"), ImmutableList.of(), TupleDomain.all());
+        KafkaTableHandle invalidTableHandle = new KafkaTableHandle("default", TOPIC, TOPIC, AvroRowDecoderFactory.NAME, AvroRowDecoderFactory.NAME, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of("another-schema"), ImmutableList.of(), TupleDomain.all(), OptionalLong.empty());
         assertThatThrownBy(() -> avroConfluentSchemaProvider.getMessage(invalidTableHandle))
                 .isInstanceOf(TrinoException.class)
                 .hasMessage("Could not resolve schema for the 'another-schema' subject");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add limit pushdown for Kafka connectors, and further refactor and enhance predicate pushdown in Kafka connector


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Add limit pushdown, and enhance predicate pushdown in Kafka connector

Significant changes have been made to improve predicate push-down support in Kafka connector. The code has been refactored to better handle intersection of old and new domains.

Additionally, the functionality to override partition end and begin offsets with range has been enhanced.

Lastly, an option to enable or disable predicate pushdown at runtime through session properties has been introduced.
By default, it supports predicate push-down. Push-down also can be disabled via ``kafka.predicate-force-push-down-enabled`` config prop  or ``kafka.predicate_force_push_down_enabled`` session prop.

I try my test to make your life easier so that extensive comments have been added across multiple files in the Kafka connector for better readability and understanding of the code.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(1) Add limit pushdown for Kafka connectors,
(2) Enhance predicate pushdown in Kafka connector.

