### PR TITLE
Fix auto formatting of throwing blocks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionManager.java
@@ -325,9 +325,15 @@ public class FunctionManager
     {
         TypeOperators typeOperators = new TypeOperators();
         GlobalFunctionCatalog functionCatalog = new GlobalFunctionCatalog(
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); });
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                });
         functionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
         functionCatalog.addFunctions(new InternalFunctionBundle(new LiteralFunction(new InternalBlockEncodingSerde(new BlockEncodingManager(), TESTING_TYPE_MANAGER))));
         return new FunctionManager(CatalogServiceProvider.fail(), functionCatalog, LanguageFunctionProvider.DISABLED);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -2044,7 +2044,9 @@ public final class MetadataManager
                 .map(Variable::getName)
                 .filter(variableName -> !assignedVariables.contains(variableName))
                 .findAny()
-                .ifPresent(variableName -> { throw new IllegalStateException("Unbound variable: " + variableName); });
+                .ifPresent(variableName -> {
+                    throw new IllegalStateException("Unbound variable: " + variableName);
+                });
     }
 
     @Override
@@ -2762,9 +2764,15 @@ public final class MetadataManager
             GlobalFunctionCatalog globalFunctionCatalog = this.globalFunctionCatalog;
             if (globalFunctionCatalog == null) {
                 globalFunctionCatalog = new GlobalFunctionCatalog(
-                        () -> { throw new UnsupportedOperationException(); },
-                        () -> { throw new UnsupportedOperationException(); },
-                        () -> { throw new UnsupportedOperationException(); });
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        },
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        },
+                        () -> {
+                            throw new UnsupportedOperationException();
+                        });
                 TypeOperators typeOperators = new TypeOperators();
                 globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
                 globalFunctionCatalog.addFunctions(new InternalFunctionBundle(new LiteralFunction(new InternalBlockEncodingSerde(new BlockEncodingManager(), typeManager))));

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2532,7 +2532,9 @@ class StatementAnalyzer
             analysis.unregisterTableForView();
 
             checkViewStaleness(columns, descriptor.getVisibleFields(), name, table)
-                    .ifPresent(explanation -> { throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation); });
+                    .ifPresent(explanation -> {
+                        throw semanticException(VIEW_IS_STALE, table, "View '%s' is stale or in invalid state: %s", name, explanation);
+                    });
 
             // Derive the type of the view from the stored definition, not from the analysis of the underlying query.
             // This is needed in case the underlying table(s) changed and the query in the view now produces types that

--- a/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
+++ b/core/trino-main/src/test/java/io/trino/dispatcher/TestLocalDispatchQuery.java
@@ -134,9 +134,15 @@ public class TestLocalDispatchQuery
                 new FunctionManager(
                         new ConnectorCatalogServiceProvider<>("function provider", new NoConnectorServicesProvider(), ConnectorServices::getFunctionProvider),
                         new GlobalFunctionCatalog(
-                                () -> { throw new UnsupportedOperationException(); },
-                                () -> { throw new UnsupportedOperationException(); },
-                                () -> { throw new UnsupportedOperationException(); }),
+                                () -> {
+                                    throw new UnsupportedOperationException();
+                                },
+                                () -> {
+                                    throw new UnsupportedOperationException();
+                                },
+                                () -> {
+                                    throw new UnsupportedOperationException();
+                                }),
                         LanguageFunctionProvider.DISABLED),
                 new QueryMonitorConfig());
         CreateTable createTable = new CreateTable(QualifiedName.of("table"), ImmutableList.of(), FAIL, ImmutableList.of(), Optional.empty());

--- a/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestGlobalFunctionCatalog.java
@@ -101,9 +101,15 @@ public class TestGlobalFunctionCatalog
 
         TypeOperators typeOperators = new TypeOperators();
         GlobalFunctionCatalog globalFunctionCatalog = new GlobalFunctionCatalog(
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); });
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                });
         globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), NodeVersion.UNKNOWN));
         globalFunctionCatalog.addFunctions(functionBundle);
         assertThatThrownBy(() -> globalFunctionCatalog.addFunctions(functionBundle))
@@ -118,9 +124,15 @@ public class TestGlobalFunctionCatalog
 
         TypeOperators typeOperators = new TypeOperators();
         GlobalFunctionCatalog globalFunctionCatalog = new GlobalFunctionCatalog(
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); },
-                () -> { throw new UnsupportedOperationException(); });
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                },
+                () -> {
+                    throw new UnsupportedOperationException();
+                });
         globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(new FeaturesConfig(), typeOperators, new BlockTypeOperators(typeOperators), NodeVersion.UNKNOWN));
         assertThatThrownBy(() -> globalFunctionCatalog.addFunctions(functions))
                 .isInstanceOf(IllegalStateException.class)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestingPlannerContext.java
@@ -120,9 +120,15 @@ public final class TestingPlannerContext
             parametricTypes.forEach(typeRegistry::addParametricType);
 
             GlobalFunctionCatalog globalFunctionCatalog = new GlobalFunctionCatalog(
-                    () -> { throw new UnsupportedOperationException(); },
-                    () -> { throw new UnsupportedOperationException(); },
-                    () -> { throw new UnsupportedOperationException(); });
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    },
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    },
+                    () -> {
+                        throw new UnsupportedOperationException();
+                    });
             globalFunctionCatalog.addFunctions(SystemFunctionBundle.create(featuresConfig, typeOperators, new BlockTypeOperators(typeOperators), UNKNOWN));
             functionBundles.forEach(globalFunctionCatalog::addFunctions);
 

--- a/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceOutputSelector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/exchange/ExchangeSourceOutputSelector.java
@@ -173,7 +173,9 @@ public class ExchangeSourceOutputSelector
                         .collect(toMap(
                                 Entry::getKey,
                                 Entry::getValue,
-                                (a, b) -> { throw new IllegalArgumentException("got duplicate key " + a + ", " + b); },
+                                (a, b) -> {
+                                    throw new IllegalArgumentException("got duplicate key " + a + ", " + b);
+                                },
                                 TreeMap::new)))
                 .add("finalSelector=" + finalSelector)
                 .toString();

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -640,7 +640,9 @@ public final class TupleDomain<T>
         return toMap(
                 keyMapper,
                 valueMapper,
-                (u, v) -> { throw new IllegalStateException(format("Duplicate values for a key: %s and %s", u, v)); },
+                (u, v) -> {
+                    throw new IllegalStateException(format("Duplicate values for a key: %s and %s", u, v));
+                },
                 LinkedHashMap::new);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -86,7 +86,9 @@ public class DefaultQueryBuilder
                     .filter(domains::containsKey)
                     .filter(column -> columnExpressions.containsKey(column.getColumnName()))
                     .findFirst()
-                    .ifPresent(column -> { throw new IllegalArgumentException(format("Column %s has an expression and a constraint attached at the same time", column)); });
+                    .ifPresent(column -> {
+                        throw new IllegalArgumentException(format("Column %s has an expression and a constraint attached at the same time", column));
+                    });
         }
 
         ImmutableList.Builder<String> conjuncts = ImmutableList.builder();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSessionProperties.java
@@ -167,7 +167,9 @@ public final class DeltaLakeSessionProperties
                         "Internal Delta Lake connector property",
                         HiveTimestampPrecision.class,
                         MILLISECONDS,
-                        value -> { throw new IllegalStateException("The property cannot be set"); },
+                        value -> {
+                            throw new IllegalStateException("The property cannot be set");
+                        },
                         true),
                 durationProperty(
                         DYNAMIC_FILTERING_WAIT_TIMEOUT,

--- a/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
+++ b/plugin/trino-ignite/src/test/java/io/trino/plugin/ignite/TestIgniteClient.java
@@ -79,7 +79,9 @@ public class TestIgniteClient
 
     public static final JdbcClient JDBC_CLIENT = new IgniteClient(
             new BaseJdbcConfig(),
-            session -> { throw new UnsupportedOperationException(); },
+            session -> {
+                throw new UnsupportedOperationException();
+            },
             new DefaultQueryBuilder(RemoteQueryModifier.NONE),
             new DefaultIdentifierMapping(),
             RemoteQueryModifier.NONE);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -1390,7 +1390,9 @@ public class PostgreSqlClient
         return ColumnMapping.sliceMapping(
                 jsonType,
                 arrayAsJsonReadFunction(session, baseElementMapping),
-                (statement, index, block) -> { throw new UnsupportedOperationException(); },
+                (statement, index, block) -> {
+                    throw new UnsupportedOperationException();
+                },
                 DISABLE_PUSHDOWN);
     }
 
@@ -1518,7 +1520,9 @@ public class PostgreSqlClient
                         return utf8Slice(resultSet.getString(columnIndex));
                     }
                 },
-                (statement, index, value) -> { throw new TrinoException(NOT_SUPPORTED, "Money type is not supported for INSERT"); },
+                (statement, index, value) -> {
+                    throw new TrinoException(NOT_SUPPORTED, "Money type is not supported for INSERT");
+                },
                 DISABLE_PUSHDOWN);
     }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -108,7 +108,9 @@ public class TestPostgreSqlClient
             new BaseJdbcConfig(),
             new PostgreSqlConfig(),
             new JdbcStatisticsConfig(),
-            session -> { throw new UnsupportedOperationException(); },
+            session -> {
+                throw new UnsupportedOperationException();
+            },
             new DefaultQueryBuilder(RemoteQueryModifier.NONE),
             TESTING_TYPE_MANAGER,
             new DefaultIdentifierMapping(),


### PR DESCRIPTION
`{ throw ...; }` lambdas read very well. However, all recent IntelliJ versions insist on removing whitespace before `throw` and after final `;`. This results in checkstyle violation when IDE automatic formatting is used.

Reformat lambdas in a way that IDE automatic formatting does not violate checkstyle rules, in order to save time when working with code.
