### PR TITLE
Correct FTE encryption detail in docs

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -152,10 +152,10 @@ cluster that handles short queries.
 (fte-encryption)=
 ## Encryption
 
-Trino encrypts data before spooling it to storage. This prevents access to query data
-by anyone besides the Trino cluster that wrote it, including administrators of the
-storage system. A new encryption key is randomly generated for every query, and keys
-are discarded once a query is completed.
+Trino encrypts data before spooling it to storage. This prevents access to query
+data by anyone besides the Trino cluster that wrote it, including administrators
+of the storage system. A new encryption key is randomly generated for every
+exchange with every query, and keys are discarded once a query is completed.
 
 ## Advanced configuration
 


### PR DESCRIPTION
## Description

Fix for https://github.com/trinodb/trino/pull/20298#discussion_r1447237535 since the detail is there .. it should at least be correct.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
