### PR TITLE
HIVE/AVRO: Handle all union options coersion to single type

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPageDataReader.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/avro/AvroPageDataReader.java
@@ -193,11 +193,12 @@ public class AvroPageDataReader
             case RECORD -> new RowBlockBuildingDecoder(action, typeManager);
             case ENUM -> new EnumBlockBuildingDecoder((Resolver.EnumAdjust) action);
             case WRITER_UNION -> {
-                if (isSimpleNullableUnion(action.reader)) {
-                    yield new WriterUnionBlockBuildingDecoder((Resolver.WriterUnion) action, typeManager);
+                if (action.reader.getType() == Schema.Type.UNION && !isSimpleNullableUnion(action.reader)) {
+                    yield new WriterUnionCoercedIntoRowBlockBuildingDecoder((Resolver.WriterUnion) action, typeManager);
                 }
                 else {
-                    yield new WriterUnionCoercedIntoRowBlockBuildingDecoder((Resolver.WriterUnion) action, typeManager);
+                    // reading a union with non-union or nullable union, optimistically try to create the reader, will fail at read time with any underlying issues
+                    yield new WriterUnionBlockBuildingDecoder((Resolver.WriterUnion) action, typeManager);
                 }
             }
             case READER_UNION -> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Hive/Avro: Handle all union options coersion to single type

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
#20310 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(X ) Release notes are required, with the following suggested text:
Hive/Avro: Handle all union options coersion to single type.
For example: can now read: `["string","bytes"]` with  schema `"string"` or `"bytes"`. 

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
