### PR TITLE
Optimize when we read tiny ORC file into memory

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReader.java
@@ -101,8 +101,6 @@ public class OrcReader
             Optional<OrcWriteValidation> writeValidation)
             throws IOException
     {
-        orcDataSource = wrapWithCacheIfTiny(orcDataSource, options.getTinyStripeThreshold());
-
         // read the tail of the file, and check if the file is actually empty
         long estimatedFileSize = orcDataSource.getEstimatedSize();
         if (estimatedFileSize > 0 && estimatedFileSize <= MAGIC.length()) {
@@ -314,7 +312,7 @@ public class OrcReader
                 fieldMapperFactory);
     }
 
-    private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize)
+    static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize)
             throws IOException
     {
         if (dataSource instanceof MemoryOrcDataSource || dataSource instanceof CachingOrcDataSource) {


### PR DESCRIPTION
Delay reading the file into memory until after we've determined that there is at least one stripe which needs to be read.

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Right now, we're reading an entire ORC file into memory prior to even determining whether we need to read the file altogether. We can do better by delaying this logic until after the record reader has at least used basic file statistics to determine whether any stripes need to be read.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( x ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
