### PR TITLE
[test] try logback 1.3.x instead of 1.4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,8 @@
         <dep.tcnative.version>2.0.62.Final</dep.tcnative.version>
         <dep.tempto.version>201</dep.tempto.version>
         <dep.wire.version>4.8.1</dep.wire.version>
+        <!-- TODO remove - this is only to test if this version works, before upgrading it in Airbase -->
+        <dep.logback.version>1.3.14</dep.logback.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

We know that logback >=1.4.9 causes some theads to hang, so try the 1.3.x branch. The only difference between 1.3.x and 1.4.x is the former targets JDK 8 and uses the Java EE APIs, and the latter switched to Jakarta EE.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
