### PR TITLE
Fix divide by zero

### DIFF
--- a/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
+++ b/core/trino-main/src/main/java/io/trino/event/QueryMonitor.java
@@ -92,6 +92,7 @@ import static io.trino.execution.QueryState.QUEUED;
 import static io.trino.execution.StageInfo.getAllStages;
 import static io.trino.sql.planner.planprinter.PlanPrinter.jsonDistributedPlan;
 import static io.trino.sql.planner.planprinter.PlanPrinter.textDistributedPlan;
+import static io.trino.util.MoreMath.firstNonNaN;
 import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 import static java.time.Duration.ofMillis;
@@ -717,7 +718,7 @@ public class QueryMonitor
                 (long) snapshot.getMin(),
                 (long) snapshot.getMax(),
                 (long) snapshot.getTotal(),
-                snapshot.getTotal() / snapshot.getCount());
+                firstNonNaN(snapshot.getTotal() / snapshot.getCount(), 0.0));
     }
 
     private static List<StageOutputBufferUtilization> getStageOutputBufferUtilizations(QueryInfo queryInfo)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fix calculating `zero/zero` when setting [StageCpuDistribution average](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageCpuDistribution.java) value and set it as 0.0 value when snapshot has no info for stage. 

e.g) Sample data for `List<StageCpuDistribution>` in [QueryStatistics](https://github.com/trinodb/trino/blob/master/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java#L128) shows that in some stages, tasks/p values is all zero so snapshot total/count is also zero.
> [{"stageId":"0","tasks":"0","p25":"0","p50":"0","p75":"0","p90":"0","p95":"0","p99":"0","min":"0","max":"0","total":"0","average":"NaN"},{"stageId":"1","tasks":"93","p25":"3","p50":"3","p75":"3","p90":"3","p95":"3","p99":"7","min":"1","max":"7","total":"274","average":"2.946236559139785"},{"stageId":"2","tasks":"1","p25":"1","p50":"1","p75":"1","p90":"1","p95":"1","p99":"1","min":"1","max":"1","total":"1","average":"1.0"},{"stageId":"3","tasks":"100","p25":"1","p50":"1","p75":"1","p90":"1","p95":"1","p99":"1","min":"0","max":"1","total":"99","average":"0.99"},{"stageId":"4","tasks":"0","p25":"0","p50":"0","p75":"0","p90":"0","p95":"0","p99":"0","min":"0","max":"0","total":"0","average":"NaN"},{"stageId":"5","tasks":"100","p25":"1","p50":"1","p75":"1","p90":"1","p95":"1","p99":"1","min":"1","max":"1","total":"100","average":"1.0"},{"stageId":"6","tasks":"0","p25":"0","p50":"0","p75":"0","p90":"0","p95":"0","p99":"0","min":"0","max":"0","total":"0","average":"NaN"},{"stageId":"7","tasks":"0","p25":"0","p50":"0","p75":"0","p90":"0","p95":"0","p99":"0","min":"0","max":"0","total":"0","average":"NaN"}]

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
