### PR TITLE
Adjust logging level to debug

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -251,16 +251,14 @@ public class TaskInfoFetcher
         TaskStatus newRemoteTaskStatus = newTaskInfo.getTaskStatus();
 
         if (!newRemoteTaskStatus.getTaskId().equals(taskId)) {
-            log.debug("Task ID mismatch on remote task status.  Member task ID is %s, but remote task ID is %s.  This will confuse finalTaskInfo listeners.",
-                    taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
+            log.debug("Task ID mismatch on remote task status. Member task ID is %s, but remote task ID is %s. This will confuse finalTaskInfo listeners.", taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
         }
 
         if (localTaskStatus.getState().isDone() && newRemoteTaskStatus.getState().isDone() && localTaskStatus.getState() != newRemoteTaskStatus.getState()) {
             // prefer local
             newTaskInfo = newTaskInfo.withTaskStatus(localTaskStatus);
             if (!localTaskStatus.getTaskId().equals(taskId)) {
-                log.debug("Task ID mismatch on local task status.  Member task ID is %s, but status-fetcher ID is %s.  This will confuse finalTaskInfo listeners.",
-                        taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
+                log.debug("Task ID mismatch on local task status. Member task ID is %s, but status-fetcher ID is %s. This will confuse finalTaskInfo listeners.", taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
             }
         }
 
@@ -271,7 +269,7 @@ public class TaskInfoFetcher
         if (newTaskInfo.getTaskStatus().getState().isDone()) {
             boolean wasSet = spoolingOutputStats.compareAndSet(null, newTaskInfo.getOutputBuffers().getSpoolingOutputStats().orElse(null));
             if (wasSet && spoolingOutputStats.get() == null) {
-                log.debug("Task %s was updated to null spoolingOutputStats.  Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId.toString());
+                log.debug("Task %s was updated to null spoolingOutputStats. Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId.toString());
             }
             newTaskInfo = newTaskInfo.pruneSpoolingOutputStats();
         }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -251,7 +251,7 @@ public class TaskInfoFetcher
         TaskStatus newRemoteTaskStatus = newTaskInfo.getTaskStatus();
 
         if (!newRemoteTaskStatus.getTaskId().equals(taskId)) {
-            log.warn("Task ID mismatch on remote task status.  Member task ID is %s, but remote task ID is %s.  This will confuse finalTaskInfo listeners.",
+            log.debug("Task ID mismatch on remote task status.  Member task ID is %s, but remote task ID is %s.  This will confuse finalTaskInfo listeners.",
                     taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
         }
 
@@ -259,7 +259,7 @@ public class TaskInfoFetcher
             // prefer local
             newTaskInfo = newTaskInfo.withTaskStatus(localTaskStatus);
             if (!localTaskStatus.getTaskId().equals(taskId)) {
-                log.warn("Task ID mismatch on local task status.  Member task ID is %s, but status-fetcher ID is %s.  This will confuse finalTaskInfo listeners.",
+                log.debug("Task ID mismatch on local task status.  Member task ID is %s, but status-fetcher ID is %s.  This will confuse finalTaskInfo listeners.",
                         taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
             }
         }
@@ -271,7 +271,7 @@ public class TaskInfoFetcher
         if (newTaskInfo.getTaskStatus().getState().isDone()) {
             boolean wasSet = spoolingOutputStats.compareAndSet(null, newTaskInfo.getOutputBuffers().getSpoolingOutputStats().orElse(null));
             if (wasSet && spoolingOutputStats.get() == null) {
-                log.warn("Task %s was updated to null spoolingOutputStats.  Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId.toString());
+                log.debug("Task %s was updated to null spoolingOutputStats.  Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId.toString());
             }
             newTaskInfo = newTaskInfo.pruneSpoolingOutputStats();
         }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -251,14 +251,14 @@ public class TaskInfoFetcher
         TaskStatus newRemoteTaskStatus = newTaskInfo.getTaskStatus();
 
         if (!newRemoteTaskStatus.getTaskId().equals(taskId)) {
-            log.debug("Task ID mismatch on remote task status. Member task ID is %s, but remote task ID is %s. This will confuse finalTaskInfo listeners.", taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
+            log.debug("Task ID mismatch on remote task status. Member task ID is %s, but remote task ID is %s. This will confuse finalTaskInfo listeners.", taskId, newRemoteTaskStatus.getTaskId());
         }
 
         if (localTaskStatus.getState().isDone() && newRemoteTaskStatus.getState().isDone() && localTaskStatus.getState() != newRemoteTaskStatus.getState()) {
             // prefer local
             newTaskInfo = newTaskInfo.withTaskStatus(localTaskStatus);
             if (!localTaskStatus.getTaskId().equals(taskId)) {
-                log.debug("Task ID mismatch on local task status. Member task ID is %s, but status-fetcher ID is %s. This will confuse finalTaskInfo listeners.", taskId.toString(), newRemoteTaskStatus.getTaskId().toString());
+                log.debug("Task ID mismatch on local task status. Member task ID is %s, but status-fetcher ID is %s. This will confuse finalTaskInfo listeners.", taskId, newRemoteTaskStatus.getTaskId());
             }
         }
 
@@ -269,7 +269,7 @@ public class TaskInfoFetcher
         if (newTaskInfo.getTaskStatus().getState().isDone()) {
             boolean wasSet = spoolingOutputStats.compareAndSet(null, newTaskInfo.getOutputBuffers().getSpoolingOutputStats().orElse(null));
             if (wasSet && spoolingOutputStats.get() == null) {
-                log.debug("Task %s was updated to null spoolingOutputStats. Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId.toString());
+                log.debug("Task %s was updated to null spoolingOutputStats. Future calls to retrieveAndDropSpoolingOutputStats will fail.", taskId);
             }
             newTaskInfo = newTaskInfo.pruneSpoolingOutputStats();
         }


### PR DESCRIPTION
They result in very verbose logs in tests and are not actionable for anyone managing a Trino deployment


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
