### PR TITLE
Fix array growth calculation in RowBlockBuilder

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlockBuilder.java
@@ -378,8 +378,7 @@ public class RowBlockBuilder
             return;
         }
 
-        // todo add lazy initialize
-        int newSize = BlockUtil.calculateNewArraySize(rowIsNull.length);
+        int newSize = BlockUtil.calculateNewArraySize(rowIsNull.length, capacity);
         rowIsNull = Arrays.copyOf(rowIsNull, newSize);
     }
 


### PR DESCRIPTION
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix ArrayIndexOutOfBoundsException with RowBlockBuilder during output operations. ({issue}`20426`)
```
