### PR TITLE
Use explicit values for MaxResults in all Glue APIs

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -185,6 +185,9 @@ public class GlueHiveMetastore
     private static final int BATCH_CREATE_PARTITION_MAX_PAGE_SIZE = 100;
     private static final int BATCH_UPDATE_PARTITION_MAX_PAGE_SIZE = 100;
     private static final int AWS_GLUE_GET_PARTITIONS_MAX_RESULTS = 1000;
+    private static final int AWS_GLUE_GET_DATABASES_MAX_RESULTS = 100;
+    private static final int AWS_GLUE_GET_FUNCTIONS_MAX_RESULTS = 100;
+    private static final int AWS_GLUE_GET_TABLES_MAX_RESULTS = 100;
     private static final Comparator<Iterable<String>> PARTITION_VALUE_COMPARATOR = lexicographical(String.CASE_INSENSITIVE_ORDER);
     private static final Predicate<com.amazonaws.services.glue.model.Table> SOME_KIND_OF_VIEW_FILTER = table -> VIRTUAL_VIEW.name().equals(getTableTypeNullable(table));
     private static final RetryPolicy<?> CONCURRENT_MODIFICATION_EXCEPTION_RETRY_POLICY = RetryPolicy.builder()
@@ -253,7 +256,8 @@ public class GlueHiveMetastore
         try {
             List<String> databaseNames = getPaginatedResults(
                     glueClient::getDatabases,
-                    new GetDatabasesRequest(),
+                    new GetDatabasesRequest()
+                            .withMaxResults(AWS_GLUE_GET_DATABASES_MAX_RESULTS),
                     GetDatabasesRequest::setNextToken,
                     GetDatabasesResult::getNextToken,
                     stats.getGetDatabases())
@@ -1291,7 +1295,8 @@ public class GlueHiveMetastore
                     glueClient::getUserDefinedFunctions,
                     new GetUserDefinedFunctionsRequest()
                             .withDatabaseName(databaseName)
-                            .withPattern(functionNamePattern),
+                            .withPattern(functionNamePattern)
+                            .withMaxResults(AWS_GLUE_GET_FUNCTIONS_MAX_RESULTS),
                     GetUserDefinedFunctionsRequest::setNextToken,
                     GetUserDefinedFunctionsResult::getNextToken,
                     stats.getGetUserDefinedFunctions())
@@ -1370,7 +1375,8 @@ public class GlueHiveMetastore
         return getPaginatedResults(
                 glueClient::getTables,
                 new GetTablesRequest()
-                        .withDatabaseName(databaseName),
+                        .withDatabaseName(databaseName)
+                        .withMaxResults(AWS_GLUE_GET_TABLES_MAX_RESULTS),
                 GetTablesRequest::setNextToken,
                 GetTablesResult::getNextToken,
                 stats.getGetTables())


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Most listing Glue APIs accept a MaxResults parameter which decides how many objects are returned in a single API call. The default values are not documented but observed behaviour is that the default values change
on some basis.

This commit adds explicit values for MaxResults in the APIs which support it to the maximum possible values.

This possibly reduces the number of Glue calls when listing tables, databases or functions in some cases.

This is similar to https://github.com/trinodb/trino/commit/4f22b0ebb52c71e07370b41f785fa88dde289c22 and https://github.com/trinodb/trino/commit/45dc37d4b68b6e7e72d2b50810fe96ebab08c0c3.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Iceberg, Delta
* Reduce number of requests made to AWS Glue when listing tables, schemas or functions in some cases. ({issue}`20189`)
```
