### PR TITLE
Increase stale operations count

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'trinodb/trino'
     steps:
-      - uses: actions/stale@v8.0.0
+      - uses: actions/stale@v9.0.0
         with:
           stale-pr-message: 'This pull request has gone a while without any activity. Tagging the Trino developer relations team: @bitsondatadev @colebow @mosabua'
           days-before-pr-stale: 21
@@ -21,3 +21,7 @@ jobs:
           stale-pr-label: 'stale'
           start-date: '2023-01-01T00:00:00Z'
           exempt-draft-pr: true
+          operations-per-run: 200
+          # Avoid processing issues completely, see https://github.com/actions/stale/issues/1112
+          days-before-issue-stale: -1
+          day-before-issue-closed: -1


### PR DESCRIPTION
## Description

- Currently uses default 30 and thats too low
- Also update to latest version of the action
- Also configure to only process PRs

## Additional context and related issues

* See runs at https://github.com/trinodb/trino/actions/workflows/stale.yml 
* specifically see error message at https://github.com/trinodb/trino/actions/runs/7349673496 and other runs ... I assume we are not hitting the API limit hence enlarging the number .. docs even suggest to go to 1000 or so .. but I think this is a good first try.
* Also see https://github.com/actions/stale/issues/1112

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
