### PR TITLE
Bump number of queryExecutor threads in tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/FaultTolerantExecutionConnectorTestHelper.java
@@ -42,8 +42,7 @@ public final class FaultTolerantExecutionConnectorTestHelper
                 // to trigger spilling
                 .put("exchange.deduplication-buffer-size", "1kB")
                 .put("fault-tolerant-execution-task-memory", "1GB")
-                // limit number of threads to detect potential thread leaks
-                .put("query.executor-pool-size", "10")
+
                 // enable exchange compression to follow production deployment recommendations
                 .put("exchange.compression-enabled", "true")
                 .put("max-tasks-waiting-for-execution-per-query", "2")


### PR DESCRIPTION
While by default number of queryExecutor threads is 1000 in tests we limitted it to 10. This values was too small though. If tests are run in parallel all threads may be consumed by long running jobs running EventDrivenFaultTolerantQueryScheduler.Scheduler#run. In such case we are not able to run Future callback which use same executor and are also needed for queries to progress. If that happens test queries would hang.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
