### PR TITLE
Remove outdated takari-local-repository extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>io.takari.aether</groupId>
-        <artifactId>takari-local-repository</artifactId>
-        <version>0.11.3</version>
-    </extension>
-</extensions>


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
