### PR TITLE
Use maven-resolver locking instead of takari

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<extensions>
-    <extension>
-        <groupId>io.takari.aether</groupId>
-        <artifactId>takari-local-repository</artifactId>
-        <version>0.11.3</version>
-    </extension>
-</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,4 @@
 --strict-checksums
+-Daether.syncContext.named.factory=file-lock
+-Daether.syncContext.named.nameMapper=file-hgav
 

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -235,6 +235,16 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Drop `takari-local-repository` extension, use Maven 3.9.x instead. 

Also, fix module `testing/trino-product-tests-launcher` as it enlists `io.confluent:kafka-protobuf-provider:pom:7.5.1` as direct dependency, and it must (and can) come only from `confluent` remote repository, while this module has only `central` and `sonatype-nexus-snapshots` remote repositories in scope only.

Explanation: Maven 3.9.x is more strict, and "local repo" is not just a "bunch of files" anymore. More about it can be found here https://maven.apache.org/resolver/local-repository.html#enhanced-lrm In short, what happened is exactly the example from 1st paragraph (A artifact was downloaded from R1 repository, that later in the build, is not defined and resolution is attempted without R1 being defined => failure). This is also a new Maven 3.9.x feature, meant to help devs to more easier spot these issues, it is more strict regarding "scoping" in local repository.

This actually physically enforced by "split repository" feature, where files are stored physically in different locations (dependending on their origin), ensuring there is no clash, as GAV per Repo is unique, but across more repositories is not.