### PR TITLE
Fixed constant expression being passed to Connector through applyProjection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.Assignment;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.expression.ConnectorExpression;
+import io.trino.spi.expression.Constant;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
@@ -115,6 +116,8 @@ public class PushProjectionIntoTableScan
                                 typeAnalyzer,
                                 context.getSymbolAllocator().getTypes(),
                                 plannerContext).entrySet().stream())
+                // Filter out constant expressions. Constant expressions should not be pushed to the connector.
+                .filter(entry -> !(entry.getValue() instanceof Constant))
                 // Avoid duplicates
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue, (first, ignore) -> first));
 


### PR DESCRIPTION
Constant expression should not be passed to the Connector since the connector cannot do anything meaningful with it. Added fix to filter out constant expressions before being pushed to the connector.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes #19988. Constant expressions are being passed on to the connector via `Metadata.applyProjection` method during planning in the rule `PushProjectionIntoTableScan`. But, the connector cannot do anything meaningful with it. Therefore, this PR filters out constant expressions before applying the projections to the connector. Also, have changed the `TestPushProjectionIntoTableScan.testPushProjection` test for verification.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
