### PR TITLE
Fix incorrectly concurrent tests

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -60,10 +60,10 @@ import static io.trino.testing.TestingTaskContext.createTaskContext;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD)
 public class TestExchangeOperator
 {
     private static final List<Type> TYPES = ImmutableList.of(VARCHAR);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestMinimalFunctionality.java
@@ -18,6 +18,7 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AllowAllAccessControl;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Map;
 import java.util.Optional;
@@ -25,7 +26,9 @@ import java.util.Optional;
 import static io.trino.testing.TransactionBuilder.transaction;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // clearData(), populateData() looks like shared mutable state
 public class TestMinimalFunctionality
         extends AbstractTestMinimalFunctionality
 {

--- a/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/informationschema/TestInformationSchemaConnector.java
@@ -27,6 +27,7 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -34,7 +35,9 @@ import java.util.stream.Stream;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.stream.Collectors.joining;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // countingMockConnector is shared mutable state
 public class TestInformationSchemaConnector
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestKillQuery.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestKillQuery.java
@@ -24,6 +24,7 @@ import io.trino.testng.services.ReportOrphanedExecutors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -43,7 +44,9 @@ import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // e.g. some tests methods modify AC configuration
 public class TestKillQuery
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestBeginQuery.java
@@ -42,6 +42,7 @@ import io.trino.testing.TestingPageSinkProvider;
 import io.trino.testing.TestingSplitManager;
 import io.trino.testing.TestingTransactionHandle;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // TestMetadata is shared mutable state
 public class TestBeginQuery
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestCompletedEventWarnings.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestCompletedEventWarnings.java
@@ -39,10 +39,10 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD) // EventsAwaitingQueries is shared mutable state
 public class TestCompletedEventWarnings
 {
     private static final int TEST_WARNINGS = 5;

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerWithSplits.java
@@ -36,6 +36,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +49,9 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // EventsAwaitingQueries is shared mutable state
 public class TestEventListenerWithSplits
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
@@ -25,6 +25,7 @@ import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -32,9 +33,11 @@ import static io.trino.SystemSessionProperties.QUERY_MAX_PLANNING_TIME;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 // Tests need to finish before strict timeouts. Any background work
 // may make them flaky
+@Execution(SAME_THREAD) // CountDownLatches are shared mutable state
 public class TestQueryTracker
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueues.java
@@ -28,6 +28,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Optional;
 import java.util.Set;
@@ -49,8 +50,9 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-// run single threaded to avoid creating multiple query runners at once
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestQueues
 {
     private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestEnvironments.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestEnvironments.java
@@ -18,6 +18,7 @@ import io.trino.spi.QueryId;
 import io.trino.testing.DistributedQueryRunner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import static io.trino.execution.QueryRunnerUtil.createQuery;
 import static io.trino.execution.QueryRunnerUtil.waitForQueryState;
@@ -29,7 +30,9 @@ import static io.trino.execution.resourcegroups.db.H2TestUtil.adhocSession;
 import static io.trino.execution.resourcegroups.db.H2TestUtil.createQueryRunner;
 import static io.trino.execution.resourcegroups.db.H2TestUtil.getDao;
 import static io.trino.execution.resourcegroups.db.H2TestUtil.getDbConfigUrl;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestEnvironments
 {
     private static final String LONG_LASTING_QUERY = "SELECT COUNT(*) FROM lineitem";

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/TestQueuesDb.java
@@ -32,8 +32,8 @@ import io.trino.testing.MaterializedResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.Optional;
 import java.util.Set;
@@ -69,10 +69,9 @@ import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-// run single threaded to avoid creating multiple query runners at once
-@TestInstance(PER_METHOD)
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestQueuesDb
 {
     // Copy of TestQueues with tests for db reconfiguration of resource groups

--- a/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/memory/TestMemoryManager.java
@@ -57,10 +57,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestMemoryManager
 {
     private static final Session SESSION = testSessionBuilder()

--- a/testing/trino-tests/src/test/java/io/trino/security/TestSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestSystemSecurityMetadata.java
@@ -21,10 +21,13 @@ import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // TestingSystemSecurityMetadata is shared mutable state
 public class TestSystemSecurityMetadata
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
@@ -45,10 +45,10 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestGracefulShutdown
 {
     private static final long SHUTDOWN_TIMEOUT_MILLIS = 240_000;

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -50,7 +50,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 /**
  * This is integration / unit test suite.
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
  * This mapping has to be manually cleaned when query finishes execution (Metadata#cleanupQuery method).
  */
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD) // metadataManager.getActiveQueryIds() is shared mutable state that affects the test outcome
 public class TestMetadataManager
 {
     private DistributedQueryRunner queryRunner;

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCall.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCall.java
@@ -26,6 +26,7 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
 
 import java.util.List;
 
@@ -34,7 +35,9 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+@Execution(SAME_THREAD) // ProcedureTester is shared mutable state
 public class TestProcedureCall
         extends AbstractTestQueryFramework
 {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
@@ -49,10 +49,10 @@ import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
+import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 @TestInstance(PER_CLASS)
-@Execution(CONCURRENT)
+@Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestQueryManager
 {
     private DistributedQueryRunner queryRunner;

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryManager.java
@@ -27,10 +27,7 @@ import io.trino.spi.TrinoException;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.TestingSessionContext;
 import io.trino.tests.tpch.TpchQueryRunnerBuilder;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.parallel.Execution;
 
@@ -48,64 +45,48 @@ import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
-@TestInstance(PER_CLASS)
 @Execution(SAME_THREAD) // run single threaded to avoid creating multiple query runners at once
 public class TestQueryManager
 {
-    private DistributedQueryRunner queryRunner;
-
-    @BeforeAll
-    public void setUp()
-            throws Exception
-    {
-        queryRunner = TpchQueryRunnerBuilder.builder().build();
-    }
-
-    @AfterAll
-    public void tearDown()
-    {
-        queryRunner.close();
-        queryRunner = null;
-    }
-
     @Test
     @Timeout(60)
     public void testFailQuery()
             throws Exception
     {
-        DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
-        QueryId queryId = dispatchManager.createQueryId();
-        dispatchManager.createQuery(
-                queryId,
-                Span.getInvalid(),
-                Slug.createNew(),
-                TestingSessionContext.fromSession(TEST_SESSION),
-                "SELECT * FROM lineitem")
-                .get();
+        try (DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder().build()) {
+            DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
+            QueryId queryId = dispatchManager.createQueryId();
+            dispatchManager.createQuery(
+                            queryId,
+                            Span.getInvalid(),
+                            Slug.createNew(),
+                            TestingSessionContext.fromSession(TEST_SESSION),
+                            "SELECT * FROM lineitem")
+                    .get();
 
-        // wait until query starts running
-        while (true) {
-            QueryState state = dispatchManager.getQueryInfo(queryId).getState();
-            if (state.isDone()) {
-                fail("unexpected query state: " + state);
+            // wait until query starts running
+            while (true) {
+                QueryState state = dispatchManager.getQueryInfo(queryId).getState();
+                if (state.isDone()) {
+                    fail("unexpected query state: " + state);
+                }
+                if (state == RUNNING) {
+                    break;
+                }
+                Thread.sleep(100);
             }
-            if (state == RUNNING) {
-                break;
-            }
-            Thread.sleep(100);
+
+            // cancel query
+            QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+            queryManager.failQuery(queryId, new TrinoException(GENERIC_INTERNAL_ERROR, "mock exception"));
+            QueryInfo queryInfo = queryManager.getFullQueryInfo(queryId);
+            assertThat(queryInfo.getState()).isEqualTo(FAILED);
+            assertThat(queryInfo.getErrorCode()).isEqualTo(GENERIC_INTERNAL_ERROR.toErrorCode());
+            assertThat(queryInfo.getFailureInfo()).isNotNull();
+            assertThat(queryInfo.getFailureInfo().getMessage()).isEqualTo("mock exception");
         }
-
-        // cancel query
-        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
-        queryManager.failQuery(queryId, new TrinoException(GENERIC_INTERNAL_ERROR, "mock exception"));
-        QueryInfo queryInfo = queryManager.getFullQueryInfo(queryId);
-        assertThat(queryInfo.getState()).isEqualTo(FAILED);
-        assertThat(queryInfo.getErrorCode()).isEqualTo(GENERIC_INTERNAL_ERROR.toErrorCode());
-        assertThat(queryInfo.getFailureInfo()).isNotNull();
-        assertThat(queryInfo.getFailureInfo().getMessage()).isEqualTo("mock exception");
     }
 
     @Test


### PR DESCRIPTION
Some tests being fixed simply fail because they do not support concurrent test method execution.
Others worked, but could allocate lots of resources, potentially leading to OOM failures on CI.

The tests where found by looking at
9a7cf10d16253d165253218ae8345f22e6d480c8 commit:

    git show 9a7cf10d16253d165253218ae8345f22e6d480c8 | grep -A 3 '@Test(singleThreaded = true)'


potentially relates to https://github.com/trinodb/trino/issues/20199