### PR TITLE
Allow building with preview features

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -11,3 +11,4 @@
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=100
+--enable-preview

--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <!-- always disable preview features for target 8 -->
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
         <main-class>io.trino.cli.Trino</main-class>
         <dep.jline.version>3.25.0</dep.jline.version>
     </properties>

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <!-- always disable preview features for target 8 -->
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
     </properties>
 
     <dependencies>

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <!-- always disable preview features for target 8 -->
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
         <shadeBase>io.trino.jdbc.\$internal</shadeBase>
     </properties>
 

--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -15,3 +15,4 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
+--enable-preview

--- a/core/trino-grammar/pom.xml
+++ b/core/trino-grammar/pom.xml
@@ -14,6 +14,8 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <!-- always disable preview features for target 8 -->
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
     </properties>
 
     <dependencies>

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -16,6 +16,8 @@
         <!-- allow dependencies with newer bytecode versions -->
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <!-- always disable preview features for target 8 -->
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
     </properties>
 
     <dependencies>

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -14,3 +14,4 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
+--enable-preview

--- a/plugin/trino-accumulo-iterators/pom.xml
+++ b/plugin/trino-accumulo-iterators/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
+        <air.compiler.enable-preview>false</air.compiler.enable-preview>
     </properties>
 
     <dependencies>

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlPlugin.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlPlugin.java
@@ -15,6 +15,8 @@ package io.trino.plugin.postgresql;
 
 import io.trino.plugin.jdbc.JdbcPlugin;
 
+import java.lang.foreign.Arena;
+
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 
 public class PostgreSqlPlugin
@@ -23,5 +25,9 @@ public class PostgreSqlPlugin
     public PostgreSqlPlugin()
     {
         super("postgresql", combine(new PostgreSqlClientModule(), new PostgreSqlConnectionFactoryModule()));
+
+        try (Arena arena = Arena.ofAuto()) {
+            System.out.println("allocated " + arena.allocate(1024));
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
         <air.javadoc.lint>-missing</air.javadoc.lint>
         <air.main.basedir>${project.basedir}</air.main.basedir>
         <air.modernizer.java-version>8</air.modernizer.java-version>
+        <air.compiler.enable-preview>true</air.compiler.enable-preview>
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
         <!--
           America/Bahia_Banderas has:

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
@@ -15,3 +15,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+--enable-preview

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
@@ -15,3 +15,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+--enable-preview

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -14,3 +14,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+--enable-preview

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -13,3 +13,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+--enable-preview

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -14,3 +14,4 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+--enable-preview


### PR DESCRIPTION
Last two commits to be dropped but first two can be merged.

In order to make this work for IntelliJ, one need to change the compiler configuration to allow for preview features for a given module or project.

This is due to the: https://youtrack.jetbrains.com/issue/IDEA-296303/Support-for-Maven-Compiler-Plugin-enablePreview-parameter