### PR TITLE
Conditional rewrites in JDBC complex expression pushdown

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionRewriter.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionRewriter.java
@@ -87,6 +87,9 @@ public final class ConnectorExpressionRewriter<Result>
             ConnectorExpression expression,
             RewriteContext<Result> context)
     {
+        if (!rule.isEnabled(context.getSession())) {
+            return Optional.empty();
+        }
         Capture<ExpressionType> expressionCapture = newCapture();
         Pattern<ExpressionType> pattern = rule.getPattern().capturedAs(expressionCapture);
         Iterator<Match> matches = pattern.match(expression, context).iterator();

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/ConnectorExpressionRule.java
@@ -27,6 +27,11 @@ import static java.util.Objects.requireNonNull;
 
 public interface ConnectorExpressionRule<ExpressionType extends ConnectorExpression, Result>
 {
+    default boolean isEnabled(ConnectorSession session)
+    {
+        return true;
+    }
+
     Pattern<ExpressionType> getPattern();
 
     Optional<Result> rewrite(ExpressionType expression, Captures captures, RewriteContext<Result> context);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.jdbc.expression;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
@@ -67,7 +68,7 @@ public class JdbcConnectorExpressionRewriterBuilder
     public ExpectRewriteTarget map(String expressionPattern)
     {
         return rewritePattern -> {
-            rules.add(new GenericRewrite(typeClasses, expressionPattern, rewritePattern));
+            rules.add(new GenericRewrite(ImmutableMap.copyOf(typeClasses), expressionPattern, rewritePattern));
             return JdbcConnectorExpressionRewriterBuilder.this;
         };
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
@@ -64,7 +64,7 @@ public class JdbcConnectorExpressionRewriterBuilder
         return this;
     }
 
-    public ExpressionMapping map(String expressionPattern)
+    public ExpectRewriteTarget map(String expressionPattern)
     {
         return rewritePattern -> {
             rules.add(new GenericRewrite(typeClasses, expressionPattern, rewritePattern));
@@ -77,7 +77,7 @@ public class JdbcConnectorExpressionRewriterBuilder
         return new ConnectorExpressionRewriter<>(rules.build());
     }
 
-    public interface ExpressionMapping
+    public interface ExpectRewriteTarget
     {
         JdbcConnectorExpressionRewriterBuilder to(String rewritePattern);
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
@@ -64,16 +64,11 @@ public class JdbcConnectorExpressionRewriterBuilder
         return this;
     }
 
-    public ExpressionMapping<JdbcConnectorExpressionRewriterBuilder> map(String expressionPattern)
+    public ExpressionMapping map(String expressionPattern)
     {
-        return new ExpressionMapping<>()
-        {
-            @Override
-            public JdbcConnectorExpressionRewriterBuilder to(String rewritePattern)
-            {
-                rules.add(new GenericRewrite(typeClasses, expressionPattern, rewritePattern));
-                return JdbcConnectorExpressionRewriterBuilder.this;
-            }
+        return rewritePattern -> {
+            rules.add(new GenericRewrite(typeClasses, expressionPattern, rewritePattern));
+            return JdbcConnectorExpressionRewriterBuilder.this;
         };
     }
 
@@ -82,8 +77,8 @@ public class JdbcConnectorExpressionRewriterBuilder
         return new ConnectorExpressionRewriter<>(rules.build());
     }
 
-    public interface ExpressionMapping<Continuation>
+    public interface ExpressionMapping
     {
-        Continuation to(String rewritePattern);
+        JdbcConnectorExpressionRewriterBuilder to(String rewritePattern);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/JdbcConnectorExpressionRewriterBuilder.java
@@ -17,11 +17,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.base.expression.ConnectorExpressionRewriter;
 import io.trino.plugin.base.expression.ConnectorExpressionRule;
+import io.trino.spi.connector.ConnectorSession;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -65,12 +67,16 @@ public class JdbcConnectorExpressionRewriterBuilder
         return this;
     }
 
+    public ExpectSourceExpression when(Predicate<ConnectorSession> condition)
+    {
+        return new GenericRewriteBuilder()
+                .when(condition);
+    }
+
     public ExpectRewriteTarget map(String expressionPattern)
     {
-        return rewritePattern -> {
-            rules.add(new GenericRewrite(ImmutableMap.copyOf(typeClasses), expressionPattern, rewritePattern));
-            return JdbcConnectorExpressionRewriterBuilder.this;
-        };
+        return new GenericRewriteBuilder()
+                .map(expressionPattern);
     }
 
     public ConnectorExpressionRewriter<ParameterizedExpression> build()
@@ -78,8 +84,40 @@ public class JdbcConnectorExpressionRewriterBuilder
         return new ConnectorExpressionRewriter<>(rules.build());
     }
 
+    public interface ExpectSourceExpression
+    {
+        ExpectRewriteTarget map(String expressionPattern);
+    }
+
     public interface ExpectRewriteTarget
     {
         JdbcConnectorExpressionRewriterBuilder to(String rewritePattern);
+    }
+
+    private class GenericRewriteBuilder
+            implements ExpectSourceExpression, ExpectRewriteTarget
+    {
+        private Predicate<ConnectorSession> condition = session -> true;
+        private String expressionPattern;
+
+        GenericRewriteBuilder when(Predicate<ConnectorSession> condition)
+        {
+            this.condition = requireNonNull(condition, "condition is null");
+            return this;
+        }
+
+        @Override
+        public ExpectRewriteTarget map(String expressionPattern)
+        {
+            this.expressionPattern = requireNonNull(expressionPattern, "expressionPattern is null");
+            return this;
+        }
+
+        @Override
+        public JdbcConnectorExpressionRewriterBuilder to(String rewritePattern)
+        {
+            rules.add(new GenericRewrite(ImmutableMap.copyOf(typeClasses), condition, expressionPattern, rewritePattern));
+            return JdbcConnectorExpressionRewriterBuilder.this;
+        }
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/TestGenericRewrite.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/expression/TestGenericRewrite.java
@@ -41,7 +41,7 @@ public class TestGenericRewrite
     @Test
     public void testRewriteCall()
     {
-        GenericRewrite rewrite = new GenericRewrite(Map.of(), "add(foo: decimal(p, s), bar: bigint): decimal(rp, rs)", "foo + bar::decimal(rp,rs)");
+        GenericRewrite rewrite = new GenericRewrite(Map.of(), session -> true, "add(foo: decimal(p, s), bar: bigint): decimal(rp, rs)", "foo + bar::decimal(rp,rs)");
         ConnectorExpression expression = new Call(
                 createDecimalType(21, 2),
                 new FunctionName("add"),
@@ -58,7 +58,7 @@ public class TestGenericRewrite
     public void testRewriteCallWithTypeClass()
     {
         Map<String, Set<String>> typeClasses = Map.of("integer_class", Set.of("integer", "bigint"));
-        GenericRewrite rewrite = new GenericRewrite(typeClasses, "add(foo: integer_class, bar: bigint): integer_class", "foo + bar");
+        GenericRewrite rewrite = new GenericRewrite(typeClasses, session -> true, "add(foo: integer_class, bar: bigint): integer_class", "foo + bar");
 
         assertThat(apply(rewrite, new Call(
                 BIGINT,


### PR DESCRIPTION
Add support for conditional rewrites in `JdbcConnectorExpressionRewriterBuilder`.
This allows merging `PostgreSqlClient`'s two different rewrite objects into one.