### PR TITLE
Add tracing for SplitManager.getSplits

### DIFF
--- a/core/trino-main/src/main/java/io/trino/split/SplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitManager.java
@@ -132,10 +132,10 @@ public class SplitManager
         return new TracingSplitSource(splitSource, tracer, Optional.of(span), "split-buffer");
     }
 
-    private Span splitSourceSpan(Span querySpan, CatalogHandle catalogHandle)
+    private Span splitSourceSpan(Span parentSpan, CatalogHandle catalogHandle)
     {
         return tracer.spanBuilder("split-source")
-                .setParent(Context.current().with(querySpan))
+                .setParent(Context.current().with(parentSpan))
                 .setAttribute(TrinoAttributes.CATALOG, catalogHandle.getCatalogName())
                 .startSpan();
     }

--- a/core/trino-main/src/main/java/io/trino/split/SplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitManager.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.SystemSessionProperties.isAllowPushdownIntoConnectors;
+import static io.trino.tracing.ScopedSpan.scopedSpan;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 
@@ -80,12 +81,18 @@ public class SplitManager
 
         ConnectorSession connectorSession = session.toConnectorSession(catalogHandle);
 
-        ConnectorSplitSource source = splitManager.getSplits(
-                table.getTransaction(),
-                connectorSession,
-                table.getConnectorHandle(),
-                dynamicFilter,
-                constraint);
+        ConnectorSplitSource source;
+        try (var ignore = scopedSpan(tracer.spanBuilder("SplitManager.getSplits")
+                .setParent(Context.current().with(parentSpan))
+                .setAttribute(TrinoAttributes.TABLE, table.getConnectorHandle().toString())
+                .startSpan())) {
+            source = splitManager.getSplits(
+                    table.getTransaction(),
+                    connectorSession,
+                    table.getConnectorHandle(),
+                    dynamicFilter,
+                    constraint);
+        }
 
         SplitSource splitSource = new ConnectorAwareSplitSource(catalogHandle, source);
 
@@ -108,10 +115,16 @@ public class SplitManager
         CatalogHandle catalogHandle = function.getCatalogHandle();
         ConnectorSplitManager splitManager = splitManagerProvider.getService(catalogHandle);
 
-        ConnectorSplitSource source = splitManager.getSplits(
-                function.getTransactionHandle(),
-                session.toConnectorSession(catalogHandle),
-                function.getFunctionHandle());
+        ConnectorSplitSource source;
+        try (var ignore = scopedSpan(tracer.spanBuilder("SplitManager.getSplits")
+                .setParent(Context.current().with(parentSpan))
+                .setAttribute(TrinoAttributes.FUNCTION, function.getFunctionHandle().toString())
+                .startSpan())) {
+            source = splitManager.getSplits(
+                    function.getTransactionHandle(),
+                    session.toConnectorSession(catalogHandle),
+                    function.getFunctionHandle());
+        }
 
         SplitSource splitSource = new ConnectorAwareSplitSource(catalogHandle, source);
 


### PR DESCRIPTION
Sometimes, `ConnectorSplitManager.getSplits` can take long to construct `ConnectorSplitSource`. For example, in Delta, there is IO work being done before `ConnectorSplitSource` is returned. This work would better be delayed until `ConnectorSplitSource.getNextBatch` is invoked, but currently this is not the case. Let's add tracing so that time spent in `ConnectorSplitManager.getSplits` is attributable.
