### PR TITLE
Fix docs from compression codec use

### DIFF
--- a/docs/src/main/sphinx/admin/fault-tolerant-execution.md
+++ b/docs/src/main/sphinx/admin/fault-tolerant-execution.md
@@ -55,7 +55,6 @@ connector. The following connectors support fault-tolerant execution:
 The following configuration properties control the behavior of fault-tolerant
 execution on a Trino cluster:
 
-
 :::{list-table} Fault-tolerant execution configuration properties
 :widths: 30, 50, 20
 :header-rows: 1
@@ -76,15 +75,14 @@ execution on a Trino cluster:
     exceeded" error message unless an [exchange manager](fte-exchange-manager)
     is configured.
   - `32MB`
-* - `exchange.compression-enabled`
-  - Enable compression of spooling data. Setting to `true` is recommended
-    when using an [exchange manager](fte-exchange-manager).
-  - ``false``
 * - `fault-tolerant-execution.exchange-encryption-enabled`
   - Enable encryption of spooling data, see [Encryption](fte-encryption) for details. 
     Setting this property to false is not recommended if Trino processes sensitive data.
   - ``true``
 :::
+
+Find further related properties in [](/admin/properties), specifically in
+[](/admin/properties-resource-management) and [](/admin/properties-exchange).
 
 (fte-retry-policy)=
 

--- a/docs/src/main/sphinx/admin/properties-exchange.md
+++ b/docs/src/main/sphinx/admin/properties-exchange.md
@@ -32,6 +32,7 @@ the maximum number of clients is
 value adjusts the heuristic, which may increase concurrency and improve
 network utilization.
 
+(prop-exchange-compression-codec)=
 ## `exchange.compression-codec`
 
 - **Type:** {ref}`prop-type-string`
@@ -39,7 +40,7 @@ network utilization.
 - **Default value:** `NONE`
 
 The compression codec to use when exchanging data between nodes.
-Use `LZ4` in `Fault Tolerant Execution` mode by default.
+Defaults to `LZ4` with [](/admin/fault-tolerant-execution) mode.
 
 ## `exchange.data-integrity-verification`
 

--- a/docs/src/main/sphinx/admin/properties-spilling.md
+++ b/docs/src/main/sphinx/admin/properties-spilling.md
@@ -65,13 +65,7 @@ Max spill space to be used by a single query on a single node.
 
 Limit for memory used for unspilling a single aggregation operator instance.
 
-## `spill-compression-enabled`
-
-- **Type:** {ref}`prop-type-boolean`
-- **Default value:** `false`
-
-Enables data compression for pages spilled to disk. It is replaced by `spill-compression-codec`.
-
+(prop-spill-compression-codec)=
 ## `spill-compression-codec`
 
 - **Type:** {ref}`prop-type-string`

--- a/docs/src/main/sphinx/admin/spill.md
+++ b/docs/src/main/sphinx/admin/spill.md
@@ -56,10 +56,10 @@ there is no need to use RAID for spill.
 
 ## Spill compression
 
-When spill compression is enabled (`spill-compression-enabled` property in
-{doc}`properties-spilling`), spilled pages are compressed, before being
-written to disk. Enabling this feature can reduce disk IO at the cost
-of extra CPU load to compress and decompress spilled pages.
+When spill compression is enabled with the [`spill-compression-codec`
+property](/admin/properties-spilling), spilled pages are compressed, before
+being written to disk. Enabling this feature can reduce disk IO at the cost of
+extra CPU load to compress and decompress spilled pages.
 
 ## Spill encryption
 


### PR DESCRIPTION
## Description

* Update wording and related content
* Remove deprecated property

## Additional context and related issues

Follow up to https://github.com/trinodb/trino/pull/20274

Ideally we should get this PR in before the release since the current docs are kinda wrong.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
