### PR TITLE
Make createExclusive atomic

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureOutputFile.java
@@ -71,13 +71,6 @@ class AzureOutputFile
         return createOutputStream(memoryContext, true);
     }
 
-    @Override
-    public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
-            throws IOException
-    {
-        return create(memoryContext);
-    }
-
     private AzureOutputStream createOutputStream(AggregatedMemoryContext memoryContext, boolean overwrite)
             throws IOException
     {

--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -100,6 +100,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/AbstractTestGcsFileSystem.java
@@ -126,6 +126,12 @@ public abstract class AbstractTestGcsFileSystem
     }
 
     @Override
+    protected final boolean supportsCreateExclusive()
+    {
+        return true;
+    }
+
+    @Override
     protected final boolean supportsRenameFile()
     {
         return false;

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3OutputFile.java
@@ -18,7 +18,6 @@ import io.trino.filesystem.TrinoOutputFile;
 import io.trino.memory.context.AggregatedMemoryContext;
 import software.amazon.awssdk.services.s3.S3Client;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 import static java.util.Objects.requireNonNull;
@@ -49,13 +48,6 @@ final class S3OutputFile
     public OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
     {
         return new S3OutputStream(memoryContext, client, context, location);
-    }
-
-    @Override
-    public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
-            throws IOException
-    {
-        throw new IOException("S3 does not support exclusive create");
     }
 
     @Override

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/AbstractTestS3FileSystem.java
@@ -82,7 +82,7 @@ public abstract class AbstractTestS3FileSystem
     }
 
     @Override
-    protected final boolean supportsCreateExclusive()
+    protected boolean isCreateExclusive()
     {
         return false;
     }

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -60,6 +60,12 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>
         </dependency>

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoOutputFile.java
@@ -14,6 +14,7 @@
 
 package io.trino.filesystem;
 
+import io.airlift.slice.Slice;
 import io.trino.memory.context.AggregatedMemoryContext;
 
 import java.io.IOException;
@@ -35,10 +36,13 @@ public interface TrinoOutputFile
         return createOrOverwrite(newSimpleAggregatedMemoryContext());
     }
 
-    default OutputStream createExclusive()
+    /**
+     * Create file exclusively and atomically with specified contents.
+     */
+    default void createExclusive(Slice content)
             throws IOException
     {
-        return createExclusive(newSimpleAggregatedMemoryContext());
+        createExclusive(content, newSimpleAggregatedMemoryContext());
     }
 
     OutputStream create(AggregatedMemoryContext memoryContext)
@@ -47,8 +51,14 @@ public interface TrinoOutputFile
     OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
             throws IOException;
 
-    OutputStream createExclusive(AggregatedMemoryContext memoryContext)
-            throws IOException;
+    /**
+     * Create file exclusively and atomically with specified contents.
+     */
+    default void createExclusive(Slice content, AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        throw new UnsupportedOperationException("createExclusive not supported by " + getClass());
+    }
 
     Location location();
 }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalOutputFile.java
@@ -73,13 +73,6 @@ public class LocalOutputFile
     }
 
     @Override
-    public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
-            throws IOException
-    {
-        return create(memoryContext);
-    }
-
-    @Override
     public Location location()
     {
         return location;

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryOutputFile.java
@@ -64,10 +64,10 @@ class MemoryOutputFile
     }
 
     @Override
-    public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
+    public void createExclusive(Slice content, AggregatedMemoryContext memoryContext)
             throws IOException
     {
-        return create(memoryContext);
+        outputBlob.createBlob(content);
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingOutputFile.java
@@ -13,6 +13,7 @@
  */
 package io.trino.filesystem.tracing;
 
+import io.airlift.slice.Slice;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.trino.filesystem.Location;
@@ -58,13 +59,13 @@ final class TracingOutputFile
     }
 
     @Override
-    public OutputStream createExclusive()
+    public void createExclusive(Slice content)
             throws IOException
     {
         Span span = tracer.spanBuilder("OutputFile.createExclusive")
                 .setAttribute(FileSystemAttributes.FILE_LOCATION, toString())
                 .startSpan();
-        return withTracing(span, () -> delegate.createExclusive());
+        withTracing(span, () -> delegate.createExclusive(content));
     }
 
     @Override
@@ -88,13 +89,13 @@ final class TracingOutputFile
     }
 
     @Override
-    public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
+    public void createExclusive(Slice content, AggregatedMemoryContext memoryContext)
             throws IOException
     {
         Span span = tracer.spanBuilder("OutputFile.createExclusive")
                 .setAttribute(FileSystemAttributes.FILE_LOCATION, toString())
                 .startSpan();
-        return withTracing(span, () -> delegate.createExclusive(memoryContext));
+        withTracing(span, () -> delegate.createExclusive(content, memoryContext));
     }
 
     @Override

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
@@ -14,6 +14,7 @@
 package io.trino.filesystem;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.spi.security.ConnectorIdentity;
 
@@ -306,11 +307,11 @@ public class TrackingFileSystemFactory
         }
 
         @Override
-        public OutputStream createExclusive(AggregatedMemoryContext memoryContext)
+        public void createExclusive(Slice content, AggregatedMemoryContext memoryContext)
                 throws IOException
         {
             tracker.accept(OUTPUT_FILE_CREATE_EXCLUSIVE);
-            return delegate.createExclusive(memoryContext);
+            delegate.createExclusive(content, memoryContext);
         }
 
         @Override

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/memory/TestMemoryFileSystem.java
@@ -45,6 +45,12 @@ public class TestMemoryFileSystem
     }
 
     @Override
+    protected boolean supportsCreateExclusive()
+    {
+        return true;
+    }
+
+    @Override
     protected TrinoFileSystem getFileSystem()
     {
         return fileSystem;

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -13,9 +13,6 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <!-- Move TestFileSystemCache to separate profile to isolate it from interactions coming
-             from other threads against the global file system cache, resulting in flaky CI -->
-        <isolatedJvmTests>**/TestFileSystemCache.java</isolatedJvmTests>
     </properties>
 
     <dependencies>
@@ -295,7 +292,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <exclude>${isolatedJvmTests}</exclude>
+                                <exclude>**/TestFileSystemCache.java</exclude>
                                 <exclude>**/TestTrinoS3FileSystemAwsS3.java</exclude>
                             </excludes>
                         </configuration>
@@ -313,7 +310,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <includes>
-                                <include>${isolatedJvmTests}</include>
+                                <include>**/TestFileSystemCache.java</include>
                             </includes>
                             <reuseForks>false</reuseForks>
                             <forkCount>1</forkCount>

--- a/lib/trino-hdfs/src/main/java/io/trino/hdfs/gcs/GcsAtomicOutputStream.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/hdfs/gcs/GcsAtomicOutputStream.java
@@ -24,14 +24,14 @@ import org.apache.hadoop.fs.Path;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-public class GcsExclusiveOutputStream
+public class GcsAtomicOutputStream
         extends ByteArrayOutputStream
 {
     private final Storage storage;
     private final Path path;
     private boolean closed;
 
-    public GcsExclusiveOutputStream(HdfsEnvironment environment, HdfsContext context, Path path)
+    public GcsAtomicOutputStream(HdfsEnvironment environment, HdfsContext context, Path path)
     {
         this.storage = environment.createGcsStorage(context, path);
         this.path = path;

--- a/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemS3Mock.java
+++ b/lib/trino-hdfs/src/test/java/io/trino/filesystem/hdfs/TestHdfsFileSystemS3Mock.java
@@ -109,7 +109,7 @@ public class TestHdfsFileSystemS3Mock
     }
 
     @Override
-    protected final boolean supportsCreateExclusive()
+    protected boolean isCreateExclusive()
     {
         return false;
     }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/GcsTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/GcsTransactionLogSynchronizer.java
@@ -20,9 +20,9 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.spi.connector.ConnectorSession;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.io.UncheckedIOException;
 
+import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.util.Objects.requireNonNull;
 
 public class GcsTransactionLogSynchronizer
@@ -42,8 +42,8 @@ public class GcsTransactionLogSynchronizer
     public void write(ConnectorSession session, String clusterId, Location newLogEntryPath, byte[] entryContents)
     {
         TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        try (OutputStream outputStream = fileSystem.newOutputFile(newLogEntryPath).createExclusive()) {
-            outputStream.write(entryContents);
+        try {
+            fileSystem.newOutputFile(newLogEntryPath).createExclusive(wrappedBuffer(entryContents));
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
`GcsTransactionLogSynchronizer` requires that the new transaction log file is created exclusively and atomically. Otherwise concurrent readers of a table may see a file partially written (or not written yet, just empty) and fail. This commit:

- fixes the GCS native filesystem implementation so that it's atomic
- changes the method signature to indicate atomic creation and remove default not atomic implementation.
- makes it clear in-memory buffering occurs (previously it was implicitly done in `HdfsOutputFile` which could be considered surprising)

Fixes https://github.com/trinodb/trino/issues/20168
Required by https://github.com/trinodb/trino/pull/19991 