### PR TITLE
Run maven-checks with JDK 22-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       matrix:
         java-version:
           - 21
+          - 22-ea
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This will check for forward compatibility with newer Java version (at least for compilation and APIs used)