### PR TITLE
Replace BlockBuilder beginEntry/closeEntry with buildEntry connectors.md

### DIFF
--- a/docs/src/main/sphinx/develop/connectors.md
+++ b/docs/src/main/sphinx/develop/connectors.md
@@ -772,13 +772,12 @@ private SqlMap encodeMap(Map<String, ?> map)
     MapType mapType = typeManager.getType(TypeSignature.mapType(
                             VARCHAR.getTypeSignature(),
                             VARCHAR.getTypeSignature()));
-    BlockBuilder values = mapType.createBlockBuilder(null, map != null ? map.size() : 0);
+    MapBlockBuilder values = mapType.createBlockBuilder(null, map != null ? map.size() : 0);
     if (map == null) {
         values.appendNull();
         return values.build().getObject(0, Block.class);
     }
-    BlockBuilder builder = values.beginBlockEntry();
-    builder.buildEntry((keyBuilder, valueBuilder) -> map.foreach((key, value) -> {
+    values.buildEntry((keyBuilder, valueBuilder) -> map.foreach((key, value) -> {
         VARCHAR.writeString(keyBuilder, key);
         if (value == null) {
             valueBuilder.appendNull();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Beginning with version 421, the Begin Entry/close Entry of the BlockBuilder class has disappeared.
However, the 437 version of the Connectors Guide example code still uses beginEntry/closeEntry, and we changed it to buildEntry accordingly.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
