### PR TITLE
Expand catalog routine docs

### DIFF
--- a/docs/src/main/sphinx/routines/introduction.md
+++ b/docs/src/main/sphinx/routines/introduction.md
@@ -55,8 +55,13 @@ SELECT abs(-10); -- -20, not 10!
 ## Catalog routines
 
 You can store a routine in the context of a catalog, if the connector used in
-the catalog supports routine storage. In this scenario, the following commands
-can be used:
+the catalog supports routine storage. The following connectors support catalog
+routine storage:
+
+* [](/connector/hive)
+* [](/connector/memory)
+
+In this scenario, the following commands can be used:
 
 * [](/sql/create-function) to create and store a routine.
 * [](/sql/drop-function) to remove a routine.


### PR DESCRIPTION
## Description

Add explicit mention what connector support storage so readers dont have to go looking through all connectors to find out.

## Additional context and related issues

Follow up from painpoint found during creation of SQL training material for routines.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
