### PR TITLE
Allow configuring maximum value count of pages written in parquet

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -199,6 +199,9 @@ The following table describes {ref}`catalog session properties
 * - `parquet_writer_page_size`
   - The maximum page size created by the Parquet writer.
   - `1MB`
+* - `parquet_writer_page_value_count`
+  - The maximum value count of pages created by the Parquet writer.
+  - `60000`
 * - `parquet_writer_batch_size`
   - Maximum number of rows processed by the Parquet writer in a batch.
   - `10000`

--- a/docs/src/main/sphinx/connector/object-storage-file-formats.md
+++ b/docs/src/main/sphinx/connector/object-storage-file-formats.md
@@ -72,10 +72,13 @@ with Parquet files performed by supported object storage connectors:
     off by setting this property to `0`.
   - `5`
 * - `parquet.writer.page-size`
-  - Maximum page size for the Parquet writer.
+  - Maximum size of pages written by Parquet writer.
   - `1 MB`
+* - `parquet.writer.page-value-count`
+  - Maximum values count of pages written by Parquet writer.
+  - `80000`
 * - `parquet.writer.block-size`
-  - Maximum row group size for the Parquet writer.
+  - Maximum size of row groups written by Parquet writer.
   - `128 MB`
 * - `parquet.writer.batch-size`
   - Maximum number of rows processed by the parquet writer in a batch.

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -389,7 +389,13 @@ public class ParquetWriter
                 .withPageSize(writerOption.getMaxPageSize())
                 .build();
 
-        this.columnWriters = ParquetWriters.getColumnWriters(messageType, primitiveTypes, parquetProperties, compressionCodec, parquetTimeZone);
+        this.columnWriters = ParquetWriters.getColumnWriters(
+                messageType,
+                primitiveTypes,
+                parquetProperties,
+                compressionCodec,
+                writerOption.getMaxPageValueCount(),
+                parquetTimeZone);
     }
 
     private static class FileFooter

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -21,6 +21,9 @@ public class ParquetWriterOptions
 {
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE);
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE);
+    // org.apache.parquet.column.DEFAULT_PAGE_ROW_COUNT_LIMIT is 20_000 to improve selectivity of page indexes
+    // This value should be revisited when TODO https://github.com/trinodb/trino/issues/9359 is implemented
+    public static final int DEFAULT_MAX_PAGE_VALUE_COUNT = 60_000;
     public static final int DEFAULT_BATCH_SIZE = 10_000;
 
     public static ParquetWriterOptions.Builder builder()
@@ -30,12 +33,14 @@ public class ParquetWriterOptions
 
     private final int maxRowGroupSize;
     private final int maxPageSize;
+    private final int maxPageValueCount;
     private final int batchSize;
 
-    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize, int batchSize)
+    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize, int maxPageValueCount, int batchSize)
     {
         this.maxRowGroupSize = Ints.saturatedCast(maxBlockSize.toBytes());
         this.maxPageSize = Ints.saturatedCast(maxPageSize.toBytes());
+        this.maxPageValueCount = maxPageValueCount;
         this.batchSize = batchSize;
     }
 
@@ -49,6 +54,11 @@ public class ParquetWriterOptions
         return maxPageSize;
     }
 
+    public int getMaxPageValueCount()
+    {
+        return maxPageValueCount;
+    }
+
     public int getBatchSize()
     {
         return batchSize;
@@ -58,6 +68,7 @@ public class ParquetWriterOptions
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
+        private int maxPageValueCount = DEFAULT_MAX_PAGE_VALUE_COUNT;
         private int batchSize = DEFAULT_BATCH_SIZE;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
@@ -72,6 +83,12 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setMaxPageValueCount(int maxPageValueCount)
+        {
+            this.maxPageValueCount = maxPageValueCount;
+            return this;
+        }
+
         public Builder setBatchSize(int batchSize)
         {
             this.batchSize = batchSize;
@@ -80,7 +97,7 @@ public class ParquetWriterOptions
 
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize, batchSize);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize, maxPageValueCount, batchSize);
         }
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -90,10 +90,11 @@ final class ParquetWriters
             Map<List<String>, Type> trinoTypes,
             ParquetProperties parquetProperties,
             CompressionCodec compressionCodec,
+            int pageValueCountLimit,
             Optional<DateTimeZone> parquetTimeZone)
     {
         TrinoValuesWriterFactory valuesWriterFactory = new TrinoValuesWriterFactory(parquetProperties);
-        WriteBuilder writeBuilder = new WriteBuilder(messageType, trinoTypes, parquetProperties, valuesWriterFactory, compressionCodec, parquetTimeZone);
+        WriteBuilder writeBuilder = new WriteBuilder(messageType, trinoTypes, parquetProperties, valuesWriterFactory, compressionCodec, pageValueCountLimit, parquetTimeZone);
         ParquetTypeVisitor.visit(messageType, writeBuilder);
         return writeBuilder.build();
     }
@@ -106,6 +107,7 @@ final class ParquetWriters
         private final ParquetProperties parquetProperties;
         private final TrinoValuesWriterFactory valuesWriterFactory;
         private final CompressionCodec compressionCodec;
+        private final int pageValueCountLimit;
         private final Optional<DateTimeZone> parquetTimeZone;
         private final ImmutableList.Builder<ColumnWriter> builder = ImmutableList.builder();
 
@@ -115,6 +117,7 @@ final class ParquetWriters
                 ParquetProperties parquetProperties,
                 TrinoValuesWriterFactory valuesWriterFactory,
                 CompressionCodec compressionCodec,
+                int pageValueCountLimit,
                 Optional<DateTimeZone> parquetTimeZone)
         {
             this.type = requireNonNull(messageType, "messageType is null");
@@ -122,6 +125,7 @@ final class ParquetWriters
             this.parquetProperties = requireNonNull(parquetProperties, "parquetProperties is null");
             this.valuesWriterFactory = requireNonNull(valuesWriterFactory, "valuesWriterFactory is null");
             this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
+            this.pageValueCountLimit = pageValueCountLimit;
             this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
         }
 
@@ -177,7 +181,8 @@ final class ParquetWriters
                     parquetProperties.newDefinitionLevelWriter(columnDescriptor),
                     parquetProperties.newRepetitionLevelWriter(columnDescriptor),
                     compressionCodec,
-                    parquetProperties.getPageSizeThreshold());
+                    parquetProperties.getPageSizeThreshold(),
+                    pageValueCountLimit);
         }
 
         private String[] currentPath()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/AbstractDeltaLakePageSink.java
@@ -60,6 +60,7 @@ import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_BAD_WRITE;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.hive.util.HiveUtil.escapePathName;
 import static java.lang.Math.min;
@@ -462,6 +463,7 @@ public abstract class AbstractDeltaLakePageSink
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
+                .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                 .build();
         CompressionCodec compressionCodec = getCompressionCodec(session).getParquetCompressionCodec();
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -70,6 +70,7 @@ import static io.trino.plugin.deltalake.DeltaLakeMetadata.relativePath;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getCompressionCodec;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.deltalake.DeltaLakeSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.deltalake.DeltaLakeTypes.toParquetType;
 import static io.trino.plugin.deltalake.transactionlog.TransactionLogParser.deserializePartitionValue;
 import static io.trino.spi.block.RowBlock.getRowFieldsFromBlock;
@@ -359,6 +360,7 @@ public class DeltaLakeMergeSink
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxBlockSize(getParquetWriterBlockSize(session))
                 .setMaxPageSize(getParquetWriterPageSize(session))
+                .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                 .build();
         CompressionCodec compressionCodec = getCompressionCodec(session).getParquetCompressionCodec();
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -37,7 +37,9 @@ import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.enumProperty;
@@ -59,6 +61,7 @@ public final class DeltaLakeSessionProperties
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String TARGET_MAX_FILE_SIZE = "target_max_file_size";
     private static final String IDLE_WRITER_MIN_FILE_SIZE = "idle_writer_min_file_size";
     private static final String COMPRESSION_CODEC = "compression_codec";
@@ -150,6 +153,18 @@ public final class DeltaLakeSessionProperties
                         value -> {
                             validateMinDataSize(PARQUET_WRITER_PAGE_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MIN_PAGE_SIZE));
                             validateMaxDataSize(PARQUET_WRITER_PAGE_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_PAGE_SIZE));
+                        },
+                        false),
+                integerProperty(
+                        PARQUET_WRITER_PAGE_VALUE_COUNT,
+                        "Parquet: Writer page row count",
+                        parquetWriterConfig.getPageValueCount(),
+                        value -> {
+                            if (value < PARQUET_WRITER_MIN_PAGE_VALUE_COUNT || value > PARQUET_WRITER_MAX_PAGE_VALUE_COUNT) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be between %s and %s: %s", PARQUET_WRITER_PAGE_VALUE_COUNT, PARQUET_WRITER_MIN_PAGE_VALUE_COUNT, PARQUET_WRITER_MAX_PAGE_VALUE_COUNT, value));
+                            }
                         },
                         false),
                 dataSizeProperty(
@@ -276,6 +291,11 @@ public final class DeltaLakeSessionProperties
     public static DataSize getParquetWriterPageSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterPageValueCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_PAGE_VALUE_COUNT, Integer.class);
     }
 
     public static long getTargetMaxFileSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -103,6 +103,7 @@ public class ParquetFileWriterFactory
 
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxPageSize(HiveSessionProperties.getParquetWriterPageSize(session))
+                .setMaxPageValueCount(HiveSessionProperties.getParquetWriterPageValueCount(session))
                 .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
                 .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
                 .build();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -23,6 +23,8 @@ import io.airlift.units.MinDataSize;
 import io.trino.parquet.writer.ParquetWriterOptions;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.apache.parquet.hadoop.ParquetWriter;
 
 @DefunctConfig({
@@ -35,9 +37,12 @@ public class ParquetWriterConfig
     public static final String PARQUET_WRITER_MAX_BLOCK_SIZE = "2GB";
     public static final String PARQUET_WRITER_MIN_PAGE_SIZE = "8kB";
     public static final String PARQUET_WRITER_MAX_PAGE_SIZE = "8MB";
+    public static final int PARQUET_WRITER_MIN_PAGE_VALUE_COUNT = 1000;
+    public static final int PARQUET_WRITER_MAX_PAGE_VALUE_COUNT = 200_000;
 
     private DataSize blockSize = DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE);
     private DataSize pageSize = DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE);
+    private int pageValueCount = ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT;
     private int batchSize = ParquetWriterOptions.DEFAULT_BATCH_SIZE;
     private double validationPercentage = 5;
 
@@ -67,6 +72,20 @@ public class ParquetWriterConfig
     public ParquetWriterConfig setPageSize(DataSize pageSize)
     {
         this.pageSize = pageSize;
+        return this;
+    }
+
+    @Min(PARQUET_WRITER_MIN_PAGE_VALUE_COUNT)
+    @Max(PARQUET_WRITER_MAX_PAGE_VALUE_COUNT)
+    public int getPageValueCount()
+    {
+        return pageValueCount;
+    }
+
+    @Config("parquet.writer.page-value-count")
+    public ParquetWriterConfig setPageValueCount(int pageValueCount)
+    {
+        this.pageValueCount = pageValueCount;
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -811,7 +811,8 @@ class ParquetTester
                 schemaConverter.getMessageType(),
                 schemaConverter.getPrimitiveTypes(),
                 ParquetWriterOptions.builder()
-                        .setMaxPageSize(DataSize.ofBytes(100))
+                        .setMaxPageSize(DataSize.ofBytes(2000))
+                        .setMaxPageValueCount(200)
                         .setMaxBlockSize(DataSize.ofBytes(100000))
                         .build(),
                 compressionCodec,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -34,6 +34,7 @@ public class TestParquetWriterConfig
         assertRecordedDefaults(recordDefaults(ParquetWriterConfig.class)
                 .setBlockSize(DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE))
                 .setPageSize(DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE))
+                .setPageValueCount(ParquetWriterOptions.DEFAULT_MAX_PAGE_VALUE_COUNT)
                 .setBatchSize(ParquetWriterOptions.DEFAULT_BATCH_SIZE)
                 .setValidationPercentage(5));
     }
@@ -59,12 +60,14 @@ public class TestParquetWriterConfig
         Map<String, String> properties = Map.of(
                 "parquet.writer.block-size", "234MB",
                 "parquet.writer.page-size", "6MB",
+                "parquet.writer.page-value-count", "10000",
                 "parquet.writer.batch-size", "100",
                 "parquet.writer.validation-percentage", "10");
 
         ParquetWriterConfig expected = new ParquetWriterConfig()
                 .setBlockSize(DataSize.of(234, MEGABYTE))
                 .setPageSize(DataSize.of(6, MEGABYTE))
+                .setPageValueCount(10_000)
                 .setBatchSize(100)
                 .setValidationPercentage(10);
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -69,6 +69,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterValid
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBatchSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageValueCount;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
@@ -176,6 +177,7 @@ public class IcebergFileWriterFactory
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
+                    .setMaxPageValueCount(getParquetWriterPageValueCount(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
                     .build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -40,7 +40,9 @@ import static io.trino.plugin.base.session.PropertyMetadataUtil.validateMinDataS
 import static io.trino.plugin.hive.parquet.ParquetReaderConfig.PARQUET_READER_MAX_SMALL_FILE_THRESHOLD;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_BLOCK_SIZE;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_SIZE;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MAX_PAGE_VALUE_COUNT;
 import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_SIZE;
+import static io.trino.plugin.hive.parquet.ParquetWriterConfig.PARQUET_WRITER_MIN_PAGE_VALUE_COUNT;
 import static io.trino.plugin.iceberg.IcebergConfig.COLLECT_EXTENDED_STATISTICS_ON_WRITE_DESCRIPTION;
 import static io.trino.plugin.iceberg.IcebergConfig.EXTENDED_STATISTICS_DESCRIPTION;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
@@ -79,6 +81,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_IGNORE_STATISTICS = "parquet_ignore_statistics";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_PAGE_VALUE_COUNT = "parquet_writer_page_value_count";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
     public static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
     private static final String STATISTICS_ENABLED = "statistics_enabled";
@@ -254,6 +257,18 @@ public final class IcebergSessionProperties
                         value -> {
                             validateMinDataSize(PARQUET_WRITER_PAGE_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MIN_PAGE_SIZE));
                             validateMaxDataSize(PARQUET_WRITER_PAGE_SIZE, value, DataSize.valueOf(PARQUET_WRITER_MAX_PAGE_SIZE));
+                        },
+                        false))
+                .add(integerProperty(
+                        PARQUET_WRITER_PAGE_VALUE_COUNT,
+                        "Parquet: Writer page row count",
+                        parquetWriterConfig.getPageValueCount(),
+                        value -> {
+                            if (value < PARQUET_WRITER_MIN_PAGE_VALUE_COUNT || value > PARQUET_WRITER_MAX_PAGE_VALUE_COUNT) {
+                                throw new TrinoException(
+                                        INVALID_SESSION_PROPERTY,
+                                        format("%s must be between %s and %s: %s", PARQUET_WRITER_PAGE_VALUE_COUNT, PARQUET_WRITER_MIN_PAGE_VALUE_COUNT, PARQUET_WRITER_MAX_PAGE_VALUE_COUNT, value));
+                            }
                         },
                         false))
                 .add(integerProperty(
@@ -462,6 +477,11 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterPageSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterPageValueCount(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_PAGE_VALUE_COUNT, Integer.class);
     }
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)


### PR DESCRIPTION
## Description
Allows reducing the size of pages kept in memory by parquet reader

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://trinodb.slack.com/archives/CJ6UC075E/p1703253052321499?thread_ts=1700671385.606089&cid=CJ6UC075E


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Delta Lake, Iceberg
* Allow configuring maximum value count of pages written in parquet files. The default value of 60000 can be modified using the catalog configuration property `parquet.writer.page-value-count` or the corresponding catalog session property. ({issue}`20171`)
```
