### PR TITLE
Reduce repetitions of testCreateFileRetry

### DIFF
--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemGcs.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemGcs.java
@@ -38,8 +38,12 @@ public class TestGcsFileSystemGcs
     @Test
     void testCreateFileRetry()
     {
+        // Note: this test is meant to expose flakiness
+        // Without retries it may fail non-deterministically.
+        // Retries are enabled in the default GcsFileSystemConfig.
+        // In practice this may happen between 7 and 20 retries.
         assertThatNoException().isThrownBy(() -> {
-            for (int i = 1; i <= 100; i++) {
+            for (int i = 1; i <= 30; i++) {
                 TrinoOutputFile outputFile = getFileSystem().newOutputFile(getRootLocation().appendPath("testFile"));
                 try (OutputStream out = outputFile.createOrOverwrite()) {
                     out.write("test".getBytes(UTF_8));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Reduce the time from about 120-130s to 35-37s by reducing the repetitions from 100 -> 30.
Also added a comment explaining the reason for the testCreateFileRetry test.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
