### PR TITLE
Fix impacted features inclusion in product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteClients.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteClients.java
@@ -32,7 +32,7 @@ public class SuiteClients
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinode.class)
                         .withGroups(
-                                "configured-features",
+                                "configured_features",
                                 "cli",
                                 "jdbc",
                                 "trino_jdbc")

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteFunctions.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteFunctions.java
@@ -31,7 +31,7 @@ public class SuiteFunctions
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinode.class)
-                        .withGroups("configured-features", "functions")
+                        .withGroups("configured_features", "functions")
                         .build());
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteGcs.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteGcs.java
@@ -31,7 +31,7 @@ public class SuiteGcs
     {
         return ImmutableList.of(
                 testOnEnvironment(EnvMultinodeGcs.class)
-                        .withGroups("delta-lake-gcs", "configured-features")
+                        .withGroups("delta-lake-gcs", "configured_features")
                         .build());
     }
 }


### PR DESCRIPTION
In few suites `configured_features` was misspelled as `configured-features`.
