### PR TITLE
Add timestamp with tz to JSON cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemFunctionBundle.java
@@ -223,6 +223,7 @@ import io.trino.operator.scalar.timestamptz.CurrentTimestamp;
 import io.trino.operator.scalar.timestamptz.DateToTimestampWithTimeZoneCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneOperators;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToDateCast;
+import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToJsonCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToTimeCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToTimeWithTimeZoneCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToTimestampCast;
@@ -675,6 +676,7 @@ public final class SystemFunctionBundle
                 .scalar(TimestampWithTimeZoneToTimestampWithTimeZoneCast.class)
                 .scalar(TimestampWithTimeZoneToTimeWithTimeZoneCast.class)
                 .scalar(TimestampWithTimeZoneToVarcharCast.class)
+                .scalar(TimestampWithTimeZoneToJsonCast.class)
                 .scalar(TimeToTimestampWithTimeZoneCast.class)
                 .scalar(TimeWithTimeZoneToTimestampWithTimeZoneCast.class)
                 .scalar(VarcharToTimestampWithTimeZoneCast.class);

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/timestamptz/TimestampWithTimeZoneToJsonCast.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar.timestamptz;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarOperator;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.LongTimestampWithTimeZone;
+import io.trino.type.DateTimes;
+
+import java.io.IOException;
+import java.time.ZoneId;
+
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.trino.spi.function.OperatorType.CAST;
+import static io.trino.spi.type.DateTimeEncoding.unpackMillisUtc;
+import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
+import static io.trino.spi.type.StandardTypes.JSON;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
+import static io.trino.type.DateTimes.formatTimestampWithTimeZone;
+import static io.trino.util.JsonUtil.createJsonFactory;
+import static io.trino.util.JsonUtil.createJsonGenerator;
+import static java.lang.String.format;
+
+@ScalarOperator(CAST)
+public final class TimestampWithTimeZoneToJsonCast
+{
+    private static final JsonFactory JSON_FACTORY = createJsonFactory();
+
+    private TimestampWithTimeZoneToJsonCast() {}
+
+    @LiteralParameters({"x", "p"})
+    @SqlType(JSON)
+    public static Slice cast(@LiteralParameter("p") long precision, @SqlType("timestamp(p) with time zone") long packedEpochMillis)
+    {
+        long epochMillis = unpackMillisUtc(packedEpochMillis);
+        ZoneId zoneId = unpackZoneKey(packedEpochMillis).getZoneId();
+
+        return toJson(formatTimestampWithTimeZone((int) precision, epochMillis, 0, zoneId));
+    }
+
+    @LiteralParameters({"x", "p"})
+    @SqlType(JSON)
+    public static Slice cast(@LiteralParameter("p") long precision, @SqlType("timestamp(p) with time zone") LongTimestampWithTimeZone timestamp)
+    {
+        return toJson(DateTimes.formatTimestampWithTimeZone(
+                (int) precision,
+                timestamp.getEpochMillis(),
+                timestamp.getPicosOfMilli(),
+                getTimeZoneKey(timestamp.getTimeZoneKey()).getZoneId()));
+    }
+
+    private static Slice toJson(String formatted)
+    {
+        try {
+            SliceOutput output = new DynamicSliceOutput(formatted.length() + 2); // 2 for the quotes
+            try (JsonGenerator jsonGenerator = createJsonGenerator(JSON_FACTORY, output)) {
+                jsonGenerator.writeString(formatted);
+            }
+            return output.slice();
+        }
+        catch (IOException e) {
+            throw new TrinoException(INVALID_CAST_ARGUMENT, format("Cannot cast '%s' to %s", formatted, JSON));
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/timestamptz/TestTimestampWithTimeZone.java
@@ -1797,6 +1797,14 @@ public class TestTimestampWithTimeZone
     }
 
     @Test
+    public void testCastToJson()
+    {
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56 Asia/Kathmandu' AS JSON)")).matches("JSON '\"2020-05-01 12:34:56 Asia/Kathmandu\"'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.1 Asia/Kathmandu' AS JSON)")).isEqualTo("JSON '\"2020-05-01 12:34:56.1 Asia/Kathmandu\"'");
+        assertThat(assertions.expression("CAST(TIMESTAMP '2020-05-01 12:34:56.123456789012 Asia/Kathmandu' AS JSON)")).isEqualTo("JSON '\"2020-05-01 12:34:56.123456789012 Asia/Kathmandu\"'");
+    }
+
+    @Test
     public void testCastFromVarchar()
     {
         // round down


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

> This is a follow-up PR from #20161 from our main organization

The Timestamp with TZ cast to JSON currently fails with `Cannot cast timestamp(0) with time zone to json`. 

```
select cast(timestamp '2000-01-01 00:00:00 UTC' as json);
```

This has been fixed now with this PR. 

Note: this is my first PR for trino, so please let me know if something is missing. The CLA request is on the way. 

> I wasn't able to run the tests locally, I hope the tests work though. Local manual tests worked though. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Related issue: #18733

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


