### PR TITLE
Swap updatePartition(s)Statistics method names

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -146,13 +146,13 @@ public class HiveMetastoreClosure
             Function<PartitionStatistics, PartitionStatistics> update)
     {
         Table table = getExistingTable(databaseName, tableName);
-        delegate.updatePartitionsStatistics(table, partitionName, update);
+        delegate.updatePartitionStatistics(table, partitionName, update);
     }
 
     public void updatePartitionStatistics(String databaseName, String tableName, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         Table table = getExistingTable(databaseName, tableName);
-        delegate.updatePartitionStatistics(table, updates);
+        delegate.updatePartitionsStatistics(table, updates);
     }
 
     public List<String> getTables(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/ForwardingHiveMetastore.java
@@ -95,20 +95,20 @@ public abstract class ForwardingHiveMetastore
     }
 
     @Override
-    public void updatePartitionsStatistics(
+    public void updatePartitionStatistics(
             Table table,
             String partitionName,
             Function<PartitionStatistics, PartitionStatistics> update)
     {
-        delegate.updatePartitionsStatistics(table, partitionName, update);
+        delegate.updatePartitionStatistics(table, partitionName, update);
     }
 
     @Override
-    public void updatePartitionStatistics(
+    public void updatePartitionsStatistics(
             Table table,
             Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
-        delegate.updatePartitionStatistics(table, updates);
+        delegate.updatePartitionsStatistics(table, updates);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -56,12 +56,12 @@ public interface HiveMetastore
 
     void updateTableStatistics(String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update);
 
-    default void updatePartitionsStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    default void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        updatePartitionStatistics(table, ImmutableMap.of(partitionName, update));
+        updatePartitionsStatistics(table, ImmutableMap.of(partitionName, update));
     }
 
-    void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
+    void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
 
     List<String> getTables(String databaseName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -559,10 +559,10 @@ public final class CachingHiveMetastore
     }
 
     @Override
-    public void updatePartitionsStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
     {
         try {
-            delegate.updatePartitionsStatistics(table, partitionName, update);
+            delegate.updatePartitionStatistics(table, partitionName, update);
         }
         finally {
             HivePartitionName hivePartitionName = hivePartitionName(hiveTableName(table.getDatabaseName(), table.getTableName()), partitionName);
@@ -573,10 +573,10 @@ public final class CachingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         try {
-            delegate.updatePartitionStatistics(table, updates);
+            delegate.updatePartitionsStatistics(table, updates);
         }
         finally {
             updates.forEach((partitionName, update) -> {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -514,7 +514,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public synchronized void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         updates.forEach((partitionName, update) -> {
             PartitionStatistics originalStatistics = getPartitionStatisticsInternal(table, extractPartitionValues(partitionName));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -368,7 +368,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         Iterables.partition(updates.entrySet(), BATCH_CREATE_PARTITION_MAX_PAGE_SIZE).forEach(partitionUpdates ->
                 updatePartitionStatisticsBatch(table, partitionUpdates.stream().collect(toImmutableMap(Entry::getKey, Entry::getValue))));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -138,7 +138,7 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         io.trino.hive.thrift.metastore.Table metastoreTable = toMetastoreApiTable(table);
         updates.forEach((partitionName, update) -> delegate.updatePartitionStatistics(metastoreTable, partitionName, update));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -149,24 +149,24 @@ public class TracingHiveMetastore
     }
 
     @Override
-    public void updatePartitionsStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
     {
         Span span = tracer.spanBuilder("HiveMetastore.updatePartitionsStatistics")
                 .setAttribute(SCHEMA, table.getDatabaseName())
                 .setAttribute(TABLE, table.getTableName())
                 .setAttribute(PARTITION, partitionName)
                 .startSpan();
-        withTracing(span, () -> delegate.updatePartitionsStatistics(table, partitionName, update));
+        withTracing(span, () -> delegate.updatePartitionStatistics(table, partitionName, update));
     }
 
     @Override
-    public void updatePartitionStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionsStatistics(Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         Span span = tracer.spanBuilder("HiveMetastore.updatePartitionStatistics")
                 .setAttribute(SCHEMA, table.getDatabaseName())
                 .setAttribute(TABLE, table.getTableName())
                 .startSpan();
-        withTracing(span, () -> delegate.updatePartitionStatistics(table, updates));
+        withTracing(span, () -> delegate.updatePartitionsStatistics(table, updates));
     }
 
     @Override


### PR DESCRIPTION
Let `updatePartitionStatistics` denote update of one partition.
Let `updatePartitionsStatistics` denote update of many partitions.

Follows https://github.com/trinodb/trino/commit/11a024fd08b23725eee8090fa20e3665c7de21d5