### PR TITLE
Change the default precision of timestamp datatypes to micros (6) from millis (3)

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -226,6 +226,42 @@
                                     <old>method void io.trino.spi.connector.ConnectorMetadata::createMaterializedView(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.SchemaTableName, io.trino.spi.connector.ConnectorMaterializedViewDefinition, boolean, boolean)</old>
                                     <new>method void io.trino.spi.connector.ConnectorMetadata::createMaterializedView(io.trino.spi.connector.ConnectorSession, io.trino.spi.connector.SchemaTableName, io.trino.spi.connector.ConnectorMaterializedViewDefinition, java.util.Map&lt;java.lang.String, java.lang.Object&gt;, boolean, boolean)</new>
                                 </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.field.constantValueChanged</code>
+                                    <old>field io.trino.spi.type.TimeType.DEFAULT_PRECISION</old>
+                                    <new>field io.trino.spi.type.TimeType.DEFAULT_PRECISION</new>
+                                    <justification>Change the precision to 6 as specified by SQL Standard</justification>
+                                    <oldValue>3</oldValue>
+                                    <newValue>6</newValue>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.field.constantValueChanged</code>
+                                    <old>field io.trino.spi.type.TimeWithTimeZoneType.DEFAULT_PRECISION</old>
+                                    <new>field io.trino.spi.type.TimeWithTimeZoneType.DEFAULT_PRECISION</new>
+                                    <justification>Change the precision to 6 as specified by SQL Standard</justification>
+                                    <oldValue>3</oldValue>
+                                    <newValue>6</newValue>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.field.constantValueChanged</code>
+                                    <old>field io.trino.spi.type.TimestampType.DEFAULT_PRECISION</old>
+                                    <new>field io.trino.spi.type.TimestampType.DEFAULT_PRECISION</new>
+                                    <justification>Change the precision to 6 as specified by SQL Standard</justification>
+                                    <oldValue>3</oldValue>
+                                    <newValue>6</newValue>
+                                </item>
+                                <item>
+                                    <ignore>true</ignore>
+                                    <code>java.field.constantValueChanged</code>
+                                    <old>field io.trino.spi.type.TimestampWithTimeZoneType.DEFAULT_PRECISION</old>
+                                    <new>field io.trino.spi.type.TimestampWithTimeZoneType.DEFAULT_PRECISION</new>
+                                    <justification>Change the precision to 6 as specified by SQL Standard</justification>
+                                    <oldValue>3</oldValue>
+                                    <newValue>6</newValue>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeType.java
@@ -48,7 +48,7 @@ public final class TimeType
     private static final VarHandle LONG_HANDLE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final int MAX_PRECISION = 12;
-    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 6;
 
     private static final TimeType[] TYPES = new TimeType[MAX_PRECISION + 1];
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeWithTimeZoneType.java
@@ -27,7 +27,7 @@ public abstract sealed class TimeWithTimeZoneType
     public static final int MAX_PRECISION = 12;
     public static final int MAX_SHORT_PRECISION = 9;
 
-    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 6;
 
     private static final TimeWithTimeZoneType[] TYPES = new TimeWithTimeZoneType[MAX_PRECISION + 1];
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimestampType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimestampType.java
@@ -33,7 +33,7 @@ public abstract sealed class TimestampType
     public static final int MAX_PRECISION = 12;
 
     public static final int MAX_SHORT_PRECISION = 6;
-    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 6;
 
     private static final TimestampType[] TYPES = new TimestampType[MAX_PRECISION + 1];
 

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimestampWithTimeZoneType.java
@@ -31,7 +31,7 @@ public abstract sealed class TimestampWithTimeZoneType
     public static final int MAX_PRECISION = 12;
 
     public static final int MAX_SHORT_PRECISION = 3;
-    public static final int DEFAULT_PRECISION = 3; // TODO: should be 6 per SQL spec
+    public static final int DEFAULT_PRECISION = 6;
 
     private static final TimestampWithTimeZoneType[] TYPES = new TimestampWithTimeZoneType[MAX_PRECISION + 1];
 

--- a/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
+++ b/testing/trino-test-jdbc-compatibility-old-driver/src/test/java/io/trino/TestJdbcCompatibility.java
@@ -73,7 +73,7 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 public class TestJdbcCompatibility
 {
     private static final Optional<Integer> VERSION_UNDER_TEST = testedVersion();
-    private static final int TIMESTAMP_DEFAULT_PRECISION = 3;
+    private static final int TIMESTAMP_DEFAULT_PRECISION = 6;
 
     private final TestingTrinoServer server;
     private final String serverUrl;


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Github issue: https://github.com/trinodb/trino/issues/20292

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
