### PR TITLE
Revert "Update Iceberg from 1.3.1 to 1.4.1"

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- Nessie version (matching to Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
-        <dep.nessie.version>0.71.0</dep.nessie.version>
+        <dep.nessie.version>0.59.0</dep.nessie.version>
     </properties>
 
     <dependencies>
@@ -228,6 +228,11 @@
         <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-hadoop</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gaul</groupId>
+            <artifactId>modernizer-maven-annotations</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.iceberg.parquet.ParquetUtil.footerMetrics;
+import static org.apache.iceberg.parquet.TrinoParquetUtil.footerMetrics;
 
 public final class IcebergParquetFileWriter
         implements IcebergFileWriter

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractIcebergTableOperations.java
@@ -40,7 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -235,13 +234,6 @@ public abstract class AbstractIcebergTableOperations
 
     protected void refreshFromMetadataLocation(String newLocation)
     {
-        refreshFromMetadataLocation(
-                newLocation,
-                metadataLocation -> TableMetadataParser.read(fileIo, fileIo.newInputFile(metadataLocation)));
-    }
-
-    protected void refreshFromMetadataLocation(String newLocation, Function<String, TableMetadata> metadataLoader)
-    {
         // use null-safe equality check because new tables have a null metadata location
         if (Objects.equals(currentMetadataLocation, newLocation)) {
             shouldRefresh = false;
@@ -262,7 +254,7 @@ public abstract class AbstractIcebergTableOperations
                             .withMaxDuration(Duration.ofMinutes(10))
                             .abortOn(failure -> failure instanceof ValidationException || isNotFoundException(failure))
                             .build())
-                    .get(() -> metadataLoader.apply(newLocation));
+                    .get(() -> TableMetadataParser.read(fileIo, io().newInputFile(newLocation)));
         }
         catch (Throwable failure) {
             if (isNotFoundException(failure)) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
@@ -49,6 +49,7 @@ public class IcebergNessieCatalogModule
     {
         HttpClientBuilder builder = HttpClientBuilder.builder()
                 .withUri(icebergNessieCatalogConfig.getServerUri())
+                .withEnableApiCompatibilityCheck(false)
                 .withDisableCompression(!icebergNessieCatalogConfig.isCompressionEnabled())
                 .withReadTimeout(toIntExact(icebergNessieCatalogConfig.getReadTimeout().toMillis()))
                 .withConnectionTimeout(toIntExact(icebergNessieCatalogConfig.getConnectionTimeout().toMillis()));

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
@@ -19,11 +19,9 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.nessie.NessieIcebergClient;
-import org.apache.iceberg.nessie.NessieUtil;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.ContentKey;
@@ -80,16 +78,6 @@ public class IcebergNessieTableOperations
     {
         refreshNessieClient();
         return super.refresh(invalidateCaches);
-    }
-
-    @Override
-    protected void refreshFromMetadataLocation(String newLocation)
-    {
-        super.refreshFromMetadataLocation(
-                newLocation,
-                location -> NessieUtil.updateTableMetadataWithNessieSpecificProperties(
-                    TableMetadataParser.read(fileIo, location),
-                    location, table, getSchemaTableName().toString(), nessieClient.getReference()));
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/rest/TrinoRestCatalog.java
@@ -278,16 +278,13 @@ public class TrinoRestCatalog
     @Override
     public void registerTable(ConnectorSession session, SchemaTableName tableName, TableMetadata tableMetadata)
     {
-        restSessionCatalog.registerTable(convert(session), toIdentifier(tableName), tableMetadata.metadataFileLocation());
+        throw new TrinoException(NOT_SUPPORTED, "registerTable is not supported for Iceberg REST catalog");
     }
 
     @Override
     public void unregisterTable(ConnectorSession session, SchemaTableName tableName)
     {
-        if (!restSessionCatalog.dropTable(convert(session), toIdentifier(tableName))) {
-            throw new TableNotFoundException(tableName);
-        }
-        invalidateTableCache(tableName);
+        throw new TrinoException(NOT_SUPPORTED, "unregisterTable is not supported for Iceberg REST catalogs");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/org/apache/iceberg/parquet/TrinoParquetUtil.java
+++ b/plugin/trino-iceberg/src/main/java/org/apache/iceberg/parquet/TrinoParquetUtil.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.MetricsModes.MetricsMode;
+import org.apache.iceberg.MetricsUtil;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.column.page.PageReader;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.gaul.modernizer_maven_annotations.SuppressModernizer;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+// Copied from https://github.com/apache/iceberg/blob/master/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+@Deprecated // This class will be removed after new Iceberg library including https://github.com/apache/iceberg/pull/8559 is released
+@SuppressModernizer
+public class TrinoParquetUtil // Renamed from ParquetUtil for avoiding duplicate resources
+{
+    // not meant to be instantiated
+    private TrinoParquetUtil() {}
+
+    private static final long UNIX_EPOCH_JULIAN = 2_440_588L;
+
+    public static Metrics fileMetrics(InputFile file, MetricsConfig metricsConfig)
+    {
+        return fileMetrics(file, metricsConfig, null);
+    }
+
+    public static Metrics fileMetrics(
+            InputFile file, MetricsConfig metricsConfig, NameMapping nameMapping)
+    {
+        try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(file))) {
+            return footerMetrics(reader.getFooter(), Stream.empty(), metricsConfig, nameMapping);
+        }
+        catch (IOException e) {
+            throw new RuntimeIOException(e, "Failed to read footer of file: %s", file);
+        }
+    }
+
+    public static Metrics footerMetrics(
+            ParquetMetadata metadata, Stream<FieldMetrics<?>> fieldMetrics, MetricsConfig metricsConfig)
+    {
+        return footerMetrics(metadata, fieldMetrics, metricsConfig, null);
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    public static Metrics footerMetrics(
+            ParquetMetadata metadata,
+            Stream<FieldMetrics<?>> fieldMetrics,
+            MetricsConfig metricsConfig,
+            NameMapping nameMapping)
+    {
+        checkNotNull(fieldMetrics, "fieldMetrics should not be null");
+
+        long rowCount = 0;
+        Map<Integer, Long> columnSizes = Maps.newHashMap();
+        Map<Integer, Long> valueCounts = Maps.newHashMap();
+        Map<Integer, Long> nullValueCounts = Maps.newHashMap();
+        Map<Integer, Literal<?>> lowerBounds = Maps.newHashMap();
+        Map<Integer, Literal<?>> upperBounds = Maps.newHashMap();
+        Set<Integer> missingStats = Sets.newHashSet();
+
+        // ignore metrics for fields we failed to determine reliable IDs
+        MessageType parquetTypeWithIds = getParquetTypeWithIds(metadata, nameMapping);
+        Schema fileSchema = ParquetSchemaUtil.convertAndPrune(parquetTypeWithIds);
+
+        Map<Integer, FieldMetrics<?>> fieldMetricsMap =
+                fieldMetrics.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
+
+        List<BlockMetaData> blocks = metadata.getBlocks();
+        for (BlockMetaData block : blocks) {
+            rowCount += block.getRowCount();
+            for (ColumnChunkMetaData column : block.getColumns()) {
+                Integer fieldId = fileSchema.aliasToId(column.getPath().toDotString());
+                if (fieldId == null) {
+                    // fileSchema may contain a subset of columns present in the file
+                    // as we prune columns we could not assign ids
+                    continue;
+                }
+
+                increment(columnSizes, fieldId, column.getTotalSize());
+
+                MetricsMode metricsMode = MetricsUtil.metricsMode(fileSchema, metricsConfig, fieldId);
+                if (metricsMode == MetricsModes.None.get()) {
+                    continue;
+                }
+                increment(valueCounts, fieldId, column.getValueCount());
+
+                Statistics stats = column.getStatistics();
+                if (stats != null && !stats.isEmpty()) {
+                    increment(nullValueCounts, fieldId, stats.getNumNulls());
+
+                    // when there are metrics gathered by Iceberg for a column, we should use those instead
+                    // of the ones from Parquet
+                    if (metricsMode != MetricsModes.Counts.get() && !fieldMetricsMap.containsKey(fieldId)) {
+                        Types.NestedField field = fileSchema.findField(fieldId);
+                        if (field != null && stats.hasNonNullValue() && shouldStoreBounds(column, fileSchema)) {
+                            Literal<?> min =
+                                    ParquetConversions.fromParquetPrimitive(
+                                            field.type(), column.getPrimitiveType(), stats.genericGetMin());
+                            updateMin(lowerBounds, fieldId, field.type(), min, metricsMode);
+                            Literal<?> max =
+                                    ParquetConversions.fromParquetPrimitive(
+                                            field.type(), column.getPrimitiveType(), stats.genericGetMax());
+                            updateMax(upperBounds, fieldId, field.type(), max, metricsMode);
+                        }
+                    }
+                }
+                else if (!stats.isEmpty()) {
+                    missingStats.add(fieldId);
+                }
+            }
+        }
+
+        // discard accumulated values if any stats were missing
+        for (Integer fieldId : missingStats) {
+            nullValueCounts.remove(fieldId);
+            lowerBounds.remove(fieldId);
+            upperBounds.remove(fieldId);
+        }
+
+        updateFromFieldMetrics(fieldMetricsMap, metricsConfig, fileSchema, lowerBounds, upperBounds);
+
+        return new Metrics(
+                rowCount,
+                columnSizes,
+                valueCounts,
+                nullValueCounts,
+                MetricsUtil.createNanValueCounts(
+                        fieldMetricsMap.values().stream(), metricsConfig, fileSchema),
+                toBufferMap(fileSchema, lowerBounds),
+                toBufferMap(fileSchema, upperBounds));
+    }
+
+    private static void updateFromFieldMetrics(
+            Map<Integer, FieldMetrics<?>> idToFieldMetricsMap,
+            MetricsConfig metricsConfig,
+            Schema schema,
+            Map<Integer, Literal<?>> lowerBounds,
+            Map<Integer, Literal<?>> upperBounds)
+    {
+        idToFieldMetricsMap
+                .entrySet()
+                .forEach(
+                        entry -> {
+                            int fieldId = entry.getKey();
+                            FieldMetrics<?> metrics = entry.getValue();
+                            MetricsMode metricsMode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+
+                            // only check for MetricsModes.None, since we don't truncate float/double values.
+                            if (metricsMode != MetricsModes.None.get()) {
+                                if (!metrics.hasBounds()) {
+                                    lowerBounds.remove(fieldId);
+                                    upperBounds.remove(fieldId);
+                                }
+                                else if (metrics.upperBound() instanceof Float) {
+                                    lowerBounds.put(fieldId, Literal.of((Float) metrics.lowerBound()));
+                                    upperBounds.put(fieldId, Literal.of((Float) metrics.upperBound()));
+                                }
+                                else if (metrics.upperBound() instanceof Double) {
+                                    lowerBounds.put(fieldId, Literal.of((Double) metrics.lowerBound()));
+                                    upperBounds.put(fieldId, Literal.of((Double) metrics.upperBound()));
+                                }
+                                else {
+                                    throw new UnsupportedOperationException(
+                                            "Expected only float or double column metrics");
+                                }
+                            }
+                        });
+    }
+
+    private static MessageType getParquetTypeWithIds(
+            ParquetMetadata metadata, NameMapping nameMapping)
+    {
+        MessageType type = metadata.getFileMetaData().getSchema();
+
+        if (ParquetSchemaUtil.hasIds(type)) {
+            return type;
+        }
+
+        if (nameMapping != null) {
+            return ParquetSchemaUtil.applyNameMapping(type, nameMapping);
+        }
+
+        return ParquetSchemaUtil.addFallbackIds(type);
+    }
+
+    /**
+     * Returns a list of offsets in ascending order determined by the starting position of the row
+     * groups.
+     */
+    public static List<Long> getSplitOffsets(ParquetMetadata md)
+    {
+        List<Long> splitOffsets = Lists.newArrayListWithExpectedSize(md.getBlocks().size());
+        for (BlockMetaData blockMetaData : md.getBlocks()) {
+            splitOffsets.add(blockMetaData.getStartingPos());
+        }
+        Collections.sort(splitOffsets);
+        return splitOffsets;
+    }
+
+    // we allow struct nesting, but not maps or arrays
+    private static boolean shouldStoreBounds(ColumnChunkMetaData column, Schema schema)
+    {
+        if (column.getPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
+            // stats for INT96 are not reliable
+            return false;
+        }
+
+        ColumnPath columnPath = column.getPath();
+        Iterator<String> pathIterator = columnPath.iterator();
+        Type currentType = schema.asStruct();
+
+        while (pathIterator.hasNext()) {
+            if (currentType == null || !currentType.isStructType()) {
+                return false;
+            }
+            String fieldName = pathIterator.next();
+            currentType = currentType.asStructType().fieldType(fieldName);
+        }
+
+        return currentType != null && currentType.isPrimitiveType();
+    }
+
+    private static void increment(Map<Integer, Long> columns, int fieldId, long amount)
+    {
+        if (columns != null) {
+            if (columns.containsKey(fieldId)) {
+                columns.put(fieldId, columns.get(fieldId) + amount);
+            }
+            else {
+                columns.put(fieldId, amount);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void updateMin(
+            Map<Integer, Literal<?>> lowerBounds,
+            int id,
+            Type type,
+            Literal<T> min,
+            MetricsMode metricsMode)
+    {
+        Literal<T> currentMin = (Literal<T>) lowerBounds.get(id);
+        if (currentMin == null || min.comparator().compare(min.value(), currentMin.value()) < 0) {
+            if (metricsMode == MetricsModes.Full.get()) {
+                lowerBounds.put(id, min);
+            }
+            else {
+                MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
+                int truncateLength = truncateMode.length();
+                switch (type.typeId()) {
+                    case STRING:
+                        lowerBounds.put(
+                                id, UnicodeUtil.truncateStringMin((Literal<CharSequence>) min, truncateLength));
+                        break;
+                    case FIXED:
+                    case BINARY:
+                        lowerBounds.put(
+                                id, BinaryUtil.truncateBinaryMin((Literal<ByteBuffer>) min, truncateLength));
+                        break;
+                    default:
+                        lowerBounds.put(id, min);
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void updateMax(
+            Map<Integer, Literal<?>> upperBounds,
+            int id,
+            Type type,
+            Literal<T> max,
+            MetricsMode metricsMode)
+    {
+        Literal<T> currentMax = (Literal<T>) upperBounds.get(id);
+        if (currentMax == null || max.comparator().compare(max.value(), currentMax.value()) > 0) {
+            if (metricsMode == MetricsModes.Full.get()) {
+                upperBounds.put(id, max);
+            }
+            else {
+                MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
+                int truncateLength = truncateMode.length();
+                switch (type.typeId()) {
+                    case STRING:
+                        Literal<CharSequence> truncatedMaxString =
+                                UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength);
+                        if (truncatedMaxString != null) {
+                            upperBounds.put(id, truncatedMaxString);
+                        }
+                        break;
+                    case FIXED:
+                    case BINARY:
+                        Literal<ByteBuffer> truncatedMaxBinary =
+                                BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength);
+                        if (truncatedMaxBinary != null) {
+                            upperBounds.put(id, truncatedMaxBinary);
+                        }
+                        break;
+                    default:
+                        upperBounds.put(id, max);
+                }
+            }
+        }
+    }
+
+    private static Map<Integer, ByteBuffer> toBufferMap(Schema schema, Map<Integer, Literal<?>> map)
+    {
+        Map<Integer, ByteBuffer> bufferMap = Maps.newHashMap();
+        for (Map.Entry<Integer, Literal<?>> entry : map.entrySet()) {
+            bufferMap.put(
+                    entry.getKey(),
+                    Conversions.toByteBuffer(schema.findType(entry.getKey()), entry.getValue().value()));
+        }
+        return bufferMap;
+    }
+
+    @SuppressWarnings("deprecation")
+    public static boolean hasNonDictionaryPages(ColumnChunkMetaData meta)
+    {
+        EncodingStats stats = meta.getEncodingStats();
+        if (stats != null) {
+            return stats.hasNonDictionaryEncodedPages();
+        }
+
+        // without EncodingStats, fall back to testing the encoding list
+        Set<Encoding> encodings = Sets.newHashSet(meta.getEncodings());
+        if (encodings.remove(Encoding.PLAIN_DICTIONARY)) {
+            // if remove returned true, PLAIN_DICTIONARY was present, which means at
+            // least one page was dictionary encoded and 1.0 encodings are used
+
+            // RLE and BIT_PACKED are only used for repetition or definition levels
+            encodings.remove(Encoding.RLE);
+            encodings.remove(Encoding.BIT_PACKED);
+
+            // when empty, no encodings other than dictionary or rep/def levels
+            return !encodings.isEmpty();
+        }
+        else {
+            // if PLAIN_DICTIONARY wasn't present, then either the column is not
+            // dictionary-encoded, or the 2.0 encoding, RLE_DICTIONARY, was used.
+            // for 2.0, this cannot determine whether a page fell back without
+            // page encoding stats
+            return true;
+        }
+    }
+
+    public static boolean hasNoBloomFilterPages(ColumnChunkMetaData meta)
+    {
+        return meta.getBloomFilterOffset() <= 0;
+    }
+
+    public static Dictionary readDictionary(ColumnDescriptor desc, PageReader pageSource)
+    {
+        DictionaryPage dictionaryPage = pageSource.readDictionaryPage();
+        if (dictionaryPage != null) {
+            try {
+                return dictionaryPage.getEncoding().initDictionary(desc, dictionaryPage);
+            }
+            catch (IOException e) {
+                throw new ParquetDecodingException("could not decode the dictionary for " + desc, e);
+            }
+        }
+        return null;
+    }
+
+    public static boolean isIntType(PrimitiveType primitiveType)
+    {
+        if (primitiveType.getOriginalType() != null) {
+            switch (primitiveType.getOriginalType()) {
+                case INT_8:
+                case INT_16:
+                case INT_32:
+                case DATE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        return primitiveType.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT32;
+    }
+
+    /**
+     * Method to read timestamp (parquet Int96) from bytebuffer. Read 12 bytes in byteBuffer: 8 bytes
+     * (time of day nanos) + 4 bytes(julianDay)
+     */
+    public static long extractTimestampInt96(ByteBuffer buffer)
+    {
+        // 8 bytes (time of day nanos)
+        long timeOfDayNanos = buffer.getLong();
+        // 4 bytes(julianDay)
+        int julianDay = buffer.getInt();
+        return TimeUnit.DAYS.toMicros(julianDay - UNIX_EPOCH_JULIAN)
+               + TimeUnit.NANOSECONDS.toMicros(timeOfDayNanos);
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -4691,7 +4691,7 @@ public abstract class BaseIcebergConnectorTest
         assertThat(actual).isNotNull();
         MaterializedResult expected = resultBuilder(getSession())
                 .row("write.format.default", format.name())
-                .row("write.parquet.compression-codec", "zstd").build();
+                .build();
         assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -71,10 +71,10 @@ public class TestPartitionFields
         assertInvalid("bucket()", "Invalid partition field declaration: bucket()");
         assertInvalid("abc", "Cannot find source column: abc");
         assertInvalid("notes", "Cannot partition by non-primitive source field: list<string>");
-        assertInvalid("bucket(price, 42)", "Invalid source type double for transform: bucket[42]");
-        assertInvalid("bucket(notes, 88)", "Cannot partition by non-primitive source field: list<string>");
-        assertInvalid("truncate(ts, 13)", "Invalid source type timestamp for transform: truncate[13]");
-        assertInvalid("year(order_key)", "Invalid source type long for transform: year");
+        assertInvalid("bucket(price, 42)", "Cannot bucket by type: double");
+        assertInvalid("bucket(notes, 88)", "Cannot bucket by type: list<string>");
+        assertInvalid("truncate(ts, 13)", "Cannot truncate type: timestamp");
+        assertInvalid("year(order_key)", "Cannot partition type long by year");
         assertInvalid("\"test\"", "Cannot find source column: test");
         assertInvalid("\"test with space\"", "Cannot find source column: test with space");
         assertInvalid("\"test \"with space\"", "Invalid partition field declaration: \"test \"with space\"");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -140,7 +138,7 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     @Override
     protected void dropTableFromMetastore(String tableName)
     {
-        backend.dropTable(toIdentifier(tableName), false);
+        // used when registering a table, which is not supported by the REST catalog
     }
 
     @Override
@@ -160,6 +158,94 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     protected boolean locationExists(String location)
     {
         return java.nio.file.Files.exists(Path.of(location));
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTableLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTableLocation)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithComments()
+    {
+        assertThatThrownBy(super::testRegisterTableWithComments)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithShowCreateTable()
+    {
+        assertThatThrownBy(super::testRegisterTableWithShowCreateTable)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithReInsert()
+    {
+        assertThatThrownBy(super::testRegisterTableWithReInsert)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithDifferentTableName()
+    {
+        assertThatThrownBy(super::testRegisterTableWithDifferentTableName)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithMetadataFile()
+    {
+        assertThatThrownBy(super::testRegisterTableWithMetadataFile)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testRegisterTableWithTrailingSpaceInLocation()
+    {
+        assertThatThrownBy(super::testRegisterTableWithTrailingSpaceInLocation)
+                .hasMessageContaining("registerTable is not supported for Iceberg REST catalog");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTable()
+    {
+        assertThatThrownBy(super::testUnregisterTable)
+                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterBrokenTable()
+    {
+        assertThatThrownBy(super::testUnregisterBrokenTable)
+                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
+    }
+
+    @Test
+    @Override
+    public void testUnregisterTableNotExistingTable()
+    {
+        assertThatThrownBy(super::testUnregisterTableNotExistingTable)
+                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
+    }
+
+    @Test
+    @Override
+    public void testRepeatUnregisterTable()
+    {
+        assertThatThrownBy(super::testRepeatUnregisterTable)
+                .hasMessageContaining("unregisterTable is not supported for Iceberg REST catalogs");
     }
 
     @Test
@@ -214,12 +300,7 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
     @Override
     protected void deleteDirectory(String location)
     {
-        try {
-            deleteRecursively(Path.of(location), ALLOW_INSECURE);
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        // used when unregistering a table, which is not supported by the REST catalog
     }
 
     private TableIdentifier toIdentifier(String tableName)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -28,7 +28,7 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.71.0";
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.59.0";
     public static final String DEFAULT_HOST_NAME = "nessie";
     public static final String VERSION_STORE_TYPE = "INMEMORY";
 

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dep.errorprone.version>2.23.0</dep.errorprone.version>
         <dep.flyway.version>10.3.0</dep.flyway.version>
         <dep.google.http.client.version>1.43.3</dep.google.http.client.version>
-        <dep.iceberg.version>1.4.2</dep.iceberg.version>
+        <dep.iceberg.version>1.3.1</dep.iceberg.version>
         <dep.jna.version>5.14.0</dep.jna.version>
         <dep.jsonwebtoken.version>0.12.3</dep.jsonwebtoken.version>
         <dep.kafka-clients.version>3.6.1</dep.kafka-clients.version>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
@@ -37,7 +37,7 @@ public class EnvSinglenodeSparkIcebergNessie
 {
     private static final int SPARK_THRIFT_PORT = 10213;
     private static final int NESSIE_PORT = 19120;
-    private static final String NESSIE_VERSION = "0.71.0";
+    private static final String NESSIE_VERSION = "0.59.0";
     private static final String SPARK = "spark";
 
     private final DockerFiles dockerFiles;

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -590,7 +590,7 @@ public class TestIcebergSparkCompatibility
         onTrino().executeQuery("DROP TABLE " + trinoTableName);
     }
 
-    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC}, dataProvider = "storageFormatsWithSpecVersion")
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE}, dataProvider = "storageFormatsWithSpecVersion")
     public void testTrinoReadingSparkIcebergTablePropertiesData(StorageFormat storageFormat, int specVersion)
     {
         String baseTableName = toLowerCase("test_trino_reading_spark_iceberg_table_properties_" + storageFormat);
@@ -984,24 +984,6 @@ public class TestIcebergSparkCompatibility
                 .hasMessageMatching(".*Metadata not found in metadata location for table default." + tableSameLocation2);
 
         onTrino().executeQuery(format("DROP TABLE %s", trinoTableName(tableSameLocation2)));
-    }
-
-    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS, ICEBERG_REST, ICEBERG_JDBC, ICEBERG_NESSIE})
-    public void testTrinoWritingDataAfterSpark()
-    {
-        String baseTableName = toLowerCase("test_trino_write_after_spark");
-        String sparkTableName = sparkTableName(baseTableName);
-        String trinoTableName = trinoTableName(baseTableName);
-
-        onSpark().executeQuery("CREATE TABLE " + sparkTableName + " (a INT) USING ICEBERG");
-        onSpark().executeQuery("INSERT INTO " + sparkTableName + " VALUES 1");
-
-        onTrino().executeQuery("INSERT INTO " + trinoTableName + " VALUES 2");
-
-        List<Row> expected = ImmutableList.of(row(1), row(2));
-        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
-        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
-        onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 
     @Test(groups = {ICEBERG, ICEBERG_JDBC, PROFILE_SPECIFIC_TESTS, ICEBERG_NESSIE}, dataProvider = "storageFormatsWithSpecVersion")


### PR DESCRIPTION
## Description

This reverts commits e6c145971f02e04d9ffeb8a1c88adbc3f5cc03d9, face6d8660e2dd2da5d9082c19c930bf353c259c. and  bb66918ce46913a9f4017a73c72aa08d8860f854.

Iceberg 1.4.x contains a silent correctness issue when concurrently committing writes to a table.

See: https://github.com/apache/iceberg/issues/9227

## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/20092



## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
