### PR TITLE
Add Delta table read version to connectorInfo

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInputInfo.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeInputInfo.java
@@ -21,17 +21,25 @@ import java.util.Objects;
 public class DeltaLakeInputInfo
 {
     private final boolean partitioned;
+    private final long version;
 
     @JsonCreator
-    public DeltaLakeInputInfo(@JsonProperty("partitioned") boolean partitioned)
+    public DeltaLakeInputInfo(@JsonProperty("partitioned") boolean partitioned, @JsonProperty("version") long version)
     {
         this.partitioned = partitioned;
+        this.version = version;
     }
 
     @JsonProperty
     public boolean isPartitioned()
     {
         return partitioned;
+    }
+
+    @JsonProperty
+    public long getVersion()
+    {
+        return version;
     }
 
     @Override
@@ -43,12 +51,12 @@ public class DeltaLakeInputInfo
         if (!(o instanceof DeltaLakeInputInfo that)) {
             return false;
         }
-        return partitioned == that.partitioned;
+        return partitioned == that.partitioned && version == that.version;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(partitioned);
+        return Objects.hash(partitioned, version);
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -2362,8 +2362,9 @@ public class DeltaLakeMetadata
     @Override
     public Optional<Object> getInfo(ConnectorTableHandle table)
     {
-        boolean isPartitioned = !((DeltaLakeTableHandle) table).getMetadataEntry().getLowercasePartitionColumns().isEmpty();
-        return Optional.of(new DeltaLakeInputInfo(isPartitioned));
+        DeltaLakeTableHandle handle = (DeltaLakeTableHandle) table;
+        boolean isPartitioned = !handle.getMetadataEntry().getLowercasePartitionColumns().isEmpty();
+        return Optional.of(new DeltaLakeInputInfo(isPartitioned, handle.getReadVersion()));
     }
 
     @Override

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeMetadata.java
@@ -475,7 +475,7 @@ public class TestDeltaLakeMetadata
                 ImmutableList.of(BIGINT_COLUMN_1));
         deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable());
-        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(true)));
+        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(true, 0)));
         deltaLakeMetadata.cleanupQuery(SESSION);
     }
 
@@ -488,7 +488,7 @@ public class TestDeltaLakeMetadata
                 ImmutableList.of());
         deltaLakeMetadata.createTable(SESSION, tableMetadata, false);
         DeltaLakeTableHandle tableHandle = (DeltaLakeTableHandle) deltaLakeMetadata.getTableHandle(SESSION, tableMetadata.getTable());
-        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(false)));
+        assertThat(deltaLakeMetadata.getInfo(tableHandle)).isEqualTo(Optional.of(new DeltaLakeInputInfo(false, 0)));
         deltaLakeMetadata.cleanupQuery(SESSION);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Add Delta table read version to `connectorInfo`. It will show up in the query information as:
```json
   ...
  "inputs" : [ {
    "catalogName" : "delta",
    "catalogVersion" : "default",
    "schema" : "test",
    "table" : "test",
    "connectorInfo" : {
      "partitioned" : true,
      "version": 1234
    },
   ...
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/20242


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
