### PR TITLE
Fix  TypedKeyValueHeap compaction

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
@@ -56,7 +56,6 @@ public final class TypedKeyValueHeap
      * The fixed chunk contains an array of records. The records are laid out as follows:
      * <ul>
      *     <li>12 byte optional pointer to variable width data (only present if the key or value is variable width)</li>
-     *     <li>4 byte optional integer for variable size of the key (only present if the key is variable width)</li>
      *     <li>1 byte null flag for the value</li>
      *     <li>N byte fixed size data for the key type</li>
      *     <li>N byte fixed size data for the value type</li>
@@ -105,7 +104,7 @@ public final class TypedKeyValueHeap
         recordValueOffset = recordKeyOffset + keyType.getFlatFixedSize();
         recordSize = recordValueOffset + valueType.getFlatFixedSize();
 
-        // allocate the fixed chunk with on extra slow for use in swap
+        // allocate the fixed chunk with on extra slot for use in swap
         fixedChunk = new byte[recordSize * (capacity + 1)];
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxbyn/TypedKeyValueHeap.java
@@ -56,7 +56,7 @@ public final class TypedKeyValueHeap
      * The fixed chunk contains an array of records. The records are laid out as follows:
      * <ul>
      *     <li>12 byte optional pointer to variable width data (only present if the key or value is variable width)</li>
-     *     <li>1 byte null flag for the value</li>
+     *     <li>1 byte null flag for the value. 0 means the value is not-null</li>
      *     <li>N byte fixed size data for the key type</li>
      *     <li>N byte fixed size data for the value type</li>
      * </ul>
@@ -260,7 +260,7 @@ public final class TypedKeyValueHeap
                 positionCount,
                 (fixedSizeOffset, variableWidthChunk, variableWidthChunkOffset) -> {
                     int keyVariableWidth = keyType.relocateFlatVariableWidthOffsets(fixedChunk, fixedSizeOffset + recordKeyOffset, variableWidthChunk, variableWidthChunkOffset);
-                    if (fixedChunk[fixedSizeOffset + recordKeyOffset - 1] != 0) {
+                    if (fixedChunk[fixedSizeOffset + recordKeyOffset - 1] == 0) {
                         valueType.relocateFlatVariableWidthOffsets(fixedChunk, fixedSizeOffset + recordValueOffset, variableWidthChunk, variableWidthChunkOffset + keyVariableWidth);
                     }
                 });


### PR DESCRIPTION
## Description
Fix compaction of TestTypedKeyValueHeap with non-null variable-width values.

Fixes #20524

## Additional context and related issues
Reproducing the underlying bug requires triggering compaction in a way that triggers an array index of out bounds.  The can be reproduced with the following code in `TestTypedKeyValueHeap`, but requires a lot of rounds to reproduce.

```java
    @Test
    public void testCompaction()
    {
        int capacity = 3;

        int maxSize = 1_000_000;
        int chunkSize = 1000;
        Slice entry = Slices.allocate(maxSize);
        entry.fill((byte) 'x');

        int round = 1;
        while (true) {
            System.out.println("test round: " + round++);
            TypedKeyValueHeap heap = createTypedKeyValueHeap(BIGINT, VARCHAR, false, capacity);
            BlockBuilder keyBlockBuilder = BIGINT.createBlockBuilder(null, heap.getCapacity());
            BlockBuilder valueBlockBuilder = VARCHAR.createBlockBuilder(null, heap.getCapacity());
            for (int i = 0; i < 10_000; i++) {
                int length = ThreadLocalRandom.current().nextInt(maxSize / 2, maxSize);
                BIGINT.writeLong(keyBlockBuilder, length);
                VARCHAR.writeSlice(valueBlockBuilder, entry, 0, length);
                if (keyBlockBuilder.getPositionCount() % chunkSize == 0) {
                    getAddAll(heap, keyBlockBuilder.buildValueBlock(), valueBlockBuilder.buildValueBlock());
                    keyBlockBuilder = BIGINT.createBlockBuilder(null, chunkSize);
                    valueBlockBuilder = VARCHAR.createBlockBuilder(null, chunkSize, maxSize / 2);

                    heap.writeValuesSorted(VARCHAR.createBlockBuilder(null, heap.getCapacity()));
                }
            }
        }
    }
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix failure in `max_by(x, y, n)` for large variable-width values. ({issue}`20524`)
```
