### PR TITLE
Only set partition count for HASH partitioned exchanges in FTE

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -636,6 +636,11 @@ public final class PlanMatchPattern
         return exchange(scope, Optional.empty(), Optional.of(partitioningHandle), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), ImmutableList.of(), Optional.of(partitionCount), sources);
     }
 
+    public static PlanMatchPattern exchange(ExchangeNode.Scope scope, ExchangeNode.Type type, PartitioningHandle partitioningHandle, Optional<Integer> partitionCount, PlanMatchPattern... sources)
+    {
+        return exchange(scope, Optional.of(type), Optional.of(partitioningHandle), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), ImmutableList.of(), Optional.of(partitionCount), sources);
+    }
+
     public static PlanMatchPattern exchange(
             ExchangeNode.Scope scope,
             Optional<ExchangeNode.Type> type,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeterminePartitionCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeterminePartitionCount.java
@@ -26,6 +26,7 @@ import io.trino.spi.statistics.Estimate;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.sql.planner.plan.AggregationNode;
+import io.trino.sql.planner.plan.DynamicFilterSourceNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.LocalQueryRunner;
@@ -34,13 +35,22 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static io.trino.SystemSessionProperties.FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT;
+import static io.trino.SystemSessionProperties.FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT;
+import static io.trino.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
 import static io.trino.SystemSessionProperties.MAX_HASH_PARTITION_COUNT;
 import static io.trino.SystemSessionProperties.MIN_HASH_PARTITION_COUNT;
 import static io.trino.SystemSessionProperties.MIN_INPUT_ROWS_PER_TASK;
 import static io.trino.SystemSessionProperties.MIN_INPUT_SIZE_PER_TASK;
+import static io.trino.SystemSessionProperties.RETRY_POLICY;
 import static io.trino.spi.statistics.TableStatistics.empty;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
@@ -67,6 +77,7 @@ public class TestDeterminePartitionCount
                 .withGetTableHandle((session, tableName) -> {
                     if (tableName.getTableName().equals("table_with_stats_a")
                             || tableName.getTableName().equals("table_with_stats_b")
+                            || tableName.getTableName().equals("small_table_with_stats")
                             || tableName.getTableName().equals("table_without_stats_a")
                             || tableName.getTableName().equals("table_without_stats_b")) {
                         return new MockConnectorTableHandle(tableName);
@@ -86,6 +97,15 @@ public class TestDeterminePartitionCount
                                         new ColumnStatistics(Estimate.of(0), Estimate.of(10000), Estimate.of(DataSize.of(100, MEGABYTE).toBytes()), Optional.empty()),
                                         new MockConnectorColumnHandle("column_b", VARCHAR),
                                         new ColumnStatistics(Estimate.of(0), Estimate.of(10000), Estimate.of(DataSize.of(100, MEGABYTE).toBytes()), Optional.empty())));
+                    }
+                    if (tableName.getTableName().equals("small_table_with_stats")) {
+                        return new TableStatistics(
+                                Estimate.of(20),
+                                ImmutableMap.of(
+                                        new MockConnectorColumnHandle("column_a", VARCHAR),
+                                        new ColumnStatistics(Estimate.of(0), Estimate.of(20), Estimate.of(DataSize.of(1, KILOBYTE).toBytes()), Optional.empty()),
+                                        new MockConnectorColumnHandle("column_b", VARCHAR),
+                                        new ColumnStatistics(Estimate.of(0), Estimate.of(20), Estimate.of(DataSize.of(1, KILOBYTE).toBytes()), Optional.empty())));
                     }
                     return empty();
                 })
@@ -467,5 +487,288 @@ public class TestDeterminePartitionCount
                                                 exchange(REMOTE, REPARTITION, Optional.of(10),
                                                         node(AggregationNode.class,
                                                                 node(TableScanNode.class))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetries()
+    {
+        @Language("SQL") String query = """
+                SELECT count(column_a) FROM table_with_stats_a group by column_b
+                """;
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "21")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .build(),
+                output(
+                        project(
+                                node(AggregationNode.class,
+                                        exchange(LOCAL,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(10),
+                                                        node(AggregationNode.class,
+                                                                node(TableScanNode.class))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesMinEnforced()
+    {
+        @Language("SQL") String query = """
+                SELECT count(column_a) FROM table_with_stats_a group by column_b
+                """;
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "21")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "11")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .build(),
+                output(
+                        project(
+                                node(AggregationNode.class,
+                                        exchange(LOCAL,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(11),
+                                                        node(AggregationNode.class,
+                                                                node(TableScanNode.class))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesMaxEnforced()
+    {
+        @Language("SQL") String query = """
+                SELECT count(column_a) FROM table_with_stats_a group by column_b
+                """;
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "8")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .build(),
+                output(
+                        project(
+                                node(AggregationNode.class,
+                                        exchange(LOCAL,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.empty(),
+                                                        node(AggregationNode.class,
+                                                                node(TableScanNode.class))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesJoinHashDistribution()
+    {
+        @Language("SQL") String query = """
+                SELECT a.column_a FROM table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("column_a", "column_a_0")
+                                .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(10),
+                                        node(FilterNode.class,
+                                                tableScan("table_with_stats_a", ImmutableMap.of("column_a", "column_a")))))
+                                .right(exchange(LOCAL,
+                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(10),
+                                                node(DynamicFilterSourceNode.class,
+                                                        tableScan("table_with_stats_b", ImmutableMap.of("column_a_0", "column_a")))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesJoinBroadcastJoin()
+    {
+        @Language("SQL") String query = """
+                SELECT a.column_a FROM table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "broadcast")
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("column_a", "column_a_0")
+                                        .left(node(FilterNode.class,
+                                                tableScan("table_with_stats_a", ImmutableMap.of("column_a", "column_a"))))
+                                        .right(exchange(LOCAL,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION, Optional.empty(),
+                                                        node(DynamicFilterSourceNode.class,
+                                                                tableScan("table_with_stats_b", ImmutableMap.of("column_a_0", "column_a")))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesTwoPartitionedJoins()
+    {
+        @Language("SQL") String query = """
+                SELECT a.column_a FROM
+                   (table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a)
+                   JOIN
+                   small_table_with_stats s ON a.column_b = s.column_b
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned") // enforce partitioned joins
+                        .setSystemProperty(JOIN_REORDERING_STRATEGY, "none") // keep syntactic order
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("column_b", "column_b_3")
+                                .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                        join(INNER, builder2 -> builder2
+                                                                .equiCriteria("column_a", "column_a_0")
+                                                                .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                                        node(FilterNode.class,
+                                                                                tableScan("table_with_stats_a", ImmutableMap.of("column_a", "column_a", "column_b", "column_b")))))
+                                                                .right(exchange(LOCAL,
+                                                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                                                node(DynamicFilterSourceNode.class,
+                                                                                        tableScan("table_with_stats_b", ImmutableMap.of("column_a_0", "column_a")))))))))
+                                .right(exchange(LOCAL,
+                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                node(DynamicFilterSourceNode.class,
+                                                        tableScan("small_table_with_stats", ImmutableMap.of("column_b_3", "column_b")))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesTwoBroadcastJoins()
+    {
+        @Language("SQL") String query = """
+                SELECT a.column_a FROM
+                   (table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a)
+                   JOIN
+                   small_table_with_stats s ON a.column_b = s.column_b
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "broadcast") // enforce broadcast joins
+                        .setSystemProperty(JOIN_REORDERING_STRATEGY, "none") // keep syntactic order
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("column_b", "column_b_3")
+                                .left(join(INNER, builder2 -> builder2
+                                                .equiCriteria("column_a", "column_a_0")
+                                        .left(node(FilterNode.class,
+                                                tableScan("table_with_stats_a", ImmutableMap.of("column_a", "column_a", "column_b", "column_b"))))
+                                        .right(exchange(LOCAL,
+                                                exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION, Optional.empty(),
+                                                        tableScan("table_with_stats_b", ImmutableMap.of("column_a_0", "column_a")))))))
+                                .right(exchange(LOCAL,
+                                        exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION, Optional.empty(),
+                                                tableScan("small_table_with_stats", ImmutableMap.of("column_b_3", "column_b"))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesBroadcastJoinOverPartitionedJoin()
+    {
+        @Language("SQL") String query = """
+                SELECT a.column_a FROM
+                   (table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a)
+                   JOIN
+                   small_table_with_stats s ON a.column_b = s.column_b
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .setSystemProperty(JOIN_REORDERING_STRATEGY, "none") // keep syntactic order
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .equiCriteria("column_b", "column_b_3")
+                                .left(join(INNER, builder2 -> builder2
+                                        .equiCriteria("column_a", "column_a_0")
+                                        .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                node(FilterNode.class,
+                                                        tableScan("table_with_stats_a", ImmutableMap.of("column_a", "column_a", "column_b", "column_b")))))
+                                        .right(exchange(LOCAL,
+                                                exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                        node(DynamicFilterSourceNode.class,
+                                                                tableScan("table_with_stats_b", ImmutableMap.of("column_a_0", "column_a"))))))))
+                                .right(exchange(LOCAL,
+                                        exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION, Optional.empty(),
+                                                node(DynamicFilterSourceNode.class,
+                                                        tableScan("small_table_with_stats", ImmutableMap.of("column_b_3", "column_b")))))))));
+    }
+
+    @Test
+    public void testFireWithTaskRetriesArbitraryExchangeOverHashDistributedStage()
+    {
+        @Language("SQL") String query = """
+                SELECT j.column_a FROM
+                   ((SELECT a.column_a, a.column_b FROM table_with_stats_a as a JOIN table_with_stats_b as b ON a.column_a = b.column_a) UNION ALL SELECT * FROM small_table_with_stats s) j
+                   JOIN
+                   small_table_with_stats s2 ON j.column_b = s2.column_b
+                """;
+
+        assertDistributedPlan(
+                query,
+                Session.builder(getQueryRunner().getDefaultSession())
+                        .setSystemProperty(RETRY_POLICY, "task")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MAX_PARTITION_COUNT, "50")
+                        .setSystemProperty(FAULT_TOLERANT_EXECUTION_MIN_PARTITION_COUNT, "4")
+                        .setSystemProperty(MIN_INPUT_SIZE_PER_TASK, "20MB")
+                        .setSystemProperty(MIN_INPUT_ROWS_PER_TASK, "400")
+                        .setSystemProperty(JOIN_REORDERING_STRATEGY, "none") // keep syntactic order
+                        .build(),
+                output(
+                        join(INNER, builder -> builder
+                                .ignoreEquiCriteria() // criteria uses new symbols output by exchange left exchange which cannot be expressed in plan matcher
+                                .left(exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION, Optional.of(15),
+                                        join(INNER, builder2 -> builder2
+                                                .equiCriteria("column_a_0", "column_a_2")
+                                                .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                        node(FilterNode.class,
+                                                                tableScan("table_with_stats_a", ImmutableMap.of("column_a_0", "column_a", "column_b_1", "column_b")))))
+                                                .right(exchange(LOCAL,
+                                                        exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),
+                                                                node(DynamicFilterSourceNode.class,
+                                                                        tableScan("table_with_stats_b", ImmutableMap.of("column_a_2", "column_a"))))))),
+                                        node(FilterNode.class,
+                                                tableScan("small_table_with_stats", ImmutableMap.of("column_a_4", "column_a", "column_b_5", "column_b")))))
+
+                                .right(exchange(LOCAL,
+                                        exchange(REMOTE, REPLICATE, FIXED_BROADCAST_DISTRIBUTION, Optional.empty(),
+                                                node(DynamicFilterSourceNode.class,
+                                                        tableScan("small_table_with_stats", ImmutableMap.of("column_b_7", "column_b")))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeterminePartitionCount.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeterminePartitionCount.java
@@ -753,7 +753,7 @@ public class TestDeterminePartitionCount
                 output(
                         join(INNER, builder -> builder
                                 .ignoreEquiCriteria() // criteria uses new symbols output by exchange left exchange which cannot be expressed in plan matcher
-                                .left(exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION, Optional.of(15),
+                                .left(exchange(REMOTE, REPARTITION, FIXED_ARBITRARY_DISTRIBUTION, Optional.empty(),
                                         join(INNER, builder2 -> builder2
                                                 .equiCriteria("column_a_0", "column_a_2")
                                                 .left(exchange(REMOTE, REPARTITION, FIXED_HASH_DISTRIBUTION, Optional.of(15),


### PR DESCRIPTION
The notion of partitions count make sense for pipelined exection even
for arbitrary partitioned exchanges as it directly translates to number
of execution tasks.

In FTE the number of partitions for arbitrary distributed exchanges is
alwasy 1 and number of tasks comes from the bin-packing logic done in
Split assigner.