### PR TITLE
Add support for dropping corrupted tables to Iceberg Nessie Catalog

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/TrinoNessieCatalog.java
@@ -34,6 +34,7 @@ import io.trino.spi.connector.RelationCommentMetadata;
 import io.trino.spi.connector.RelationType;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.TypeManager;
 import org.apache.iceberg.BaseTable;
@@ -47,6 +48,7 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.nessie.NessieIcebergClient;
+import org.projectnessie.model.IcebergTable;
 
 import java.util.Iterator;
 import java.util.List;
@@ -255,7 +257,14 @@ public class TrinoNessieCatalog
     @Override
     public void dropCorruptedTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        throw new TrinoException(NOT_SUPPORTED, "Cannot drop corrupted table %s from Iceberg Nessie catalog".formatted(schemaTableName));
+        IcebergTable table = nessieClient.table(toIdentifier(schemaTableName));
+        if (table == null) {
+            throw new TableNotFoundException(schemaTableName);
+        }
+        nessieClient.dropTable(toIdentifier(schemaTableName), true);
+        String tableLocation = table.getMetadataLocation().replaceFirst("/metadata/[^/]*$", "");
+        deleteTableDirectory(fileSystemFactory.create(session), schemaTableName, tableLocation);
+        invalidateTableCache(schemaTableName);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestIcebergNessieCatalogConnectorSmokeTest.java
@@ -261,14 +261,6 @@ public class TestIcebergNessieCatalogConnectorSmokeTest
                 .hasMessageContaining("metadata location for register_table is not supported");
     }
 
-    @Test
-    @Override
-    public void testDropTableWithNonExistentTableLocation()
-    {
-        assertThatThrownBy(super::testDropTableWithNonExistentTableLocation)
-                .hasMessageMatching("Cannot drop corrupted table (.*)");
-    }
-
     @Override
     protected boolean isFileSorted(Location path, String sortColumnName)
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

PR [#16674](https://github.com/trinodb/trino/pull/16674) added support for dropping corrupted Iceberg tables but the Nessie catalog implementation was missing.

Similar as done in the Glue catalog implementation, we load the metadata location from Nessie and extract the table location from it. This allows us to drop the directory where the Iceberg table is located in.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This is a follow up of [#16674](https://github.com/trinodb/trino/pull/16674)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

This is not user-visible or is docs only, and no release notes are required.