### PR TITLE
Fix IcebergSplitSource.scannedFiles set semantics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1435,8 +1435,8 @@ public class IcebergMetadata
         ImmutableSet.Builder<DataFile> scannedDataFilesBuilder = ImmutableSet.builder();
         ImmutableSet.Builder<DeleteFile> scannedDeleteFilesBuilder = ImmutableSet.builder();
         splitSourceInfo.stream().map(DataFileWithDeleteFiles.class::cast).forEach(dataFileWithDeleteFiles -> {
-            scannedDataFilesBuilder.add(dataFileWithDeleteFiles.getDataFile());
-            scannedDeleteFilesBuilder.addAll(dataFileWithDeleteFiles.getDeleteFiles());
+            scannedDataFilesBuilder.add(dataFileWithDeleteFiles.dataFile());
+            scannedDeleteFilesBuilder.addAll(dataFileWithDeleteFiles.deleteFiles());
         });
 
         Set<DataFile> scannedDataFiles = scannedDataFilesBuilder.build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/DataFileWithDeleteFiles.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/DataFileWithDeleteFiles.java
@@ -21,24 +21,11 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public class DataFileWithDeleteFiles
+public record DataFileWithDeleteFiles(DataFile dataFile, List<DeleteFile> deleteFiles)
 {
-    private final DataFile dataFile;
-    private final List<DeleteFile> deleteFiles;
-
-    public DataFileWithDeleteFiles(DataFile dataFile, List<DeleteFile> deleteFiles)
+    public DataFileWithDeleteFiles
     {
-        this.dataFile = requireNonNull(dataFile, "dataFile is null");
-        this.deleteFiles = ImmutableList.copyOf(requireNonNull(deleteFiles, "deleteFiles is null"));
-    }
-
-    public DataFile getDataFile()
-    {
-        return dataFile;
-    }
-
-    public List<DeleteFile> getDeleteFiles()
-    {
-        return deleteFiles;
+        requireNonNull(dataFile, "dataFile is null");
+        deleteFiles = ImmutableList.copyOf(requireNonNull(deleteFiles, "deleteFiles is null"));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Previous implementation was missing equal and hashcode 


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

() This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(Fixes 'splits already set to' in Iceberg optimize) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
