### PR TITLE
Fix never run some product tests groups

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigDefault.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigDefault.java
@@ -16,8 +16,6 @@ package io.trino.tests.product.launcher.env.configs;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentDefaults;
 
-import java.util.List;
-
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.trino.tests.product.launcher.Configurations.nameForConfigClass;
 
@@ -52,26 +50,6 @@ public class ConfigDefault
     public String getConfigName()
     {
         return nameForConfigClass(getClass());
-    }
-
-    @Override
-    public List<String> getExcludedGroups()
-    {
-        return List.of(
-                // 'default' config's Hive is slower than e.g. HDP3. Exclude some test groups to shorten product test execution time.
-                // The groups excluded here do not explicitly depend on Hive version, so it's not important to run them for all
-                // Hive versions.
-                "aggregate",
-                "group-by",
-                "join",
-                "orderby",
-                "union",
-                "window",
-                "with_clause",
-                // This test group doesn't exercise hive connector, so it's enough to run it with one config. It's retained for ConfigHdp3.
-                "no_from",
-                // This test group doesn't exercise hive connector, so it's enough to run it with one config. It's retained for ConfigHdp3.
-                "tpch_connector");
     }
 
     @Override


### PR DESCRIPTION
The default config was excluding some tests in favor of `config-hdp3` (`ConfigHdp3`), which was faster. But the latter got removed in ceb8e1572047c7ecb8854f28ae21a5e4200c3e34. Since then the tests in affected groups were probably not run.
