### PR TITLE
Fix link title in Kafka docs

### DIFF
--- a/docs/src/main/sphinx/connector/kafka.md
+++ b/docs/src/main/sphinx/connector/kafka.md
@@ -910,7 +910,8 @@ for the equivalent Avro field type.
 
 No other types are supported.
 
-The following example shows an Avro field definition in a [kafka.table-description-dirition file](#table-definition-files) for a Kafka message:
+The following example shows an Avro field definition in a [table definition
+file](#table-definition-files) for a Kafka message:
 
 ```json
 {


### PR DESCRIPTION
## Description

This is just a quick fix. I will probably send another PR for a major clean up of that doc.

## Additional context and related issues

Also @Jessie212 is there some outstanding work on all those decoders/encoders to be brought into consistent fragment usage or am I remembering wrongly and that work is already complete? 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
