### PR TITLE
Fix Databricks 13.3 timestamp compatibility test

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/deltalake/util/DatabricksVersion.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 public record DatabricksVersion(int majorVersion, int minorVersion)
         implements Comparable<DatabricksVersion>
 {
+    public static final DatabricksVersion DATABRICKS_133_RUNTIME_VERSION = new DatabricksVersion(13, 3);
     public static final DatabricksVersion DATABRICKS_122_RUNTIME_VERSION = new DatabricksVersion(12, 2);
     public static final DatabricksVersion DATABRICKS_113_RUNTIME_VERSION = new DatabricksVersion(11, 3);
     public static final DatabricksVersion DATABRICKS_104_RUNTIME_VERSION = new DatabricksVersion(10, 4);


### PR DESCRIPTION
## Description

Could not find a reason for this behavior change in the Databricks release notes, but the incorrect behavior in the Databricks engine seems to have stopped.

Results from the last build on `master`

```
tests               | 2024-01-19 20:03:39 INFO: FAILURE     /    io.trino.tests.product.deltalake.TestDeltaLakeInsertCompatibility.testTimestampInsertCompatibility (Groups: profile_specific_tests, delta-lake-exclude-91, delta-lake-databricks, delta-lake-oss) took 11.5 seconds
tests               | 2024-01-19 20:03:39 SEVERE: Failure cause:
tests               | java.lang.AssertionError: Could not find rows:
tests               | [1, 0001-01-03 00:00:00.000]
tests               | 
tests               | actual rows:
tests               | [1, 0001-01-01 00:00:00.000]
tests               | [2, 2023-01-02 01:02:03.999]
tests               | [3, 2023-03-04 01:02:03.999]
tests               | [4, 9999-12-31 23:59:59.999]
```

## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text: