### PR TITLE
Document encryption of FTE spool

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -80,6 +80,10 @@ execution on a Trino cluster:
   - Enable compression of spooling data. Setting to `true` is recommended
     when using an [exchange manager](fte-exchange-manager).
   - ``false``
+* - `fault-tolerant-execution.exchange-encryption-enabled`
+  - Enable encryption of spooling data, see [Encryption](fte-encryption) for details. 
+    Setting this property to false is not recommended if Trino processes sensitive data.
+  - ``true``
 :::
 
 (fte-retry-policy)=
@@ -144,6 +148,14 @@ volume. As a best practice, it is recommended to run a dedicated cluster
 with a `TASK` retry policy for large batch queries, separate from another
 cluster that handles short queries.
 :::
+
+(fte-encryption)=
+## Encryption
+
+Trino encrypts data before spooling it to storage. This prevents access to query data
+by anyone besides the Trino cluster that wrote it, including administrators of the
+storage system. A new encryption key is randomly generated for every query, and keys
+are discarded once a query is completed.
 
 ## Advanced configuration
 
@@ -449,7 +461,11 @@ the property may be configured for:
   - AWS S3, GCS
 * - `exchange.s3.endpoint`
   - S3 storage endpoint server if using an S3-compatible storage system that
-    is not AWS. If using AWS S3, this can be ignored. If using GCS, set it
+    is not AWS. If using AWS S3, this can be ignored unless HTTPS is required 
+    by an AWS bucket policy. If TLS is required, then this property can be 
+    set to an https endpoint such as ``https://s3.us-east-1.amazonaws.com``. 
+    Note that TLS is redundant due to {ref}`automatic encryption <fte-encryption>`. 
+    If using GCS, set it
     to `https://storage.googleapis.com`.
   -
   - Any S3-compatible storage


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Trino automatically encrypts exchange data before spooling when FTE is enabled. This should be documented so that security concerns can be addressed and users do not needlessly enable TLS.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
