### PR TITLE
Throwing a TrinoException instead of ArithmeticException on sum aggregation of decimals

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
@@ -63,7 +63,7 @@ public final class DataSizeFunctions
         try {
             return Decimals.valueOf(bytes);
         }
-        catch (ArithmeticException e) {
+        catch (TrinoException e) {
             throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, format("Value out of range: '%s' ('%sB')", dataSize, bytes));
         }
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDecimalSumAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDecimalSumAggregation.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import io.trino.operator.aggregation.state.LongDecimalWithOverflowState;
 import io.trino.operator.aggregation.state.LongDecimalWithOverflowStateFactory;
+import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.Int128ArrayBlock;
 import io.trino.spi.block.VariableWidthBlockBuilder;
@@ -131,7 +132,7 @@ public class TestDecimalSumAggregation
 
         assertThat(state.getOverflow()).isEqualTo(1);
         assertThatThrownBy(() -> DecimalSumAggregation.outputDecimal(state, new VariableWidthBlockBuilder(null, 10, 100)))
-                .isInstanceOf(ArithmeticException.class)
+                .isInstanceOf(TrinoException.class)
                 .hasMessage("Decimal overflow");
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/Decimals.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/Decimals.java
@@ -305,10 +305,13 @@ public final class Decimals
         catch (Exception e) {
             throw new ArithmeticException("Decimal overflow");
         }
-        throwIfOverflows(result.getHigh(), result.getLow());
+        if (overflows(result.getHigh(), result.getLow())) {
+            throw new TrinoException(NUMERIC_VALUE_OUT_OF_RANGE, "Decimal overflow");
+        }
         return result;
     }
 
+    @Deprecated(forRemoval = true)
     public static void throwIfOverflows(long high, long low)
     {
         if (overflows(high, low)) {


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Throwing a TrinoException instead of ArithmeticException on sum aggregation of decimals


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Closes #20227 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
