### PR TITLE
Sometimes EventListener.queryCompleted() called too early

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -22,6 +22,7 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.trino.Session;
+import io.trino.event.QueryMonitor;
 import io.trino.execution.QueryIdGenerator;
 import io.trino.execution.QueryInfo;
 import io.trino.execution.QueryManagerConfig;
@@ -56,6 +57,7 @@ import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.QueryState.RUNNING;
 import static io.trino.spi.StandardErrorCode.QUERY_TEXT_TOO_LARGE;
 import static io.trino.tracing.ScopedSpan.scopedSpan;
+import static io.trino.util.Failures.toFailure;
 import static io.trino.util.StatementUtils.getQueryType;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -80,6 +82,7 @@ public class DispatchManager
     private final QueryTracker<DispatchQuery> queryTracker;
 
     private final QueryManagerStats stats = new QueryManagerStats();
+    private final QueryMonitor queryMonitor;
 
     @Inject
     public DispatchManager(
@@ -94,7 +97,8 @@ public class DispatchManager
             SessionPropertyManager sessionPropertyManager,
             Tracer tracer,
             QueryManagerConfig queryManagerConfig,
-            DispatchExecutor dispatchExecutor)
+            DispatchExecutor dispatchExecutor,
+            QueryMonitor queryMonitor)
     {
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
         this.queryPreparer = requireNonNull(queryPreparer, "queryPreparer is null");
@@ -112,6 +116,7 @@ public class DispatchManager
         this.dispatchExecutor = dispatchExecutor.getExecutor();
 
         this.queryTracker = new QueryTracker<>(queryManagerConfig, dispatchExecutor.getScheduledExecutor());
+        this.queryMonitor = requireNonNull(queryMonitor, "queryMonitor is null");
     }
 
     @PostConstruct
@@ -236,6 +241,11 @@ public class DispatchManager
             Optional<String> preparedSql = Optional.ofNullable(preparedQuery).flatMap(PreparedQuery::getPrepareSql);
             DispatchQuery failedDispatchQuery = failedDispatchQueryFactory.createFailedDispatchQuery(session, query, preparedSql, Optional.empty(), throwable);
             queryCreated(failedDispatchQuery);
+            // maintain proper order of calls such that EventListener has access to QueryInfo
+            // - add query to tracker
+            // - fire query created event
+            // - fire query completed event
+            queryMonitor.queryImmediateFailureEvent(failedDispatchQuery.getBasicQueryInfo(), toFailure(throwable));
             querySpan.setStatus(StatusCode.ERROR, throwable.getMessage())
                     .recordException(throwable)
                     .end();

--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQueryFactory.java
@@ -24,7 +24,6 @@ import io.trino.spi.resourcegroups.ResourceGroupId;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
-import static io.trino.util.Failures.toFailure;
 import static java.util.Objects.requireNonNull;
 
 public class FailedDispatchQueryFactory
@@ -58,7 +57,6 @@ public class FailedDispatchQueryFactory
         BasicQueryInfo queryInfo = failedDispatchQuery.getBasicQueryInfo();
 
         queryMonitor.queryCreatedEvent(queryInfo);
-        queryMonitor.queryImmediateFailureEvent(queryInfo, toFailure(throwable));
 
         return failedDispatchQuery;
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

For really bad queries, the ones that do not even parse to a proper SQL, we have the following sequence of calls:
- `EventListener.queryCompleted()`
- query is added to the `QueryTracker`

To work around incorrect sequence of these calls, an `EventListener` will typically use a retry mechanism combined with switching to a separate thread.

This PR inverts the sequence of calls so that `EventListener`s can now be coded single-threaded.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/issues/20225


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( X ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
