### PR TITLE
Short circuit page source in case of partition mismatch

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -429,7 +429,9 @@ public class IcebergPageSourceProvider
         if (!partitionMatchesPredicate(partitionColumns, partitionValues, dynamicFilterPredicate)) {
             return TupleDomain.none();
         }
-
+        // Filter out partition columns domains from the dynamic filter because they should be irrelevant at data file level
+        dynamicFilterPredicate = dynamicFilterPredicate
+                .filter((columnHandle, domain) -> !partitionKeys.containsKey(columnHandle.getId()));
         return unenforcedPredicate.intersect(dynamicFilterPredicate);
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.iceberg;
 
-import com.google.common.base.Suppliers;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.BiMap;
@@ -133,6 +132,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -170,9 +170,11 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcNestedLazy;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.useParquetBloomFilter;
 import static io.trino.plugin.iceberg.IcebergSplitManager.ICEBERG_DOMAIN_COMPACTION_THRESHOLD;
+import static io.trino.plugin.iceberg.IcebergSplitSource.partitionMatchesPredicate;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumnHandle;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
+import static io.trino.plugin.iceberg.IcebergUtil.getPartitionValues;
 import static io.trino.plugin.iceberg.IcebergUtil.schemaFromHandles;
 import static io.trino.plugin.iceberg.delete.EqualityDeleteFilter.readEqualityDeletes;
 import static io.trino.plugin.iceberg.delete.PositionDeleteFilter.readPositionDeletes;
@@ -332,8 +334,11 @@ public class IcebergPageSourceProvider
                     }
                 });
 
-        TupleDomain<IcebergColumnHandle> effectivePredicate = unenforcedPredicate
-                .intersect(dynamicFilter.getCurrentPredicate().transformKeys(IcebergColumnHandle.class::cast))
+        TupleDomain<IcebergColumnHandle> effectivePredicate = getEffectivePredicate(
+                tableSchema,
+                partitionKeys,
+                dynamicFilter.getCurrentPredicate().transformKeys(IcebergColumnHandle.class::cast),
+                unenforcedPredicate)
                 .simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD);
         if (effectivePredicate.isNone()) {
             return new EmptyPageSource();
@@ -386,7 +391,7 @@ public class IcebergPageSourceProvider
                 .map(readerColumns -> readerColumns.get().stream().map(IcebergColumnHandle.class::cast).collect(toList()))
                 .orElse(requiredColumns);
 
-        Supplier<Optional<RowPredicate>> deletePredicate = Suppliers.memoize(() -> {
+        Supplier<Optional<RowPredicate>> deletePredicate = memoize(() -> {
             List<DeleteFilter> deleteFilters = readDeletes(
                     session,
                     tableSchema,
@@ -406,6 +411,26 @@ public class IcebergPageSourceProvider
                 dataPageSource.get(),
                 projectionsAdapter,
                 deletePredicate);
+    }
+
+    private TupleDomain<IcebergColumnHandle> getEffectivePredicate(
+            Schema tableSchema,
+            Map<Integer, Optional<String>> partitionKeys,
+            TupleDomain<IcebergColumnHandle> dynamicFilterPredicate,
+            TupleDomain<IcebergColumnHandle> unenforcedPredicate)
+    {
+        if (dynamicFilterPredicate.isAll() || dynamicFilterPredicate.isNone() || partitionKeys.isEmpty()) {
+            return unenforcedPredicate.intersect(dynamicFilterPredicate);
+        }
+        Set<IcebergColumnHandle> partitionColumns = partitionKeys.keySet().stream()
+                .map(fieldId -> getColumnHandle(tableSchema.findField(fieldId), typeManager))
+                .collect(toImmutableSet());
+        Supplier<Map<ColumnHandle, NullableValue>> partitionValues = memoize(() -> getPartitionValues(partitionColumns, partitionKeys));
+        if (!partitionMatchesPredicate(partitionColumns, partitionValues, dynamicFilterPredicate)) {
+            return TupleDomain.none();
+        }
+
+        return unenforcedPredicate.intersect(dynamicFilterPredicate);
     }
 
     private Set<IcebergColumnHandle> requiredColumnsForDeletes(Schema schema, List<DeleteFile> deletes)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -118,9 +118,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
             try (ConnectorPageSource nonEmptyPageSource = createTestingPageSource(transaction, icebergConfig, inputFile, getDynamicFilter(getNonSelectiveTupleDomain()))) {
                 Page page = nonEmptyPageSource.getNextPage();
                 assertThat(page).isNotNull();
-                assertThat(page.getBlock(0).getPositionCount()).isEqualTo(1);
+                assertThat(page.getPositionCount()).isEqualTo(1);
                 assertThat(page.getBlock(0).getInt(0, 0)).isEqualTo(KEY_COLUMN_VALUE);
-                assertThat(page.getBlock(1).getPositionCount()).isEqualTo(1);
                 assertThat(page.getBlock(1).getSlice(0, 0, page.getBlock(1).getSliceLength(0)).toStringUtf8()).isEqualTo(DATA_COLUMN_VALUE);
             }
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -30,7 +30,6 @@ import io.trino.orc.OrcWriterStats;
 import io.trino.orc.OutputStreamOrcDataSink;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveTransactionHandle;
-import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
@@ -65,8 +64,6 @@ import java.util.concurrent.CompletableFuture;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
-import static io.trino.plugin.hive.HiveType.HIVE_INT;
-import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.util.OrcTypeConverter.toOrcType;
@@ -80,28 +77,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIcebergNodeLocalDynamicSplitPruning
 {
-    private static final String SCHEMA_NAME = "test";
-    private static final String TABLE_NAME = "test";
-    private static final Column KEY_COLUMN = new Column("a_integer", HIVE_INT, Optional.empty(), Map.of());
-    private static final ColumnIdentity KEY_COLUMN_IDENTITY = new ColumnIdentity(1, KEY_COLUMN.getName(), PRIMITIVE, ImmutableList.of());
-    private static final IcebergColumnHandle KEY_ICEBERG_COLUMN_HANDLE = new IcebergColumnHandle(KEY_COLUMN_IDENTITY, INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
-    private static final int KEY_COLUMN_VALUE = 42;
-    private static final Column DATA_COLUMN = new Column("a_varchar", HIVE_STRING, Optional.empty(), Map.of());
-    private static final ColumnIdentity DATA_COLUMN_IDENTITY = new ColumnIdentity(2, DATA_COLUMN.getName(), PRIMITIVE, ImmutableList.of());
-    private static final IcebergColumnHandle DATA_ICEBERG_COLUMN_HANDLE = new IcebergColumnHandle(DATA_COLUMN_IDENTITY, VARCHAR, ImmutableList.of(), VARCHAR, Optional.empty());
-    private static final String DATA_COLUMN_VALUE = "hello world";
-    private static final Schema TABLE_SCHEMA = new Schema(
-            optional(KEY_COLUMN_IDENTITY.getId(), KEY_COLUMN.getName(), Types.IntegerType.get()),
-            optional(DATA_COLUMN_IDENTITY.getId(), DATA_COLUMN.getName(), Types.StringType.get()));
     private static final OrcReaderConfig ORC_READER_CONFIG = new OrcReaderConfig();
     private static final OrcWriterConfig ORC_WRITER_CONFIG = new OrcWriterConfig();
     private static final ParquetReaderConfig PARQUET_READER_CONFIG = new ParquetReaderConfig();
     private static final ParquetWriterConfig PARQUET_WRITER_CONFIG = new ParquetWriterConfig();
 
     @Test
-    public void testDynamicSplitPruning()
+    public void testDynamicSplitPruningOnUnpartitionedTable()
             throws IOException
     {
+        String tableName = "unpartitioned_table";
+        String keyColumnName = "a_integer";
+        ColumnIdentity keyColumnIdentity = new ColumnIdentity(1, keyColumnName, PRIMITIVE, ImmutableList.of());
+        IcebergColumnHandle keyColumnHandle = new IcebergColumnHandle(keyColumnIdentity, INTEGER, ImmutableList.of(), INTEGER, Optional.empty());
+        int keyColumnValue = 42;
+        String dataColumnName = "a_varchar";
+        ColumnIdentity dataColumnIdentity = new ColumnIdentity(2, dataColumnName, PRIMITIVE, ImmutableList.of());
+        IcebergColumnHandle dataColumnHandle = new IcebergColumnHandle(dataColumnIdentity, VARCHAR, ImmutableList.of(), VARCHAR, Optional.empty());
+        String dataColumnValue = "hello world";
+        Schema tableSchema = new Schema(
+                optional(keyColumnIdentity.getId(), keyColumnName, Types.IntegerType.get()),
+                optional(dataColumnIdentity.getId(), dataColumnName, Types.StringType.get()));
+
         IcebergConfig icebergConfig = new IcebergConfig();
         HiveTransactionHandle transaction = new HiveTransactionHandle(false);
         try (TempFile file = new TempFile()) {
@@ -109,87 +106,94 @@ public class TestIcebergNodeLocalDynamicSplitPruning
 
             TrinoOutputFile outputFile = new LocalOutputFile(file.file());
             TrinoInputFile inputFile = new LocalInputFile(file.file());
-            writeOrcContent(outputFile);
+            List<String> columnNames = ImmutableList.of(keyColumnName, dataColumnName);
+            List<Type> types = ImmutableList.of(INTEGER, VARCHAR);
 
-            try (ConnectorPageSource emptyPageSource = createTestingPageSource(transaction, icebergConfig, inputFile, getDynamicFilter(getTupleDomainForSplitPruning()))) {
+            try (OrcWriter writer = new OrcWriter(
+                    OutputStreamOrcDataSink.create(outputFile),
+                    columnNames,
+                    types,
+                    toOrcType(tableSchema),
+                    NONE,
+                    new OrcWriterOptions(),
+                    ImmutableMap.of(),
+                    true,
+                    OrcWriteValidation.OrcWriteValidationMode.BOTH,
+                    new OrcWriterStats())) {
+                BlockBuilder keyBuilder = INTEGER.createBlockBuilder(null, 1);
+                INTEGER.writeLong(keyBuilder, keyColumnValue);
+                BlockBuilder dataBuilder = VARCHAR.createBlockBuilder(null, 1);
+                VARCHAR.writeString(dataBuilder, dataColumnValue);
+                writer.write(new Page(keyBuilder.build(), dataBuilder.build()));
+            }
+
+            IcebergSplit split = new IcebergSplit(
+                    inputFile.toString(),
+                    0,
+                    inputFile.length(),
+                    inputFile.length(),
+                    -1, // invalid; normally known
+                    ORC,
+                    PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
+                    PartitionData.toJson(new PartitionData(new Object[] {})),
+                    ImmutableList.of(),
+                    SplitWeight.standard());
+
+            String tablePath = inputFile.location().fileName();
+            TableHandle tableHandle = new TableHandle(
+                    TEST_CATALOG_HANDLE,
+                    new IcebergTableHandle(
+                            CatalogHandle.fromId("iceberg:NORMAL:v12345"),
+                            "test_schema",
+                            tableName,
+                            TableType.DATA,
+                            Optional.empty(),
+                            SchemaParser.toJson(tableSchema),
+                            Optional.of(PartitionSpecParser.toJson(PartitionSpec.unpartitioned())),
+                            2,
+                            TupleDomain.withColumnDomains(ImmutableMap.of(keyColumnHandle, Domain.singleValue(INTEGER, (long) keyColumnValue))),
+                            TupleDomain.all(),
+                            OptionalLong.empty(),
+                            ImmutableSet.of(keyColumnHandle),
+                            Optional.empty(),
+                            tablePath,
+                            ImmutableMap.of(),
+                            false,
+                            Optional.empty(),
+                            ImmutableSet.of(),
+                            Optional.of(false)),
+                    transaction);
+
+            TupleDomain<ColumnHandle> splitPruningPredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            keyColumnHandle,
+                            Domain.singleValue(INTEGER, 1L)));
+            try (ConnectorPageSource emptyPageSource = createTestingPageSource(transaction, icebergConfig, split, tableHandle, ImmutableList.of(keyColumnHandle, dataColumnHandle), getDynamicFilter(splitPruningPredicate))) {
                 assertThat(emptyPageSource.getNextPage()).isNull();
             }
 
-            try (ConnectorPageSource nonEmptyPageSource = createTestingPageSource(transaction, icebergConfig, inputFile, getDynamicFilter(getNonSelectiveTupleDomain()))) {
+            TupleDomain<ColumnHandle> nonSelectivePredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            keyColumnHandle,
+                            Domain.singleValue(INTEGER, (long) keyColumnValue)));
+            try (ConnectorPageSource nonEmptyPageSource = createTestingPageSource(transaction, icebergConfig, split, tableHandle, ImmutableList.of(keyColumnHandle, dataColumnHandle), getDynamicFilter(nonSelectivePredicate))) {
                 Page page = nonEmptyPageSource.getNextPage();
                 assertThat(page).isNotNull();
                 assertThat(page.getPositionCount()).isEqualTo(1);
-                assertThat(page.getBlock(0).getInt(0, 0)).isEqualTo(KEY_COLUMN_VALUE);
-                assertThat(page.getBlock(1).getSlice(0, 0, page.getBlock(1).getSliceLength(0)).toStringUtf8()).isEqualTo(DATA_COLUMN_VALUE);
+                assertThat(page.getBlock(0).getInt(0, 0)).isEqualTo(keyColumnValue);
+                assertThat(page.getBlock(1).getSlice(0, 0, page.getBlock(1).getSliceLength(0)).toStringUtf8()).isEqualTo(dataColumnValue);
             }
         }
     }
 
-    private static void writeOrcContent(TrinoOutputFile outputFile)
-            throws IOException
+    private static ConnectorPageSource createTestingPageSource(
+            HiveTransactionHandle transaction,
+            IcebergConfig icebergConfig,
+            IcebergSplit split,
+            TableHandle tableHandle,
+            List<ColumnHandle> columns,
+            DynamicFilter dynamicFilter)
     {
-        List<String> columnNames = ImmutableList.of(KEY_COLUMN.getName(), DATA_COLUMN.getName());
-        List<Type> types = ImmutableList.of(INTEGER, VARCHAR);
-
-        try (OrcWriter writer = new OrcWriter(
-                OutputStreamOrcDataSink.create(outputFile),
-                columnNames,
-                types,
-                toOrcType(TABLE_SCHEMA),
-                NONE,
-                new OrcWriterOptions(),
-                ImmutableMap.of(),
-                true,
-                OrcWriteValidation.OrcWriteValidationMode.BOTH,
-                new OrcWriterStats())) {
-            BlockBuilder keyBuilder = INTEGER.createBlockBuilder(null, 1);
-            INTEGER.writeLong(keyBuilder, KEY_COLUMN_VALUE);
-            BlockBuilder dataBuilder = VARCHAR.createBlockBuilder(null, 1);
-            VARCHAR.writeString(dataBuilder, DATA_COLUMN_VALUE);
-            writer.write(new Page(keyBuilder.build(), dataBuilder.build()));
-        }
-    }
-
-    private static ConnectorPageSource createTestingPageSource(HiveTransactionHandle transaction, IcebergConfig icebergConfig, TrinoInputFile inputFile, DynamicFilter dynamicFilter)
-            throws IOException
-    {
-        IcebergSplit split = new IcebergSplit(
-                inputFile.toString(),
-                0,
-                inputFile.length(),
-                inputFile.length(),
-                -1, // invalid; normally known
-                ORC,
-                PartitionSpecParser.toJson(PartitionSpec.unpartitioned()),
-                PartitionData.toJson(new PartitionData(new Object[] {})),
-                ImmutableList.of(),
-                SplitWeight.standard());
-
-        String tablePath = inputFile.location().fileName();
-        TableHandle tableHandle = new TableHandle(
-                TEST_CATALOG_HANDLE,
-                new IcebergTableHandle(
-                        CatalogHandle.fromId("iceberg:NORMAL:v12345"),
-                        SCHEMA_NAME,
-                        TABLE_NAME,
-                        TableType.DATA,
-                        Optional.empty(),
-                        SchemaParser.toJson(TABLE_SCHEMA),
-                        Optional.of(PartitionSpecParser.toJson(PartitionSpec.unpartitioned())),
-                        2,
-                        TupleDomain.withColumnDomains(ImmutableMap.of(KEY_ICEBERG_COLUMN_HANDLE, Domain.singleValue(INTEGER, (long) KEY_COLUMN_VALUE))),
-                        TupleDomain.all(),
-                        OptionalLong.empty(),
-                        ImmutableSet.of(KEY_ICEBERG_COLUMN_HANDLE),
-                        Optional.empty(),
-                        tablePath,
-                        ImmutableMap.of(),
-                        false,
-                        Optional.empty(),
-                        ImmutableSet.of(),
-                        Optional.of(false)),
-                transaction);
-
         FileFormatDataSourceStats stats = new FileFormatDataSourceStats();
         IcebergPageSourceProvider provider = new IcebergPageSourceProvider(
                 new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS),
@@ -203,24 +207,8 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 getSession(icebergConfig),
                 split,
                 tableHandle.getConnectorHandle(),
-                ImmutableList.of(KEY_ICEBERG_COLUMN_HANDLE, DATA_ICEBERG_COLUMN_HANDLE),
+                columns,
                 dynamicFilter);
-    }
-
-    private static TupleDomain<ColumnHandle> getTupleDomainForSplitPruning()
-    {
-        return TupleDomain.withColumnDomains(
-                ImmutableMap.of(
-                        KEY_ICEBERG_COLUMN_HANDLE,
-                        Domain.singleValue(INTEGER, 1L)));
-    }
-
-    private static TupleDomain<ColumnHandle> getNonSelectiveTupleDomain()
-    {
-        return TupleDomain.withColumnDomains(
-                ImmutableMap.of(
-                        KEY_ICEBERG_COLUMN_HANDLE,
-                        Domain.singleValue(INTEGER, (long) KEY_COLUMN_VALUE)));
     }
 
     private static TestingConnectorSession getSession(IcebergConfig icebergConfig)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergNodeLocalDynamicSplitPruning.java
@@ -42,7 +42,11 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.SqlDecimal;
 import io.trino.spi.type.Type;
 import io.trino.testing.TestingConnectorSession;
 import org.apache.iceberg.PartitionSpec;
@@ -53,7 +57,9 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +73,8 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_STATS;
 import static io.trino.plugin.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.util.OrcTypeConverter.toOrcType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.writeShortDecimal;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.TestingHandles.TEST_CATALOG_HANDLE;
@@ -182,6 +190,149 @@ public class TestIcebergNodeLocalDynamicSplitPruning
                 assertThat(page.getPositionCount()).isEqualTo(1);
                 assertThat(page.getBlock(0).getInt(0, 0)).isEqualTo(keyColumnValue);
                 assertThat(page.getBlock(1).getSlice(0, 0, page.getBlock(1).getSliceLength(0)).toStringUtf8()).isEqualTo(dataColumnValue);
+            }
+        }
+    }
+
+    @Test
+    public void testDynamicSplitPruningWithExplicitPartitionFilter()
+            throws IOException
+    {
+        String tableName = "sales_table";
+        String dateColumnName = "date";
+        ColumnIdentity dateColumnIdentity = new ColumnIdentity(1, dateColumnName, PRIMITIVE, ImmutableList.of());
+        IcebergColumnHandle dateColumnHandle = new IcebergColumnHandle(dateColumnIdentity, DATE, ImmutableList.of(), DATE, Optional.empty());
+        long dateColumnValue = LocalDate.of(2023, 1, 10).toEpochDay();
+        String receiptColumnName = "receipt";
+        ColumnIdentity receiptColumnIdentity = new ColumnIdentity(2, receiptColumnName, PRIMITIVE, ImmutableList.of());
+        IcebergColumnHandle receiptColumnHandle = new IcebergColumnHandle(receiptColumnIdentity, VARCHAR, ImmutableList.of(), VARCHAR, Optional.empty());
+        String receiptColumnValue = "#12345";
+        String amountColumnName = "amount";
+        ColumnIdentity amountColumnIdentity = new ColumnIdentity(3, amountColumnName, PRIMITIVE, ImmutableList.of());
+        DecimalType amountColumnType = DecimalType.createDecimalType(10, 2);
+        IcebergColumnHandle amountColumnHandle = new IcebergColumnHandle(amountColumnIdentity, amountColumnType, ImmutableList.of(), amountColumnType, Optional.empty());
+        BigDecimal amountColumnValue = new BigDecimal("1234567.65");
+        Schema tableSchema = new Schema(
+                optional(dateColumnIdentity.getId(), dateColumnName, Types.DateType.get()),
+                optional(receiptColumnIdentity.getId(), receiptColumnName, Types.StringType.get()),
+                optional(amountColumnIdentity.getId(), amountColumnName, Types.DecimalType.of(10, 2)));
+        PartitionSpec partitionSpec = PartitionSpec.builderFor(tableSchema)
+                .identity(dateColumnName)
+                .build();
+
+        IcebergConfig icebergConfig = new IcebergConfig();
+        HiveTransactionHandle transaction = new HiveTransactionHandle(false);
+        try (TempFile file = new TempFile()) {
+            Files.delete(file.path());
+
+            TrinoOutputFile outputFile = new LocalOutputFile(file.file());
+            TrinoInputFile inputFile = new LocalInputFile(file.file());
+            List<String> columnNames = ImmutableList.of(dateColumnName, receiptColumnName, amountColumnName);
+            List<Type> types = ImmutableList.of(DATE, VARCHAR, amountColumnType);
+
+            try (OrcWriter writer = new OrcWriter(
+                    OutputStreamOrcDataSink.create(outputFile),
+                    columnNames,
+                    types,
+                    toOrcType(tableSchema),
+                    NONE,
+                    new OrcWriterOptions(),
+                    ImmutableMap.of(),
+                    true,
+                    OrcWriteValidation.OrcWriteValidationMode.BOTH,
+                    new OrcWriterStats())) {
+                BlockBuilder dateBuilder = DATE.createBlockBuilder(null, 1);
+                DATE.writeLong(dateBuilder, dateColumnValue);
+                BlockBuilder receiptBuilder = VARCHAR.createBlockBuilder(null, 1);
+                VARCHAR.writeString(receiptBuilder, receiptColumnValue);
+                BlockBuilder amountBuilder = amountColumnType.createBlockBuilder(null, 1);
+                writeShortDecimal(amountBuilder, amountColumnValue.unscaledValue().longValueExact());
+                writer.write(new Page(dateBuilder.build(), receiptBuilder.build(), amountBuilder.build()));
+            }
+
+            IcebergSplit split = new IcebergSplit(
+                    inputFile.toString(),
+                    0,
+                    inputFile.length(),
+                    inputFile.length(),
+                    -1, // invalid; normally known
+                    ORC,
+                    PartitionSpecParser.toJson(partitionSpec),
+                    PartitionData.toJson(new PartitionData(new Object[] {dateColumnValue})),
+                    ImmutableList.of(),
+                    SplitWeight.standard());
+
+            String tablePath = inputFile.location().fileName();
+            TableHandle tableHandle = new TableHandle(
+                    TEST_CATALOG_HANDLE,
+                    new IcebergTableHandle(
+                            CatalogHandle.fromId("iceberg:NORMAL:v12345"),
+                            "test_schema",
+                            tableName,
+                            TableType.DATA,
+                            Optional.empty(),
+                            SchemaParser.toJson(tableSchema),
+                            Optional.of(PartitionSpecParser.toJson(partitionSpec)),
+                            2,
+                            TupleDomain.all(),
+                            TupleDomain.all(),
+                            OptionalLong.empty(),
+                            ImmutableSet.of(dateColumnHandle),
+                            Optional.empty(),
+                            tablePath,
+                            ImmutableMap.of(),
+                            false,
+                            Optional.empty(),
+                            ImmutableSet.of(),
+                            Optional.of(false)),
+                    transaction);
+
+            // Simulate situations where the dynamic filter (e.g.: while performing a JOIN with another table) reduces considerably
+            // the amount of data to be processed from the current table
+
+            TupleDomain<ColumnHandle> differentDatePredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            dateColumnHandle,
+                            Domain.singleValue(DATE, LocalDate.of(2023, 2, 2).toEpochDay())));
+            TupleDomain<ColumnHandle> nonOverlappingDatePredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            dateColumnHandle,
+                            Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(DATE, LocalDate.of(2023, 2, 2).toEpochDay())), true)));
+            for (TupleDomain<ColumnHandle> partitionPredicate : List.of(differentDatePredicate, nonOverlappingDatePredicate)) {
+                try (ConnectorPageSource emptyPageSource = createTestingPageSource(
+                        transaction,
+                        icebergConfig,
+                        split,
+                        tableHandle,
+                        ImmutableList.of(dateColumnHandle, receiptColumnHandle, amountColumnHandle),
+                        getDynamicFilter(partitionPredicate))) {
+                    assertThat(emptyPageSource.getNextPage()).isNull();
+                }
+            }
+
+            TupleDomain<ColumnHandle> sameDatePredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            dateColumnHandle,
+                            Domain.singleValue(DATE, dateColumnValue)));
+            TupleDomain<ColumnHandle> overlappingDatePredicate = TupleDomain.withColumnDomains(
+                    ImmutableMap.of(
+                            dateColumnHandle,
+                            Domain.create(ValueSet.ofRanges(Range.range(DATE, LocalDate.of(2023, 1, 1).toEpochDay(), true, LocalDate.of(2023, 2, 1).toEpochDay(), false)), true)));
+            for (TupleDomain<ColumnHandle> partitionPredicate : List.of(sameDatePredicate, overlappingDatePredicate)) {
+                try (ConnectorPageSource nonEmptyPageSource = createTestingPageSource(
+                        transaction,
+                        icebergConfig,
+                        split,
+                        tableHandle,
+                        ImmutableList.of(dateColumnHandle, receiptColumnHandle, amountColumnHandle),
+                        getDynamicFilter(partitionPredicate))) {
+                    Page page = nonEmptyPageSource.getNextPage();
+                    assertThat(page).isNotNull();
+                    assertThat(page.getPositionCount()).isEqualTo(1);
+                    assertThat(page.getBlock(0).getInt(0, 0)).isEqualTo(dateColumnValue);
+                    assertThat(page.getBlock(1).getSlice(0, 0, page.getBlock(1).getSliceLength(0)).toStringUtf8()).isEqualTo(receiptColumnValue);
+                    assertThat(((SqlDecimal) amountColumnType.getObjectValue(null, page.getBlock(2), 0)).toBigDecimal()).isEqualTo(amountColumnValue);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In case that the dynamic filter completes after scheduling of split
on the worker, the results in the split will be getting pruned in
the situation that there is a partition predicate mismatch.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve performance of queries with selective joins on partitioning columns. ({issue}`20212`)
```
