### PR TITLE
Fixing the issue where the 'Filter required...' error occurs even though the query has a partition filter

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -3049,7 +3049,7 @@ public class HiveMetadata
             List<HiveColumnHandle> partitionColumns = handle.getPartitionColumns();
             if (!partitionColumns.isEmpty()) {
                 Set<ColumnHandle> referencedColumns = handle.getConstraintColumns();
-                if (Collections.disjoint(referencedColumns, partitionColumns)) {
+                if (Collections.disjoint(referencedColumns, partitionColumns) && handle.getCompactEffectivePredicate().filter((column, domain) -> partitionColumns.contains(column)).isAll()) {
                     String partitionColumnNames = partitionColumns.stream()
                             .map(HiveColumnHandle::getName)
                             .collect(joining(", "));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -255,7 +255,7 @@ public final class HiveQueryRunner
                     hiveProperties.put("hive.parquet.time-zone", TIME_ZONE.getID());
                 }
                 hiveProperties.put("hive.max-partitions-per-scan", "1000");
-                hiveProperties.put("hive.max-partitions-for-eager-load", "1000");
+                hiveProperties.put("hive.max-partitions-for-eager-load", "200");
                 hiveProperties.put("hive.security", SQL_STANDARD);
                 hiveProperties.putAll(this.hiveProperties.buildOrThrow());
 


### PR DESCRIPTION
## Description

If the option `hive.query-partition-filter-requested` is `true` in the Hive catalog, the query must contain a conditional clause containing at least one partition column.
However, even if a conditional clause containing at least one partition column is specified in the query, a 'Filter required on . . .' error will occur if partitions above `hive.max-partitions-for-eager-load` are queried.

### Reproduce

For easy reproducibility, set the `hive.max-partitions-for-eager-load` value to 3.

```
create table hive.default.test_partition_limit (id int, dt varchar)
with (
	partitioned_by=array['dt']
);
insert into hive.default.test_partition_limit values (1, '20231201'), (2, '20231202'), (3, '20231203'), (4, '20231204');
set session hive.query_partition_filter_required = true;
select * from hive.default.test_partition_limit where dt <= '20231212';
```

When execute above queries, then error occured:
```
SQL Error [31]: Query failed (#20231217_163836_00017_vmkmg): Filter required on default.test_partition_limit for at least one partition column: dt
```

--- 

Even if a partition filter condition exists, the condition is not set in `enforceConstraint` if the number of partitions queried exceeds `hive.max-partitions-for-eager-load` (but it is set in `effectivePredicate`)
'HiveMetadata.validateScan' checks whether the partition filter is applied only on the 'enforcedConstraint' basis, so I think that error occurs.
As in `HivePartitionMetadata.getPartitions`, I believe that not only `enforcedConstraint` but also `effectivePredicate` should be included in the confirmation of the existence of partition filters.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
