### PR TITLE
Propagate RowPositionsAppender reset to fields

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -214,6 +214,9 @@ public class RowPositionsAppender
     @Override
     public void reset()
     {
+        for (UnnestingPositionsAppender field : fieldAppenders) {
+            field.reset();
+        }
         initialEntryCount = calculateBlockResetSize(positionCount);
         initialized = false;
         rowIsNull = new boolean[0];


### PR DESCRIPTION
RowPositionsAppender reset call was not being propigated to nested fields.  This would result in missized fields blocks that were not the correct size for the row block.

Add validation calls as row fields are built to detect bugs closer to the source.

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix failure of queries over data with deeply nested rows. ({issue}`20529`)
```
