### PR TITLE
Change IO metadata output for refresh materialized view operation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -693,8 +693,8 @@ class StatementAnalyzer
             accessControl.checkCanRefreshMaterializedView(session.toSecurityContext(), name);
             analysis.setUpdateType("REFRESH MATERIALIZED VIEW");
 
+            CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, refreshMaterializedView, name.getCatalogName());
             if (metadata.delegateMaterializedViewRefreshToConnector(session, name)) {
-                CatalogHandle catalogHandle = getRequiredCatalogHandle(metadata, session, refreshMaterializedView, name.getCatalogName());
                 analysis.setDelegatedRefreshMaterializedView(name);
                 analysis.setUpdateTarget(
                         catalogHandle.getVersion(),
@@ -744,8 +744,8 @@ class StatementAnalyzer
                     Column::new);
 
             analysis.setUpdateTarget(
-                    targetTableHandle.getCatalogHandle().getVersion(),
-                    targetTable,
+                    catalogHandle.getVersion(),
+                    name,
                     Optional.empty(),
                     Optional.of(Streams.zip(
                                     columns,

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -612,7 +612,7 @@ public class TestEventListenerBasic
 
         assertThat(event.getIoMetadata().getOutput().get().getCatalogName()).isEqualTo("mock");
         assertThat(event.getIoMetadata().getOutput().get().getSchema()).isEqualTo("default");
-        assertThat(event.getIoMetadata().getOutput().get().getTable()).isEqualTo("test_materialized_view_stale$materialized_view_storage");
+        assertThat(event.getIoMetadata().getOutput().get().getTable()).isEqualTo("test_materialized_view_stale");
         assertThat(event.getIoMetadata().getOutput().get().getColumns().get())
                 .containsExactly(new OutputColumnMetadata("test_column", BIGINT_TYPE, ImmutableSet.of(new ColumnDetail("tpch", "tiny", "nation", "nationkey"))));
 


### PR DESCRIPTION
## Description
- This PR changes the IO output metadata for `REFRESH MATERIALIZED VIEW` statements
    * Currently the IO output metadata is registered for the MV storage table (`<mvName$materialized_view_storage>`
    * Since Trino recently abstracted the Materialized View storage table to the end user, this PR changes the IO output metadata to be registered for the Materialized View itself, instead of it's storage table


## Additional context and related issues



## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Change the event listener output metadata for materialized view refreshes to target the materialized view definition instead of its storage table
```
