### PR TITLE
Test: Enable metadata cache in TestBigQueryAvroConnectorTest

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryAvroConnectorTest.java
@@ -43,7 +43,7 @@ public class TestBigQueryAvroConnectorTest
     {
         return BigQueryQueryRunner.createQueryRunner(
                 ImmutableMap.of(),
-                ImmutableMap.of("bigquery.job.label-name", "trino_query", "bigquery.job.label-format", "q_$QUERY_ID__t_$TRACE_TOKEN"),
+                ImmutableMap.of("bigquery.job.label-name", "trino_query", "bigquery.job.label-format", "q_$QUERY_ID__t_$TRACE_TOKEN", "bigquery.metadata.cache-ttl", "5m"),
                 REQUIRED_TPCH_TABLES);
     }
 


### PR DESCRIPTION
## Description

Relates to CI timeout in BigQuery connector
https://github.com/trinodb/trino/actions/runs/7765836111/job/21181005201

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
