### PR TITLE
Add support for HTTP transport in thrift metastore client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -893,6 +893,7 @@ jobs:
             - suite-delta-lake-databricks113
             - suite-delta-lake-databricks122
             - suite-delta-lake-databricks133
+            - suite-databricks-unity-http-hms
             - suite-gcs
             - suite-clients
             - suite-functions
@@ -937,6 +938,11 @@ jobs:
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
             - suite: suite-delta-lake-databricks133
+              ignore exclusion if: >-
+                ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
+            - suite: suite-databricks-unity-http-hms
+              config: hdp3
+            - suite: suite-databricks-unity-http-hms
               ignore exclusion if: >-
                 ${{ env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || secrets.DATABRICKS_TOKEN != '' }}
 
@@ -985,6 +991,10 @@ jobs:
           DATABRICKS_113_JDBC_URL:
           DATABRICKS_122_JDBC_URL:
           DATABRICKS_133_JDBC_URL:
+          DATABRICKS_UNITY_JDBC_URL:
+          DATABRICKS_UNITY_CATALOG_NAME:
+          DATABRICKS_UNITY_EXTERNAL_LOCATION:
+          DATABRICKS_HOST:
           DATABRICKS_LOGIN:
           DATABRICKS_TOKEN:
           GCP_CREDENTIALS_KEY:
@@ -1052,6 +1062,10 @@ jobs:
           DATABRICKS_113_JDBC_URL: ${{ secrets.DATABRICKS_113_JDBC_URL }}
           DATABRICKS_122_JDBC_URL: ${{ secrets.DATABRICKS_122_JDBC_URL }}
           DATABRICKS_133_JDBC_URL: ${{ secrets.DATABRICKS_133_JDBC_URL }}
+          DATABRICKS_UNITY_JDBC_URL: ${{ secrets.DATABRICKS_UNITY_JDBC_URL }}
+          DATABRICKS_UNITY_CATALOG_NAME: ${{ vars.DATABRICKS_UNITY_CATALOG_NAME }}
+          DATABRICKS_UNITY_EXTERNAL_LOCATION: ${{ vars.DATABRICKS_UNITY_EXTERNAL_LOCATION }}
+          DATABRICKS_HOST: ${{ vars.DATABRICKS_HOST }}
           DATABRICKS_LOGIN: token
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           GCP_CREDENTIALS_KEY: ${{ secrets.GCP_CREDENTIALS_KEY }}

--- a/docs/src/main/sphinx/connector/metastores.md
+++ b/docs/src/main/sphinx/connector/metastores.md
@@ -185,6 +185,26 @@ properties:
 * - `hive.metastore.thrift.txn-lock-max-wait`
   - Maximum time to wait to acquire hive transaction lock.
   - `10m`
+* - ``hive.metastore.http.client.bearer-token``
+  - Bearer token used to authenticate with the metastore service
+    when https transport mode is used. This must not be set when
+    using http url.
+  -
+* - ``hive.metastore.http.client.additional-headers``
+  - Additional headers which can be sent to the metastore service
+    http thrift requests when using the http transport mode. These
+    headers must be comma-separated and delimited using ``:``. E.g
+    header1:value1,header2:value2 sends two headers header1 and
+    header2 with their values as value1 and value2 respectively.
+    If you need to use a comma(``,``) or colon(``:``) in a header name
+    or value, escape it using a backslash (``\``).
+  -
+* - ``hive.metastore.http.client.authentication.type``
+  - The authentication type to be used for the http metastore client.
+    Currently, the only supported type is ``BEARER``. When set to ``BEARER``
+    the token configured in ``hive.metastore.http.client.bearer-token``
+    is used to authenticate the client to the http metastore service.
+  -
 :::
 
 (hive-glue-metastore)=

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -195,7 +195,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
                     "hive",
                     ImmutableMap.<String, String>builder()
                             .put("hive.metastore", "thrift")
-                            .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                            .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                             .put("hive.allow-drop-table", "true")
                             .putAll(hiveStorageConfiguration())
                             .buildOrThrow());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/DeltaLakeQueryRunner.java
@@ -229,7 +229,7 @@ public final class DeltaLakeQueryRunner
                 .setCoordinatorProperties(coordinatorProperties)
                 .addExtraProperties(extraProperties)
                 .setDeltaProperties(ImmutableMap.<String, String>builder()
-                        .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                         .putAll(connectorProperties)
                         .buildOrThrow())
                 .build();

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeSharedHiveMetastoreWithViews.java
@@ -66,7 +66,7 @@ public class TestDeltaLakeSharedHiveMetastoreWithViews
                 "hive",
                 ImmutableMap.<String, String>builder()
                         .put("hive.metastore", "thrift")
-                        .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                         .put("hive.allow-drop-table", "true")
                         .putAll(s3Properties)
                         .buildOrThrow());

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -24,6 +24,7 @@
           TODO (https://github.com/trinodb/trino/issues/11294) remove when we upgrade to surefire with https://issues.apache.org/jira/browse/SUREFIRE-1967
           -->
         <air.test.parallel>instances</air.test.parallel>
+        <dep.http.version>5.2.1</dep.http.version>
     </properties>
 
     <dependencies>
@@ -208,6 +209,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${dep.http.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${dep.http.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-column</artifactId>
         </dependency>
@@ -286,6 +299,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>node</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk</artifactId>
             <scope>runtime</scope>
@@ -310,8 +329,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.13</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.parquet</groupId>
             <artifactId>parquet-common</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty.toolchain</groupId>
+            <artifactId>jetty-jakarta-servlet-api</artifactId>
             <scope>runtime</scope>
         </dependency>
 
@@ -319,6 +351,12 @@
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>http-server</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/HttpThriftMetastoreClientFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import io.trino.spi.NodeManager;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
+import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.config.Registry;
+import org.apache.hc.core5.http.config.RegistryBuilder;
+import org.apache.thrift.transport.THttpClient;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+import javax.net.ssl.SSLContext;
+
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class HttpThriftMetastoreClientFactory
+        implements ThriftMetastoreClientFactory
+{
+    private final int readTimeoutMillis;
+    private final String hostname;
+    private final Optional<ThriftHttpMetastoreConfig.AuthenticationMode> authenticationMode;
+    private final Optional<String> token;
+    private final Map<String, String> additionalHeaders;
+
+    @Inject
+    public HttpThriftMetastoreClientFactory(
+            ThriftHttpMetastoreConfig httpMetastoreConfig,
+            NodeManager nodeManager)
+    {
+        this.readTimeoutMillis = toIntExact(httpMetastoreConfig.getReadTimeout().toMillis());
+        this.hostname = requireNonNull(nodeManager.getCurrentNode().getHost(), "hostname is null");
+        this.authenticationMode = httpMetastoreConfig.getAuthenticationMode();
+        this.token = httpMetastoreConfig.getHttpBearerToken();
+        this.additionalHeaders = ImmutableMap.copyOf(httpMetastoreConfig.getAdditionalHeaders());
+    }
+
+    @Override
+    public ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
+            throws TTransportException
+    {
+        return new ThriftHiveMetastoreClient(
+                () -> createHttpTransport(uri),
+                hostname,
+                new MetastoreSupportsDateStatistics(),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE),
+                new AtomicInteger(Integer.MAX_VALUE));
+    }
+
+    private TTransport createHttpTransport(URI uri)
+            throws TTransportException
+    {
+        HttpClientBuilder httpClientBuilder = HttpClientBuilder.create();
+        if ("https".equals(uri.getScheme().toLowerCase(ENGLISH))) {
+            checkArgument(token.isPresent(), "'hive.metastore.http.client.bearer-token' must be set while using https metastore URIs in 'hive.metastore.uri'");
+            checkArgument(authenticationMode.isPresent(), "'hive.metastore.http.client.authentication.type' must be set while using http/https metastore URIs in 'hive.metastore.uri'");
+            SSLConnectionSocketFactory socketFactory;
+            try {
+                socketFactory = new SSLConnectionSocketFactory(SSLContext.getDefault(), new DefaultHostnameVerifier());
+            }
+            catch (NoSuchAlgorithmException e) {
+                throw new TTransportException(e);
+            }
+            Registry<ConnectionSocketFactory> registry = RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("https", socketFactory)
+                    .build();
+            httpClientBuilder.setConnectionManager(new BasicHttpClientConnectionManager(registry));
+            httpClientBuilder.addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) -> httpRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token.get()));
+        }
+        else {
+            checkArgument(token.isEmpty(), "'hive.metastore.http.client.bearer-token' must not be set while using http metastore URIs in 'hive.metastore.uri'");
+        }
+        httpClientBuilder.addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) -> additionalHeaders.forEach(httpRequest::addHeader));
+        httpClientBuilder.setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS).build());
+        return new THttpClient(uri.toString(), httpClientBuilder.build());
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.metastore.thrift;
 import com.google.common.base.Splitter;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import jakarta.validation.constraints.AssertFalse;
 import jakarta.validation.constraints.NotNull;
 
 import java.net.URI;
@@ -66,5 +67,24 @@ public class StaticMetastoreConfig
     {
         this.metastoreUsername = metastoreUsername;
         return this;
+    }
+
+    @AssertFalse(message = "'hive.metastore.uri' cannot contain both http and https URI schemes")
+    public boolean isMetastoreHttpUrisValid()
+    {
+        boolean hasHttpMetastore = metastoreUris.stream().anyMatch(uri -> "http".equalsIgnoreCase(uri.getScheme()));
+        boolean hasHttpsMetastore = metastoreUris.stream().anyMatch(uri -> "https".equalsIgnoreCase(uri.getScheme()));
+        if (hasHttpsMetastore || hasHttpMetastore) {
+            return hasHttpMetastore && hasHttpsMetastore;
+        }
+        return false;
+    }
+
+    @AssertFalse(message = "'hive.metastore.uri' cannot contain both http(s) and thrift URI schemes")
+    public boolean isEitherThriftOrHttpMetastore()
+    {
+        boolean hasHttpMetastore = metastoreUris.stream().anyMatch(uri -> "http".equalsIgnoreCase(uri.getScheme()) || "https".equalsIgnoreCase(uri.getScheme()));
+        boolean hasThriftMetastore = metastoreUris.stream().anyMatch(uri -> "thrift".equalsIgnoreCase(uri.getScheme()));
+        return hasHttpMetastore && hasThriftMetastore;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareHttpMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareHttpMetastoreClientFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.trino.spi.security.ConnectorIdentity;
+import org.apache.thrift.TException;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class StaticTokenAwareHttpMetastoreClientFactory
+        implements IdentityAwareMetastoreClientFactory
+{
+    private final ThriftMetastoreClientFactory clientProvider;
+    private final ImmutableList<URI> metastoreUris;
+
+    @Inject
+    StaticTokenAwareHttpMetastoreClientFactory(StaticMetastoreConfig config, ThriftMetastoreClientFactory clientProvider)
+    {
+        this.clientProvider = requireNonNull(clientProvider, "clientProvider is null");
+        this.metastoreUris = config.getMetastoreUris().stream()
+                .map(StaticTokenAwareHttpMetastoreClientFactory::checkMetastoreUri)
+                .collect(toImmutableList());
+    }
+
+    private static URI checkMetastoreUri(URI uri)
+    {
+        requireNonNull(uri, "uri is null");
+        String scheme = uri.getScheme();
+        checkArgument(!isNullOrEmpty(scheme), "metastoreUri scheme is missing: %s", uri);
+        checkArgument(scheme.equals("https") || scheme.equals("http"), "metastoreUri scheme must be http or https: %s", uri);
+        checkArgument(uri.getHost() != null, "metastoreUri host is missing: %s", uri);
+        return uri;
+    }
+
+    @Override
+    public ThriftMetastoreClient createMetastoreClientFor(Optional<ConnectorIdentity> identity)
+            throws TException
+    {
+        TException lastException = null;
+        for (URI metastoreUri : metastoreUris) {
+            try {
+                return clientProvider.create(metastoreUri, Optional.empty());
+            }
+            catch (TException e) {
+                lastException = e;
+            }
+        }
+        throw lastException;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticTokenAwareMetastoreClientFactory.java
@@ -76,8 +76,7 @@ public class StaticTokenAwareMetastoreClientFactory
         checkArgument(!metastoreUris.isEmpty(), "metastoreUris must specify at least one URI");
         this.backoffs = metastoreUris.stream()
                 .map(StaticTokenAwareMetastoreClientFactory::checkMetastoreUri)
-                .map(uri -> HostAndPort.fromParts(uri.getHost(), uri.getPort()))
-                .map(address -> new Backoff(address, ticker))
+                .map(uri -> new Backoff(uri, ticker))
                 .collect(toImmutableList());
 
         this.metastoreUsername = metastoreUsername;
@@ -105,7 +104,7 @@ public class StaticTokenAwareMetastoreClientFactory
         TException lastException = null;
         for (Backoff backoff : backoffsSorted) {
             try {
-                return getClient(backoff.getAddress(), backoff, delegationToken);
+                return getClient(backoff.getUri(), backoff, delegationToken);
             }
             catch (TException e) {
                 lastException = e;
@@ -116,10 +115,10 @@ public class StaticTokenAwareMetastoreClientFactory
         throw new TException("Failed connecting to Hive metastore: " + addresses, lastException);
     }
 
-    private ThriftMetastoreClient getClient(HostAndPort address, Backoff backoff, Optional<String> delegationToken)
+    private ThriftMetastoreClient getClient(URI uri, Backoff backoff, Optional<String> delegationToken)
             throws TException
     {
-        ThriftMetastoreClient client = new FailureAwareThriftMetastoreClient(clientFactory.create(address, delegationToken), new Callback()
+        ThriftMetastoreClient client = new FailureAwareThriftMetastoreClient(clientFactory.create(uri, delegationToken), new Callback()
         {
             @Override
             public void success()
@@ -156,20 +155,25 @@ public class StaticTokenAwareMetastoreClientFactory
         static final long MIN_BACKOFF = new Duration(50, MILLISECONDS).roundTo(NANOSECONDS);
         static final long MAX_BACKOFF = new Duration(60, SECONDS).roundTo(NANOSECONDS);
 
-        private final HostAndPort address;
+        private final URI uri;
         private final Ticker ticker;
         private long backoffDuration = MIN_BACKOFF;
         private OptionalLong lastFailureTimestamp = OptionalLong.empty();
 
-        Backoff(HostAndPort address, Ticker ticker)
+        Backoff(URI uri, Ticker ticker)
         {
-            this.address = requireNonNull(address, "address is null");
+            this.uri = requireNonNull(uri, "uri is null");
             this.ticker = requireNonNull(ticker, "ticker is null");
         }
 
         public HostAndPort getAddress()
         {
-            return address;
+            return HostAndPort.fromParts(uri.getHost(), uri.getPort());
+        }
+
+        public URI getUri()
+        {
+            return uri;
         }
 
         synchronized void fail()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreConfig.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+import io.airlift.units.Duration;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class ThriftHttpMetastoreConfig
+{
+    public enum AuthenticationMode
+    {
+        BEARER
+    }
+
+    private Duration readTimeout = new Duration(60, TimeUnit.SECONDS);
+    private AuthenticationMode authenticationMode;
+    private Optional<String> httpBearerToken = Optional.empty();
+    private Map<String, String> additionalHeaders = ImmutableMap.of();
+
+    @NotNull
+    public Duration getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    @Config("hive.metastore.http.client.read-timeout")
+    @ConfigDescription("Socket read timeout for metastore client")
+    public ThriftHttpMetastoreConfig setReadTimeout(Duration readTimeout)
+    {
+        this.readTimeout = readTimeout;
+        return this;
+    }
+
+    @NotNull
+    public Optional<AuthenticationMode> getAuthenticationMode()
+    {
+        return Optional.ofNullable(authenticationMode);
+    }
+
+    @Config("hive.metastore.http.client.authentication.type")
+    @ConfigDescription("Authentication mode for thrift http based metastore client")
+    public ThriftHttpMetastoreConfig setAuthenticationMode(AuthenticationMode authenticationMode)
+    {
+        this.authenticationMode = authenticationMode;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getHttpBearerToken()
+    {
+        return httpBearerToken;
+    }
+
+    @Config("hive.metastore.http.client.bearer-token")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Bearer token to authenticate with a HTTP transport based metastore service")
+    public ThriftHttpMetastoreConfig setHttpBearerToken(String httpBearerToken)
+    {
+        this.httpBearerToken = Optional.ofNullable(httpBearerToken);
+        return this;
+    }
+
+    public Map<String, String> getAdditionalHeaders()
+    {
+        return additionalHeaders;
+    }
+
+    @Config("hive.metastore.http.client.additional-headers")
+    @ConfigDescription("Comma separated key:value pairs to be send to metastore as additional headers")
+    public ThriftHttpMetastoreConfig setAdditionalHeaders(String httpHeaders)
+    {
+        try {
+            // we allow escaping the delimiters like , and : using back-slash.
+            // To support that we create a negative lookbehind of , and : which
+            // are not preceded by a back-slash.
+            String headersDelim = "(?<!\\\\),";
+            String kvDelim = "(?<!\\\\):";
+            Map<String, String> temp = new HashMap<>();
+            if (httpHeaders != null) {
+                for (String kv : httpHeaders.split(headersDelim)) {
+                    String key = kv.split(kvDelim, 2)[0].trim();
+                    String val = kv.split(kvDelim, 2)[1].trim();
+                    temp.put(key, val);
+                }
+                this.additionalHeaders = ImmutableMap.copyOf(temp);
+            }
+        }
+        catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(String.format("Invalid format for 'hive.metastore.http.client.additional-headers'. " +
+                    "Value provided is %s", httpHeaders), e);
+        }
+        return this;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHttpMetastoreFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.inject.Inject;
+import io.airlift.units.Duration;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.plugin.hive.util.RetryDriver;
+import io.trino.spi.security.ConnectorIdentity;
+import org.weakref.jmx.Flatten;
+import org.weakref.jmx.Managed;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class ThriftHttpMetastoreFactory
+        implements ThriftMetastoreFactory
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final IdentityAwareMetastoreClientFactory metastoreClientFactory;
+    private final ExecutorService writeStatisticsExecutor;
+    private final ThriftMetastoreStats stats = new ThriftMetastoreStats();
+
+    @Inject
+    public ThriftHttpMetastoreFactory(
+            TrinoFileSystemFactory fileSystemFactory,
+            IdentityAwareMetastoreClientFactory metastoreClientFactory,
+            @ThriftHiveWriteStatisticsExecutor ExecutorService writeStatisticsExecutor)
+    {
+        this.fileSystemFactory = requireNonNull(fileSystemFactory, "fileSystemFactory is null");
+        this.metastoreClientFactory = requireNonNull(metastoreClientFactory, "metastoreClientFactory is null");
+        this.writeStatisticsExecutor = requireNonNull(writeStatisticsExecutor, "writeStatisticsExecutor is null");
+    }
+
+    @Override
+    public boolean isImpersonationEnabled()
+    {
+        return false;
+    }
+
+    @Override
+    public ThriftMetastore createMetastore(Optional<ConnectorIdentity> identity)
+    {
+        // we pass the default values from the ThriftMetastoreConfig for most of these
+        // parameters, as they are not used in the in HttpMetastore implementation.
+        // if needed we can make them configurable for these parameters in the future.
+        return new ThriftHiveMetastore(
+                identity,
+                fileSystemFactory,
+                metastoreClientFactory,
+                RetryDriver.DEFAULT_SCALE_FACTOR,
+                RetryDriver.DEFAULT_SLEEP_TIME,
+                RetryDriver.DEFAULT_SLEEP_TIME,
+                RetryDriver.DEFAULT_MAX_RETRY_TIME,
+                new Duration(10, MINUTES),
+                RetryDriver.DEFAULT_MAX_ATTEMPTS,
+                false,
+                false,
+                false,
+                false,
+                true,
+                stats,
+                writeStatisticsExecutor);
+    }
+
+    @Managed
+    @Flatten
+    public ThriftMetastoreStats getStats()
+    {
+        return stats;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClientFactory.java
@@ -13,13 +13,13 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
-import com.google.common.net.HostAndPort;
 import org.apache.thrift.transport.TTransportException;
 
+import java.net.URI;
 import java.util.Optional;
 
 public interface ThriftMetastoreClientFactory
 {
-    ThriftMetastoreClient create(HostAndPort address, Optional<String> delegationToken)
+    ThriftMetastoreClient create(URI uri, Optional<String> delegationToken)
             throws TTransportException;
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -379,7 +379,9 @@ public final class ThriftMetastoreUtil
 
         return Database.builder()
                 .setDatabaseName(database.getName())
-                .setLocation(Optional.ofNullable(database.getLocationUri()))
+                // Some metastore implementations like Databricks Unity Catalog can return empty strings
+                // for database locations. We treat them as null.
+                .setLocation(Optional.ofNullable(emptyToNull(database.getLocationUri())))
                 .setOwnerName(Optional.of(ownerName))
                 .setOwnerType(Optional.of(ownerType))
                 .setComment(Optional.ofNullable(database.getDescription()))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestingThriftHiveMetastoreBuilder.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.hdfs.HdfsFileSystemFactory;
@@ -27,6 +26,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
 import io.trino.plugin.hive.metastore.thrift.TokenAwareMetastoreClientFactory;
 import io.trino.plugin.hive.metastore.thrift.UgiBasedMetastoreClientFactory;
 
+import java.net.URI;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -51,7 +51,15 @@ public final class TestingThriftHiveMetastoreBuilder
 
     private TestingThriftHiveMetastoreBuilder() {}
 
-    public TestingThriftHiveMetastoreBuilder metastoreClient(HostAndPort address, Duration timeout)
+    public TestingThriftHiveMetastoreBuilder metastoreClient(URI metastoreUri)
+    {
+        requireNonNull(metastoreUri, "metastoreUri is null");
+        checkState(tokenAwareMetastoreClientFactory == null, "Metastore client already set");
+        tokenAwareMetastoreClientFactory = new TestingTokenAwareMetastoreClientFactory(HiveTestUtils.SOCKS_PROXY, metastoreUri);
+        return this;
+    }
+
+    public TestingThriftHiveMetastoreBuilder metastoreClient(URI address, Duration timeout)
     {
         requireNonNull(address, "address is null");
         requireNonNull(timeout, "timeout is null");
@@ -60,19 +68,11 @@ public final class TestingThriftHiveMetastoreBuilder
         return this;
     }
 
-    public TestingThriftHiveMetastoreBuilder metastoreClient(HostAndPort address, MetastoreClientAdapterProvider metastoreClientAdapterProvider)
+    public TestingThriftHiveMetastoreBuilder metastoreClient(URI uri, MetastoreClientAdapterProvider metastoreClientAdapterProvider)
     {
-        requireNonNull(address, "address is null");
+        requireNonNull(uri, "uri is null");
         checkState(tokenAwareMetastoreClientFactory == null, "Metastore client already set");
-        tokenAwareMetastoreClientFactory = new TestingTokenAwareMetastoreClientFactory(HiveTestUtils.SOCKS_PROXY, address, TIMEOUT, metastoreClientAdapterProvider);
-        return this;
-    }
-
-    public TestingThriftHiveMetastoreBuilder metastoreClient(HostAndPort address)
-    {
-        requireNonNull(address, "address is null");
-        checkState(tokenAwareMetastoreClientFactory == null, "Metastore client already set");
-        tokenAwareMetastoreClientFactory = new TestingTokenAwareMetastoreClientFactory(HiveTestUtils.SOCKS_PROXY, address);
+        tokenAwareMetastoreClientFactory = new TestingTokenAwareMetastoreClientFactory(HiveTestUtils.SOCKS_PROXY, uri, TIMEOUT, metastoreClientAdapterProvider);
         return this;
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
@@ -22,6 +22,7 @@ import io.trino.testing.containers.BaseTestContainer;
 import io.trino.testing.containers.PrintingLogConsumer;
 import org.testcontainers.containers.Network;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -91,9 +92,10 @@ public class HiveHadoop
         return executeInContainerFailOnError("mysql", "-D", "metastore", "-uroot", "-proot", "--batch", "--column-names=false", "-e", query).replaceAll("\n$", "");
     }
 
-    public HostAndPort getHiveMetastoreEndpoint()
+    public URI getHiveMetastoreEndpoint()
     {
-        return getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+        HostAndPort address = getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+        return URI.create("thrift://" + address.getHost() + ":" + address.getPort());
     }
 
     public static class Builder

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestHiveMetastoreMetadataQueriesAccessOperations.java
@@ -85,7 +85,7 @@ public class TestHiveMetastoreMetadataQueriesAccessOperations
                 .setNodeCount(1)
                 .addCoordinatorProperty("optimizer.experimental-max-prefetched-information-schema-prefixes", Integer.toString(MAX_PREFIXES_COUNT))
                 .addHiveProperty("hive.metastore", "thrift")
-                .addHiveProperty("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                .addHiveProperty("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                 .addHiveProperty("hive.metastore.thrift.batch-fetch.enabled", "true")
                 .addHiveProperty("hive.hive-views.enabled", "true")
                 .setCreateTpchSchemas(false)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreClient.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.hive.thrift.metastore.Database;
+import io.trino.hive.thrift.metastore.NoSuchObjectException;
+import io.trino.testing.TestingNodeManager;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.trino.plugin.hive.TestingThriftHiveMetastoreBuilder.testingThriftHiveMetastoreBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestThriftHttpMetastoreClient
+{
+    private static ThriftMetastore delegate;
+
+    @BeforeAll
+    public static void setup()
+            throws Exception
+    {
+        File tempDir = Files.createTempDirectory(null).toFile();
+        tempDir.deleteOnExit();
+        delegate = testingThriftHiveMetastoreBuilder().metastoreClient(createFakeMetastoreClient()).build();
+    }
+
+    private static ThriftMetastoreClient createFakeMetastoreClient()
+    {
+        return new MockThriftMetastoreClient()
+        {
+            @Override
+            public Database getDatabase(String databaseName)
+                    throws NoSuchObjectException
+            {
+                if (databaseName.equals("testDbName")) {
+                    return new Database(databaseName, "testOwner", "testLocation", Map.of("key", "value"));
+                }
+                throw new NoSuchObjectException("Database does not exist");
+            }
+
+            @Override
+            public List<String> getAllDatabases()
+            {
+                return ImmutableList.of("testDbName");
+            }
+        };
+    }
+
+    @Test
+    public void testHttpThriftConnection()
+            throws Exception
+    {
+        ThriftHttpMetastoreConfig config = new ThriftHttpMetastoreConfig();
+        config.setAuthenticationMode(ThriftHttpMetastoreConfig.AuthenticationMode.BEARER);
+        config.setAdditionalHeaders("key1:value1, key2:value2");
+
+        try (TestingThriftHttpMetastoreServer metastoreServer = new TestingThriftHttpMetastoreServer(delegate, new TestRequestHeaderInterceptor())) {
+            ThriftMetastoreClientFactory factory = new HttpThriftMetastoreClientFactory(config, new TestingNodeManager());
+            URI metastoreUri = URI.create("http://localhost:" + metastoreServer.getPort());
+            ThriftMetastoreClient client = factory.create(
+                    metastoreUri, Optional.empty());
+            assertThat(client.getAllDatabases()).containsExactly("testDbName");
+            assertThat(client.getDatabase("testDbName")).isEqualTo(new Database("testDbName", "testOwner", "testLocation", Map.of("key", "value")));
+            // negative case
+            assertThatThrownBy(() -> client.getDatabase("does-not-exist")).isInstanceOf(NoSuchObjectException.class);
+        }
+    }
+
+    private static class TestRequestHeaderInterceptor
+            implements Consumer<HttpServletRequest>
+    {
+        @Override
+        public void accept(HttpServletRequest httpServletRequest)
+        {
+            assertThat(Collections.list(httpServletRequest.getHeaderNames())).contains("key1", "key2");
+            assertThat(httpServletRequest.getHeader("key1")).isEqualTo("value1");
+            assertThat(httpServletRequest.getHeader("key2")).isEqualTo("value2");
+            assertThat(httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION)).isNull();
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftHttpMetastoreConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.hive.metastore.thrift.ThriftHttpMetastoreConfig.AuthenticationMode.BEARER;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestThriftHttpMetastoreConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(ThriftHttpMetastoreConfig.class)
+                .setReadTimeout(new Duration(60, SECONDS))
+                .setHttpBearerToken(null)
+                .setAdditionalHeaders(null)
+                .setAuthenticationMode(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.http.client.bearer-token", "test-token")
+                .put("hive.metastore.http.client.additional-headers", "key\\:1:value\\,1, key\\,2:value\\:2")
+                .put("hive.metastore.http.client.authentication.type", "BEARER")
+                .put("hive.metastore.http.client.read-timeout", "1s")
+                .buildOrThrow();
+
+        ThriftHttpMetastoreConfig expected = new ThriftHttpMetastoreConfig()
+                .setHttpBearerToken("test-token")
+                .setAdditionalHeaders("key\\:1:value\\,1, key\\,2:value\\:2")
+                .setReadTimeout(new Duration(1, SECONDS))
+                .setAuthenticationMode(BEARER);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingThriftHttpMetastoreServer.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingThriftHttpMetastoreServer.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.thrift;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import com.google.inject.TypeLiteral;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.airlift.http.server.HttpServerInfo;
+import io.airlift.http.server.TheServlet;
+import io.airlift.http.server.testing.TestingHttpServerModule;
+import io.airlift.node.testing.TestingNodeModule;
+import io.trino.hive.thrift.metastore.Database;
+import io.trino.hive.thrift.metastore.NoSuchObjectException;
+import io.trino.hive.thrift.metastore.ThriftHiveMetastore;
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.thrift.TProcessor;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.server.TServlet;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.google.common.reflect.Reflection.newProxy;
+
+public class TestingThriftHttpMetastoreServer
+        implements Closeable
+{
+    private final TestingThriftHttpServlet thriftHttpServlet;
+    private final LifeCycleManager lifeCycleManager;
+    private final URI baseUri;
+
+    public TestingThriftHttpMetastoreServer(ThriftMetastore delegate, Consumer<HttpServletRequest> requestInterceptor)
+    {
+        ThriftHiveMetastore.Iface mockThriftHandler = proxyHandler(delegate, ThriftHiveMetastore.Iface.class);
+        TProcessor processor = new ThriftHiveMetastore.Processor<>(mockThriftHandler);
+        thriftHttpServlet = new TestingThriftHttpServlet(processor, new TBinaryProtocol.Factory(), requestInterceptor);
+        Bootstrap app = new Bootstrap(
+                new TestingNodeModule(),
+                new TestingHttpServerModule(),
+                binder -> {
+                    binder.bind(new TypeLiteral<Map<String, String>>() {}).annotatedWith(TheServlet.class).toInstance(ImmutableMap.of());
+                    binder.bind(Servlet.class).annotatedWith(TheServlet.class).toInstance(thriftHttpServlet);
+                });
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .initialize();
+
+        lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        HttpServerInfo httpServerInfo = injector.getInstance(HttpServerInfo.class);
+        baseUri = httpServerInfo.getHttpUri();
+    }
+
+    private static <T> T proxyHandler(ThriftMetastore delegate, Class<T> iface)
+    {
+        return newProxy(iface, (proxy, method, args) -> switch (method.getName()) {
+            case "getAllDatabases" -> delegate.getAllDatabases();
+            case "getDatabase" -> {
+                Optional<Database> optionalDatabase = delegate.getDatabase(args[0].toString());
+                yield optionalDatabase.orElseThrow(() -> new NoSuchObjectException(""));
+            }
+            default -> throw new UnsupportedOperationException();
+        });
+    }
+
+    public int getPort()
+    {
+        return baseUri.getPort();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        lifeCycleManager.stop();
+    }
+
+    private static class TestingThriftHttpServlet
+            extends TServlet
+    {
+        private final Consumer<HttpServletRequest> requestInterceptor;
+
+        public TestingThriftHttpServlet(
+                TProcessor processor,
+                TProtocolFactory protocolFactory,
+                Consumer<HttpServletRequest> requestInterceptor)
+        {
+            super(processor, protocolFactory);
+            this.requestInterceptor = requestInterceptor;
+        }
+
+        @Override
+        protected void doPost(HttpServletRequest request,
+                HttpServletResponse response)
+                throws ServletException, IOException
+        {
+            requestInterceptor.accept(request);
+            super.doPost(request, response);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestingTokenAwareMetastoreClientFactory.java
@@ -17,6 +17,7 @@ import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import org.apache.thrift.TException;
 
+import java.net.URI;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -29,24 +30,24 @@ public class TestingTokenAwareMetastoreClientFactory
     public static final Duration TIMEOUT = new Duration(20, SECONDS);
 
     private final DefaultThriftMetastoreClientFactory factory;
-    private final HostAndPort address;
+    private final URI address;
 
     private final MetastoreClientAdapterProvider metastoreClientAdapterProvider;
 
-    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI uri)
     {
-        this(socksProxy, address, TIMEOUT, delegate -> delegate);
+        this(socksProxy, uri, TIMEOUT, delegate -> delegate);
     }
 
-    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI address, Duration timeout)
     {
         this(socksProxy, address, timeout, delegate -> delegate);
     }
 
-    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, HostAndPort address, Duration timeout, MetastoreClientAdapterProvider metastoreClientAdapterProvider)
+    public TestingTokenAwareMetastoreClientFactory(Optional<HostAndPort> socksProxy, URI uri, Duration timeout, MetastoreClientAdapterProvider metastoreClientAdapterProvider)
     {
         this.factory = new DefaultThriftMetastoreClientFactory(Optional.empty(), socksProxy, timeout, timeout, AUTHENTICATION, "localhost");
-        this.address = requireNonNull(address, "address is null");
+        this.address = requireNonNull(uri, "uri is null");
         this.metastoreClientAdapterProvider = requireNonNull(metastoreClientAdapterProvider, "metastoreClientAdapterProvider is null");
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.s3;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.HostAndPort;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
@@ -28,6 +27,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import io.trino.tpch.TpchTable;
 
+import java.net.URI;
 import java.util.Locale;
 import java.util.Map;
 
@@ -76,7 +76,7 @@ public final class S3HiveQueryRunner
     public static class Builder
             extends HiveQueryRunner.Builder<Builder>
     {
-        private HostAndPort hiveMetastoreEndpoint;
+        private URI hiveMetastoreEndpoint;
         private Duration thriftMetastoreTimeout = TestingTokenAwareMetastoreClientFactory.TIMEOUT;
         private ThriftMetastoreConfig thriftMetastoreConfig = new ThriftMetastoreConfig();
         private String s3Region;
@@ -86,7 +86,7 @@ public final class S3HiveQueryRunner
         private String bucketName;
 
         @CanIgnoreReturnValue
-        public Builder setHiveMetastoreEndpoint(HostAndPort hiveMetastoreEndpoint)
+        public Builder setHiveMetastoreEndpoint(URI hiveMetastoreEndpoint)
         {
             this.hiveMetastoreEndpoint = requireNonNull(hiveMetastoreEndpoint, "hiveMetastoreEndpoint is null");
             return this;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergMinioConnectorSmokeTest.java
@@ -71,7 +71,7 @@ public abstract class BaseIcebergMinioConnectorSmokeTest
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
-                                .put("hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint())
+                                .put("hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("fs.hadoop.enabled", "false")
                                 .put("fs.native-s3.enabled", "true")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -227,7 +227,7 @@ public final class IcebergQueryRunner
                             "http-server.http.port", "8080"))
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
-                            "hive.metastore.uri", "thrift://" + hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint(),
+                            "hive.metastore.uri", hiveMinioDataLake.getHiveHadoop().getHiveMetastoreEndpoint().toString(),
                             "fs.hadoop.enabled", "false",
                             "fs.native-s3.enabled", "true",
                             "s3.aws-access-key", MINIO_ACCESS_KEY,
@@ -332,7 +332,7 @@ public final class IcebergQueryRunner
                             "http-server.http.port", "8080"))
                     .setIcebergProperties(Map.of(
                             "iceberg.catalog.type", "HIVE_METASTORE",
-                            "hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint(),
+                            "hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString(),
                             "hive.azure.abfs-storage-account", azureAccount,
                             "hive.azure.abfs-access-key", azureAccessKey))
                     .setSchemaInitializer(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAbfsConnectorSmokeTest.java
@@ -84,7 +84,7 @@ public class TestIcebergAbfsConnectorSmokeTest
                         ImmutableMap.<String, String>builder()
                                 .put("iceberg.file-format", format.name())
                                 .put("iceberg.catalog.type", "HIVE_METASTORE")
-                                .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                                .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                                 .put("hive.metastore.thrift.client.read-timeout", "1m") // read timed out sometimes happens with the default timeout
                                 .put("hive.azure.abfs-storage-account", account)
                                 .put("hive.azure.abfs-access-key", accessKey)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergGcsConnectorSmokeTest.java
@@ -97,7 +97,7 @@ public class TestIcebergGcsConnectorSmokeTest
                         .put("fs.hadoop.enabled", "false")
                         .put("fs.native-gcs.enabled", "true")
                         .put("gcs.json-key", gcpCredentials)
-                        .put("hive.metastore.uri", "thrift://" + hiveHadoop.getHiveMetastoreEndpoint())
+                        .put("hive.metastore.uri", hiveHadoop.getHiveMetastoreEndpoint().toString())
                         .put("iceberg.file-format", format.name())
                         .put("iceberg.register-table-procedure.enabled", "true")
                         .put("iceberg.writer-sort-buffer-size", "1MB")

--- a/testing/trino-product-tests-groups/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests-groups/src/main/java/io/trino/tests/product/TestGroups.java
@@ -91,6 +91,7 @@ public final class TestGroups
     public static final String DELTA_LAKE_DATABRICKS_104 = "delta-lake-databricks-104";
     public static final String DELTA_LAKE_DATABRICKS_113 = "delta-lake-databricks-113";
     public static final String DELTA_LAKE_DATABRICKS_122 = "delta-lake-databricks-122";
+    public static final String DATABRICKS_UNITY_HTTP_HMS = "databricks-unity-http-hms";
     public static final String DELTA_LAKE_EXCLUDE_91 = "delta-lake-exclude-91";
     public static final String DELTA_LAKE_ALLUXIO_CACHING = "delta-lake-alluxio-caching";
     public static final String HUDI = "hudi";

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeDatabricksHttpHms.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env.environment;
+
+import com.google.inject.Inject;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.DockerContainer;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentProvider;
+import io.trino.tests.product.launcher.env.common.StandardMultinode;
+import io.trino.tests.product.launcher.env.common.TestsEnvironment;
+
+import java.io.File;
+
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.configureTempto;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
+import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+@TestsEnvironment
+public class EnvMultinodeDatabricksHttpHms
+        extends EnvironmentProvider
+{
+    private static final File DATABRICKS_JDBC_PROVIDER = new File("testing/trino-product-tests-launcher/target/databricks-jdbc.jar");
+
+    private final DockerFiles.ResourceProvider configDir;
+
+    @Inject
+    public EnvMultinodeDatabricksHttpHms(StandardMultinode standardMultinode, DockerFiles dockerFiles)
+    {
+        super(standardMultinode);
+        requireNonNull(dockerFiles, "dockerFiles is null");
+        configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment/multinode-databricks-http-hms");
+    }
+
+    @Override
+    public void extendEnvironment(Environment.Builder builder)
+    {
+        String databricksTestJdbcUrl = requireNonNull(getEnvVariable("DATABRICKS_UNITY_JDBC_URL"), "Environment DATABRICKS_UNITY_JDBC_URL was not set");
+        String databricksTestLogin = requireNonNull(getEnvVariable("DATABRICKS_LOGIN"), "Environment DATABRICKS_LOGIN was not set");
+        String databricksTestToken = requireNonNull(getEnvVariable("DATABRICKS_TOKEN"), "Environment DATABRICKS_TOKEN was not set");
+        String awsRegion = requireNonNull(getEnvVariable("AWS_REGION"), "Environment AWS_REGION was not set");
+
+        builder.configureContainers(container -> {
+            if (isTrinoContainer(container.getLogicalName())) {
+                exportAwsCredentials(container)
+                        .withEnv("AWS_REGION", awsRegion)
+                        .withEnv("DATABRICKS_TOKEN", databricksTestToken)
+                        .withEnv("DATABRICKS_HOST", getEnvVariable("DATABRICKS_HOST"))
+                        .withEnv("DATABRICKS_UNITY_CATALOG_NAME", getEnvVariable("DATABRICKS_UNITY_CATALOG_NAME"));
+            }
+        });
+
+        builder.configureContainer(TESTS, container -> exportAwsCredentials(container)
+                .withEnv("DATABRICKS_JDBC_URL", databricksTestJdbcUrl)
+                .withEnv("DATABRICKS_LOGIN", databricksTestLogin)
+                .withEnv("DATABRICKS_TOKEN", databricksTestToken)
+                .withEnv("DATABRICKS_UNITY_CATALOG_NAME", getEnvVariable("DATABRICKS_UNITY_CATALOG_NAME"))
+                .withEnv("DATABRICKS_UNITY_EXTERNAL_LOCATION", getEnvVariable("DATABRICKS_UNITY_EXTERNAL_LOCATION"))
+                .withCopyFileToContainer(
+                        forHostPath(DATABRICKS_JDBC_PROVIDER.getAbsolutePath()),
+                        "/docker/jdbc/databricks-jdbc.jar"));
+
+        builder.addConnector("hive", forHostPath(configDir.getPath("hive.properties")));
+        builder.addConnector(
+                "delta_lake",
+                forHostPath(configDir.getPath("delta.properties")),
+                CONTAINER_TRINO_ETC + "/catalog/delta.properties");
+        configureTempto(builder, configDir);
+    }
+
+    private static String getEnvVariable(String name)
+    {
+        String credentialValue = System.getenv(name);
+        if (credentialValue == null) {
+            throw new IllegalStateException(format("Environment variable %s not set", name));
+        }
+        return credentialValue;
+    }
+
+    private DockerContainer exportAwsCredentials(DockerContainer container)
+    {
+        container = exportAwsCredential(container, "TRINO_AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID", true);
+        container = exportAwsCredential(container, "TRINO_AWS_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY", true);
+        return exportAwsCredential(container, "TRINO_AWS_SESSION_TOKEN", "AWS_SESSION_TOKEN", false);
+    }
+
+    private static DockerContainer exportAwsCredential(DockerContainer container, String credentialEnvVariable, String containerEnvVariable, boolean required)
+    {
+        String credentialValue = System.getenv(credentialEnvVariable);
+        if (credentialValue == null) {
+            if (required) {
+                throw new IllegalStateException(format("Environment variable %s not set", credentialEnvVariable));
+            }
+            return container;
+        }
+        return container.withEnv(containerEnvVariable, credentialValue);
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDatabricksUnityHttpHms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/SuiteDatabricksUnityHttpHms.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.suite.suites;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.environment.EnvMultinodeDatabricksHttpHms;
+import io.trino.tests.product.launcher.suite.Suite;
+import io.trino.tests.product.launcher.suite.SuiteTestRun;
+
+import java.util.List;
+
+import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
+
+public class SuiteDatabricksUnityHttpHms
+        extends Suite
+{
+    @Override
+    public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
+    {
+        return ImmutableList.of(
+                testOnEnvironment(EnvMultinodeDatabricksHttpHms.class)
+                        .withGroups("configured_features", "databricks-unity-http-hms")
+                        .build());
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/delta.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/delta.properties
@@ -1,0 +1,8 @@
+connector.name=delta_lake
+hive.metastore.uri=https://${ENV:DATABRICKS_HOST}:443/api/2.0/unity-hms-proxy/metadata
+hive.metastore.http.client.bearer-token=${ENV:DATABRICKS_TOKEN}
+hive.metastore.http.client.additional-headers=X-Databricks-Catalog-Name:${ENV:DATABRICKS_UNITY_CATALOG_NAME}
+hive.metastore.http.client.authentication.type=BEARER
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
+hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL
+delta.enable-non-concurrent-writes=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/hive.properties
@@ -1,0 +1,7 @@
+connector.name=hive
+hive.metastore.uri=https://${ENV:DATABRICKS_HOST}:443/api/2.0/unity-hms-proxy/metadata
+hive.metastore.http.client.bearer-token=${ENV:DATABRICKS_TOKEN}
+hive.metastore.http.client.additional-headers=X-Databricks-Catalog-Name:${ENV:DATABRICKS_UNITY_CATALOG_NAME}
+hive.metastore.http.client.authentication.type=BEARER
+# We need to give access to bucket owner (the AWS account integrated with Databricks), otherwise files won't be readable from Databricks
+hive.s3.upload-acl-type=BUCKET_OWNER_FULL_CONTROL

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/tempto-configuration.yaml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-databricks-http-hms/tempto-configuration.yaml
@@ -1,0 +1,16 @@
+databases:
+  presto:
+    jdbc_user: root
+  delta:
+    jdbc_driver_class: com.databricks.client.jdbc.Driver
+    jdbc_jar: /docker/jdbc/databricks-jdbc.jar
+    schema: default
+    prepare_statement:
+      - USE ${databases.delta.schema}
+    table_manager_type: jdbc
+    jdbc_url: ${DATABRICKS_JDBC_URL};EnableArrow=0
+    jdbc_user: ${DATABRICKS_LOGIN}
+    jdbc_password: ${DATABRICKS_TOKEN}
+
+s3:
+  server_type: aws

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUnityCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/TestDeltaLakeDatabricksUnityCompatibility.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tempto.AfterMethodWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.tempto.assertions.QueryAssert;
+import io.trino.testng.services.Flaky;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DATABRICKS_UNITY_HTTP_HMS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestDeltaLakeDatabricksUnityCompatibility
+        extends ProductTest
+{
+    private final String schemaName = "test_delta_basic_" + randomNameSuffix();
+    private String unityCatalogName;
+    private String externalLocationPath;
+
+    @BeforeMethodWithContext
+    public void setUp()
+    {
+        unityCatalogName = requireNonNull(System.getenv("DATABRICKS_UNITY_CATALOG_NAME"), "Environment variable not set: DATABRICKS_UNITY_CATALOG_NAME");
+        externalLocationPath = requireNonNull(System.getenv("DATABRICKS_UNITY_EXTERNAL_LOCATION"), "Environment variable not set: DATABRICKS_UNITY_EXTERNAL_LOCATION");
+        onDelta().executeQuery(format("CREATE SCHEMA %s.%s", unityCatalogName, schemaName));
+    }
+
+    @AfterMethodWithContext
+    public void cleanUp()
+    {
+        onDelta().executeQuery(format("DROP SCHEMA IF EXISTS %s.%s CASCADE", unityCatalogName, schemaName));
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testBasicTableReadWrite()
+    {
+        String tableName = "test_read_write_" + randomNameSuffix();
+        String deltaTableName = "delta.%s.%s".formatted(schemaName, tableName);
+        String unityTableName = "%s.%s.%s".formatted(unityCatalogName, schemaName, tableName);
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+
+        onDelta().executeQuery("CREATE TABLE " + unityTableName + " (c1 int, c2 string) USING delta LOCATION '" + tableLocation + "'");
+        onDelta().executeQuery("INSERT INTO " + unityTableName + " VALUES (1, 'one')");
+
+        assertThat(onTrino().executeQuery("SHOW SCHEMAS FROM delta"))
+                .contains(row(schemaName.toLowerCase(ENGLISH)));
+
+        assertThat(onTrino().executeQuery("SHOW TABLES IN delta." + schemaName))
+                .containsOnly(row(tableName.toLowerCase(ENGLISH)));
+
+        // select
+        assertThat(onTrino().executeQuery("SELECT * FROM " + deltaTableName))
+                .containsOnly(row(1, "one"));
+
+        // insert
+        List<QueryAssert.Row> expectedRowsForInsert = ImmutableList.of(row(1, "one"), row(2, "two"));
+        onTrino().executeQuery("INSERT INTO " + deltaTableName + " VALUES (2, 'two')");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + deltaTableName))
+                .containsOnly(expectedRowsForInsert);
+        assertThat(onDelta().executeQuery("SELECT * FROM " + unityTableName))
+                .containsOnly(expectedRowsForInsert);
+
+        // update
+        List<QueryAssert.Row> expectedRowsForUpdate = ImmutableList.of(row(1, "one"), row(2, "two hundred"));
+        onTrino().executeQuery("UPDATE " + deltaTableName + " SET c2 = 'two hundred' WHERE c1 = 2");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + deltaTableName))
+                .containsOnly(expectedRowsForUpdate);
+        assertThat(onDelta().executeQuery("SELECT * FROM " + unityTableName))
+                .containsOnly(expectedRowsForUpdate);
+
+        // delete
+        List<QueryAssert.Row> expectedRowsForDelete = ImmutableList.of(row(2, "two hundred"));
+        onTrino().executeQuery("DELETE FROM " + deltaTableName + " WHERE c2 = 'one'");
+        assertThat(onTrino().executeQuery("SELECT * FROM " + deltaTableName))
+                .containsOnly(expectedRowsForDelete);
+        assertThat(onDelta().executeQuery("SELECT * FROM " + unityTableName))
+                .containsOnly(expectedRowsForDelete);
+
+        // merge
+        List<QueryAssert.Row> expectedRowsForMerge = ImmutableList.of(row(1, "one"), row(2, "two"), row(3, "three"));
+        String sourceTableName = "test_source_" + randomNameSuffix();
+        String tableLocation2 = format("%s/%s/%s", externalLocationPath, schemaName, sourceTableName);
+        onDelta().executeQuery(format("CREATE TABLE %s.%s.%s (c1 int, c2 string) using delta location '%s'", unityCatalogName, schemaName, sourceTableName, tableLocation2));
+        onDelta().executeQuery(format("INSERT INTO %s.%s.%s values (1, 'one'), (2, 'two'), (3, 'three')", unityCatalogName, schemaName, sourceTableName));
+
+        onTrino().executeQuery(format("MERGE INTO delta.%s.%s t USING delta.%s.%s s on t.c1 = s.c1 " +
+                "WHEN MATCHED THEN UPDATE SET c2 = s.c2 " +
+                "WHEN NOT MATCHED THEN INSERT (c1, c2) VALUES (s.c1, s.c2)", schemaName, tableName, schemaName, sourceTableName));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + deltaTableName))
+                .containsOnly(expectedRowsForMerge);
+        assertThat(onDelta().executeQuery("SELECT * FROM " + unityTableName))
+                .containsOnly(expectedRowsForMerge);
+    }
+
+    /**
+     * The Unity Catalog's HMS API has a limitation where managed tables are not supported. This test
+     * verifies that if a managed table is created using Databricks delta lake, Trino which connects
+     * to Unity Catalog's HMS endpoint doesn't see it.
+     */
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testManagedTable()
+    {
+        String tableName = "test_managed_table_" + randomNameSuffix();
+        String unityTableName = "%s.%s.%s".formatted(unityCatalogName, schemaName, tableName);
+
+        onDelta().executeQuery("CREATE TABLE " + unityTableName + " (c1 int, c2 string)");
+        assertThat(onTrino().executeQuery("SHOW CREATE SCHEMA delta." + schemaName))
+                .containsOnly(row("CREATE SCHEMA delta." + schemaName));
+        assertThat(onTrino().executeQuery("SHOW TABLES IN delta." + schemaName)).hasNoRows();
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testColumnTypes()
+    {
+        String tableName = "test_column_types" + randomNameSuffix();
+        String deltaTableName = "delta.%s.%s".formatted(schemaName, tableName);
+        String unityTableName = "%s.%s.%s".formatted(unityCatalogName, schemaName, tableName);
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+
+        onDelta().executeQuery(format("CREATE TABLE %s (" +
+                "int_col INT," +
+                "string_col STRING," +
+                "tinyint_col TINYINT," +
+                "smallint_col SMALLINT," +
+                "bigint_col BIGINT," +
+                "decimal_col DECIMAL," +
+                "float_col FLOAT," +
+                "double_col DOUBLE," +
+                "date_col DATE," +
+                "timestamp_col TIMESTAMP," +
+                "binary_col BINARY," +
+                "bool_col BOOLEAN," +
+                "array_int_col ARRAY<int>," +
+                "map_col MAP<TIMESTAMP,INT>," +
+                "struct_col struct<a: LONG, b: String NOT NULL>" +
+                ") " +
+                "USING DELTA " +
+                "LOCATION '%s'", unityTableName, tableLocation));
+        assertThat(
+                onTrino().executeQuery("SHOW TABLES IN delta." + schemaName))
+                .containsOnly(row(tableName));
+        assertThat(
+                onTrino().executeQuery("SHOW COLUMNS IN " + deltaTableName))
+                .containsOnly(
+                    row("int_col", "integer", "", ""),
+                    row("string_col", "varchar", "", ""),
+                    row("tinyint_col", "tinyint", "", ""),
+                    row("smallint_col", "smallint", "", ""),
+                    row("bigint_col", "bigint", "", ""),
+                    row("decimal_col", "decimal(10,0)", "", ""),
+                    row("float_col", "real", "", ""),
+                    row("double_col", "double", "", ""),
+                    row("date_col", "date", "", ""),
+                    row("timestamp_col", "timestamp(3) with time zone", "", ""),
+                    row("binary_col", "varbinary", "", ""),
+                    row("bool_col", "boolean", "", ""),
+                    row("array_int_col", "array(integer)", "", ""),
+                    row("map_col", "map(timestamp(3) with time zone, integer)", "", ""),
+                    row("struct_col", "row(a bigint, b varchar)", "", ""));
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testUnsupportedStatements()
+    {
+        String tableName = "test_unsupported_" + randomNameSuffix();
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+        String trinoLocation = format("%s/%s", externalLocationPath, "trino_test_" + randomNameSuffix());
+
+        onDelta().executeQuery(format("CREATE TABLE %s.%s.%s (c1 int, c2 string) USING delta LOCATION '%s'", unityCatalogName, schemaName, tableName, tableLocation));
+
+        assertQueryFailure(() -> onTrino().executeQuery(format("CREATE TABLE delta.%s.new_table (c1 int) WITH (location = '%s')", schemaName, trinoLocation)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("CREATE TABLE delta.%s.new_table (c1) WITH (location = '%s') AS SELECT 1", schemaName, trinoLocation)))
+                .hasRootCauseMessage("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE delta.%s.%s RENAME TO delta.%s.new_t1", schemaName, tableName, schemaName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("DROP TABLE delta.%s.%s", schemaName, tableName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+        assertQueryFailure(() -> onTrino().executeQuery(format("DROP SCHEMA delta.%s CASCADE", schemaName)))
+                .hasMessageContaining("DDL not enabled in Hive metastore interface.");
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDatabricksUnityCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDatabricksUnityCompatibility.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.tempto.AfterMethodWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
+import io.trino.tempto.ProductTest;
+import io.trino.testng.services.Flaky;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.testing.TestingNames.randomNameSuffix;
+import static io.trino.tests.product.TestGroups.DATABRICKS_UNITY_HTTP_HMS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_ISSUE;
+import static io.trino.tests.product.deltalake.util.DeltaLakeTestUtils.DATABRICKS_COMMUNICATION_FAILURE_MATCH;
+import static io.trino.tests.product.utils.QueryExecutors.onDelta;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHiveDatabricksUnityCompatibility
+        extends ProductTest
+{
+    private String unityCatalogName;
+    private String externalLocationPath;
+    private final String schemaName = "test_basic_hive_" + randomNameSuffix();
+
+    @BeforeMethodWithContext
+    public void setUp()
+    {
+        unityCatalogName = requireNonNull(System.getenv("DATABRICKS_UNITY_CATALOG_NAME"), "Environment variable not set: DATABRICKS_UNITY_CATALOG_NAME");
+        externalLocationPath = requireNonNull(System.getenv("DATABRICKS_UNITY_EXTERNAL_LOCATION"), "Environment variable not set: DATABRICKS_UNITY_EXTERNAL_LOCATION");
+        String schemaLocation = format("%s/%s", externalLocationPath, schemaName);
+        onDelta().executeQuery("CREATE SCHEMA " + unityCatalogName + "." + schemaName + " MANAGED LOCATION '" + schemaLocation + "'");
+    }
+
+    @AfterMethodWithContext
+    public void cleanUp()
+    {
+        onDelta().executeQuery("DROP SCHEMA IF EXISTS " + unityCatalogName + "." + schemaName + " CASCADE");
+    }
+
+    @Test(groups = {DATABRICKS_UNITY_HTTP_HMS, PROFILE_SPECIFIC_TESTS})
+    @Flaky(issue = DATABRICKS_COMMUNICATION_FAILURE_ISSUE, match = DATABRICKS_COMMUNICATION_FAILURE_MATCH)
+    public void testBasicHiveOperations()
+    {
+        String tableName = "test_table_" + randomNameSuffix();
+        String hiveTableName = "hive.%s.%s".formatted(schemaName, tableName);
+        String unityTableName = "%s.%s.%s".formatted(unityCatalogName, schemaName, tableName);
+        String tableLocation = format("%s/%s/%s", externalLocationPath, schemaName, tableName);
+
+        onDelta().executeQuery("CREATE TABLE " + unityTableName + "(c1 int, c2 string) USING PARQUET LOCATION '" + tableLocation + "'");
+        onDelta().executeQuery("INSERT INTO " + unityTableName + " VALUES (1, 'one')");
+
+        assertThat(onTrino().executeQuery("SHOW SCHEMAS FROM hive"))
+                .contains(row(schemaName));
+
+        assertThat(onTrino().executeQuery("SHOW TABLES IN hive." + schemaName))
+                .containsOnly(row(tableName));
+
+        assertThat(onTrino().executeQuery("SELECT * FROM " + hiveTableName))
+                .containsOnly(row(1, "one"));
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMetastoreClientFactory.java
@@ -13,7 +13,6 @@
  */
 package io.trino.tests.product.hive;
 
-import com.google.common.net.HostAndPort;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.airlift.units.Duration;
@@ -50,8 +49,6 @@ public final class TestHiveMetastoreClientFactory
             throws TException
     {
         URI metastore = URI.create("thrift://" + metastoreHost + ":" + metastorePort);
-        return thriftMetastoreClientFactory.create(
-                HostAndPort.fromParts(metastore.getHost(), metastore.getPort()),
-                Optional.empty());
+        return thriftMetastoreClientFactory.create(metastore, Optional.empty());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR adds support for using HTTP as the transport for the thrift metastore client. In this mode the hive.metastore.uri can support a http(s) URL to the metastore service. Since each thrift API is a POST request to the the metastore endpoint, this PR also adds support for adding a HTTP bearer token which must be configured to authenticate the metastore client to the metastore server. The token can be configured using a configuration hive.metastore.http.client.bearer-token. To support Databricks Unity Catalog's HMS API interface, the configuration hive.metastore.http.client.additional-headers must be set to X-Databricks-Unity-Catalog-Name=<catalog_name> where the catalog_name is the name of the catalog object in Databricks Unity Catalog.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Thrift has support HTTP based transport for a long time. Ref https://github.com/apache/thrift/blob/master/lib/javame/src/org/apache/thrift/transport/THttpClient.java. We have used the http mode for thrift on various services in other projects like HiveServer2 in Apache Hive and Apache Spark for a while now.

More recently, Apache Hive also added support for Hive Metastore server to use HTTP mode.
https://issues.apache.org/jira/browse/HIVE-21456

This PR modifies the logic in HttpThriftMetastoreClientFactory to instantiate THttpClient for the transport when creating the thrift metastore client.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or docs only and no release notes are required.
( ) Release notes are required, please propose a release note for me.
(x) Release notes are required, with the following suggested text:

Add HTTP support for the thrift metastore client.
