### PR TITLE
Fix page partitioner output bytes on release handling

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/PagePartitioner.java
@@ -169,11 +169,16 @@ public class PagePartitioner
         // adjust the amount to eagerly report as output by the amount already eagerly reported if the new value
         // is larger, since this indicates that no data was flushed and only the delta between the two values should
         // be reported eagerly
-        if (outputSizeReportedBeforeRelease > 0 && bufferedBytesOnRelease >= outputSizeReportedBeforeRelease) {
-            bufferedBytesOnRelease -= outputSizeReportedBeforeRelease;
-            outputSizeReportedBeforeRelease += bufferedBytesOnRelease;
+        if (bufferedBytesOnRelease > outputSizeReportedBeforeRelease) {
+            long additionalBufferedBytes = bufferedBytesOnRelease - outputSizeReportedBeforeRelease;
+            outputSizeReportedBeforeRelease = bufferedBytesOnRelease;
+            return additionalBufferedBytes;
         }
-        return bufferedBytesOnRelease;
+        else {
+            // buffered size is unchanged or reduced (as a result of flushing) since last release, so
+            // do not report any additional bytes as output eagerly
+            return 0;
+        }
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes a logical error introduced by https://github.com/trinodb/trino/pull/19806 which fails to record output buffered bytes eagerly reported as output and could result in overstating the output size of partitioned output operators.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
