### PR TITLE
Add Trino 437 release notes

### DIFF
--- a/docs/release-template.md
+++ b/docs/release-template.md
@@ -1,4 +1,4 @@
-# Release xyz (dd MMM 2023)
+# Release xyz (dd MMM 2024)
 
 ## General
 

--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-437
 release/release-436
 ```
 

--- a/docs/src/main/sphinx/release/release-437.md
+++ b/docs/src/main/sphinx/release/release-437.md
@@ -1,0 +1,33 @@
+# Release 437 (24 Jan 2024)
+
+## General
+
+* Add support for `char(n)` values in {func}`to_utf8`. ({issue}`20158`)
+* Add support for `char(n)` values in {func}`lpad`. ({issue}`16907`)
+* {{breaking}} Replace the `exchange.compression-enabled` configuration property
+  and `exchange_compression` session property with
+  [the`exchange.compression-codec`and `exchange_compression_codec` properties](prop-exchange-compression-codec),
+  respectively. ({issue}`20274`)
+* {{breaking}} Replace the `spill-compression-enabled` configuration property 
+  with [the `spill-compression-codec` property](prop-spill-compression-codec). ({issue}`20274`)
+* {{breaking}} Remove the deprecated `experimental.spill-compression-enabled`
+  configuration property. ({issue}`20274`)
+* Fix materialized views being permanently stale when they reference
+  [table functions](/functions/table). ({issue}`19904`)
+* Fix failure when invoking functions that may return null values. ({issue}`18456`)
+* Fix `ArrayIndexOutOfBoundsException` with RowBlockBuilder during output
+  operations. ({issue}`20426`)
+
+## Delta Lake connector
+
+* Improve query performance for queries that don't use table statistics. ({issue}`20054`)
+
+## Hive connector
+
+* Fix error when coercing union-typed data to a single type when reading Avro
+  files. ({issue}`20310`)
+
+## Iceberg connector
+
+* Improve performance of queries with filters on `ROW` columns stored in Parquet
+  files. ({issue}`17133`)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Assemble the release notes for the upcoming Trino 437 release. Fixes #20353 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.

## Verification for each pull request

Format: maintainer, PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 11 Jan 2024

* #20351 ✅ rn ✅ docs
* #20354 ✅ rn ✅ docs

## 12 Jan 2024

* #20350 ✅ rn ✅ docs
* #20328 ✅ rn ✅ docs
* #20345 ✅ rn ✅ docs
* #20352 ✅ rn ✅ docs
* #20160 ✅ rn ✅ docs
* #20357 ✅ rn ✅ docs
* #20322 ✅ rn ✅ docs
* #20356 ✅ rn ✅ docs
* #20321 ✅ rn ✅ docs
* #20158 ✅ rn ❌ docs
* #20358 ✅ rn ✅ docs
* #20364 ✅ rn ✅ docs

## 13 Jan 2024

* #20365 ✅ rn ✅ docs
* #20370 ✅ rn ✅ docs

## 14 Jan 2024

* #20369 ✅ rn ✅ docs
* #20241 ✅ rn ✅ docs
* #20090 ✅ rn ✅ docs

## 15 Jan 2024

* #12623 ✅ rn ✅ docs
* #18745 ✅ rn ✅ docs
* #20382 ✅ rn ✅ docs
* #20054 ✅ rn ✅ docs
* #20381 ✅ rn ✅ docs

## 16 Jan 2024

* #20386 ✅ rn ✅ docs
* #16907 ✅ rn ❌ docs
* #20399 ✅ rn ✅ docs

## 17 Jan 2024

* #20211 ✅ rn ✅ docs
* #20355 ✅ rn ✅ docs
* #20403 ✅ rn ✅ docs
* #20406 ✅ rn ✅ docs

## 18 Jan 2024

* #20408 ✅ rn ✅ docs
* #17133 ✅ rn ✅ docs
* #17956 ✅ rn ✅ docs
* #20274 ✅ rn ✅ docs
* #20416 ✅ rn ✅ docs
* #20361 ✅ rn ✅ docs

## 19 Jan 2024

* #20418 ✅ rn ✅ docs
* #20096 ❌ rn ✅ docs
* #20426 ✅ rn ✅ docs
* #20420 ✅ rn ✅ docs
* #20429 ✅ rn ✅ docs

## 20 Jan 2024

* #20430 ✅ rn ✅ docs
* #20431 ✅ rn ✅ docs

## 22 Jan 2024

* #20436 ✅ rn ✅ docs
* #20405 ✅ rn ✅ docs
* #20336 ✅ rn ✅ docs
* #20440 ✅ rn ✅ docs
* #20415 ✅ rn ✅ docs
* #20441 ✅ rn ✅ docs

## 23 Jan 2024

* #20435 ✅ rn ✅ docs
* #20444 ✅ rn ✅ docs
* #20443 ✅ rn ✅ docs
* #20331 ✅ rn ✅ docs

## 24 Jan 2024

* #20450 ✅ rn ✅ docs