### PR TITLE
introduced test for Elasticsearch 8, which is always secure. fix #20238

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -75,15 +75,21 @@ public abstract class BaseElasticsearchConnectorTest
         elasticsearch = new ElasticsearchServer(image, ImmutableMap.of());
 
         HostAndPort address = elasticsearch.getAddress();
-        client = new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
+        client = createElasticsearchClient(elasticsearch);
 
         return createElasticsearchQueryRunner(
-                elasticsearch.getAddress(),
+                address,
                 TpchTable.getTables(),
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 3,
-                catalogName);
+                catalogName, client);
+    }
+
+    protected RestHighLevelClient createElasticsearchClient(ElasticsearchServer esServer)
+    {
+        HostAndPort address = esServer.getAddress();
+        return new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
     }
 
     @AfterAll
@@ -92,7 +98,9 @@ public abstract class BaseElasticsearchConnectorTest
     {
         elasticsearch.stop();
         elasticsearch = null;
-        client.close();
+        if (client != null) {
+            client.close();
+        }
         client = null;
     }
 

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -19,9 +19,12 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import javax.net.ssl.SSLContext;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Map;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
@@ -51,7 +54,7 @@ public class ElasticsearchServer
         container.withNetwork(network);
         container.withNetworkAliases("elasticsearch-server");
         container.withEnv("DISABLE_SECURITY_PLUGIN", "true"); // Required for OpenSearch container
-
+        container.withStartupTimeout(Duration.ofSeconds(300));
         configurationPath = createTempDirectory(null);
         for (Map.Entry<String, String> entry : configurationFiles.entrySet()) {
             String name = entry.getKey();
@@ -81,5 +84,10 @@ public class ElasticsearchServer
     public HostAndPort getAddress()
     {
         return HostAndPort.fromString(container.getHttpHostAddress());
+    }
+
+    public SSLContext createSslContextFromCa()
+    {
+        return container.createSslContextFromCa();
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch8ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch8ConnectorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.common.net.HostAndPort;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.Assertions;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+public class TestElasticsearch8ConnectorTest
+        extends BaseElasticsearchConnectorTest
+{
+    public TestElasticsearch8ConnectorTest()
+    {
+        super("elasticsearch:8.11.3", "elasticsearch8");
+    }
+
+    @Override
+    protected RestHighLevelClient createElasticsearchClient(ElasticsearchServer esServer)
+    {
+        final CredentialsProvider credentialsProvider =
+                new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials("elastic", ElasticsearchContainer.ELASTICSEARCH_DEFAULT_PASSWORD));
+
+        HostAndPort address = esServer.getAddress();
+        HttpHost httpsHost = new HttpHost(address.getHost(), address.getPort(), "https");
+        RestClientBuilder builder = RestClient.builder(httpsHost)
+                .setHttpClientConfigCallback(httpAsyncClientBuilder -> {
+                    httpAsyncClientBuilder.setSSLContext(esServer.createSslContextFromCa());
+                    httpAsyncClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                    return httpAsyncClientBuilder;
+                });
+        RestHighLevelClient client = new RestHighLevelClient(builder);
+        try {
+            boolean ping = client.ping(RequestOptions.DEFAULT);
+            Assertions.assertTrue(ping);
+        }
+        catch (IOException e) {
+            Assertions.fail(e);
+        }
+        return client;
+    }
+
+    @Override
+    protected String indexEndpoint(String index, String docId)
+    {
+        return format("/%s/_doc/%s", index, docId);
+    }
+
+    @Override
+    protected String indexMapping(String properties)
+    {
+        return "{\"mappings\": " + properties + "}";
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

so far it reproduces two problems with Elasticsearch 8 (#20238) : 
obvious one
```
 Caused by: org.elasticsearch.client.ResponseException: method [POST], host [https://localhost:56693], URI [/_bulk?refresh=true&timeout=1m], status line [HTTP/1
.1 400 Bad Request]
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Action/metadata line [1] contains an unknown parameter [_type]"}],"type":"illegal_argument_excep
tion","reason":"Action/metadata line [1] contains an unknown parameter [_type]"},"status":400}

        at org.elasticsearch.client.RestHighLevelClient.bulk(RestHighLevelClient.java:484)
        at io.trino.plugin.elasticsearch.ElasticsearchLoader$ElasticsearchLoadingSession.addResults(ElasticsearchLoader.java:112)

        at io.trino.plugin.elasticsearch.ElasticsearchQueryRunner.loadTpchTopic(ElasticsearchQueryRunner.java:170)
```

```
 io.trino.plugin.elasticsearch.client.ElasticsearchClient        Error refreshing nodes
io.trino.spi.TrinoException: Connection is closed
        at io.trino.plugin.elasticsearch.client.ElasticsearchClient.doRequest(ElasticsearchClient.java:732)
..
        at io.trino.plugin.elasticsearch.client.ElasticsearchClient.refreshNodes(ElasticsearchClient.java:173)
        at io.trino.plugin.elasticsearch.client.ElasticsearchClient.initialize(ElasticsearchClient.java:155)
```
In this moment elasticsearch logs an error about non-https request and drops the conn.  

It boils down to configuring ES plugin in Trino nodes via properties, it needs to pass login,pass,https schema, and some certificate. The question is which of security configuration is the most suitable for prod setup Trino->ES. 
Is there another https plugin where I can sneak peek the approach?   

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. (#20238 )
```
