### PR TITLE
Reduce assertThatThrownBy scope in TestOidcDiscovery

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -107,40 +107,40 @@ public class TestOidcDiscovery
 
     @Test
     public void testIssuerCheck()
+            throws Exception
     {
-        assertThatThrownBy(() -> {
-            try (MetadataServer metadataServer = new MetadataServer(
-                    ImmutableMap.<String, String>builder()
-                            .put("/.well-known/openid-configuration", "oidc/openid-configuration-invalid-issuer.json")
-                            .put("/jwks.json", "jwk/jwk-public.json")
-                            .buildOrThrow());
-                    TestingTrinoServer server = createServer(
-                            ImmutableMap.<String, String>builder()
-                                    .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
-                                    .put("http-server.authentication.oauth2.oidc.discovery", "true")
-                                    .buildOrThrow())) {
-                // should throw an exception
-                server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
-            }
-        }).hasMessageContaining(
-                "Invalid response from OpenID Metadata endpoint. " +
-                        "The value of the \"issuer\" claim in Metadata document different than the Issuer URL used for the Configuration Request.");
+        try (MetadataServer metadataServer = new MetadataServer(
+                ImmutableMap.<String, String>builder()
+                        .put("/.well-known/openid-configuration", "oidc/openid-configuration-invalid-issuer.json")
+                        .put("/jwks.json", "jwk/jwk-public.json")
+                        .buildOrThrow());
+                TestingTrinoServer server = createServer(
+                        ImmutableMap.<String, String>builder()
+                                .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
+                                .put("http-server.authentication.oauth2.oidc.discovery", "true")
+                                .buildOrThrow())) {
+            OAuth2ServerConfigProvider provider = server.getInstance(Key.get(OAuth2ServerConfigProvider.class));
+            assertThatThrownBy(provider::get)
+                    .hasMessageContaining(
+                            "Invalid response from OpenID Metadata endpoint. " +
+                                    "The value of the \"issuer\" claim in Metadata document different than the Issuer URL used for the Configuration Request.");
+        }
     }
 
     @Test
     public void testStopOnClientError()
+            throws Exception
     {
-        assertThatThrownBy(() -> {
-            try (MetadataServer metadataServer = new MetadataServer(ImmutableMap.of());
-                    TestingTrinoServer server = createServer(
-                            ImmutableMap.<String, String>builder()
-                                    .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
-                                    .put("http-server.authentication.oauth2.oidc.discovery", "true")
-                                    .buildOrThrow())) {
-                // should throw an exception
-                server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
-            }
-        }).hasMessageContaining("Invalid response from OpenID Metadata endpoint. Expected response code to be 200, but was 404");
+        try (MetadataServer metadataServer = new MetadataServer(ImmutableMap.of());
+                TestingTrinoServer server = createServer(
+                        ImmutableMap.<String, String>builder()
+                                .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
+                                .put("http-server.authentication.oauth2.oidc.discovery", "true")
+                                .buildOrThrow())) {
+            OAuth2ServerConfigProvider provider = server.getInstance(Key.get(OAuth2ServerConfigProvider.class));
+            assertThatThrownBy(provider::get)
+                    .hasMessageContaining("Invalid response from OpenID Metadata endpoint. Expected response code to be 200, but was 404");
+        }
     }
 
     @Test
@@ -165,23 +165,23 @@ public class TestOidcDiscovery
 
     @Test
     public void testOidcDiscoveryTimesOut()
+            throws Exception
     {
-        assertThatThrownBy(() -> {
-            try (MetadataServer metadataServer = new MetadataServer(new MetadataServletWithStartup(
-                    ImmutableMap.<String, String>builder()
-                            .put("/.well-known/openid-configuration", "oidc/openid-configuration.json")
-                            .put("/jwks.json", "jwk/jwk-public.json")
-                            .buildOrThrow(), 60));
-                    TestingTrinoServer server = createServer(
-                            ImmutableMap.<String, String>builder()
-                                    .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
-                                    .put("http-server.authentication.oauth2.oidc.discovery", "true")
-                                    .put("http-server.authentication.oauth2.oidc.discovery.timeout", "5s")
-                                    .buildOrThrow())) {
-                // should throw an exception
-                server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
-            }
-        }).hasMessageContaining("Invalid response from OpenID Metadata endpoint: 429");
+        try (MetadataServer metadataServer = new MetadataServer(new MetadataServletWithStartup(
+                ImmutableMap.<String, String>builder()
+                        .put("/.well-known/openid-configuration", "oidc/openid-configuration.json")
+                        .put("/jwks.json", "jwk/jwk-public.json")
+                        .buildOrThrow(), 60));
+                TestingTrinoServer server = createServer(
+                        ImmutableMap.<String, String>builder()
+                                .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
+                                .put("http-server.authentication.oauth2.oidc.discovery", "true")
+                                .put("http-server.authentication.oauth2.oidc.discovery.timeout", "5s")
+                                .buildOrThrow())) {
+            OAuth2ServerConfigProvider provider = server.getInstance(Key.get(OAuth2ServerConfigProvider.class));
+            assertThatThrownBy(provider::get)
+                    .hasMessageContaining("Invalid response from OpenID Metadata endpoint: 429");
+        }
     }
 
     @Test


### PR DESCRIPTION
Pull the part which is not supposed to throw outside of `assertThatThrownBy`.
