### PR TITLE
Log long tests' duration 

### DIFF
--- a/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
+++ b/testing/trino-testing-containers/src/main/java/io/trino/testing/containers/junit/ReportLeakedContainers.java
@@ -28,6 +28,7 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.testing.services.junit.Listeners.reportListenerFailure;
 import static java.lang.Boolean.getBoolean;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -70,17 +71,13 @@ public final class ReportLeakedContainers
                     .collect(toImmutableList());
 
             if (!containers.isEmpty()) {
-                log.error("Leaked containers: %s", containers.stream()
+                reportListenerFailure(getClass(), "Leaked containers: %s", containers.stream()
                         .map(container -> toStringHelper("container")
                                 .add("id", container.getId())
                                 .add("image", container.getImage())
                                 .add("imageId", container.getImageId())
                                 .toString())
                         .collect(joining(", ", "[", "]")));
-
-                // JUnit does not fail on a listener exception.
-                System.err.println("JVM will be terminated");
-                System.exit(1);
             }
         }
     }

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -54,6 +54,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <!-- it's either on classpath because anyway, or not needed at all. Let's not force the dependency on downstream when not needed. -->
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <!-- it's either on classpath because anyway, or not needed at all. Let's not force the dependency on downstream when not needed. -->
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
         </dependency>

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -65,6 +65,12 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>junit-extensions</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- testing -->
         <dependency>
             <groupId>io.trino.tempto</groupId>
@@ -75,6 +81,18 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -105,6 +123,19 @@
                         <io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>true</io.trino.testng.services.FlakyTestRetryAnalyzer.enabled>
                     </systemPropertyVariables>
                 </configuration>
+                <dependencies>
+                    <!-- allow both JUnit and TestNG -->
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-testng</artifactId>
+                        <version>${dep.plugin.surefire.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/services/junit/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/services/junit/Listeners.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.services.junit;
+
+import com.google.errorprone.annotations.FormatMethod;
+
+import static java.lang.String.format;
+
+/**
+ * @see io.trino.testng.services.Listeners for utlity class for TestNG listeners
+ */
+public final class Listeners
+{
+    private Listeners() {}
+
+    /**
+     * Print error to standard error and exit JVM.
+     *
+     * @apiNote A JUnit listener cannot throw an exception, as they are not propagated by JUnit framework.
+     */
+    @FormatMethod
+    public static void reportListenerFailure(Class<?> listenerClass, String format, Object... args)
+    {
+        System.err.println(format("FATAL: %s: ", listenerClass.getName()) + format(format, args));
+        System.err.println("JVM will be terminated");
+
+        // JUnit does not fail on a listener exception.
+        // Therefore, instead of throwing, we terminate the JVM.
+        System.exit(1);
+    }
+}

--- a/testing/trino-testing-services/src/main/java/io/trino/testing/services/junit/LogTestDurationListener.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testing/services/junit/LogTestDurationListener.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.services.junit;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.jvm.Threads;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.units.Duration.nanosSince;
+import static io.trino.testing.services.junit.Listeners.reportListenerFailure;
+import static java.lang.String.format;
+import static java.lang.management.ManagementFactory.getThreadMXBean;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.joining;
+
+public class LogTestDurationListener
+        implements TestExecutionListener
+{
+    private static final Logger log = Logger.get(LogTestDurationListener.class);
+
+    private static final Duration TEST_LOGGING_THRESHOLD = new Duration(20, SECONDS);
+    private static final Duration GLOBAL_IDLE_LOGGING_THRESHOLD = new Duration(8, MINUTES);
+
+    private final boolean enabled;
+    private final ScheduledExecutorService scheduledExecutorService;
+
+    private TestPlan currentTestPlan;
+    private final Map<TestIdentifier, Long> started = new ConcurrentHashMap<>();
+    private final AtomicLong lastChange = new AtomicLong(System.nanoTime());
+    private final AtomicBoolean hangLogged = new AtomicBoolean();
+    private final AtomicBoolean finished = new AtomicBoolean();
+    @GuardedBy("this")
+    private ScheduledFuture<?> monitorHangTask;
+
+    public LogTestDurationListener()
+    {
+        enabled = isEnabled();
+        scheduledExecutorService = newSingleThreadScheduledExecutor(daemonThreadsNamed("TestHangMonitor"));
+        log.info("LogTestDurationListener enabled: %s", enabled);
+    }
+
+    private static boolean isEnabled()
+    {
+        if (System.getProperty("LogTestDurationListener.enabled") != null) {
+            return Boolean.getBoolean("LogTestDurationListener.enabled");
+        }
+        if (System.getenv("CONTINUOUS_INTEGRATION") != null) {
+            return true;
+        }
+        // For local development, logging durations is not typically useful.
+        return false;
+    }
+
+    @Override
+    public synchronized void testPlanExecutionStarted(TestPlan testPlan)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            checkState(currentTestPlan == null, "currentTestPlan already set to %s when starting %s", currentTestPlan, testPlan);
+            currentTestPlan = testPlan;
+
+            resetHangMonitor();
+            finished.set(false);
+            if (monitorHangTask == null) {
+                monitorHangTask = scheduledExecutorService.scheduleWithFixedDelay(this::checkForTestHang, 5, 5, TimeUnit.SECONDS);
+            }
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(getClass(), "testPlanExecutionStarted: \n%s", getStackTraceAsString(e));
+        }
+    }
+
+    @Override
+    public void testPlanExecutionFinished(TestPlan testPlan)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            checkState(currentTestPlan == testPlan, "currentTestPlan set to %s when finishing %s", currentTestPlan, testPlan);
+            currentTestPlan = null;
+
+            resetHangMonitor();
+            finished.set(true);
+            // do not stop hang task so notification of hung test JVM will fire
+            // Note: since the monitor uses daemon threads it will not prevent JVM shutdown
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(getClass(), "testPlanExecutionFinished: \n%s", getStackTraceAsString(e));
+        }
+    }
+
+    private void checkForTestHang()
+    {
+        if (hangLogged.get()) {
+            return;
+        }
+
+        Duration duration = nanosSince(lastChange.get());
+        if (duration.compareTo(GLOBAL_IDLE_LOGGING_THRESHOLD) < 0) {
+            return;
+        }
+
+        if (!hangLogged.compareAndSet(false, true)) {
+            return;
+        }
+
+        Map<TestIdentifier, Long> runningTests = ImmutableMap.copyOf(started);
+        if (!runningTests.isEmpty()) {
+            String testDetails = runningTests.entrySet().stream()
+                    .map(entry -> format("%s running for %s", testName(entry.getKey()), nanosSince(entry.getValue())))
+                    .collect(joining("\n\t", "\n\t", ""));
+            dumpAllThreads(format("No test started or completed in %s. Running tests:%s.", GLOBAL_IDLE_LOGGING_THRESHOLD, testDetails));
+        }
+        else if (finished.get()) {
+            dumpAllThreads(format("Tests finished, but JVM did not shutdown in %s.", GLOBAL_IDLE_LOGGING_THRESHOLD));
+        }
+        else {
+            dumpAllThreads(format("No test started in %s", GLOBAL_IDLE_LOGGING_THRESHOLD));
+        }
+    }
+
+    private static void dumpAllThreads(String message)
+    {
+        log.warn("%s\n\nFull Thread Dump:\n%s", message,
+                Arrays.stream(getThreadMXBean().dumpAllThreads(true, true))
+                        .map(Threads::fullToString)
+                        .collect(joining("\n")));
+    }
+
+    private void resetHangMonitor()
+    {
+        lastChange.set(System.nanoTime());
+        hangLogged.set(false);
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            beginTest(testIdentifier);
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(LogTestDurationListener.class, "executionStarted: \n%s", getStackTraceAsString(e));
+        }
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult)
+    {
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            Duration duration = endTest(testIdentifier);
+            if (duration.compareTo(TEST_LOGGING_THRESHOLD) > 0) {
+                log.info("Test %s took %s", testName(testIdentifier), duration);
+            }
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(LogTestDurationListener.class, "executionFinished: \n%s", getStackTraceAsString(e));
+        }
+    }
+
+    private void beginTest(TestIdentifier testIdentifier)
+    {
+        resetHangMonitor();
+        Long existingEntry = started.putIfAbsent(testIdentifier, System.nanoTime());
+        // You can get concurrent tests with the same name when using @Factory.  Instead of adding complex support for
+        // having multiple running tests with the same name, we simply don't use @Factory.
+        checkState(existingEntry == null, "There already is a start record for test: %s", testIdentifier);
+    }
+
+    private Duration endTest(TestIdentifier testIdentifier)
+    {
+        resetHangMonitor();
+        Long startTime = started.remove(testIdentifier);
+        checkState(startTime != null, "There is no start record for test: %s", testIdentifier);
+        return nanosSince(startTime);
+    }
+
+    private String testName(TestIdentifier testIdentifier)
+    {
+        Optional<TestIdentifier> parent = currentTestPlan.getParent(testIdentifier);
+        String parentName = "";
+        if (parent.isPresent()) {
+            parentName = testName(parent.get());
+            if (parentName.equals("JUnit Jupiter")) {
+                parentName = "";
+            }
+            else {
+                parentName += ".";
+            }
+        }
+        return parentName + testIdentifier.getDisplayName();
+    }
+}

--- a/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
+++ b/testing/trino-testing-services/src/main/java/io/trino/testng/services/Listeners.java
@@ -21,7 +21,12 @@ import org.testng.ITestResult;
 
 import static java.lang.String.format;
 
-final class Listeners
+/**
+ * @see io.trino.testing.services.junit.Listeners for utlity class for JUnit listeners
+ * @deprecated Deprecated because TestNG is deprecated. Use JUnit instead.
+ */
+@Deprecated
+public final class Listeners
 {
     private Listeners() {}
 

--- a/testing/trino-testing-services/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/testing/trino-testing-services/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+io.trino.testing.services.junit.LogTestDurationListener

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportMultiThreadedBeforeOrAfterMethod.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportMultiThreadedBeforeOrAfterMethod.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestReportMultiThreadedBeforeOrAfterMethod
 {
-    @Test
+    @org.junit.jupiter.api.Test
     public void test()
     {
         // no @BeforeMethod

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportPrivateMethods.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportPrivateMethods.java
@@ -13,9 +13,9 @@
  */
 package io.trino.testng.services;
 
+import org.junit.jupiter.api.Test;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestSharedResource.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestSharedResource.java
@@ -14,7 +14,7 @@
 package io.trino.testng.services;
 
 import io.trino.testing.SharedResource;
-import org.testng.annotations.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicLong;


### PR DESCRIPTION
Copy `LogTestDurationListener` that exists for TestNG and adapt it for
JUnit. This is useful when troubleshooting tests that take long time on
CI.