### PR TITLE
Delta Lake: Add `partitionValues` information to the `remove` transaction log entries

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeResult.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeResult.java
@@ -16,22 +16,35 @@ package io.trino.plugin.deltalake;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
 
 public class DeltaLakeMergeResult
 {
+    private final List<String> partitionValues;
     private final Optional<String> oldFile;
     private final Optional<DataFileInfo> newFile;
 
     @JsonCreator
-    public DeltaLakeMergeResult(Optional<String> oldFile, Optional<DataFileInfo> newFile)
+    public DeltaLakeMergeResult(List<String> partitionValues, Optional<String> oldFile, Optional<DataFileInfo> newFile)
     {
+        // Immutable list does not allow nulls
+        // noinspection Java9CollectionFactory
+        this.partitionValues = unmodifiableList(new ArrayList<>(requireNonNull(partitionValues, "partitionValues is null")));
         this.oldFile = requireNonNull(oldFile, "oldFile is null");
         this.newFile = requireNonNull(newFile, "newFile is null");
         checkArgument(oldFile.isPresent() || newFile.isPresent(), "old or new must be present");
+    }
+
+    @JsonProperty
+    public List<String> getPartitionValues()
+    {
+        return partitionValues;
     }
 
     @JsonProperty

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMergeSink.java
@@ -303,7 +303,7 @@ public class DeltaLakeMergeSink
         insertPageSink.finish().join().stream()
                 .map(Slice::getBytes)
                 .map(dataFileInfoCodec::fromJson)
-                .map(info -> new DeltaLakeMergeResult(Optional.empty(), Optional.of(info)))
+                .map(info -> new DeltaLakeMergeResult(info.getPartitionValues(), Optional.empty(), Optional.of(info)))
                 .map(mergeResultJsonCodec::toJsonBytes)
                 .map(Slices::wrappedBuffer)
                 .forEach(fragments::add);
@@ -315,7 +315,7 @@ public class DeltaLakeMergeSink
             MoreFutures.getDone(cdfPageSink.finish()).stream()
                     .map(Slice::getBytes)
                     .map(dataFileInfoCodec::fromJson)
-                    .map(info -> new DeltaLakeMergeResult(Optional.empty(), Optional.of(info)))
+                    .map(info -> new DeltaLakeMergeResult(info.getPartitionValues(), Optional.empty(), Optional.of(info)))
                     .map(mergeResultJsonCodec::toJsonBytes)
                     .map(Slices::wrappedBuffer)
                     .forEach(fragments::add);
@@ -347,7 +347,7 @@ public class DeltaLakeMergeSink
 
             Optional<DataFileInfo> newFileInfo = rewriteParquetFile(sourceLocation, deletion, writer);
 
-            DeltaLakeMergeResult result = new DeltaLakeMergeResult(Optional.of(sourceRelativePath), newFileInfo);
+            DeltaLakeMergeResult result = new DeltaLakeMergeResult(deletion.partitionValues(), Optional.of(sourceRelativePath), newFileInfo);
             return ImmutableList.of(utf8Slice(mergeResultJsonCodec.toJson(result)));
         }
         catch (IOException e) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -1988,11 +1988,6 @@ public class DeltaLakeMetadata
                 .map(mergeResultJsonCodec::fromJson)
                 .collect(toImmutableList());
 
-        List<String> oldFiles = mergeResults.stream()
-                .map(DeltaLakeMergeResult::getOldFile)
-                .flatMap(Optional::stream)
-                .collect(toImmutableList());
-
         List<DataFileInfo> allFiles = mergeResults.stream()
                 .map(DeltaLakeMergeResult::getNewFile)
                 .flatMap(Optional::stream)
@@ -2039,8 +2034,11 @@ public class DeltaLakeMetadata
                 appendCdcFilesInfos(transactionLogWriter, cdcFiles, partitionColumns);
             }
 
-            for (String file : oldFiles) {
-                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(toUriFormat(file), writeTimestamp, true));
+            for (DeltaLakeMergeResult mergeResult : mergeResults) {
+                if (mergeResult.getOldFile().isEmpty()) {
+                    continue;
+                }
+                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(toUriFormat(mergeResult.getOldFile().get()), createPartitionValuesMap(partitionColumns, mergeResult.getPartitionValues()), writeTimestamp, true));
             }
 
             appendAddFileEntries(transactionLogWriter, newFiles, partitionColumns, getExactColumnNames(handle.getMetadataEntry()), true);
@@ -2057,6 +2055,27 @@ public class DeltaLakeMetadata
             }
             throw new TrinoException(DELTA_LAKE_BAD_WRITE, "Failed to write Delta Lake transaction log entry", e);
         }
+    }
+
+    private static Map<String, String> createPartitionValuesMap(List<String> partitionColumnNames, List<String> partitionValues)
+    {
+        checkArgument(partitionColumnNames.size() == partitionValues.size(), "partitionColumnNames and partitionValues sizes don't match");
+        // using Hashmap because partition values can be null
+        Map<String, String> partitionValuesMap = new HashMap<>();
+        for (int i = 0; i < partitionColumnNames.size(); i++) {
+            partitionValuesMap.put(partitionColumnNames.get(i), partitionValues.get(i));
+        }
+        return unmodifiableMap(partitionValuesMap);
+    }
+
+    private static Map<String, String> createPartitionValuesMap(Map<String, Optional<String>> canonicalPartitionValues)
+    {
+        // using Hashmap because partition values can be null
+        Map<String, String> partitionValuesMap = new HashMap<>();
+        for (Map.Entry<String, Optional<String>> entry : canonicalPartitionValues.entrySet()) {
+            partitionValuesMap.put(entry.getKey(), entry.getValue().orElse(null));
+        }
+        return unmodifiableMap(partitionValuesMap);
     }
 
     private static void appendCdcFilesInfos(
@@ -2203,8 +2222,8 @@ public class DeltaLakeMetadata
         String tableLocation = executeHandle.getTableLocation();
 
         // paths to be deleted
-        Set<String> scannedPaths = splitSourceInfo.stream()
-                .map(String.class::cast)
+        Set<DeltaLakeScannedDataFile> scannnedDataFiles = splitSourceInfo.stream()
+                .map(DeltaLakeScannedDataFile.class::cast)
                 .collect(toImmutableSet());
 
         // files to be added
@@ -2229,9 +2248,14 @@ public class DeltaLakeMetadata
 
             long writeTimestamp = Instant.now().toEpochMilli();
 
-            for (String scannedPath : scannedPaths) {
-                String relativePath = relativePath(tableLocation, scannedPath);
-                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(toUriFormat(relativePath), writeTimestamp, false));
+            for (DeltaLakeScannedDataFile scannedFile : scannnedDataFiles) {
+                String relativePath = relativePath(tableLocation, scannedFile.path());
+                Map<String, Optional<String>> canonicalPartitionValues = scannedFile.partitionKeys();
+                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(
+                        toUriFormat(relativePath),
+                        createPartitionValuesMap(canonicalPartitionValues),
+                        writeTimestamp,
+                        false));
             }
 
             // Note: during writes we want to preserve original case of partition columns
@@ -3537,7 +3561,7 @@ public class DeltaLakeMetadata
             Iterator<AddFileEntry> addFileEntryIterator = activeFiles.iterator();
             while (addFileEntryIterator.hasNext()) {
                 AddFileEntry addFileEntry = addFileEntryIterator.next();
-                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(addFileEntry.getPath(), writeTimestamp, true));
+                transactionLogWriter.appendRemoveFileEntry(new RemoveFileEntry(addFileEntry.getPath(), addFileEntry.getPartitionValues(), writeTimestamp, true));
 
                 Optional<Long> fileRecords = addFileEntry.getStats().flatMap(DeltaLakeFileStatistics::getNumRecords);
                 allDeletedFilesStatsPresent &= fileRecords.isPresent();

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeScannedDataFile.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeScannedDataFile.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public record DeltaLakeScannedDataFile(String path, Map<String, Optional<String>> partitionKeys)
+{
+    public DeltaLakeScannedDataFile
+    {
+        requireNonNull(path, "path is null");
+        partitionKeys = ImmutableMap.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeSplitSource.java
@@ -60,7 +60,7 @@ public class DeltaLakeSplitSource
     private final SchemaTableName tableName;
     private final AsyncQueue<ConnectorSplit> queue;
     private final boolean recordScannedFiles;
-    private final ImmutableSet.Builder<String> scannedFilePaths = ImmutableSet.builder();
+    private final ImmutableSet.Builder<DeltaLakeScannedDataFile> scannedFilePaths = ImmutableSet.builder();
     private final DynamicFilter dynamicFilter;
     private final long dynamicFilteringWaitTimeoutMillis;
     private final Stopwatch dynamicFilterWaitStopwatch;
@@ -134,7 +134,7 @@ public class DeltaLakeSplitSource
                                     split.getStatisticsPredicate().overlaps(dynamicFilterPredicate))
                             .collect(toImmutableList());
                     if (recordScannedFiles) {
-                        filteredSplits.forEach(split -> scannedFilePaths.add(((DeltaLakeSplit) split).getPath()));
+                        filteredSplits.forEach(split -> scannedFilePaths.add(new DeltaLakeScannedDataFile(((DeltaLakeSplit) split).getPath(), ((DeltaLakeSplit) split).getPartitionKeys())));
                     }
                     return new ConnectorSplitBatch(filteredSplits, noMoreSplits);
                 },

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/RemoveFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/RemoveFileEntry.java
@@ -15,24 +15,27 @@ package io.trino.plugin.deltalake.transactionlog;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.Nullable;
 
+import java.util.Map;
 import java.util.Objects;
-
-import static java.lang.String.format;
 
 public class RemoveFileEntry
 {
     private final String path;
+    private final Map<String, String> partitionValues;
     private final long deletionTimestamp;
     private final boolean dataChange;
 
     @JsonCreator
     public RemoveFileEntry(
             @JsonProperty("path") String path,
+            @JsonProperty("partitionValues") @Nullable Map<String, String> partitionValues,
             @JsonProperty("deletionTimestamp") long deletionTimestamp,
             @JsonProperty("dataChange") boolean dataChange)
     {
         this.path = path;
+        this.partitionValues = partitionValues;
         this.deletionTimestamp = deletionTimestamp;
         this.dataChange = dataChange;
     }
@@ -41,6 +44,13 @@ public class RemoveFileEntry
     public String getPath()
     {
         return path;
+    }
+
+    @Nullable
+    @JsonProperty
+    public Map<String, String> getPartitionValues()
+    {
+        return partitionValues;
     }
 
     @JsonProperty
@@ -65,20 +75,26 @@ public class RemoveFileEntry
             return false;
         }
         RemoveFileEntry that = (RemoveFileEntry) o;
-        return path.equals(that.path) &&
-                deletionTimestamp == that.deletionTimestamp &&
-                dataChange == that.dataChange;
+        return deletionTimestamp == that.deletionTimestamp &&
+                dataChange == that.dataChange &&
+                Objects.equals(path, that.path) &&
+                Objects.equals(partitionValues, that.partitionValues);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(path, deletionTimestamp, dataChange);
+        return Objects.hash(path, partitionValues, deletionTimestamp, dataChange);
     }
 
     @Override
     public String toString()
     {
-        return format("RemoveFileEntry{path=%s, deletionTimestamp=%d, dataChange=%b}", path, deletionTimestamp, dataChange);
+        return "RemoveFileEntry{" +
+                "path='" + path + '\'' +
+                ", partitionValues=" + partitionValues +
+                ", deletionTimestamp=" + deletionTimestamp +
+                ", dataChange=" + dataChange +
+                '}';
     }
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointEntryIterator.java
@@ -521,7 +521,7 @@ public class CheckpointEntryIterator
             return null;
         }
         RowType type = removeType.orElseThrow();
-        int removeFields = 3;
+        int removeFields = 4;
         SqlRow removeEntryRow = getRow(block, pagePosition);
         log.debug("Block %s has %s fields", block, removeEntryRow.getFieldCount());
         if (removeEntryRow.getFieldCount() != removeFields) {
@@ -531,6 +531,7 @@ public class CheckpointEntryIterator
         CheckpointFieldReader remove = new CheckpointFieldReader(session, removeEntryRow, type);
         RemoveFileEntry result = new RemoveFileEntry(
                 remove.getString("path"),
+                remove.getMap(stringMap, "partitionValues"),
                 remove.getLong("deletionTimestamp"),
                 remove.getBoolean("dataChange"));
         log.debug("Result: %s", result);

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointSchemaManager.java
@@ -61,13 +61,9 @@ public class CheckpointSchemaManager
             RowType.field("version", BIGINT),
             RowType.field("lastUpdated", BIGINT)));
 
-    private static final RowType REMOVE_ENTRY_TYPE = RowType.from(ImmutableList.of(
-            RowType.field("path", VARCHAR),
-            RowType.field("deletionTimestamp", BIGINT),
-            RowType.field("dataChange", BOOLEAN)));
-
     private final RowType metadataEntryType;
     private final RowType commitInfoEntryType;
+    private final RowType removeEntryType;
     private final ArrayType stringList;
 
     @Inject
@@ -109,6 +105,12 @@ public class CheckpointSchemaManager
                 RowType.field("readVersion", BIGINT),
                 RowType.field("isolationLevel", VARCHAR),
                 RowType.field("isBlindAppend", BOOLEAN)));
+
+        removeEntryType = RowType.from(ImmutableList.of(
+                RowType.field("path", VARCHAR),
+                RowType.field("partitionValues", stringMap),
+                RowType.field("deletionTimestamp", BIGINT),
+                RowType.field("dataChange", BOOLEAN)));
     }
 
     public RowType getMetadataEntryType()
@@ -209,7 +211,7 @@ public class CheckpointSchemaManager
 
     public RowType getRemoveEntryType()
     {
-        return REMOVE_ENTRY_TYPE;
+        return removeEntryType;
     }
 
     public RowType getTxnEntryType()

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/checkpoint/CheckpointWriter.java
@@ -463,8 +463,9 @@ public class CheckpointWriter
         pageBuilder.declarePosition();
         ((RowBlockBuilder) pageBuilder.getBlockBuilder(REMOVE_BLOCK_CHANNEL)).buildEntry(fieldBuilders -> {
             writeString(fieldBuilders.get(0), entryType, 0, "path", removeFileEntry.getPath());
-            writeLong(fieldBuilders.get(1), entryType, 1, "deletionTimestamp", removeFileEntry.getDeletionTimestamp());
-            writeBoolean(fieldBuilders.get(2), entryType, 2, "dataChange", removeFileEntry.isDataChange());
+            writeStringMap(fieldBuilders.get(1), entryType, 1, "partitionValues", removeFileEntry.getPartitionValues());
+            writeLong(fieldBuilders.get(2), entryType, 2, "deletionTimestamp", removeFileEntry.getDeletionTimestamp());
+            writeBoolean(fieldBuilders.get(3), entryType, 3, "dataChange", removeFileEntry.isDataChange());
         });
 
         // null for others

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestTransactionLogAccess.java
@@ -105,12 +105,12 @@ public class TestTransactionLogAccess
             "age=29/part-00000-3794c463-cb0c-4beb-8d07-7cc1e3b5920f.c000.snappy.parquet");
 
     private static final Set<RemoveFileEntry> EXPECTED_REMOVE_ENTRIES = ImmutableSet.of(
-            new RemoveFileEntry("age=30/part-00000-7e43a3c3-ea26-4ae7-8eac-8f60cbb4df03.c000.snappy.parquet", 1579190163932L, false),
-            new RemoveFileEntry("age=30/part-00000-72a56c23-01ba-483a-9062-dd0accc86599.c000.snappy.parquet", 1579190163932L, false),
-            new RemoveFileEntry("age=42/part-00000-951068bd-bcf4-4094-bb94-536f3c41d31f.c000.snappy.parquet", 1579190155406L, false),
-            new RemoveFileEntry("age=25/part-00000-609e34b1-5466-4dbc-a780-2708166e7adb.c000.snappy.parquet", 1579190163932L, false),
-            new RemoveFileEntry("age=42/part-00000-6aed618a-2beb-4edd-8466-653e67a9b380.c000.snappy.parquet", 1579190155406L, false),
-            new RemoveFileEntry("age=42/part-00000-b82d8859-84a0-4f05-872c-206b07dd54f0.c000.snappy.parquet", 1579190163932L, false));
+            new RemoveFileEntry("age=30/part-00000-7e43a3c3-ea26-4ae7-8eac-8f60cbb4df03.c000.snappy.parquet", null, 1579190163932L, false),
+            new RemoveFileEntry("age=30/part-00000-72a56c23-01ba-483a-9062-dd0accc86599.c000.snappy.parquet", null, 1579190163932L, false),
+            new RemoveFileEntry("age=42/part-00000-951068bd-bcf4-4094-bb94-536f3c41d31f.c000.snappy.parquet", null, 1579190155406L, false),
+            new RemoveFileEntry("age=25/part-00000-609e34b1-5466-4dbc-a780-2708166e7adb.c000.snappy.parquet", null, 1579190163932L, false),
+            new RemoveFileEntry("age=42/part-00000-6aed618a-2beb-4edd-8466-653e67a9b380.c000.snappy.parquet", null, 1579190155406L, false),
+            new RemoveFileEntry("age=42/part-00000-b82d8859-84a0-4f05-872c-206b07dd54f0.c000.snappy.parquet", null, 1579190163932L, false));
 
     private final TestingTelemetry testingTelemetry = TestingTelemetry.create("transaction-log-access");
     private final TracingFileSystemFactory tracingFileSystemFactory = new TracingFileSystemFactory(testingTelemetry.getTracer(), new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointBuilder.java
@@ -59,11 +59,11 @@ public class TestCheckpointBuilder
         builder.addLogEntry(transactionEntry(app2TransactionV5));
 
         AddFileEntry addA1 = new AddFileEntry("a", Map.of(), 1, 1, true, Optional.empty(), Optional.empty(), Map.of(), Optional.empty());
-        RemoveFileEntry removeA1 = new RemoveFileEntry("a", 1, true);
+        RemoveFileEntry removeA1 = new RemoveFileEntry("a", Map.of(), 1, true);
         AddFileEntry addA2 = new AddFileEntry("a", Map.of(), 2, 1, true, Optional.empty(), Optional.empty(), Map.of(), Optional.empty());
         AddFileEntry addB = new AddFileEntry("b", Map.of(), 1, 1, true, Optional.empty(), Optional.empty(), Map.of(), Optional.empty());
-        RemoveFileEntry removeB = new RemoveFileEntry("b", 1, true);
-        RemoveFileEntry removeC = new RemoveFileEntry("c", 1, true);
+        RemoveFileEntry removeB = new RemoveFileEntry("b", Map.of(), 1, true);
+        RemoveFileEntry removeC = new RemoveFileEntry("c", Map.of(), 1, true);
         builder.addLogEntry(addFileEntry(addA1));
         builder.addLogEntry(removeFileEntry(removeA1));
         builder.addLogEntry(addFileEntry(addA2));

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointEntryIterator.java
@@ -609,6 +609,8 @@ public class TestCheckpointEntryIterator
         assertThat(entries).element(3).extracting(DeltaLakeTransactionLogEntry::getRemove).isEqualTo(
                 new RemoveFileEntry(
                         "age=42/part-00000-951068bd-bcf4-4094-bb94-536f3c41d31f.c000.snappy.parquet",
+                        // partitionValues information is missing in the checkpoint
+                        null,
                         1579190155406L,
                         false));
 
@@ -921,6 +923,7 @@ public class TestCheckpointEntryIterator
         Set<RemoveFileEntry> removeEntries = IntStream.range(0, numRemoveEntries).mapToObj(x ->
                         new RemoveFileEntry(
                                 UUID.randomUUID().toString(),
+                                ImmutableMap.of("part_key", "2023-01-01 00:00:00"),
                                 1000,
                                 true))
                 .collect(toImmutableSet());

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/transactionlog/checkpoint/TestCheckpointWriter.java
@@ -175,6 +175,7 @@ public class TestCheckpointWriter
 
         RemoveFileEntry removeFileEntry = new RemoveFileEntry(
                 "removeFilePath",
+                ImmutableMap.of("part_key", "7.0"),
                 1000,
                 true);
 
@@ -311,6 +312,7 @@ public class TestCheckpointWriter
 
         RemoveFileEntry removeFileEntry = new RemoveFileEntry(
                 "removeFilePath",
+                ImmutableMap.of("part_key", "7.0"),
                 1000,
                 true);
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This information can be particularly useful in the context of concurrent writes operations to identify overlaps between  the partitions being read by the current operation and the partitions updated by an already committed operation.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

#18506 

https://github.com/delta-io/delta/blob/master/PROTOCOL.md#add-file-and-remove-file

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
