### PR TITLE
Verify the file presense for cached directory lister and retry

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableInvalidationCallback.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/TableInvalidationCallback.java
@@ -13,12 +13,20 @@
  */
 package io.trino.plugin.hive;
 
+import io.trino.filesystem.Location;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Table;
 
 public interface TableInvalidationCallback
 {
-    void invalidate(Partition partition);
+    default boolean isCached(Location location)
+    {
+        return false;
+    }
 
-    void invalidate(Table table);
+    default void invalidate(Location location) {}
+
+    default void invalidate(Partition partition) {}
+
+    default void invalidate(Table table) {}
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/CachingDirectoryLister.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive.fs;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.Weigher;
 import com.google.common.collect.ImmutableList;
@@ -118,6 +117,12 @@ public class CachingDirectoryLister
     }
 
     @Override
+    public void invalidate(Location location)
+    {
+        cache.invalidate(location);
+    }
+
+    @Override
     public void invalidate(Table table)
     {
         if (isCacheEnabledFor(table.getSchemaTableName()) && isLocationPresent(table.getStorage())) {
@@ -205,8 +210,8 @@ public class CachingDirectoryLister
         return cache.stats().requestCount();
     }
 
-    @VisibleForTesting
-    boolean isCached(Location location)
+    @Override
+    public boolean isCached(Location location)
     {
         ValueHolder cached = cache.getIfPresent(location);
         return cached != null && cached.getFiles().isPresent();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/TransactionScopeCachingDirectoryLister.java
@@ -98,6 +98,13 @@ public class TransactionScopeCachingDirectoryLister
     }
 
     @Override
+    public void invalidate(Location location)
+    {
+        cache.invalidate(new TransactionDirectoryListingCacheKey(transactionId, location));
+        delegate.invalidate(location);
+    }
+
+    @Override
     public void invalidate(Table table)
     {
         if (isLocationPresent(table.getStorage())) {
@@ -157,10 +164,10 @@ public class TransactionScopeCachingDirectoryLister
         };
     }
 
-    @VisibleForTesting
-    boolean isCached(Location location)
+    @Override
+    public boolean isCached(Location location)
     {
-        return isCached(new TransactionDirectoryListingCacheKey(transactionId, location));
+        return isCached(new TransactionDirectoryListingCacheKey(transactionId, location)) || delegate.isCached(location);
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/fs/FileSystemDirectoryLister.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.fs;
 
 import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
-import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.Table;
 
 import java.io.IOException;
@@ -28,15 +27,5 @@ public class FileSystemDirectoryLister
             throws IOException
     {
         return new TrinoFileStatusRemoteIterator(fs.listFiles(location));
-    }
-
-    @Override
-    public void invalidate(Partition partition)
-    {
-    }
-
-    @Override
-    public void invalidate(Table table)
-    {
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
These changes address the problem when the new files in manifest are not visible by `directoryLister` immediately because of the caching delay (see #20344). 

The `buildManifestFileIterator()` method now verifies if the referenced file does not appear in the listing. If that is the case it tries to invalidate the cache and reload the listing.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. 
## Additional context and related issues
-->


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(*) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

<!--
```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
-->