### PR TITLE
Add support for `ALTER COLUMN ... DROP NOT NULL` statement in Delta Lake connector

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
@@ -1621,6 +1622,46 @@ public class DeltaLakeMetadata
         }
         catch (Exception e) {
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to rename '%s' column for: %s.%s", sourceColumnName, table.getSchemaName(), table.getTableName()), e);
+        }
+    }
+
+    @Override
+    public void dropNotNullConstraint(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        DeltaLakeTableHandle table = (DeltaLakeTableHandle) tableHandle;
+        DeltaLakeColumnHandle column = (DeltaLakeColumnHandle) columnHandle;
+        verify(column.isBaseColumn(), "Unexpected dereference: %s", column);
+        String columnName = column.getBaseColumnName();
+        MetadataEntry metadataEntry = table.getMetadataEntry();
+        ProtocolEntry protocolEntry = table.getProtocolEntry();
+
+        checkUnsupportedWriterFeatures(protocolEntry);
+        checkSupportedWriterVersion(table);
+
+        Map<String, Boolean> columnsNullability = Maps.transformEntries(
+                getColumnsNullability(metadataEntry),
+                (name, nullable) -> name.equalsIgnoreCase(columnName) ? true : nullable);
+        try {
+            TransactionLogWriter transactionLogWriter = transactionLogWriterFactory.newWriter(session, table.getLocation());
+            appendTableEntries(
+                    table.getReadVersion() + 1,
+                    transactionLogWriter,
+                    metadataEntry.getId(),
+                    getExactColumnNames(metadataEntry),
+                    metadataEntry.getOriginalPartitionColumns(),
+                    getColumnTypes(metadataEntry),
+                    getColumnComments(metadataEntry),
+                    columnsNullability,
+                    getColumnsMetadata(metadataEntry),
+                    metadataEntry.getConfiguration(),
+                    CHANGE_COLUMN_OPERATION,
+                    session,
+                    Optional.ofNullable(metadataEntry.getDescription()),
+                    protocolEntry);
+            transactionLogWriter.flush();
+        }
+        catch (Exception e) {
+            throw new TrinoException(DELTA_LAKE_BAD_WRITE, format("Unable to drop not null constraint from '%s' column in: %s", columnName, table.getSchemaTableName()), e);
         }
     }
 

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeConnectorTest.java
@@ -141,7 +141,6 @@ public class TestDeltaLakeConnectorTest
                     SUPPORTS_AGGREGATION_PUSHDOWN,
                     SUPPORTS_CREATE_MATERIALIZED_VIEW,
                     SUPPORTS_DROP_FIELD,
-                    SUPPORTS_DROP_NOT_NULL_CONSTRAINT,
                     SUPPORTS_LIMIT_PUSHDOWN,
                     SUPPORTS_PREDICATE_PUSHDOWN,
                     SUPPORTS_RENAME_FIELD,
@@ -790,6 +789,38 @@ public class TestDeltaLakeConnectorTest
                     "SELECT x, a FROM " + table.getName(),
                     "VALUES ('first', 'new column'), ('second', 'new column')");
         }
+    }
+
+    @Test
+    public void testDropNotNullConstraintWithColumnMapping()
+    {
+        testDropNotNullConstraintWithColumnMapping(ColumnMappingMode.ID);
+        testDropNotNullConstraintWithColumnMapping(ColumnMappingMode.NAME);
+        testDropNotNullConstraintWithColumnMapping(ColumnMappingMode.NONE);
+    }
+
+    private void testDropNotNullConstraintWithColumnMapping(ColumnMappingMode mode)
+    {
+        String tableName = "test_drop_not_null_" + randomNameSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + "(" +
+                " data integer NOT NULL COMMENT 'test comment'," +
+                " part integer NOT NULL COMMENT 'test part comment')" +
+                "WITH (partitioned_by = ARRAY['part'], column_mapping_mode = '" + mode + "')");
+        assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN data DROP NOT NULL");
+        assertThat(columnIsNullable(tableName, "data")).isTrue();
+        assertThat(columnIsNullable(tableName, "part")).isFalse();
+
+        assertUpdate("ALTER TABLE " + tableName + " ALTER COLUMN part DROP NOT NULL");
+        assertThat(columnIsNullable(tableName, "data")).isTrue();
+        assertThat(columnIsNullable(tableName, "part")).isTrue();
+        assertThat(getColumnComment(tableName, "data")).isEqualTo("test comment");
+        assertThat(getColumnComment(tableName, "part")).isEqualTo("test part comment");
+
+        assertUpdate("INSERT INTO " + tableName + " VALUES (NULL, NULL)", 1);
+        assertQuery("SELECT * FROM " + tableName, "VALUES (NULL, NULL)");
+
+        assertUpdate("DROP TABLE " + tableName);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes #20448 

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add support for `ALTER COLUMN ... DROP NOT NULL` statement. ({issue}`20448`)
```
