### PR TITLE
Improve spilling docs for workers

### DIFF
--- a/docs/src/main/sphinx/admin/properties-spilling.md
+++ b/docs/src/main/sphinx/admin/properties-spilling.md
@@ -49,14 +49,16 @@ to saturate the underlying spilling device (for example, when using RAID).
 - **Type:** {ref}`prop-type-data-size`
 - **Default value:** `100GB`
 
-Max spill space to be used by all queries on a single node.
+Max spill space to use by all queries on a single node. Configuration on worker
+nodes only is sufficient.
 
 ## `query-max-spill-per-node`
 
 - **Type:** {ref}`prop-type-data-size`
 - **Default value:** `100GB`
 
-Max spill space to be used by a single query on a single node.
+Max spill space to use by a single query on a single node. Configuration on
+worker nodes only is sufficient.
 
 ## `aggregation-operator-unspill-memory-limit`
 


### PR DESCRIPTION
## Description

See title. Plus https://trino.io/docs/current/admin/properties.html contains 

"Unless specified otherwise, configuration properties must be set on the coordinator and all worker nodes." 

this adds a "specified otherwise"

## Additional context and related issues

Fixes #4012 


## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
