### PR TITLE
Use jdk-21.0.2+13 in product tests and docker

### DIFF
--- a/core/docker/build.sh
+++ b/core/docker/build.sh
@@ -58,7 +58,7 @@ function temurin_jdk_link() {
   local JDK_VERSION="${1}"
   local ARCH="${2}"
 
-  versionsUrl="https://api.adoptium.net/v3/info/release_names?heap_size=normal&image_type=jdk&os=linux&page=0&page_size=20&project=jdk&release_type=ga&semver=false&sort_method=DEFAULT&sort_order=ASC&vendor=eclipse&version=%28${JDK_VERSION}%2C%5D"
+  versionsUrl="https://api.adoptium.net/v3/info/release_names?heap_size=normal&image_type=jdk&os=linux&page=0&page_size=20&project=jdk&release_type=ga&semver=false&sort_method=DEFAULT&sort_order=DESC&vendor=eclipse&version=%28${JDK_VERSION}%2C%5D"
   if ! result=$(curl -fLs "$versionsUrl" -H 'accept: application/json'); then
     echo >&2 "Failed to fetch release names for JDK version [${JDK_VERSION}, ) from Temurin API : $result"
     exit 1

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/Temurin21JdkProvider.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/jdk/Temurin21JdkProvider.java
@@ -28,6 +28,6 @@ public class Temurin21JdkProvider
     @Override
     protected String getReleaseName()
     {
-        return "jdk-21.0.1+12";
+        return "jdk-21.0.2+13";
     }
 }


### PR DESCRIPTION
No release notes needed