### PR TITLE
[WIP] Retry manifest iteration with cache invalidation

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -432,7 +432,7 @@ public class BackgroundHiveSplitLoader
                     fileIterators.addLast(buildManifestFileIterator(splitFactory, entry.getKey(), entry.getValue(), splittable));
                 }
                 catch (TrinoException e) {
-                    if (HIVE_FILE_NOT_FOUND.equals(e.getErrorCode()) && directoryLister instanceof CachingDirectoryLister) {
+                    if (HIVE_FILE_NOT_FOUND.toErrorCode().equals(e.getErrorCode()) && directoryLister instanceof CachingDirectoryLister) {
                         // Invalidate the cache and retry
                         if (partition.getPartition().isPresent()) {
                             directoryLister.invalidate(partition.getPartition().get());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -31,6 +31,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.hive.HiveSplit.BucketConversion;
 import io.trino.plugin.hive.HiveSplit.BucketValidation;
+import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.HiveFileIterator;
 import io.trino.plugin.hive.fs.TrinoFileStatus;


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
These changes address the problem when the new files in manifest are not visible by `directoryLister` immediately because of the caching delay (see #20344). 

The `buildManifestFileIterator()` method now throws an exception if the referenced file does not appear in the listing. The suggested code catches that exception, invalidates the cache and retries the manifest processing.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. 
## Additional context and related issues
-->


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(*) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

<!--
```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
-->