### PR TITLE
Fix typo in stalebot config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,4 +24,4 @@ jobs:
           operations-per-run: 200
           # Avoid processing issues completely, see https://github.com/actions/stale/issues/1112
           days-before-issue-stale: -1
-          day-before-issue-closed: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
## Description

New run failed due to the typo.

## Additional context and related issues

See https://github.com/trinodb/trino/actions/runs/7450714357

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
