### PR TITLE
Restore getLoadedBlock methods (for dictionary and RLE)

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -534,6 +534,23 @@ public final class DictionaryBlock
     }
 
     @Override
+    public boolean isLoaded()
+    {
+        return dictionary.isLoaded();
+    }
+
+    @Override
+    public Block getLoadedBlock()
+    {
+        ValueBlock loadedDictionary = (ValueBlock) dictionary.getLoadedBlock();
+
+        if (loadedDictionary == dictionary) {
+            return this;
+        }
+        return createInternal(idsOffset, getPositionCount(), loadedDictionary, ids, randomDictionaryId());
+    }
+
+    @Override
     public List<Block> getChildren()
     {
         return singletonList(getDictionary());

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -297,6 +297,23 @@ public final class RunLengthEncodedBlock
     }
 
     @Override
+    public boolean isLoaded()
+    {
+        return value.isLoaded();
+    }
+
+    @Override
+    public Block getLoadedBlock()
+    {
+        Block loadedValueBlock = value.getLoadedBlock();
+
+        if (loadedValueBlock == value) {
+            return this;
+        }
+        return create(loadedValueBlock, positionCount);
+    }
+
+    @Override
     public ValueBlock getUnderlyingValueBlock()
     {
         return value;


### PR DESCRIPTION
This is required because RowBlock is ValueBlock
but can still be lazy.

```markdown
# Section
* Fix lazy block errors while reading table data. ({issue}`issuenumber`)
```
