### PR TITLE
Fix incorrect IsNull predicate for row of nulls

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -439,6 +439,15 @@ public class ExpressionInterpreter
                 return new IsNullPredicate(toExpression(value, type(node.getValue())));
             }
 
+            if (value instanceof SqlRow sqlRow) {
+                for (int i = 0; i < sqlRow.getRawFieldBlocks().size(); i++) {
+                    if (!sqlRow.getRawFieldBlock(i).isNull(0)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
             return value == null;
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -265,6 +265,11 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("9876543210.9874561203 IS NULL", "false");
         assertOptimizedEquals("bound_decimal_short IS NULL", "false");
         assertOptimizedEquals("bound_decimal_long IS NULL", "false");
+
+        assertOptimizedEquals("(null, 1) is null", "false");
+        assertOptimizedEquals("(1) is null", "false");
+        assertOptimizedEquals("(null, null) is null", "true");
+        assertOptimizedEquals("(null) is null", "true");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
https://github.com/trinodb/trino/issues/19444


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix incorrect IsNull predicate for row of nulls. ({issue}`19444`)
```
