### PR TITLE
File based column mapping for JDBC connectors

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/ColumnMappingRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/ColumnMappingRule.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.mapping;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class ColumnMappingRule
+{
+    private final String remoteSchema;
+    private final String remoteTable;
+    private final String remoteColumn;
+    private final String mapping;
+
+    @JsonCreator
+    public ColumnMappingRule(
+            @JsonProperty String remoteSchema,
+            @JsonProperty String remoteTable,
+            @JsonProperty String remoteColumn,
+            @JsonProperty String mapping)
+    {
+        this.remoteSchema = requireNonNull(remoteSchema, "remoteSchema is null");
+        this.remoteTable = requireNonNull(remoteTable, "remoteTable is null");
+        this.remoteColumn = requireNonNull(remoteColumn, "remoteColumn is null");
+        this.mapping = requireNonNull(mapping, "mapping is null");
+        checkArgument(mapping.toLowerCase(ENGLISH).equals(mapping), "Mapping is not lower cased: %s", mapping);
+    }
+
+    @JsonProperty
+    public String getRemoteSchema()
+    {
+        return remoteSchema;
+    }
+
+    @JsonProperty
+    public String getRemoteTable()
+    {
+        return remoteTable;
+    }
+
+    @JsonProperty
+    public String getRemoteColumn()
+    {
+        return remoteColumn;
+    }
+
+    @JsonProperty
+    public String getMapping()
+    {
+        return mapping;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnMappingRule that = (ColumnMappingRule) o;
+        return remoteSchema.equals(that.remoteSchema) && remoteTable.equals(that.remoteTable) && remoteColumn.equals(that.remoteColumn) && mapping.equals(that.mapping);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(remoteSchema, remoteTable, mapping);
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/DefaultIdentifierMapping.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/DefaultIdentifierMapping.java
@@ -33,7 +33,7 @@ public class DefaultIdentifierMapping
     }
 
     @Override
-    public String fromRemoteColumnName(String remoteColumnName)
+    public String fromRemoteColumnName(String remoteSchemaName, String remoteTableName, String remoteColumnName)
     {
         return remoteColumnName.toLowerCase(ENGLISH);
     }
@@ -51,7 +51,7 @@ public class DefaultIdentifierMapping
     }
 
     @Override
-    public String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, String columnName)
+    public String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, ConnectorIdentity identity, String remoteSchemaName, String remoteTableName, String columnName)
     {
         return toRemoteIdentifier(columnName, remoteIdentifiers);
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/ForwardingIdentifierMapping.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/ForwardingIdentifierMapping.java
@@ -51,9 +51,9 @@ public abstract class ForwardingIdentifierMapping
     }
 
     @Override
-    public String fromRemoteColumnName(String remoteColumnName)
+    public String fromRemoteColumnName(String remoteSchemaName, String remoteTableName, String remoteColumnName)
     {
-        return delegate().fromRemoteColumnName(remoteColumnName);
+        return delegate().fromRemoteColumnName(remoteSchemaName, remoteTableName, remoteColumnName);
     }
 
     @Override
@@ -69,8 +69,8 @@ public abstract class ForwardingIdentifierMapping
     }
 
     @Override
-    public String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, String columnName)
+    public String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, ConnectorIdentity identity, String remoteSchemaName, String remoteTableName, String columnName)
     {
-        return delegate().toRemoteColumnName(remoteIdentifiers, columnName);
+        return delegate().toRemoteColumnName(remoteIdentifiers, identity, remoteSchemaName, remoteTableName, columnName);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/IdentifierMapping.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/IdentifierMapping.java
@@ -21,11 +21,11 @@ public interface IdentifierMapping
 
     String fromRemoteTableName(String remoteSchemaName, String remoteTableName);
 
-    String fromRemoteColumnName(String remoteColumnName);
+    String fromRemoteColumnName(String remoteSchemaName, String remoteTableName, String remoteColumnName);
 
     String toRemoteSchemaName(RemoteIdentifiers remoteIdentifiers, ConnectorIdentity identity, String schemaName);
 
     String toRemoteTableName(RemoteIdentifiers remoteIdentifiers, ConnectorIdentity identity, String remoteSchema, String tableName);
 
-    String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, String columnName);
+    String toRemoteColumnName(RemoteIdentifiers remoteIdentifiers, ConnectorIdentity identity, String remoteSchemaName, String remoteTableName, String columnName);
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/IdentifierMappingRules.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/IdentifierMappingRules.java
@@ -17,22 +17,26 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-import java.util.Objects;
 
+import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
 
 public class IdentifierMappingRules
 {
     private final List<SchemaMappingRule> schemas;
     private final List<TableMappingRule> tables;
+    private final List<ColumnMappingRule> columns;
 
     @JsonCreator
     public IdentifierMappingRules(
             @JsonProperty("schemas") List<SchemaMappingRule> schemas,
-            @JsonProperty("tables") List<TableMappingRule> tables)
+            @JsonProperty("tables") List<TableMappingRule> tables,
+            @JsonProperty("columns") List<ColumnMappingRule> columns)
     {
         this.schemas = requireNonNull(schemas, "schemaMappingRules is null");
         this.tables = requireNonNull(tables, "tableMappingRules is null");
+        this.columns = requireNonNullElseGet(columns, List::of);
     }
 
     @JsonProperty("schemas")
@@ -47,6 +51,12 @@ public class IdentifierMappingRules
         return tables;
     }
 
+    @JsonProperty("columns")
+    public List<ColumnMappingRule> getColumns()
+    {
+        return columns;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -57,12 +67,12 @@ public class IdentifierMappingRules
             return false;
         }
         IdentifierMappingRules that = (IdentifierMappingRules) o;
-        return schemas.equals(that.schemas) && tables.equals(that.tables);
+        return schemas.equals(that.schemas) && tables.equals(that.tables) && columns.equals(that.columns);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemas, tables);
+        return hash(schemas, tables, columns);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/RemoteColumnNameCacheKey.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/RemoteColumnNameCacheKey.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.mapping;
+
+import io.trino.spi.security.ConnectorIdentity;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class RemoteColumnNameCacheKey
+{
+    private final ConnectorIdentity identity;
+    private final String schema;
+    private final String table;
+
+    RemoteColumnNameCacheKey(ConnectorIdentity identity, String schema, String table)
+    {
+        this.identity = requireNonNull(identity, "identity is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.table = requireNonNull(table, "table is null");
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RemoteColumnNameCacheKey that = (RemoteColumnNameCacheKey) o;
+        return Objects.equals(identity, that.identity) &&
+                Objects.equals(schema, that.schema) &&
+                Objects.equals(table, that.table);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(identity, schema, table);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("identity", identity)
+                .add("schema", schema)
+                .add("table", table)
+                .toString();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/RemoteIdentifiers.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/RemoteIdentifiers.java
@@ -21,5 +21,7 @@ public interface RemoteIdentifiers
 
     Set<String> getRemoteTables(String remoteSchema);
 
+    Set<String> getRemoteColumns(String remoteSchema, String remoteTable);
+
     boolean storesUpperCaseIdentifiers();
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/mapping/RuleBasedIdentifierMappingUtils.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/mapping/RuleBasedIdentifierMappingUtils.java
@@ -34,22 +34,22 @@ public final class RuleBasedIdentifierMappingUtils
     public static Path createRuleBasedIdentifierMappingFile()
             throws Exception
     {
-        return createRuleBasedIdentifierMappingFile(ImmutableList.of(), ImmutableList.of());
+        return createRuleBasedIdentifierMappingFile(ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
     }
 
-    public static Path createRuleBasedIdentifierMappingFile(List<SchemaMappingRule> schemas, List<TableMappingRule> tables)
+    public static Path createRuleBasedIdentifierMappingFile(List<SchemaMappingRule> schemas, List<TableMappingRule> tables, List<ColumnMappingRule> columns)
             throws Exception
     {
         Path file = createTempFile("identifier-mapping-", ".json");
         file.toFile().deleteOnExit();
-        updateRuleBasedIdentifierMappingFile(file, schemas, tables);
+        updateRuleBasedIdentifierMappingFile(file, schemas, tables, columns);
         return file;
     }
 
-    public static Path updateRuleBasedIdentifierMappingFile(Path file, List<SchemaMappingRule> schemas, List<TableMappingRule> tables)
+    public static Path updateRuleBasedIdentifierMappingFile(Path file, List<SchemaMappingRule> schemas, List<TableMappingRule> tables, List<ColumnMappingRule> columns)
             throws Exception
     {
-        IdentifierMappingRules mapping = new IdentifierMappingRules(schemas, tables);
+        IdentifierMappingRules mapping = new IdentifierMappingRules(schemas, tables, columns);
 
         String json = jsonCodec(IdentifierMappingRules.class).toJson(mapping);
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/mapping/TestIdentifierMappingRules.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/mapping/TestIdentifierMappingRules.java
@@ -26,7 +26,7 @@ public class TestIdentifierMappingRules
     {
         // The JSON format is part of the user interface, changing this may affect users.
 
-        String json = "{\n" +
+        String jsonWithColumns = "{\n" +
                 "  \"schemas\" : [ {\n" +
                 "    \"remoteSchema\" : \"remote_schema\",\n" +
                 "    \"mapping\" : \"trino_schema\"\n" +
@@ -35,14 +35,40 @@ public class TestIdentifierMappingRules
                 "    \"remoteSchema\" : \"remote_schema\",\n" +
                 "    \"remoteTable\" : \"remote_table\",\n" +
                 "    \"mapping\" : \"trino_table\"\n" +
-                "  } ]\n" +
+                "  } ],\n" +
+                " \"columns\" : [ {\n" +
+                "   \"remoteSchema\" : \"remote_schema\",\n" +
+                "   \"remoteTable\" : \"remote_table\",\n" +
+                "   \"remoteColumn\" : \"remote_column\",\n" +
+                "   \"mapping\" : \"trino_column\"\n" +
+                " } ]\n" +
+                "}";
+
+        String jsonWithoutColumns = "{\n" +
+                "  \"schemas\" : [ {\n" +
+                "    \"remoteSchema\" : \"remote_schema\",\n" +
+                "    \"mapping\" : \"trino_schema\"\n" +
+                "  } ],\n" +
+                "  \"tables\" : [ {\n" +
+                "    \"remoteSchema\" : \"remote_schema\",\n" +
+                "    \"remoteTable\" : \"remote_table\",\n" +
+                "    \"mapping\" : \"trino_table\"\n" +
+                " } ]\n" +
                 "}";
 
         JsonCodec<IdentifierMappingRules> identifierMappingRulesJsonCodec = JsonCodec.jsonCodec(IdentifierMappingRules.class);
-        assertThat(identifierMappingRulesJsonCodec.fromJson(json))
+        assertThat(identifierMappingRulesJsonCodec.fromJson(jsonWithColumns))
                 .isEqualTo(new IdentifierMappingRules(
                         ImmutableList.of(new SchemaMappingRule("remote_schema", "trino_schema")),
-                        ImmutableList.of(new TableMappingRule("remote_schema", "remote_table", "trino_table"))))
-                .isNotEqualTo(new IdentifierMappingRules(ImmutableList.of(), ImmutableList.of()));
+                        ImmutableList.of(new TableMappingRule("remote_schema", "remote_table", "trino_table")),
+                        ImmutableList.of(new ColumnMappingRule("remote_schema", "remote_table", "remote_column", "trino_column"))))
+                .isNotEqualTo(new IdentifierMappingRules(ImmutableList.of(), ImmutableList.of(), ImmutableList.of()));
+
+        assertThat(identifierMappingRulesJsonCodec.fromJson(jsonWithoutColumns))
+                .isEqualTo(new IdentifierMappingRules(
+                        ImmutableList.of(new SchemaMappingRule("remote_schema", "trino_schema")),
+                        ImmutableList.of(new TableMappingRule("remote_schema", "remote_table", "trino_table")),
+                        null))
+                .isNotEqualTo(new IdentifierMappingRules(ImmutableList.of(), ImmutableList.of(), ImmutableList.of()));
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -40,11 +40,17 @@ public final class JdbcColumnHandle
     private final Type columnType;
     private final boolean nullable;
     private final Optional<String> comment;
+    private final Optional<String> remoteColumnName;
 
     // All and only required fields
     public JdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType)
     {
-        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty());
+        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty(), Optional.empty());
+    }
+
+    public JdbcColumnHandle(String columnName, JdbcTypeHandle jdbcTypeHandle, Type columnType, String remoteColumnName)
+    {
+        this(columnName, jdbcTypeHandle, columnType, true, Optional.empty(), Optional.of(remoteColumnName));
     }
 
     /**
@@ -57,13 +63,15 @@ public final class JdbcColumnHandle
             @JsonProperty("jdbcTypeHandle") JdbcTypeHandle jdbcTypeHandle,
             @JsonProperty("columnType") Type columnType,
             @JsonProperty("nullable") boolean nullable,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("remoteColumnName") Optional<String> remoteColumnName)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.jdbcTypeHandle = requireNonNull(jdbcTypeHandle, "jdbcTypeHandle is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
         this.nullable = nullable;
         this.comment = requireNonNull(comment, "comment is null");
+        this.remoteColumnName = requireNonNull(remoteColumnName, "remoteColumnName is null");
     }
 
     @JsonProperty
@@ -94,6 +102,12 @@ public final class JdbcColumnHandle
     public Optional<String> getComment()
     {
         return comment;
+    }
+
+    @JsonProperty
+    public Optional<String> getRemoteColumnName()
+    {
+        return remoteColumnName;
     }
 
     public ColumnMetadata getColumnMetadata()
@@ -149,6 +163,7 @@ public final class JdbcColumnHandle
                 + sizeOf(nullable)
                 + estimatedSizeOf(columnName)
                 + sizeOf(comment, SizeOf::estimatedSizeOf)
+                + sizeOf(remoteColumnName, SizeOf::estimatedSizeOf)
                 + jdbcTypeHandle.getRetainedSizeInBytes();
     }
 
@@ -169,6 +184,7 @@ public final class JdbcColumnHandle
         private Type columnType;
         private boolean nullable = true;
         private Optional<String> comment = Optional.empty();
+        private Optional<String> remoteColumnName = Optional.empty();
 
         public Builder() {}
 
@@ -179,6 +195,7 @@ public final class JdbcColumnHandle
             this.columnType = handle.getColumnType();
             this.nullable = handle.isNullable();
             this.comment = handle.getComment();
+            this.remoteColumnName = handle.getRemoteColumnName();
         }
 
         public Builder setColumnName(String columnName)
@@ -211,6 +228,12 @@ public final class JdbcColumnHandle
             return this;
         }
 
+        public Builder setRemoteColumnName(Optional<String> remoteColumnName)
+        {
+            this.remoteColumnName = remoteColumnName;
+            return this;
+        }
+
         public JdbcColumnHandle build()
         {
             return new JdbcColumnHandle(
@@ -218,7 +241,8 @@ public final class JdbcColumnHandle
                     jdbcTypeHandle,
                     columnType,
                     nullable,
-                    comment);
+                    comment,
+                    remoteColumnName);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRemoteIdentifiers.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRemoteIdentifiers.java
@@ -66,6 +66,21 @@ public class JdbcRemoteIdentifiers
     }
 
     @Override
+    public Set<String> getRemoteColumns(String remoteSchema, String remoteTable)
+    {
+        try (ResultSet resultSet = baseJdbcClient.getColumns(connection, remoteSchema, remoteTable)) {
+            ImmutableSet.Builder<String> columnNames = ImmutableSet.builder();
+            while (resultSet.next()) {
+                columnNames.add(resultSet.getString("COLUMN_NAME"));
+            }
+            return columnNames.build();
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
+    }
+
+    @Override
     public boolean storesUpperCaseIdentifiers()
     {
         return storesUpperCase;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteVariable.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/RewriteVariable.java
@@ -46,6 +46,6 @@ public class RewriteVariable
     public Optional<ParameterizedExpression> rewrite(Variable variable, Captures captures, RewriteContext<ParameterizedExpression> context)
     {
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(variable.getName());
-        return Optional.of(new ParameterizedExpression(identifierQuote.apply(columnHandle.getColumnName()), ImmutableList.of()));
+        return Optional.of(new ParameterizedExpression(identifierQuote.apply(columnHandle.getRemoteColumnName().orElse(columnHandle.getColumnName())), ImmutableList.of()));
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -148,9 +149,9 @@ public class TestDefaultJdbcMetadata
     {
         // known table
         assertThat(metadata.getColumnHandles(SESSION, tableHandle)).isEqualTo(ImmutableMap.of(
-                "text", new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
-                "text_short", new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                "value", new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT)));
+                "text", new JdbcColumnHandle("TEXT".toLowerCase(Locale.ENGLISH), JDBC_VARCHAR, VARCHAR),
+                "text_short", new JdbcColumnHandle("TEXT_SHORT".toLowerCase(Locale.ENGLISH), JDBC_VARCHAR, createVarcharType(32)),
+                "value", new JdbcColumnHandle("VALUE".toLowerCase(Locale.ENGLISH), JDBC_BIGINT, BIGINT)));
 
         // unknown table
         unknownTableColumnHandle(new JdbcTableHandle(new SchemaTableName("unknown", "unknown"), new RemoteTableName(Optional.of("unknown"), Optional.of("unknown"), "unknown"), Optional.empty()));
@@ -340,9 +341,9 @@ public class TestDefaultJdbcMetadata
         JdbcTableHandle tableHandleWithFilter = applyFilter(session, aggregatedTable, new Constraint(TupleDomain.withColumnDomains(ImmutableMap.of(groupByColumn, secondDomain))));
         assertThat(tableHandleWithFilter.getConstraint().getDomains())
                 .isEqualTo(
-                    // The query effectively intersects firstDomain and secondDomain, but this is not visible in JdbcTableHandle.constraint,
-                    // as firstDomain has been converted into a PreparedQuery
-                    Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
+                        // The query effectively intersects firstDomain and secondDomain, but this is not visible in JdbcTableHandle.constraint,
+                        // as firstDomain has been converted into a PreparedQuery
+                        Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
         assertThat(((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery())
                 .isEqualTo("SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -92,9 +92,9 @@ public class TestJdbcClient
         assertThat(table.get().getRequiredNamedRelation().getRemoteTableName().getTableName()).isEqualTo("NUMBERS");
         assertThat(table.get().getRequiredNamedRelation().getSchemaTableName()).isEqualTo(schemaTableName);
         assertThat(jdbcClient.getColumns(session, table.orElse(null))).containsExactly(
-                new JdbcColumnHandle("TEXT", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("TEXT_SHORT", JDBC_VARCHAR, createVarcharType(32)),
-                new JdbcColumnHandle("VALUE", JDBC_BIGINT, BIGINT));
+                new JdbcColumnHandle("TEXT".toLowerCase(ENGLISH), JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("TEXT_SHORT".toLowerCase(ENGLISH), JDBC_VARCHAR, createVarcharType(32)),
+                new JdbcColumnHandle("VALUE".toLowerCase(ENGLISH), JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -104,8 +104,8 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("TE_T", JDBC_VARCHAR, VARCHAR),
-                new JdbcColumnHandle("VA%UE", JDBC_BIGINT, BIGINT));
+                new JdbcColumnHandle("TE_T".toLowerCase(ENGLISH), JDBC_VARCHAR, VARCHAR),
+                new JdbcColumnHandle("VA%UE".toLowerCase(ENGLISH), JDBC_BIGINT, BIGINT));
     }
 
     @Test
@@ -115,10 +115,10 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("COL1", JDBC_BIGINT, BIGINT),
-                new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
-                new JdbcColumnHandle("COL4", JDBC_REAL, REAL));
+                new JdbcColumnHandle("COL1".toLowerCase(ENGLISH), JDBC_BIGINT, BIGINT),
+                new JdbcColumnHandle("COL2".toLowerCase(ENGLISH), JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("COL3".toLowerCase(ENGLISH), JDBC_DOUBLE, DOUBLE),
+                new JdbcColumnHandle("COL4".toLowerCase(ENGLISH), JDBC_REAL, REAL));
     }
 
     @Test
@@ -128,9 +128,9 @@ public class TestJdbcClient
         Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
         assertThat(table.isPresent()).withFailMessage("table is missing").isTrue();
         assertThat(jdbcClient.getColumns(session, table.get())).containsExactly(
-                new JdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
-                new JdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
-                new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS));
+                new JdbcColumnHandle("TS_3".toLowerCase(ENGLISH), JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
+                new JdbcColumnHandle("TS_6".toLowerCase(ENGLISH), JDBC_TIMESTAMP, TIMESTAMP_MICROS),
+                new JdbcColumnHandle("TS_9".toLowerCase(ENGLISH), JDBC_TIMESTAMP, TIMESTAMP_NANOS));
     }
 
     @Test

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -477,7 +477,7 @@ public class ClickHouseClient
     public void addColumn(ConnectorSession session, JdbcTableHandle handle, ColumnMetadata column)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            String remoteColumnName = getIdentifierMapping().toRemoteColumnName(getRemoteIdentifiers(connection), column.getName());
+            String remoteColumnName = getRemoteColumnName(getRemoteIdentifiers(connection), handle.asPlainTable().getSchemaTableName(), session.getIdentity(), column.getName());
             String sql = format(
                     "ALTER TABLE %s ADD COLUMN %s",
                     quoted(handle.asPlainTable().getRemoteTableName()),
@@ -505,7 +505,7 @@ public class ClickHouseClient
         String sql = format(
                 "ALTER TABLE %s COMMENT COLUMN %s %s",
                 quoted(handle.asPlainTable().getRemoteTableName()),
-                quoted(column.getColumnName()),
+                quoted(column.getRemoteColumnName().orElse(column.getColumnName())),
                 clickhouseVarcharLiteral(comment.orElse("")));
         execute(session, sql);
     }

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteClient.java
@@ -483,7 +483,7 @@ public class IgniteClient
                     .map(sortItem -> {
                         String ordering = sortItem.getSortOrder().isAscending() ? "ASC" : "DESC";
                         String nullsHandling = sortItem.getSortOrder().isNullsFirst() ? "IS NULL DESC" : "IS NULL ASC";
-                        String columnName = quoted(sortItem.getColumn().getColumnName());
+                        String columnName = quoted(sortItem.getColumn().getRemoteColumnName().orElse(sortItem.getColumn().getColumnName()));
 
                         return format("%s %s, %1$s %s", columnName, nullsHandling, ordering);
                     })

--- a/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
+++ b/plugin/trino-ignite/src/main/java/io/trino/plugin/ignite/IgniteMetadata.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.connector.RetryMode.NO_RETRIES;
@@ -93,7 +94,8 @@ public class IgniteMetadata
         ImmutableList.Builder<JdbcTypeHandle> columnJdbcTypeHandles = ImmutableList.builder();
         for (ColumnHandle column : columns) {
             JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
-            columnNames.add(columnHandle.getColumnName());
+            verify(columnHandle.getRemoteColumnName().isPresent(), "remote column name is empty");
+            columnNames.add(columnHandle.getRemoteColumnName().get());
             columnTypes.add(columnHandle.getColumnType());
             columnJdbcTypeHandles.add(columnHandle.getJdbcTypeHandle());
         }

--- a/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbCaseInsensitiveMapping.java
+++ b/plugin/trino-mariadb/src/test/java/io/trino/plugin/mariadb/TestMariaDbCaseInsensitiveMapping.java
@@ -15,13 +15,18 @@ package io.trino.plugin.mariadb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.mapping.ColumnMappingRule;
+import io.trino.plugin.base.mapping.SchemaMappingRule;
+import io.trino.plugin.base.mapping.TableMappingRule;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.createRuleBasedIdentifierMappingFile;
+import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.updateRuleBasedIdentifierMappingFile;
 import static io.trino.plugin.mariadb.MariaDbQueryRunner.createMariaDbQueryRunner;
 import static java.util.Objects.requireNonNull;
 
@@ -68,5 +73,32 @@ public class TestMariaDbCaseInsensitiveMapping
         String identifierQuote = "`";
         name = name.replace(identifierQuote, identifierQuote + identifierQuote);
         return identifierQuote + name + identifierQuote;
+    }
+
+    @Override
+    @Test
+    public void testSchemaAndTableMappingsWithColumnMappings()
+            throws Exception
+    {
+        updateRuleBasedIdentifierMappingFile(
+                getMappingFile(),
+                ImmutableList.of(new SchemaMappingRule("RemoteSchema", "remote_schema")),
+                ImmutableList.of(new TableMappingRule("RemoteSchema", "RemoteTable", "remote_table")),
+                ImmutableList.of(
+                        new ColumnMappingRule("RemoteSchema", "RemoteTable", "col1", "c1"),
+                        new ColumnMappingRule("RemoteSchema", "RemoteTable", "col2", "c2")));
+
+        try (AutoCloseable ignore1 = withSchema("RemoteSchema");
+                AutoCloseable ignore2 = withTable("RemoteSchema", "RemoteTable", "(" + quoted("col2") + " varchar(5), " + quoted("col1") + " int)")) {
+            assertTableColumnNames("remote_schema.remote_table", "c2", "c1");
+            assertUpdate("INSERT INTO remote_schema.remote_table VALUES ('a', 1)", 1);
+            assertUpdate("INSERT INTO remote_schema.remote_table (c2, c1) VALUES ('b', 2)", 1);
+            assertUpdate("INSERT INTO remote_schema.remote_table (c2) VALUES ('c')", 1);
+
+            assertQuery("SELECT * FROM remote_schema.remote_table", "VALUES ('a', 1), ('b', 2), ('c', null)");
+            assertQuery("SELECT c2, c1 FROM remote_schema.remote_table", "VALUES ('a', 1), ('b', 2), ('c', null)");
+            assertUpdate("DELETE FROM remote_schema.remote_table where c1 = 2", 1);
+            assertQuery("SELECT c2 FROM remote_schema.remote_table", "VALUES 'a', 'c'");
+        }
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
@@ -15,14 +15,19 @@ package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.base.mapping.ColumnMappingRule;
+import io.trino.plugin.base.mapping.SchemaMappingRule;
+import io.trino.plugin.base.mapping.TableMappingRule;
 import io.trino.plugin.jdbc.BaseCaseInsensitiveMappingTest;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.SqlExecutor;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.REFRESH_PERIOD_DURATION;
 import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.createRuleBasedIdentifierMappingFile;
+import static io.trino.plugin.base.mapping.RuleBasedIdentifierMappingUtils.updateRuleBasedIdentifierMappingFile;
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static java.util.Objects.requireNonNull;
 
@@ -69,5 +74,32 @@ public class TestMySqlCaseInsensitiveMapping
         String identifierQuote = "`";
         name = name.replace(identifierQuote, identifierQuote + identifierQuote);
         return identifierQuote + name + identifierQuote;
+    }
+
+    @Override
+    @Test
+    public void testSchemaAndTableMappingsWithColumnMappings()
+            throws Exception
+    {
+        updateRuleBasedIdentifierMappingFile(
+                getMappingFile(),
+                ImmutableList.of(new SchemaMappingRule("RemoteSchema", "remote_schema")),
+                ImmutableList.of(new TableMappingRule("RemoteSchema", "RemoteTable", "remote_table")),
+                ImmutableList.of(
+                        new ColumnMappingRule("RemoteSchema", "RemoteTable", "col1", "c1"),
+                        new ColumnMappingRule("RemoteSchema", "RemoteTable", "col2", "c2")));
+
+        try (AutoCloseable ignore1 = withSchema("RemoteSchema");
+                AutoCloseable ignore2 = withTable("RemoteSchema", "RemoteTable", "(" + quoted("col2") + " varchar(5), " + quoted("col1") + " int)")) {
+            assertTableColumnNames("remote_schema.remote_table", "c2", "c1");
+            assertUpdate("INSERT INTO remote_schema.remote_table VALUES ('a', 1)", 1);
+            assertUpdate("INSERT INTO remote_schema.remote_table (c2, c1) VALUES ('b', 2)", 1);
+            assertUpdate("INSERT INTO remote_schema.remote_table (c2) VALUES ('c')", 1);
+
+            assertQuery("SELECT * FROM remote_schema.remote_table", "VALUES ('a', 1), ('b', 2), ('c', null)");
+            assertQuery("SELECT c2, c1 FROM remote_schema.remote_table", "VALUES ('a', 1), ('b', 2), ('c', null)");
+            assertUpdate("DELETE FROM remote_schema.remote_table where c1 = 2", 1);
+            assertQuery("SELECT c2 FROM remote_schema.remote_table", "VALUES 'a', 'c'");
+        }
     }
 }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -640,7 +640,8 @@ public class OracleClient
         int precision = timestampType.getPrecision();
         verifyLongTimestampPrecision(timestampType);
 
-        return new ObjectWriteFunction() {
+        return new ObjectWriteFunction()
+        {
             @Override
             public Class<?> getJavaType()
             {
@@ -850,7 +851,7 @@ public class OracleClient
         String sql = format(
                 "COMMENT ON COLUMN %s.%s IS %s",
                 quoted(handle.asPlainTable().getRemoteTableName()),
-                quoted(column.getColumnName()),
+                quoted(column.getRemoteColumnName().orElse(column.getColumnName())),
                 varcharLiteral(comment.orElse("")));
         execute(session, sql);
     }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
@@ -41,6 +41,7 @@ public class TestOracleCaseInsensitiveMapping
     protected QueryRunner createQueryRunner()
             throws Exception
     {
+        useUpperCase = true;
         mappingFile = createRuleBasedIdentifierMappingFile();
         oracleServer = closeAfterClass(new TestingOracleServer());
         return createOracleQueryRunner(

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -665,7 +665,7 @@ public class PhoenixClient
                 if (column.getComment() != null) {
                     throw new TrinoException(NOT_SUPPORTED, "This connector does not support creating tables with column comment");
                 }
-                String columnName = getIdentifierMapping().toRemoteColumnName(remoteIdentifiers, column.getName());
+                String columnName = getIdentifierMapping().toRemoteColumnName(remoteIdentifiers, identity, schema, table, column.getName());
                 columnNames.add(columnName);
                 columnTypes.add(column.getType());
                 String typeStatement = toWriteMapping(session, column.getType()).getDataType();
@@ -816,7 +816,8 @@ public class PhoenixClient
 
     private static LongWriteFunction dateWriteFunctionUsingString()
     {
-        return new LongWriteFunction() {
+        return new LongWriteFunction()
+        {
             @Override
             public String getBindExpression()
             {
@@ -984,7 +985,7 @@ public class PhoenixClient
                 .map(Optional::get)
                 .collect(toImmutableSet());
         Set<String> primaryKeyColumnNames = primaryKeyColumnHandles.stream()
-                .map(JdbcColumnHandle::getColumnName)
+                .map(c -> c.getRemoteColumnName().orElse(c.getColumnName()))
                 .collect(toImmutableSet());
         checkArgument(mergeRowIdFieldNames.containsAll(primaryKeyColumnNames), "Merge row id fields should contains all primary keys");
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSourceProvider.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPageSourceProvider.java
@@ -101,7 +101,7 @@ public class PhoenixPageSourceProvider
         List<Integer> mergeRowIdSourceChannels = columnType.getFields().stream()
                 .map(RowType.Field::getName)
                 .map(Optional::get)
-                .map(fieldName -> indexOf(scanColumns.iterator(), handle -> handle.getColumnName().equals(fieldName)))
+                .map(fieldName -> indexOf(scanColumns.iterator(), handle -> handle.getRemoteColumnName().orElse(handle.getColumnName()).equals(fieldName)))
                 .peek(fieldIndex -> checkArgument(fieldIndex != -1, "Merge row id field must exist in scanned columns"))
                 .collect(toImmutableList());
         return ColumnAdaptation.mergedRowColumns(mergeRowIdSourceChannels);

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -383,7 +383,7 @@ public class RedshiftClient
                     .map(sortItem -> {
                         String ordering = sortItem.getSortOrder().isAscending() ? "ASC" : "DESC";
                         String nullsHandling = sortItem.getSortOrder().isNullsFirst() ? "NULLS FIRST" : "NULLS LAST";
-                        return format("%s %s %s", quoted(sortItem.getColumn().getColumnName()), ordering, nullsHandling);
+                        return format("%s %s %s", quoted(sortItem.getColumn().getRemoteColumnName().orElse(sortItem.getColumn().getColumnName())), ordering, nullsHandling);
                     })
                     .collect(joining(", "));
 
@@ -813,7 +813,7 @@ public class RedshiftClient
         String sql = format(
                 "COMMENT ON COLUMN %s.%s IS %s",
                 quoted(handle.asPlainTable().getRemoteTableName()),
-                quoted(column.getColumnName()),
+                quoted(column.getRemoteColumnName().orElse(column.getColumnName())),
                 comment.map(RedshiftClient::redshiftVarcharLiteral).orElse("NULL"));
         execute(session, sql);
     }

--- a/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
+++ b/plugin/trino-singlestore/src/main/java/io/trino/plugin/singlestore/SingleStoreClient.java
@@ -540,7 +540,8 @@ public class SingleStoreClient
             String orderBy = sortItems.stream()
                     .flatMap(sortItem -> {
                         String ordering = sortItem.getSortOrder().isAscending() ? "ASC" : "DESC";
-                        String columnSorting = format("%s %s", quoted(sortItem.getColumn().getColumnName()), ordering);
+                        String columnName = sortItem.getColumn().getRemoteColumnName().orElse(sortItem.getColumn().getColumnName());
+                        String columnSorting = format("%s %s", quoted(columnName), ordering);
 
                         switch (sortItem.getSortOrder()) {
                             case ASC_NULLS_FIRST:
@@ -551,11 +552,11 @@ public class SingleStoreClient
 
                             case ASC_NULLS_LAST:
                                 return Stream.of(
-                                        format("ISNULL(%s) ASC", quoted(sortItem.getColumn().getColumnName())),
+                                        format("ISNULL(%s) ASC", quoted(columnName)),
                                         columnSorting);
                             case DESC_NULLS_FIRST:
                                 return Stream.of(
-                                        format("ISNULL(%s) DESC", quoted(sortItem.getColumn().getColumnName())),
+                                        format("ISNULL(%s) DESC", quoted(columnName)),
                                         columnSorting);
                         }
                         throw new UnsupportedOperationException("Unsupported sort order: " + sortItem.getSortOrder());


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

PR for issue #8745. Added the ability to specify mapping for columns in `case-insensitive-name-matching.config-file` file, like this:

```
{
   "schemas": [
      {
         "remoteSchema": "remote_schema",
         "mapping": "trino_schema"
      }],
   "tables": [
      {
         "remoteSchema": "remote_schema",
         "remoteTable": "remote_table",
         "mapping": "trino_table"
      }],
   "columns": [
      {
         "remoteSchema": "remote_schema",
         "remoteTable": "remote_table",
         "remoteColumn": "COL"
         "mapping": "trino_column1"
      },
      {
         "remoteSchema": "remote_schema",
         "remoteTable": "remote_table",
         "remoteColumn": "col"
         "mapping": "trino_column2"
     }]
}
```
The main idea of the implementation: add a new field to the `JdbcColumnHandle` class that stores the name of a remote column and use value of this field instead of "Trino name" in the required places.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes #8745 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
