### PR TITLE
Disable file creation when Partition does not exist #20133

### DIFF
--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
@@ -40,7 +40,6 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecordBase;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -297,9 +296,7 @@ public class HudiTableFileSystemView
         if (fileIterator.hasNext()) {
             return fileIterator;
         }
-        try (OutputStream ignored = metaClient.getFileSystem().newOutputFile(partitionLocation).create()) {
-            return FileIterator.empty();
-        }
+        return FileIterator.empty();
     }
 
     public List<HudiFileGroup> addFilesToView(FileIterator partitionFiles)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- [HUDI] Disable file creation when Partition does not exist (Fix issue 20133)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- https://github.com/trinodb/trino/issues/20133


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix HUDI connector create files when partitions does not exist. ({issue}`20133`)
```
