### PR TITLE
Improve The `date_trunc` function documentation and unit millisecond

### DIFF
--- a/docs/src/main/sphinx/functions/datetime.md
+++ b/docs/src/main/sphinx/functions/datetime.md
@@ -244,6 +244,7 @@ The `date_trunc` function supports the following units:
 
 | Unit      | Example Truncated Value   |
 | --------- | ------------------------- |
+| `millisecond`  | `2001-08-22 03:04:05.321` |
 | `second`  | `2001-08-22 03:04:05.000` |
 | `minute`  | `2001-08-22 03:04:00.000` |
 | `hour`    | `2001-08-22 03:00:00.000` |


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Improve The date_trunc function documentation add unit millisecond

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. {https://github.com/trinodb/trino/issues/20427}
```
