### PR TITLE
Specify table name in testPartitionProjectionIgnore

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -1548,7 +1548,7 @@ public class TestHive3OnDataLake
         hiveMinioDataLake.getHiveHadoop().runOnHive(
                 "ALTER TABLE " + hiveTestTableName + " SET TBLPROPERTIES ( 'trino.partition_projection.ignore'='TRUE' )");
         // Flush cache to get new definition
-        computeActual("CALL system.flush_metadata_cache()");
+        computeActual("CALL system.flush_metadata_cache(schema_name => '" + HIVE_TEST_SCHEMA + "', table_name => '" + tableName + "')");
 
         // Verify query execution works
         computeActual(createInsertStatement(


### PR DESCRIPTION
## Description

Calling `flush_metadata_cache` without arguments may affect other concurrent tests. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
