### PR TITLE
Restore FTE tests increased parallelism on CI

### DIFF
--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -454,6 +454,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <!-- Failure recovery tests spend most of the time waiting for a retry, increase parallelism on CI -->
+                            <threadCount>4</threadCount>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                             <excludes>
                                 <exclude>**/io/trino/faulttolerant/delta/Test*.java</exclude>
                                 <exclude>**/io/trino/faulttolerant/hive/Test*.java</exclude>
@@ -473,8 +480,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                            <!-- Failure recovery tests spend most of the time waiting for a retry, increase parallelism on CI -->
                             <threadCount>4</threadCount>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                             <includes>
                                 <include>**/io/trino/faulttolerant/hive/Test*FaultTolerant*.java</include>
                             </includes>
@@ -492,8 +504,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                            <!-- Failure recovery tests spend most of the time waiting for a retry, increase parallelism on CI -->
                             <threadCount>4</threadCount>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                             <includes>
                                 <include>**/io/trino/faulttolerant/delta/Test*.java</include>
                             </includes>
@@ -511,8 +528,13 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                            <!-- Failure recovery tests spend most of the time waiting for a retry, increase parallelism on CI -->
                             <threadCount>4</threadCount>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                             <includes>
                                 <include>**/io/trino/faulttolerant/iceberg/Test*.java</include>
                             </includes>


### PR DESCRIPTION
We used `threadCount=4` for FTE tests to make them complete faster. Since GitHub runners typically have 2 cores, JUnit default parallelism is now smaller. Increase it back.
