### PR TITLE
Unignore re2j dependency conflicts

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -207,6 +207,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -237,6 +243,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/BaseTestJdbcResultSet.java
@@ -58,8 +58,6 @@ public abstract class BaseTestJdbcResultSet
     protected abstract Connection createConnection()
             throws SQLException;
 
-    protected abstract int getTestedServerVersion();
-
     @Test
     public void testDuplicateColumnLabels()
             throws Exception

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcResultSet.java
@@ -59,11 +59,4 @@ public class TestJdbcResultSet
         String url = format("jdbc:trino://%s", server.getAddress());
         return DriverManager.getConnection(url, "test", null);
     }
-
-    @Override
-    protected int getTestedServerVersion()
-    {
-        // Latest version
-        return Integer.MAX_VALUE;
-    }
 }

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -148,6 +148,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -155,6 +161,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -225,6 +225,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -232,6 +238,12 @@
             <artifactId>trino-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -180,12 +180,24 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.trino</groupId>
+                    <artifactId>re2j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1646,30 +1646,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.alluxio</groupId>
-                <artifactId>alluxio-shaded-client</artifactId>
-                <version>2.9.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>log4j</groupId>
-                        <artifactId>log4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>slf4j-log4j12</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-runtime</artifactId>
                 <version>${dep.antlr.version}</version>
@@ -2398,65 +2374,6 @@
                                     <resource>opencensus/proto/stats/v1/stats.proto</resource>
                                     <resource>opencensus/proto/trace/v1/trace.proto</resource>
                                     <resource>opencensus/proto/trace/v1/trace_config.proto</resource>
-                                </resources>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>io.grpc</groupId>
-                                        <artifactId>grpc-services</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>org.alluxio</groupId>
-                                        <artifactId>alluxio-shaded-client</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <resources>
-                                    <resource>grpc/binlog/v1/binarylog.proto</resource>
-                                    <resource>grpc/health/v1/health.proto</resource>
-                                    <resource>grpc/reflection/v1alpha/reflection.proto</resource>
-                                    <resource>grpc/channelz/v1/channelz.proto</resource>
-                                </resources>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>com.google.android</groupId>
-                                        <artifactId>annotations</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>org.alluxio</groupId>
-                                        <artifactId>alluxio-shaded-client</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <classes>
-                                    <class>android.annotation.SuppressLint</class>
-                                    <class>android.annotation.TargetApi</class>
-                                </classes>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
-                                        <groupId>org.alluxio</groupId>
-                                        <artifactId>alluxio-shaded-client</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>com.google.protobuf</groupId>
-                                        <artifactId>protobuf-java</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <resources>
-                                    <resource>google/protobuf/any.proto</resource>
-                                    <resource>google/protobuf/api.proto</resource>
-                                    <resource>google/protobuf/descriptor.proto</resource>
-                                    <resource>google/protobuf/duration.proto</resource>
-                                    <resource>google/protobuf/empty.proto</resource>
-                                    <resource>google/protobuf/field_mask.proto</resource>
-                                    <resource>google/protobuf/source_context.proto</resource>
-                                    <resource>google/protobuf/struct.proto</resource>
-                                    <resource>google/protobuf/timestamp.proto</resource>
-                                    <resource>google/protobuf/type.proto</resource>
-                                    <resource>google/protobuf/wrappers.proto</resource>
                                 </resources>
                             </exception>
                         </exceptions>

--- a/pom.xml
+++ b/pom.xml
@@ -2437,21 +2437,6 @@
                             <exception>
                                 <conflictingDependencies>
                                     <dependency>
-                                        <groupId>com.google.re2j</groupId>
-                                        <artifactId>re2j</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>io.trino</groupId>
-                                        <artifactId>re2j</artifactId>
-                                    </dependency>
-                                </conflictingDependencies>
-                                <packages>
-                                    <package>com.google.re2j</package>
-                                </packages>
-                            </exception>
-                            <exception>
-                                <conflictingDependencies>
-                                    <dependency>
                                         <groupId>org.alluxio</groupId>
                                         <artifactId>alluxio-shaded-client</artifactId>
                                     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2182,6 +2182,7 @@
                         <exclusions>
                             <!-- getOnlyElement is more readable than the stream analogue -->
                             <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- getLast has lower complexity for array based lists than the stream analogue (O(1) vs O(log(N)) -->
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
@@ -2202,7 +2203,6 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:([Ljava/lang/Object;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- com.google.common.io.BaseEncoding.base64 provides more reach interfaces than java.util.Base64 -->
                             <exclusion>com/google/common/io/BaseEncoding.base64:()Lcom/google/common/io/BaseEncoding;</exclusion>
 

--- a/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
+++ b/testing/trino-test-jdbc-compatibility-old-server/src/test/java/io/trino/TestJdbcResultSetCompatibilityOldServer.java
@@ -140,12 +140,6 @@ public class TestJdbcResultSetCompatibilityOldServer
     }
 
     @Override
-    protected int getTestedServerVersion()
-    {
-        return parseInt(getTestedTrinoVersion());
-    }
-
-    @Override
     public String toString()
     {
         // This allows distinguishing tests run against different Trino server version from each other.


### PR DESCRIPTION
`trino-re2j` is a fork of `com.google.re2j:re2j`. The forks diverged over time. It is not safe to ignore this dependency conflict e.g. because `com.google` version has `com.google.re2j.Pattern.matcher` accepting `CharSequence` or `byte[]` while Trino version accepts only `Slice`. They cannot be used interchangeably at all.
