### PR TITLE
Add Slice support to reduce_agg function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/GenericSliceState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/GenericSliceState.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorState;
+import io.trino.spi.function.AccumulatorStateMetadata;
+import io.trino.spi.type.Type;
+
+@AccumulatorStateMetadata(stateSerializerClass = GenericSliceStateSerializer.class)
+public interface GenericSliceState
+        extends AccumulatorState
+{
+    Slice getValue();
+
+    void setValue(Slice value);
+
+    @InitialBooleanValue(true)
+    boolean isNull();
+
+    void setNull(boolean value);
+
+    default void set(GenericSliceState state)
+    {
+        setValue(state.getValue());
+        setNull(state.isNull());
+    }
+
+    static void write(Type type, GenericSliceState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            type.writeSlice(out, state.getValue());
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/GenericSliceStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/GenericSliceStateSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public class GenericSliceStateSerializer
+        implements AccumulatorStateSerializer<GenericSliceState>
+{
+    private final Type serializedType;
+
+    public GenericSliceStateSerializer(Type serializedType)
+    {
+        this.serializedType = requireNonNull(serializedType, "serializedType is null");
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return serializedType;
+    }
+
+    @Override
+    public void serialize(GenericSliceState state, BlockBuilder out)
+    {
+        if (state.isNull()) {
+            out.appendNull();
+        }
+        else {
+            serializedType.writeSlice(out, state.getValue());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, GenericSliceState state)
+    {
+        state.setNull(false);
+        state.setValue(serializedType.getSlice(block, index));
+    }
+}

--- a/docs/src/main/sphinx/functions/aggregate.md
+++ b/docs/src/main/sphinx/functions/aggregate.md
@@ -634,5 +634,5 @@ GROUP BY id;
 -- (2, 42)
 ```
 
-The state type must be a boolean, integer, floating-point, or date/time/interval.
+The state type must be a boolean, integer, floating-point, char, varchar or date/time/interval.
 :::

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -2219,6 +2219,11 @@ public abstract class AbstractTestEngineOnlyQueries
                         "FROM (VALUES (1, CAST(5 AS DOUBLE)), (1, 6), (1, 7), (2, 8), (2, 9), (3, 10)) AS t(x, y) " +
                         "GROUP BY x",
                 "VALUES (1, CAST(5 AS DOUBLE) + 6 + 7), (2, 8 + 9), (3, 10)");
+        assertQuery(
+                "SELECT x, reduce_agg(y, '', (a, b) -> a || b, (a, b) -> a || b) " +
+                        "FROM (VALUES ('1', '5'), ('1', '6'), ('1', '7'), ('2', '8'), ('2', '9'), ('3', '10')) AS t(x, y) " +
+                        "GROUP BY x",
+                "VALUES ('1', '567'), ('2', '89'), ('3', '10')");
     }
 
     @Test


### PR DESCRIPTION
I've stumbled upon `JDK-8017163` reference while going through the process of cleaning up after switching to JDK 21. Since it's solved, I've added a support to Slice serialization in the reduce_agg function.