### PR TITLE
Add more options to S3FileSystemConfig

### DIFF
--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java
@@ -18,10 +18,13 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.airlift.units.MaxDataSize;
 import io.airlift.units.MinDataSize;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
@@ -47,6 +50,11 @@ public class S3FileSystemConfig
     private DataSize streamingPartSize = DataSize.of(16, MEGABYTE);
     private boolean requesterPays;
     private Integer maxConnections;
+    private Duration connectionTtl;
+    private Duration connectionMaxIdleTime;
+    private Duration socketConnectTimeout;
+    private Duration socketReadTimeout;
+    private boolean tcpKeepAlive;
     private HostAndPort httpProxy;
     private boolean httpProxySecure;
 
@@ -240,6 +248,71 @@ public class S3FileSystemConfig
     public S3FileSystemConfig setMaxConnections(Integer maxConnections)
     {
         this.maxConnections = maxConnections;
+        return this;
+    }
+
+    public Optional<Duration> getConnectionTtl()
+    {
+        return Optional.ofNullable(connectionTtl);
+    }
+
+    @Config("s3.connection-ttl")
+    @ConfigDescription("Maximum time allowed for connections to be reused before being replaced in the connection pool")
+    public S3FileSystemConfig setConnectionTtl(Duration connectionTtl)
+    {
+        this.connectionTtl = connectionTtl;
+        return this;
+    }
+
+    public Optional<Duration> getConnectionMaxIdleTime()
+    {
+        return Optional.ofNullable(connectionMaxIdleTime);
+    }
+
+    @Config("s3.connection-max-idle-time")
+    @ConfigDescription("Maximum time allowed for connections to remain idle in the connection pool before being closed")
+    public S3FileSystemConfig setConnectionMaxIdleTime(Duration connectionMaxIdleTime)
+    {
+        this.connectionMaxIdleTime = connectionMaxIdleTime;
+        return this;
+    }
+
+    public Optional<Duration> getSocketConnectTimeout()
+    {
+        return Optional.ofNullable(socketConnectTimeout);
+    }
+
+    @Config("s3.socket-connect-timeout")
+    @ConfigDescription("Maximum time allowed for socket connect to complete before timing out")
+    public S3FileSystemConfig setSocketConnectTimeout(Duration socketConnectTimeout)
+    {
+        this.socketConnectTimeout = socketConnectTimeout;
+        return this;
+    }
+
+    public Optional<Duration> getSocketReadTimeout()
+    {
+        return Optional.ofNullable(socketReadTimeout);
+    }
+
+    @Config("s3.socket-read-timeout")
+    @ConfigDescription("Maximum time allowed for socket reads before timing out")
+    public S3FileSystemConfig setSocketReadTimeout(Duration socketReadTimeout)
+    {
+        this.socketReadTimeout = socketReadTimeout;
+        return this;
+    }
+
+    public boolean getTcpKeepAlive()
+    {
+        return tcpKeepAlive;
+    }
+
+    @Config("s3.tcp-keep-alive")
+    @ConfigDescription("Enable TCP keep alive on created connections")
+    public S3FileSystemConfig setTcpKeepAlive(boolean tcpKeepAlive)
+    {
+        this.tcpKeepAlive = tcpKeepAlive;
         return this;
     }
 

--- a/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
+++ b/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemFactory.java
@@ -81,7 +81,13 @@ public final class S3FileSystemFactory
         }
 
         ApacheHttpClient.Builder httpClient = ApacheHttpClient.builder()
-                .maxConnections(config.getMaxConnections());
+                .maxConnections(config.getMaxConnections())
+                .tcpKeepAlive(config.getTcpKeepAlive());
+
+        config.getConnectionTtl().ifPresent(connectionTtl -> httpClient.connectionTimeToLive(connectionTtl.toJavaTime()));
+        config.getConnectionMaxIdleTime().ifPresent(connectionMaxIdleTime -> httpClient.connectionMaxIdleTime(connectionMaxIdleTime.toJavaTime()));
+        config.getSocketConnectTimeout().ifPresent(socketConnectTimeout -> httpClient.connectionTimeout(socketConnectTimeout.toJavaTime()));
+        config.getSocketReadTimeout().ifPresent(socketReadTimeout -> httpClient.socketTimeout(socketReadTimeout.toJavaTime()));
 
         if (config.getHttpProxy() != null) {
             URI endpoint = URI.create("%s://%s".formatted(

--- a/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
+++ b/lib/trino-filesystem-s3/src/test/java/io/trino/filesystem/s3/TestS3FileSystemConfig.java
@@ -16,6 +16,7 @@ package io.trino.filesystem.s3;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.trino.filesystem.s3.S3FileSystemConfig.S3SseType;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestS3FileSystemConfig
 {
@@ -47,6 +49,11 @@ public class TestS3FileSystemConfig
                 .setStreamingPartSize(DataSize.of(16, MEGABYTE))
                 .setRequesterPays(false)
                 .setMaxConnections(null)
+                .setConnectionTtl(null)
+                .setConnectionMaxIdleTime(null)
+                .setSocketConnectTimeout(null)
+                .setSocketReadTimeout(null)
+                .setTcpKeepAlive(false)
                 .setHttpProxy(null)
                 .setHttpProxySecure(false));
     }
@@ -70,6 +77,11 @@ public class TestS3FileSystemConfig
                 .put("s3.streaming.part-size", "42MB")
                 .put("s3.requester-pays", "true")
                 .put("s3.max-connections", "42")
+                .put("s3.connection-ttl", "1m")
+                .put("s3.connection-max-idle-time", "2m")
+                .put("s3.socket-connect-timeout", "3m")
+                .put("s3.socket-read-timeout", "4m")
+                .put("s3.tcp-keep-alive", "true")
                 .put("s3.http-proxy", "localhost:8888")
                 .put("s3.http-proxy.secure", "true")
                 .buildOrThrow();
@@ -90,6 +102,11 @@ public class TestS3FileSystemConfig
                 .setSseKmsKeyId("mykey")
                 .setRequesterPays(true)
                 .setMaxConnections(42)
+                .setConnectionTtl(new Duration(1, MINUTES))
+                .setConnectionMaxIdleTime(new Duration(2, MINUTES))
+                .setSocketConnectTimeout(new Duration(3, MINUTES))
+                .setSocketReadTimeout(new Duration(4, MINUTES))
+                .setTcpKeepAlive(true)
                 .setHttpProxy(HostAndPort.fromParts("localhost", 8888))
                 .setHttpProxySecure(true);
 


### PR DESCRIPTION
## Description
Adds support for specifying more configuration options in `S3FileSystemConfig`. New configuration options are:
- `s3.connection-ttl` (default: none, same as S3 client default when not specified)
- `s3.connection-max-idle-time` (default: not specified, S3 client defaults to 1 minute when not specified)
- `s3.socket-connect-timeout` (default: not specified, S3 client defaults to 2 seconds when not specified)
- `s3.socket-read-timeout` (default: not specified, S3 client defaults to 5 seconds when not specified)
- `s3.tcp-keep-alive` (default: false, same as S3 client default when not specified)

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
