### PR TITLE
Revert "Add some traceability which option is failing"

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.spi.QueryId;
@@ -126,8 +125,6 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public abstract class BaseJdbcConnectorTest
         extends BaseConnectorTest
 {
-    private static final Logger log = Logger.get(BaseJdbcConnectorTest.class);
-
     private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
 
     protected abstract SqlExecutor onRemoteDatabase();
@@ -1200,8 +1197,6 @@ public abstract class BaseJdbcConnectorTest
                 "nation_lowercase",
                 "AS SELECT nationkey, lower(name) name, regionkey FROM nation")) {
             for (JoinOperator joinOperator : JoinOperator.values()) {
-                log.info("Testing joinOperator=%s", joinOperator);
-
                 if (joinOperator == FULL_JOIN && !hasBehavior(SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN)) {
                     assertThat(query(session, "SELECT r.name, n.name FROM nation n FULL JOIN region r ON n.regionkey = r.regionkey"))
                             .joinIsNotFullyPushedDown();
@@ -1261,7 +1256,6 @@ public abstract class BaseJdbcConnectorTest
 
                 // inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
                 for (String operator : nonEqualities) {
-                    log.info("Testing [joinOperator=%s] operator=%s on number", joinOperator, operator);
                     assertJoinConditionallyPushedDown(
                             session,
                             format("SELECT n.name, c.name FROM nation n %s customer c ON n.nationkey = c.nationkey AND n.regionkey %s c.custkey", joinOperator, operator),
@@ -1270,7 +1264,6 @@ public abstract class BaseJdbcConnectorTest
 
                 // varchar inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
                 for (String operator : nonEqualities) {
-                    log.info("Testing [joinOperator=%s] operator=%s on varchar", joinOperator, operator);
                     assertJoinConditionallyPushedDown(
                             session,
                             format("SELECT n.name, nl.name FROM nation n %s %s nl ON n.regionkey = nl.regionkey AND n.name %s nl.name", joinOperator, nationLowercaseTable.getName(), operator),

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -15,7 +15,6 @@ package io.trino.plugin.postgresql;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
@@ -81,8 +80,6 @@ import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 public class TestPostgreSqlConnectorTest
         extends BaseJdbcConnectorTest
 {
-    private static final Logger log = Logger.get(TestPostgreSqlConnectorTest.class);
-
     protected TestingPostgreSqlServer postgreSqlServer;
 
     @Override
@@ -644,8 +641,6 @@ public class TestPostgreSqlConnectorTest
 
             // inequality
             for (String operator : nonEqualities) {
-                log.info("Testing operator=%s", operator);
-
                 // bigint inequality predicate
                 assertThat(query(withoutDynamicFiltering, format("SELECT r.name, n.name FROM nation n JOIN region r ON n.regionkey %s r.regionkey", operator)))
                         // Currently no pushdown as inequality predicate is removed from Join to maintain Cross Join and Filter as separate nodes
@@ -659,7 +654,6 @@ public class TestPostgreSqlConnectorTest
 
             // inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
             for (String operator : nonEqualities) {
-                log.info("Testing operator=%s", operator);
                 assertConditionallyPushedDown(
                         session,
                         format("SELECT n.name, c.name FROM nation n JOIN customer c ON n.nationkey = c.nationkey AND n.regionkey %s c.custkey", operator),
@@ -669,7 +663,6 @@ public class TestPostgreSqlConnectorTest
 
             // varchar inequality along with an equality, which constitutes an equi-condition and allows filter to remain as part of the Join
             for (String operator : nonEqualities) {
-                log.info("Testing operator=%s", operator);
                 assertConditionallyPushedDown(
                         session,
                         format("SELECT n.name, nl.name FROM nation n JOIN %s nl ON n.regionkey = nl.regionkey AND n.name %s nl.name", nationLowercaseTable.getName(), operator),


### PR DESCRIPTION
This reverts commit d69f50b8aaed2c0e8927078401c776644823929c. There was a concern voiced that the resulting logs could be too big.
