### PR TITLE
Remove redundant code from TestIcebergMigrateProcedure

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMigrateProcedure.java
@@ -47,8 +47,6 @@ public class TestIcebergMigrateProcedure
         DistributedQueryRunner queryRunner = IcebergQueryRunner.builder().setMetastoreDirectory(dataDirectory.toFile()).build();
         queryRunner.installPlugin(new TestingHivePlugin(dataDirectory));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.<String, String>builder()
-//                .put("hive.metastore", "file")
-//                .put("hive.metastore.catalog.dir", dataDirectory.toString())
                 .put("hive.security", "allow-all")
                 .buildOrThrow());
         return queryRunner;


### PR DESCRIPTION
## Description

Remove redundant code from TestIcebergMigrateProcedure

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
