### PR TITLE
Fix NPE at NULL evaluated like pattern

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -1062,6 +1062,10 @@ public final class DomainTranslator
             }
 
             LikePattern matcher = (LikePattern) evaluateConstantExpression(patternArgument, plannerContext, session);
+            if (matcher == null) {
+                // LIKE on null evaluated
+                return Optional.empty();
+            }
 
             Slice pattern = utf8Slice(matcher.getPattern());
             Optional<Slice> escape = matcher.getEscape()

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestLikeFunctions.java
@@ -354,4 +354,24 @@ public class TestLikeFunctions
                 """))
                 .matches("VALUES 'a%b', 'c%'");
     }
+
+    @Test
+    public void testLikeWithNullPattern()
+    {
+        assertThat(assertions.query("""
+                SELECT value FROM (
+                    VALUES
+                        'a') t(value)
+                WHERE value LIKE NULL
+                """))
+                .returnsEmptyResult();
+
+        assertThat(assertions.query("""
+                SELECT value FROM (
+                    VALUES
+                        'a') t(value)
+                WHERE value LIKE TRY(NULL)
+                """))
+                .returnsEmptyResult();
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

When null evaluated like pattern is used, it caused NPE with `Cannot invoke "io.trino.type.LikePattern.getPattern()" because "matcher" is null`


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

```
SELECT value FROM (
                    VALUES
                        'a') t(value)
                WHERE value LIKE TRY(NULL)
```
is one of reproducible query

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix NPE at NULL evaluated like pattern ({issue}`issuenumber`)
```
