### PR TITLE
Add timeout for git-commit-id-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2265,6 +2265,7 @@
                         <!-- git-commit-id 6.0.0 incorrectly detects the .git dir, breaking the native-git workaround; see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/639 -->
                         <!-- When Maven 4.0 is used, this can be replaced by a native Maven property (see MNG-7038), assuming git-commit-id #639 isn't yet fixed -->
                         <dotGitDirectory>${air.main.basedir}/.git</dotGitDirectory>
+                        <nativeGitTimeoutInMs>100000</nativeGitTimeoutInMs>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
I used the Docker container to compile trino, but found that there were compilation errors as follows:

<img width="953" alt="trino_build_err" src="https://github.com/trinodb/trino/assets/33423421/f57aee13-bba5-406f-b42f-e5a6fb82d94f">

I further tested on the machine and found that the git command in the plugin timed out, with a default timeout of 30 seconds

<img width="443" alt="timeout_err" src="https://github.com/trinodb/trino/assets/33423421/1c9e3495-5b2b-4701-b9d3-6173d63ab762">

We need to add a plugin's timeout configuration and increase the default timeout value！
