### PR TITLE
Adding feature to list dir non-recursively in trinofilesystem to support hudi metadir list in non-recursive fashion

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -233,11 +233,18 @@ public class AzureFileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
+        return listFiles(location, true);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
         AzureLocation azureLocation = new AzureLocation(location);
         try {
             // blob API returns directories as blobs, so it cannot be used when Gen2 is enabled
-            return isHierarchicalNamespaceEnabled(azureLocation)
-                    ? listGen2Files(azureLocation)
+            return (isHierarchicalNamespaceEnabled(azureLocation))
+                    ? listGen2Files(azureLocation, isRecursive)
                     : listBlobFiles(azureLocation);
         }
         catch (RuntimeException e) {
@@ -245,13 +252,13 @@ public class AzureFileSystem
         }
     }
 
-    private FileIterator listGen2Files(AzureLocation location)
+    private FileIterator listGen2Files(AzureLocation location, boolean isRecursive)
             throws IOException
     {
         DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location);
         PagedIterable<PathItem> pathItems;
         if (location.path().isEmpty()) {
-            pathItems = fileSystemClient.listPaths(new ListPathsOptions().setRecursive(true), null);
+            pathItems = fileSystemClient.listPaths(new ListPathsOptions().setRecursive(isRecursive), null);
         }
         else {
             DataLakeDirectoryClient directoryClient = fileSystemClient.getDirectoryClient(location.path());
@@ -261,7 +268,7 @@ public class AzureFileSystem
             if (!directoryClient.getProperties().isDirectory()) {
                 throw new IOException("Location is not a directory: " + location);
             }
-            pathItems = directoryClient.listPaths(true, false, null, null);
+            pathItems = directoryClient.listPaths(isRecursive, false, null, null);
         }
         return new AzureDataLakeFileIterator(
                 location,

--- a/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
+++ b/lib/trino-filesystem-gcs/src/main/java/io/trino/filesystem/gcs/GcsFileSystem.java
@@ -131,7 +131,7 @@ public class GcsFileSystem
         try {
             List<ListenableFuture<?>> batchFutures = new ArrayList<>();
 
-            for (List<Blob> blobBatch : partition(getPage(gcsLocation).iterateAll(), batchSize)) {
+            for (List<Blob> blobBatch : partition(getPage(gcsLocation, true).iterateAll(), batchSize)) {
                 StorageBatch batch = storage.batch();
                 for (Blob blob : blobBatch) {
                     batch.delete(blob.getBlobId());
@@ -156,9 +156,16 @@ public class GcsFileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
+        return listFiles(location, true);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
         GcsLocation gcsLocation = new GcsLocation(normalizeToDirectory(location));
         try {
-            return new GcsFileIterator(gcsLocation, getPage(gcsLocation));
+            return new GcsFileIterator(gcsLocation, getPage(gcsLocation, isRecursive));
         }
         catch (RuntimeException e) {
             throw handleGcsException(e, "listing files", gcsLocation);
@@ -180,13 +187,17 @@ public class GcsFileSystem
         checkState(!gcsLocation.path().endsWith("/"), "Location path ends with a slash: %s", gcsLocation);
     }
 
-    private Page<Blob> getPage(GcsLocation location, BlobListOption... blobListOptions)
+    private Page<Blob> getPage(GcsLocation location, boolean isRecursive, BlobListOption... blobListOptions)
     {
         List<BlobListOption> optionsBuilder = new ArrayList<>();
 
         if (!location.path().isEmpty()) {
             optionsBuilder.add(BlobListOption.prefix(location.path()));
         }
+        if (!isRecursive) {
+            optionsBuilder.add(BlobListOption.delimiter("/"));
+        }
+
         Arrays.stream(blobListOptions).forEach(optionsBuilder::add);
         optionsBuilder.add(pageSize(this.pageSize));
         return storage.list(location.bucket(), optionsBuilder.toArray(BlobListOption[]::new));
@@ -249,7 +260,7 @@ public class GcsFileSystem
     {
         GcsLocation gcsLocation = new GcsLocation(normalizeToDirectory(location));
         try {
-            Page<Blob> page = getPage(gcsLocation, currentDirectory(), matchGlob(gcsLocation.path() + "*/"));
+            Page<Blob> page = getPage(gcsLocation, true, currentDirectory(), matchGlob(gcsLocation.path() + "*/"));
             Iterator<Blob> blobIterator = Iterators.filter(page.iterateAll().iterator(), blob -> blob.isDirectory());
             ImmutableSet.Builder<Location> locationBuilder = ImmutableSet.builder();
             while (blobIterator.hasNext()) {

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/SwitchingFileSystem.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/SwitchingFileSystem.java
@@ -111,6 +111,13 @@ final class SwitchingFileSystem
     }
 
     @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
+        return fileSystem(location).listFiles(location, isRecursive);
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java
@@ -169,6 +169,13 @@ final class S3FileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
+        return listFiles(location, true);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
         S3Location s3Location = new S3Location(location);
 
         String key = s3Location.key();
@@ -176,10 +183,15 @@ final class S3FileSystem
             key += "/";
         }
 
-        ListObjectsV2Request request = ListObjectsV2Request.builder()
+        ListObjectsV2Request.Builder builder = ListObjectsV2Request.builder()
                 .bucket(s3Location.bucket())
-                .prefix(key)
-                .build();
+                .prefix(key);
+
+        if (!isRecursive) {
+            builder = builder.delimiter("/");
+        }
+
+        ListObjectsV2Request request = builder.build();
 
         try {
             Iterator<S3Object> iterator = client.listObjectsV2Paginator(request).contents().stream()

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoFileSystem.java
@@ -154,6 +154,27 @@ public interface TrinoFileSystem
             throws IOException;
 
     /**
+     * Lists all files within the specified directory recursively or non-recursively .Default
+     * implementation is recursively. The location can be empty,
+     * listing all files in the file system, otherwise the location must end with a slash. If the
+     * location does not exist, an empty iterator is returned.
+     * <p>
+     * For hierarchical file systems, if the path is not a directory, an exception is
+     * raised.
+     * For hierarchical file systems, if the path does not reference an existing
+     * directory, an empty iterator is returned. For blob file systems, all blobs
+     * that start with the location are listed. In the rare case that a blob exists with the
+     * exact name of the prefix, it is not included in the results.
+     * <p>
+     * The returned FileEntry locations will start with the specified location exactly.
+     *
+     * @param location the directory to list
+     * @throws IllegalArgumentException if location is not valid for this file system
+     */
+    FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException;
+
+    /**
      * Checks if a directory exists at the specified location. For all file system types,
      * this returns <tt>true</tt> if the location is empty (the root of the file system)
      * or if any files exist within the directory, as determined by {@link #listFiles(Location)}.

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileIterator.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileIterator.java
@@ -46,15 +46,29 @@ class LocalFileIterator
             this.iterator = emptyIterator();
         }
         else {
-            try (Stream<Path> stream = (isRecursive ? Files.walk(path) : Files.list(path))) {
-                this.iterator = stream
-                        .filter(Files::isRegularFile)
-                        // materialize full list so stream can be closed
-                        .collect(toImmutableList())
-                        .iterator();
+            if (isRecursive) {
+                try (Stream<Path> stream = Files.walk(path)) {
+                    this.iterator = stream
+                            .filter(Files::isRegularFile)
+                            // materialize full list so stream can be closed
+                            .collect(toImmutableList())
+                            .iterator();
+                }
+                catch (IOException e) {
+                    throw handleException(location, e);
+                }
             }
-            catch (IOException e) {
-                throw handleException(location, e);
+            else {
+                try (Stream<Path> stream = Files.list(path)) {
+                    this.iterator = stream
+                            .filter(Files::isRegularFile)
+                            // materialize full list so stream can be closed
+                            .collect(toImmutableList())
+                            .iterator();
+                }
+                catch (IOException e) {
+                    throw handleException(location, e);
+                }
             }
         }
     }

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileIterator.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileIterator.java
@@ -35,7 +35,7 @@ class LocalFileIterator
     private final Path rootPath;
     private final Iterator<Path> iterator;
 
-    public LocalFileIterator(Location location, Path rootPath, Path path)
+    public LocalFileIterator(Location location, Path rootPath, Path path, boolean isRecursive)
             throws IOException
     {
         this.rootPath = requireNonNull(rootPath, "rootPath is null");
@@ -46,7 +46,7 @@ class LocalFileIterator
             this.iterator = emptyIterator();
         }
         else {
-            try (Stream<Path> stream = Files.walk(path)) {
+            try (Stream<Path> stream = (isRecursive ? Files.walk(path) : Files.list(path))) {
                 this.iterator = stream
                         .filter(Files::isRegularFile)
                         // materialize full list so stream can be closed

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/local/LocalFileSystem.java
@@ -153,7 +153,14 @@ public class LocalFileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
-        return new LocalFileIterator(location, rootPath, toDirectoryPath(location));
+        return listFiles(location, true);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
+        return new LocalFileIterator(location, rootPath, toDirectoryPath(location), isRecursive);
     }
 
     @Override

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryFileSystem.java
@@ -156,6 +156,14 @@ public class MemoryFileSystem
         };
     }
 
+    // implementing same as recursive true
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
+        return listFiles(location);
+    }
+
     @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/tracing/TracingFileSystem.java
@@ -110,6 +110,16 @@ final class TracingFileSystem
     }
 
     @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
+        Span span = tracer.spanBuilder("FileSystem.listFiles")
+                .setAttribute(FileSystemAttributes.FILE_LOCATION, location.toString())
+                .startSpan();
+        return withTracing(span, () -> delegate.listFiles(location, isRecursive));
+    }
+
+    @Override
     public Optional<Boolean> directoryExists(Location location)
             throws IOException
     {

--- a/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
+++ b/lib/trino-filesystem/src/test/java/io/trino/filesystem/TrackingFileSystemFactory.java
@@ -168,6 +168,13 @@ public class TrackingFileSystemFactory
         }
 
         @Override
+        public FileIterator listFiles(Location location, boolean isRecursive)
+                throws IOException
+        {
+            return delegate.listFiles(location, isRecursive);
+        }
+
+        @Override
         public Optional<Boolean> directoryExists(Location location)
                 throws IOException
         {

--- a/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
+++ b/lib/trino-hdfs/src/main/java/io/trino/filesystem/hdfs/HdfsFileSystem.java
@@ -229,12 +229,19 @@ class HdfsFileSystem
     public FileIterator listFiles(Location location)
             throws IOException
     {
+        return listFiles(location, true);
+    }
+
+    @Override
+    public FileIterator listFiles(Location location, boolean isRecursive)
+            throws IOException
+    {
         stats.getListFilesCalls().newCall();
         Path directory = hadoopPath(location);
         FileSystem fileSystem = environment.getFileSystem(context, directory);
         return environment.doAs(context.getIdentity(), () -> {
             try (TimeStat.BlockTimer ignored = stats.getListFilesCalls().time()) {
-                return new HdfsFileIterator(location, directory, fileSystem.listFiles(directory, true));
+                return new HdfsFileIterator(location, directory, fileSystem.listFiles(directory, isRecursive));
             }
             catch (FileNotFoundException e) {
                 return FileIterator.empty();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -1306,6 +1306,26 @@ public class TestBackgroundHiveSplitLoader
                 }
 
                 @Override
+                public FileIterator listFiles(Location location, boolean isRecursive)
+                {
+                    Iterator<FileEntry> iterator = List.of(fileEntry).iterator();
+                    return new FileIterator()
+                    {
+                        @Override
+                        public boolean hasNext()
+                        {
+                            return iterator.hasNext();
+                        }
+
+                        @Override
+                        public FileEntry next()
+                        {
+                            return iterator.next();
+                        }
+                    };
+                }
+
+                @Override
                 public TrinoInputFile newInputFile(Location location)
                 {
                     throw new UnsupportedOperationException();

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiSplitSource.java
@@ -49,6 +49,7 @@ import static io.trino.plugin.hudi.HudiSessionProperties.getSplitGeneratorParall
 import static io.trino.plugin.hudi.HudiSessionProperties.getStandardSplitWeightSize;
 import static io.trino.plugin.hudi.HudiSessionProperties.isSizeBasedSplitWeightsEnabled;
 import static io.trino.plugin.hudi.HudiUtil.buildTableMetaClient;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static java.util.stream.Collectors.toList;
 
 public class HudiSplitSource
@@ -91,7 +92,12 @@ public class HudiSplitSource
                 queue,
                 new BoundedExecutor(executor, getSplitGeneratorParallelism(session)),
                 createSplitWeightProvider(session),
-                partitions);
+                partitions,
+                throwable -> {
+                    trinoException.compareAndSet(null, new TrinoException(GENERIC_INTERNAL_ERROR,
+                            "Failed to generate splits for " + table.getTableName(), throwable));
+                    queue.finish();
+                });
         this.splitLoaderFuture = splitLoaderExecutorService.schedule(splitLoader, 0, TimeUnit.MILLISECONDS);
     }
 

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
@@ -297,9 +297,7 @@ public class HudiTableFileSystemView
         if (fileIterator.hasNext()) {
             return fileIterator;
         }
-        try (OutputStream ignored = metaClient.getFileSystem().newOutputFile(partitionLocation).create()) {
-            return FileIterator.empty();
-        }
+        return FileIterator.empty();
     }
 
     public List<HudiFileGroup> addFilesToView(FileIterator partitionFiles)

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableFileSystemView.java
@@ -40,7 +40,6 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecordBase;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java
@@ -163,12 +163,14 @@ public class HudiTableMetaClient
     private List<FileEntry> scanFiles(Predicate<Location> pathPredicate)
             throws IOException
     {
-        FileIterator fileIterator = fileSystem.listFiles(metaPath);
+        FileIterator fileIterator = fileSystem.listFiles(metaPath, false);
         List<FileEntry> result = new ArrayList<>();
         while (fileIterator.hasNext()) {
             FileEntry fileEntry = fileIterator.next();
-            if (pathPredicate.test(fileEntry.location())) {
-                result.add(fileEntry);
+            if (fileEntry.location().parentDirectory().toString().equals(metaPath.toString())) { // to avoid recursive file if any
+                if (pathPredicate.test(fileEntry.location())) {
+                    result.add(fileEntry);
+                }
             }
         }
         return result;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
Details are Captured in 
#20253

Hudi connector shows incorrect table count for some of the tables where we run clustering

After digging deeper into the code we found that in newer version of trino .hudi metapath listing is done recursively (https://github.com/trinodb/trino/blob/430/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/table/HudiTableMetaClient.java#L166) which is causing to incorrect oldest timestamp file calcaution
.Since it is doing recurvely it is also reading commit files from .hoodie/.bucket_index/consistent_hashing_metadata//20231101000038468.commit which was placed to update the state of clustering . it is causing to skip some of the parquet files while listing the directory . hence incorrectly data count. This clustering commit files in hudi was done as part of this PR (https://github.com/apache/hudi/pull/8503)

if we add filter after getting the listing result the query takes time in planning phase , but after adding non-recursive implementation planning is finishing quickly

For this PR adding changes for trinofilesystem only



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
