### PR TITLE
Function to_utf8 supports char type

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -30,6 +30,7 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
+import io.trino.spi.type.Chars;
 import io.trino.spi.type.StandardTypes;
 import io.trino.type.CodePointsType;
 import io.trino.type.Constraint;
@@ -878,6 +879,15 @@ public final class StringFunctions
     public static Slice toUtf8(@SqlType("varchar(x)") Slice slice)
     {
         return slice;
+    }
+
+    @Description("Encodes the string to UTF-8")
+    @ScalarFunction
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice toUtf8(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
+    {
+        return Chars.padSpaces(slice, (int) x);
     }
 
     // TODO: implement N arguments char concat

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/StringFunctions.java
@@ -887,7 +887,7 @@ public final class StringFunctions
     @SqlType(StandardTypes.VARBINARY)
     public static Slice toUtf8(@LiteralParameter("x") long x, @SqlType("char(x)") Slice slice)
     {
-        return Chars.padSpaces(slice, (int) x);
+        return Chars.padSpaces(slice, toIntExact(x));
     }
 
     // TODO: implement N arguments char concat

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestStringFunctions.java
@@ -2240,6 +2240,10 @@ public class TestStringFunctions
                 .hasType(VARCHAR)
                 .isEqualTo("hello");
 
+        assertThat(assertions.function("from_utf8", "to_utf8(cast('hello' as char(10)))"))
+                .hasType(VARCHAR)
+                .isEqualTo("hello     ");
+
         assertThat(assertions.function("from_utf8", "from_hex('58BF')"))
                 .hasType(VARCHAR)
                 .isEqualTo("X\uFFFD");
@@ -2268,6 +2272,12 @@ public class TestStringFunctions
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
 
         assertTrinoExceptionThrownBy(assertions.function("from_utf8", "to_utf8('hello')", "1114112")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.function("from_utf8", "to_utf8(cast('hello' as char(10)))", "'foo'")::evaluate)
+                .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
+
+        assertTrinoExceptionThrownBy(assertions.function("from_utf8", "to_utf8(cast('hello' as char(10)))", "1114112")::evaluate)
                 .hasErrorCode(INVALID_FUNCTION_ARGUMENT);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Function to_utf8 doesn't support char type. When this function is applied to the char type in Hive, an error will be reported. This PR modifies to_utf8 function to support  char type in Hive. This function is important, because it also used in ranger-trino plugin for masking.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
In hive, create a table using SQL: 
CREATE TABLE char_table_test (
    id INT,
    name string,
    description CHAR(120)
);
insert into char_table_test values(1, 'xiaoming', 'he is a student');
insert into char_table_test values(2, 'honghong', 'she is a teacher');  

When using function to_utf8 in a sql, there is an error. 
To_utf8 doesn't support char type, as below:
**SQL1:**
select to_utf8(description) from char_table_test;
Query 20231218_125526_00001_ewnva failed: line 1:8: Unexpected parameters (char(120)) for function to_utf8. Expected: to_utf8(varchar(x))
select to_utf8(description) from char_table_test;

**SQL2:** 
select length(from_utf8(to_utf8(description))) from char_table_test;
Query 20231218_125334_00000_ewnva failed: line 1:25: Unexpected parameters (char(120)) for function to_utf8. Expected: to_utf8(varchar(x))
select length(from_utf8(to_utf8(description))) from char_table_test

After changed, it supports char type. As below:

SQL1:
select to_utf8(description) from char_table_test;
_col0                      
-------------------------------------------------
 68 65 20 69 73 20 61 20 73 74 75 64 65 6e 74 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20                         
 73 68 65 20 69 73 20 61 20 74 65 61 63 68 65 72+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20+
 20 20 20 20 20 20 20 20                         
(2 rows)

SQL2:
select from_utf8(to_utf8(description)) from char_table_test;
_col0                                                           
--------------------------------------------------------------------------------------------------------------------------
 she is a teacher                                                                                                         
 he is a student         

SQL3:
select length(from_utf8(to_utf8(description))) from char_table_test;
 _col0 
-------
   120 
   120 
(2 rows)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


