### PR TITLE
Pass InternalNode to HttpRemoteTask constructor

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRemoteTaskFactory.java
@@ -153,7 +153,7 @@ public class HttpRemoteTaskFactory
                 session,
                 stageSpan,
                 taskId,
-                node.getNodeIdentifier(),
+                node,
                 speculative,
                 locationFactory.createTaskLocation(node, taskId),
                 fragment,

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -57,6 +57,7 @@ import io.trino.execution.buffer.OutputBuffers;
 import io.trino.execution.buffer.PipelinedBufferInfo;
 import io.trino.execution.buffer.PipelinedOutputBuffers;
 import io.trino.execution.buffer.SpoolingOutputStats;
+import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
 import io.trino.operator.RetryPolicy;
 import io.trino.operator.TaskStats;
@@ -210,7 +211,7 @@ public final class HttpRemoteTask
             Session session,
             Span stageSpan,
             TaskId taskId,
-            String nodeId,
+            InternalNode node,
             boolean speculative,
             URI location,
             PlanFragment planFragment,
@@ -240,7 +241,7 @@ public final class HttpRemoteTask
         requireNonNull(session, "session is null");
         requireNonNull(stageSpan, "stageSpan is null");
         requireNonNull(taskId, "taskId is null");
-        requireNonNull(nodeId, "nodeId is null");
+        requireNonNull(node, "node is null");
         requireNonNull(location, "location is null");
         requireNonNull(planFragment, "planFragment is null");
         requireNonNull(outputBuffers, "outputBuffers is null");
@@ -258,7 +259,7 @@ public final class HttpRemoteTask
             this.taskId = taskId;
             this.session = session;
             this.stageSpan = stageSpan;
-            this.nodeId = nodeId;
+            this.nodeId = node.getNodeIdentifier();
             this.speculative = new AtomicBoolean(speculative);
             this.planFragment = planFragment;
             this.outputBuffers.set(outputBuffers);


### PR DESCRIPTION
This allows us to extract more info than just the node ID in the future.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Pass richer info into the `HttpRemoteTask` constructor, allowing it to do more in the future.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Right now we only pass the node identifier string into `HttpRemoteTask()`.  This doesn't let the task access, eg, the node's address.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
