### PR TITLE
Verify the file presense for cached directory lister and retry

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -31,6 +31,7 @@ import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.plugin.hive.HiveSplit.BucketConversion;
 import io.trino.plugin.hive.HiveSplit.BucketValidation;
+import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.HiveFileIterator;
 import io.trino.plugin.hive.fs.TrinoFileStatus;
@@ -512,7 +513,13 @@ public class BackgroundHiveSplitLoader
     @VisibleForTesting
     Iterator<InternalHiveSplit> buildManifestFileIterator(InternalHiveSplitFactory splitFactory, Location location, List<Location> paths, boolean splittable)
     {
+        return createInternalHiveSplitIterator(splitFactory, splittable, Optional.empty(), verifiedFileStatusesStream(location, paths));
+    }
+
+    private Stream<TrinoFileStatus> verifiedFileStatusesStream(Location location, List<Location> paths)
+    {
         TrinoFileSystem trinoFileSystem = fileSystemFactory.create(session);
+        boolean isCached = directoryLister instanceof CachingDirectoryLister && ((CachingDirectoryLister) directoryLister).isCached(location);
 
         Map<String, TrinoFileStatus> fileStatuses = new HashMap<>();
         Iterator<TrinoFileStatus> fileStatusIterator = new HiveFileIterator(table, location, trinoFileSystem, directoryLister, RECURSE);
@@ -520,7 +527,21 @@ public class BackgroundHiveSplitLoader
             checkPartitionLocationExists(trinoFileSystem, location);
         }
         fileStatusIterator.forEachRemaining(status -> fileStatuses.put(Location.of(status.getPath()).path(), status));
-        Stream<TrinoFileStatus> fileStream = paths.stream()
+
+        // If file statuses came from cache verify that all are present
+        if (isCached) {
+            boolean missing = paths.stream()
+                    .anyMatch(path -> !fileStatuses.containsKey(path));
+            // Invalidate the cache and reload
+            if (missing) {
+                ((CachingDirectoryLister)directoryLister).invalidate(location);
+                Map<String, TrinoFileStatus> newFileStatuses = new HashMap<>();
+                Iterator<TrinoFileStatus> newFileStatusIterator = new HiveFileIterator(table, location, trinoFileSystem, directoryLister, RECURSE);
+                newFileStatusIterator.forEachRemaining(status -> newFileStatuses.put(Location.of(status.getPath()).path(), status));
+            }
+        }
+
+        return paths.stream()
                 .map(path -> {
                     TrinoFileStatus status = fileStatuses.get(path.path());
                     if (status == null) {
@@ -528,7 +549,6 @@ public class BackgroundHiveSplitLoader
                     }
                     return status;
                 });
-        return createInternalHiveSplitIterator(splitFactory, splittable, Optional.empty(), fileStream);
     }
 
     private ListenableFuture<Void> getTransactionalSplits(Location path, boolean splittable, Optional<BucketConversion> bucketConversion, InternalHiveSplitFactory splitFactory)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -117,6 +117,11 @@ public class CachingDirectoryLister
         return new TrinoFileStatusRemoteIterator(fs.listFiles(location));
     }
 
+    public void invalidate(Location location)
+    {
+        cache.invalidate(location);
+    }
+
     @Override
     public void invalidate(Table table)
     {
@@ -205,8 +210,7 @@ public class CachingDirectoryLister
         return cache.stats().requestCount();
     }
 
-    @VisibleForTesting
-    boolean isCached(Location location)
+    public boolean isCached(Location location)
     {
         ValueHolder cached = cache.getIfPresent(location);
         return cached != null && cached.getFiles().isPresent();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
These changes address the problem when the new files in manifest are not visible by `directoryLister` immediately because of the caching delay (see #20344). 

The `buildManifestFileIterator()` method now verifies if the referenced file does not appear in the listing. If that is the case it tries to invalidate the cache and reload the listing.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. 
## Additional context and related issues
-->


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(*) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

<!--
```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
-->