### PR TITLE
Detect leaked containers when running with JUnit

### DIFF
--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -269,6 +269,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-testing-containers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing-services</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestingAccumuloServer.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestingAccumuloServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.accumulo;
 
 import io.trino.testing.TestingProperties;
+import io.trino.testing.containers.junit.ReportLeakedContainers;
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Connector;
@@ -63,6 +64,7 @@ public class TestingAccumuloServer
         // TODO Change this class to not be a singleton
         //  https://github.com/trinodb/trino/issues/5842
         accumuloContainer.start();
+        ReportLeakedContainers.ignoreContainerId(accumuloContainer.getContainerId());
     }
 
     public String getInstanceName()

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.rnorth.duct-tape</groupId>
             <artifactId>duct-tape</artifactId>
             <version>${dep.duct-tape.version}</version>

--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers.junit;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Container;
+import io.airlift.log.Logger;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+import org.testcontainers.DockerClientFactory;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Boolean.getBoolean;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public final class ReportLeakedContainers
+{
+    private ReportLeakedContainers() {}
+
+    private static final Logger log = Logger.get(ReportLeakedContainers.class);
+    private static final boolean DISABLED = getBoolean("ReportLeakedContainers.disabled");
+
+    private static final Set<String> ignoredIds = Collections.synchronizedSet(new HashSet<>());
+
+    public static void ignoreContainerId(String containerId)
+    {
+        ignoredIds.add(requireNonNull(containerId, "containerId is null"));
+    }
+
+    // Separate class so that ReportLeakedContainers.ignoreContainerId can be called without pulling junit platform onto classpath
+    public static class Listener
+            implements TestExecutionListener
+    {
+        @Override
+        public void testPlanExecutionFinished(TestPlan testPlan)
+        {
+            if (DISABLED) {
+                log.info("ReportLeakedContainers disabled");
+                return;
+            }
+            log.info("Checking for leaked containers");
+
+            @SuppressWarnings("resource") // Throws when close is attempted, as this is a global instance.
+            DockerClient dockerClient = DockerClientFactory.lazyClient();
+
+            List<Container> containers = dockerClient.listContainersCmd()
+                    .withLabelFilter(Map.of(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID))
+                    .exec()
+                    .stream()
+                    .filter(container -> !ignoredIds.contains(container.getId()))
+                    .collect(toImmutableList());
+
+            if (!containers.isEmpty()) {
+                log.error("Leaked containers: %s", containers.stream()
+                        .map(container -> toStringHelper("container")
+                                .add("id", container.getId())
+                                .add("image", container.getImage())
+                                .add("imageId", container.getImageId())
+                                .toString())
+                        .collect(joining(", ", "[", "]")));
+
+                // JUnit does not fail on a listener exception.
+                System.err.println("JVM will be terminated");
+                System.exit(1);
+            }
+        }
+    }
+}

--- a/testing/trino-testing-containers/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/testing/trino-testing-containers/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+io.trino.testing.containers.junit.ReportLeakedContainers$Listener


### PR DESCRIPTION
With TestNG, `ManageTestResources` was attempting to prevent resource leaks, including container leaks, in tests. It relied on certain common test patterns to operate (like storing resource on instance fields).

This commit attempts to provide similar functionality for JUnit. For now it's limited to containers. As an added bonus, it works regardless of how the test class is written.
