### PR TITLE
(WIP) Add docs for json_table

### DIFF
--- a/docs/src/main/sphinx/functions/json.md
+++ b/docs/src/main/sphinx/functions/json.md
@@ -1146,6 +1146,24 @@ FROM customers
 | 102 | 'missing' |
 | 103 | 'missing' |
 
+
+(json-table)=
+## json_table
+
+The `json_table` table function extracts a table of one or more columns and rows
+of data from a JSON value.
+
+```text
+JSON_TABLE(
+
+)
+```
+
+### Examples
+
+tbd
+
+
 (json-array)=
 
 ## json_array


### PR DESCRIPTION
## Description

Not even really started .. just getting my thoughts together. Currently I plan to add this to the json functions page .. and maybe also link from the table functions page .. will see how it goes.

Will rely on specs, tests, and help from @kasiafi and @martint .. but not yet.

## Additional context and related issues

* First released in 435 with #18017
* Fix for being able to test it at all is in 436 - #20122

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
