### PR TITLE
Accept null equal result at RowType IN operator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Throwables.throwIfUnchecked;
-import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.cache.CacheUtils.uncheckedCacheGet;
 import static io.trino.cache.SafeCaches.buildNonEvictableCache;
 import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
@@ -128,8 +127,7 @@ public final class FastutilSetHelper
         public boolean equals(long a, long b)
         {
             Boolean result = longEquals.equals(a, b);
-            // FastutilHashSet is not intended be used for indeterminate values lookup
-            verifyNotNull(result, "result is null");
+            // result can be null at null input
             return TRUE.equals(result);
         }
     }
@@ -172,8 +170,7 @@ public final class FastutilSetHelper
         public boolean equals(double a, double b)
         {
             Boolean result = doubleEquals.equals(a, b);
-            // FastutilHashSet is not intended be used for indeterminate values lookup
-            verifyNotNull(result, "result is null");
+            // result can be null at null input
             return TRUE.equals(result);
         }
     }
@@ -228,8 +225,7 @@ public final class FastutilSetHelper
                 return a == null && b == null;
             }
             Boolean result = objectEquals.equals(a, b);
-            // FastutilHashSet is not intended be used for indeterminate values lookup
-            verifyNotNull(result, "result is null");
+            // result can be null at null input
             return TRUE.equals(result);
         }
     }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
@@ -2089,6 +2089,53 @@ public class TestExpressionCompiler
         assertThat(assertions.expression("a IN (100, 101, if(rand()<0, 1), if(rand()>=0, 1))")
                 .binding("a", "2"))
                 .isNull(BOOLEAN);
+
+        // Test nulls in
+        assertThat(assertions.expression("(a, a, a) IN ((1, 2, 3))")
+                .binding("a", toLiteral(null, BIGINT)))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("""
+                (a, a, a) IN (
+                    (5544, 2353, 20707),
+                    (31151, 28065, 16095),
+                    (3438, 18492, 6766),
+                    (2760, 24192, 11910),
+                    (3742, 19535, 22987),
+                    (25095, 1010, 3350),
+                    (7041, 31411, 7591),
+                    (17249, 3966, 689)
+                )""")
+                .binding("a", toLiteral(null, BIGINT)))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("""
+                (a, a, a) IN (
+                    (0.3800333741515576,0.8791181098432054,0.8079168966591113),
+                    (0.841473183490171,0.6860318355122751,0.5095470524329374),
+                    (0.8018365844287392,0.5593077891717974,0.8910788708369497),
+                    (0.14038332668184272,0.6365466202692381,0.129021808157588),
+                    (0.5092693053249044,0.8550520748957249,0.6145972410498111),
+                    (0.29832096538891706,0.33744008233336487,0.5314014695786806),
+                    (0.6543933704493586,0.5583125620036814,0.30143883710327324),
+                    (0.18208897386302747,0.029459145253995844,0.5091670949185126)
+                )""")
+                .binding("a", toLiteral(null, DOUBLE)))
+                .isNull(BOOLEAN);
+
+        assertThat(assertions.expression("""
+                (a, a, a) IN (
+                    ('ENfsMkSuwJ','AyXdaqvmHG','KNEglPUiLq'),
+                    ('YxyzjGpwqu','lTWPpGOjfM','MTqbvaKuXJ'),
+                    ('hSxdZWuLEj','qrGZvDlkMw','MTUxntwpQe'),
+                    ('kFXxnrTZAb','yTjfKwcrEU','KOmFAaelSp'),
+                    ('FNPZQOGzKr','aFnCQOujdU','JwTMGErynA'),
+                    ('EUxWSTLrNp','JTeLWKuMtv','SIZCPrXpzO'),
+                    ('mBzobeIVrA','QLPvGtYprB','vBOLRnlaMN'),
+                    ('yznCLJqmVK','WgoKkNdSLR','mwAoQsMjrt')
+                )""")
+                .binding("a", toLiteral(null, DOUBLE)))
+                .isNull(BOOLEAN);
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

In a case that input value is null and hit the same bucket of ObjectOpenCustomHashSet, `IN` operator with `RowType` could fail by 
```
Query 20240111_010722_00017_m8msk failed: result is null
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


Here's the sample query that caused this failure through random values
```
# integer
select * from (values (null, null, null) ) t(a, b, c) where (a,b,c) in (
           (5544, 2353, 20707),
            (31151, 28065, 16095),
            (3438, 18492, 6766),
            (2760, 24192, 11910),
            (3742, 19535, 22987),
            (25095, 1010, 3350),
            (7041, 31411, 7591),
            (17249, 3966, 689) );

# double
select * from (values (null, null, null) ) t(a, b, c) where (a,b,c) in (
        (0.3800333741515576,0.8791181098432054,0.8079168966591113),
        (0.841473183490171,0.6860318355122751,0.5095470524329374),
        (0.8018365844287392,0.5593077891717974,0.8910788708369497),
        (0.14038332668184272,0.6365466202692381,0.129021808157588),
        (0.5092693053249044,0.8550520748957249,0.6145972410498111),
        (0.29832096538891706,0.33744008233336487,0.5314014695786806),
        (0.6543933704493586,0.5583125620036814,0.30143883710327324),
        (0.18208897386302747,0.029459145253995844,0.5091670949185126)
);

# String
select * from (values (null, null, null) ) t(a, b, c) where (a,b,c) in (
            ('ENfsMkSuwJ','AyXdaqvmHG','KNEglPUiLq'),
            ('YxyzjGpwqu','lTWPpGOjfM','MTqbvaKuXJ'),
            ('hSxdZWuLEj','qrGZvDlkMw','MTUxntwpQe'),
            ('kFXxnrTZAb','yTjfKwcrEU','KOmFAaelSp'),
            ('FNPZQOGzKr','aFnCQOujdU','JwTMGErynA'),
            ('EUxWSTLrNp','JTeLWKuMtv','SIZCPrXpzO'),
            ('mBzobeIVrA','QLPvGtYprB','vBOLRnlaMN'),
            ('yznCLJqmVK','WgoKkNdSLR','mwAoQsMjrt')
);
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(X) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:


