### PR TITLE
Add Trino 438 release notes

### DIFF
--- a/docs/src/main/sphinx/release.md
+++ b/docs/src/main/sphinx/release.md
@@ -6,6 +6,7 @@
 ```{toctree}
 :maxdepth: 1
 
+release/release-438
 release/release-437
 release/release-436
 ```

--- a/docs/src/main/sphinx/release/release-437.md
+++ b/docs/src/main/sphinx/release/release-437.md
@@ -6,7 +6,7 @@
 * Add support for `char(n)` values in {func}`lpad`. ({issue}`16907`)
 * {{breaking}} Replace the `exchange.compression-enabled` configuration property
   and `exchange_compression` session property with
-  [the`exchange.compression-codec`and `exchange_compression_codec` properties](prop-exchange-compression-codec),
+  [the `exchange.compression-codec`and `exchange_compression_codec` properties](prop-exchange-compression-codec),
   respectively. ({issue}`20274`)
 * {{breaking}} Replace the `spill-compression-enabled` configuration property 
   with [the `spill-compression-codec` property](prop-spill-compression-codec). ({issue}`20274`)

--- a/docs/src/main/sphinx/release/release-438.md
+++ b/docs/src/main/sphinx/release/release-438.md
@@ -1,0 +1,45 @@
+# Release 438 (1 Feb 2024)
+
+## General
+
+* Add support for using types such as `char`, `varchar`, `uuid`, `ip_address`,
+  `geometry`, and others with the {func}`reduce_agg` function. ({issue}`20452`)
+* Fix query failure when using `char` types with the {func}`reverse` function. ({issue}`20387`)
+* Fix potential query failure when using the {func}`max_by` function on large
+  datasets. ({issue}`20524`)
+* Fix query failure when querying data with deeply nested rows. ({issue}`20529`)
+
+## Security
+
+* Add support for access control with
+  [Open Policy Agent](/security/opa-access-control). ({issue}`19532`)
+
+## Delta Lake connector
+
+* Add support for configuring the maximum number of values per page when writing
+  to Parquet files with the `parquet.writer.page-value-count` configuration
+  property or the `parquet_writer_page_value_count` session property. ({issue}`20171`)
+
+## Hive connector
+
+* Add support for configuring the maximum number of values per page when writing
+  to Parquet files with the `parquet.writer.page-value-count` configuration
+  property or the `parquet_writer_page_value_count` session property. ({issue}`20171`)
+
+## Iceberg connector
+
+* Add support for `ALTER COLUMN ... DROP NOT NULL` statements. ({issue}`20315`)
+* Add support for configuring the maximum number of values per page when writing
+  to Parquet files with the `parquet.writer.page-value-count` configuration
+  property or the `parquet_writer_page_value_count` session property. ({issue}`20171`)
+* Add support for `array`, `map` and `row` types in the `migrate` table
+  procedure. ({issue}`17583`)
+* Fix potential query failure when running the `optimize` table procedure. ({issue}`20490`)
+
+## Pinot connector
+
+* Add support for the `date` type. ({issue}`13059`)
+
+## PostgreSQL connector
+
+* Add support for `ALTER COLUMN ... DROP NOT NULL` statements. ({issue}`20315`)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Assemble the release notes for the upcoming Trino 438 release.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or docs only and no release notes are required.

## Verification for each pull request

Format: PR/issue number, ✅ / ❌ rn ✅ / ❌ docs
✅ rn - release note added and verified, or assessed to be not necessary, set to ❌ rn before completion
✅ docs - need for docs assessed and merged, or assessed to be not necessary, set to ❌ docs before completion

## 25 Jan 2024

* #20442 ✅ rn ✅ docs
* #20460 ✅ rn ✅ docs
* #20288 ✅ rn ✅ docs
* #20456 ✅ rn ✅ docs
* #20463 ✅ rn ✅ docs
* #20129 ✅ rn ✅ docs
* #20465 ✅ rn ✅ docs
* #20461 ✅ rn ✅ docs
* #20459 ✅ rn ✅ docs
* #20221 ✅ rn ✅ docs
* #20172 ✅ rn ✅ docs
* #20468 ✅ rn ✅ docs
* #20452 ✅ rn ✅ docs
* #20472 ✅ rn ✅ docs
* #20376 ✅ rn ✅ docs

## 26 Jan 2024

* #20464 ✅ rn ✅ docs
* #20470 ✅ rn ✅ docs
* #20475 ✅ rn ✅ docs
* #20462 ✅ rn ✅ docs
* #20366 ✅ rn ✅ docs

## 27 Jan 2024

* #20451 ✅ rn ✅ docs
* #20479 ✅ rn ✅ docs

## 28 Jan 2024

* #20488 ✅ rn ✅ docs

## 29 Jan 2024

* #20494 ✅ rn ✅ docs
* #20171 ✅ rn ✅ docs
* #20101 ✅ rn ✅ docs
* #20383 ✅ rn ✅ docs
* #20499 ✅ rn ✅ docs
* #17582 ✅ rn ✅ docs
* #20502 ✅ rn ✅ docs
* #20493 ✅ rn ✅ docs

## 30 Jan 2024

* #20505 ✅ rn ✅ docs
* #20496 ✅ rn ✅ docs
* #20380 ✅ rn ✅ docs
* #20512 ✅ rn ✅ docs
* #20514 ✅ rn ✅ docs
* #20506  ✅ rn ✅ docs
* #20173  ✅ rn ✅ docs
* #17779  ✅ rn ✅ docs
* #20388  ✅ rn ✅ docs
* #20519  ✅ rn ✅ docs

## 31 Jan 2024

* #20360 ✅ rn ✅ docs
* #20513 ✅ rn ✅ docs
* #20490 ✅ rn ✅ docs
* #20509 ✅ rn ✅ docs
* #20226 ✅ rn ✅ docs
* #20523 ✅ rn ✅ docs
* #19532 ✅ rn ✅ docs
* #20246 ✅ rn ✅ docs
* #20483 ✅ rn ✅ docs
* #20527 ✅ rn ✅ docs

## 1 Feb 2024

* #20522 ✅ rn ✅ docs
* #20498 ✅ rn ✅ docs
* #20535 ✅ rn ✅ docs
* #20536 ✅ rn ✅ docs
* #20540 ✅ rn ✅ docs
* #20538 ✅ rn ✅ docs
* #20529 ✅ rn ✅ docs