### PR TITLE
fix: regex gap in CatalogAccessControlRule field

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogAccessControlRule.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -52,10 +53,10 @@ public class CatalogAccessControlRule
             @JsonProperty("catalog") Optional<Pattern> catalogRegex)
     {
         this.accessMode = requireNonNull(accessMode, "accessMode is null");
-        this.userRegex = requireNonNull(userRegex, "userRegex is null");
-        this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
-        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
-        this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
+        this.userRegex = regexConvert(requireNonNull(userRegex, "userRegex is null"));
+        this.roleRegex = regexConvert(requireNonNull(roleRegex, "roleRegex is null"));
+        this.groupRegex = regexConvert(requireNonNull(groupRegex, "groupRegex is null"));
+        this.catalogRegex = regexConvert(requireNonNull(catalogRegex, "catalogRegex is null"));
     }
 
     public Optional<AccessMode> match(String user, Set<String> roles, Set<String> groups, String catalog)
@@ -121,5 +122,10 @@ public class CatalogAccessControlRule
             }
             return this == other;
         }
+    }
+
+    private Optional<Pattern> regexConvert(Optional<Pattern> regex) {
+        return regex.map(pattern ->
+                Pattern.compile(pattern.pattern().replaceAll("\\s", "")));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The rules.json file looks like the following:

```
{
  "catalogs": [
    {
      "catalog": "system",
      "allow": "none"
    },
    {
      "user": "admin | user_.*",
      "catalog": "tpch",
      "allow": "all"
    }
  ]
}
```

There is an issue with accessing entries like "admin" or "user_1" due to spaces in the regular expression under the "user" field. 
Therefore, spaces have been removed to address this concern.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:
# Section
* fix regex gap in FileBasedSystemAccessControlRules
