### PR TITLE
Decouple ApplyNode expressions from AST

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
@@ -18,7 +18,6 @@ import io.trino.sql.planner.iterative.GroupReference;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
-import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -137,13 +136,6 @@ public final class ExpressionExtractor
         {
             node.getRows().ifPresent(list -> list.forEach(consumer));
             return super.visitValues(node, context);
-        }
-
-        @Override
-        public Void visitApply(ApplyNode node, Void context)
-        {
-            node.getSubqueryAssignments().getExpressions().forEach(consumer);
-            return super.visitApply(node, context);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneApplySourceColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneApplySourceColumns.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolsExtractor;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.PlanNode;
@@ -73,8 +72,8 @@ public class PruneApplySourceColumns
     @Override
     public Result apply(ApplyNode applyNode, Captures captures, Context context)
     {
-        Set<Symbol> subqueryAssignmentsSymbols = applyNode.getSubqueryAssignments().getExpressions().stream()
-                .flatMap(expression -> SymbolsExtractor.extractUnique(expression).stream())
+        Set<Symbol> subqueryAssignmentsSymbols = applyNode.getSubqueryAssignments().values().stream()
+                .flatMap(expression -> expression.inputs().stream())
                 .collect(toImmutableSet());
 
         Optional<PlanNode> prunedSubquery = restrictOutputs(context.getIdAllocator(), applyNode.getSubquery(), subqueryAssignmentsSymbols);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantExists.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantExists.java
@@ -21,7 +21,6 @@ import io.trino.sql.planner.optimizations.Cardinality;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
-import io.trino.sql.tree.ExistsPredicate;
 import io.trino.sql.tree.Expression;
 
 import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.extractCardinality;
@@ -64,9 +63,7 @@ public class RemoveRedundantExists
         implements Rule<ApplyNode>
 {
     private static final Pattern<ApplyNode> PATTERN = applyNode()
-            .matching(node -> node.getSubqueryAssignments()
-                    .getExpressions().stream()
-                    .allMatch(expression -> expression instanceof ExistsPredicate && ((ExistsPredicate) expression).getSubquery().equals(TRUE_LITERAL)));
+            .matching(node -> node.getSubqueryAssignments().values().stream().allMatch(ApplyNode.Exists.class::isInstance));
 
     @Override
     public Pattern<ApplyNode> getPattern()
@@ -92,7 +89,7 @@ public class RemoveRedundantExists
             return Result.empty();
         }
 
-        for (Symbol output : node.getSubqueryAssignments().getOutputs()) {
+        for (Symbol output : node.getSubqueryAssignments().keySet()) {
             assignments.put(output, result);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformExistsApplyToCorrelatedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformExistsApplyToCorrelatedJoin.java
@@ -33,8 +33,6 @@ import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
-import io.trino.sql.tree.ExistsPredicate;
-import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.LongLiteral;
 
 import java.util.Optional;
@@ -98,8 +96,8 @@ public class TransformExistsApplyToCorrelatedJoin
             return Result.empty();
         }
 
-        Expression expression = getOnlyElement(parent.getSubqueryAssignments().getExpressions());
-        if (!(expression instanceof ExistsPredicate)) {
+        ApplyNode.SetExpression expression = getOnlyElement(parent.getSubqueryAssignments().values());
+        if (!(expression instanceof ApplyNode.Exists)) {
             return Result.empty();
         }
 
@@ -144,7 +142,7 @@ public class TransformExistsApplyToCorrelatedJoin
             return Optional.empty();
         }
 
-        Symbol exists = getOnlyElement(applyNode.getSubqueryAssignments().getSymbols());
+        Symbol exists = getOnlyElement(applyNode.getSubqueryAssignments().keySet());
         Assignments.Builder assignments = Assignments.builder()
                 .putIdentities(applyNode.getInput().getOutputSymbols())
                 .put(exists, new CoalesceExpression(ImmutableList.of(subqueryTrue.toSymbolReference(), BooleanLiteral.FALSE_LITERAL)));
@@ -165,7 +163,7 @@ public class TransformExistsApplyToCorrelatedJoin
     {
         ResolvedFunction countFunction = plannerContext.getMetadata().resolveBuiltinFunction("count", ImmutableList.of());
         Symbol count = context.getSymbolAllocator().newSymbol("count", BIGINT);
-        Symbol exists = getOnlyElement(applyNode.getSubqueryAssignments().getSymbols());
+        Symbol exists = getOnlyElement(applyNode.getSubqueryAssignments().keySet());
 
         return new CorrelatedJoinNode(
                 applyNode.getId(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -19,8 +19,6 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
-import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.InPredicate;
 
 import java.util.Optional;
 
@@ -71,18 +69,18 @@ public class TransformUncorrelatedInPredicateSubqueryToSemiJoin
             return Result.empty();
         }
 
-        Expression expression = getOnlyElement(applyNode.getSubqueryAssignments().getExpressions());
-        if (!(expression instanceof InPredicate inPredicate)) {
+        ApplyNode.SetExpression expression = getOnlyElement(applyNode.getSubqueryAssignments().values());
+        if (!(expression instanceof ApplyNode.In inPredicate)) {
             return Result.empty();
         }
 
-        Symbol semiJoinSymbol = getOnlyElement(applyNode.getSubqueryAssignments().getSymbols());
+        Symbol semiJoinSymbol = getOnlyElement(applyNode.getSubqueryAssignments().keySet());
 
         SemiJoinNode replacement = new SemiJoinNode(context.getIdAllocator().getNextId(),
                 applyNode.getInput(),
                 applyNode.getSubquery(),
-                Symbol.from(inPredicate.getValue()),
-                Symbol.from(inPredicate.getValueList()),
+                inPredicate.value(),
+                inPredicate.reference(),
                 semiJoinSymbol,
                 Optional.empty(),
                 Optional.empty(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.spi.type.RowType;
@@ -25,9 +26,7 @@ import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.Assignments.Assignment;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.tree.Expression;
-import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.LongLiteral;
-import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.SubscriptExpression;
 
 import java.util.Map;
@@ -95,25 +94,25 @@ public class UnwrapSingleColumnRowInApply
                 .putIdentities(node.getSubquery().getOutputSymbols());
 
         boolean applied = false;
-        Assignments.Builder applyAssignments = Assignments.builder();
-        for (Map.Entry<Symbol, Expression> assignment : node.getSubqueryAssignments().entrySet()) {
+        ImmutableMap.Builder<Symbol, ApplyNode.SetExpression> applyAssignments = ImmutableMap.builder();
+        for (Map.Entry<Symbol, ApplyNode.SetExpression> assignment : node.getSubqueryAssignments().entrySet()) {
             Symbol output = assignment.getKey();
-            Expression expression = assignment.getValue();
+            ApplyNode.SetExpression expression = assignment.getValue();
 
             Optional<Unwrapping> unwrapped = Optional.empty();
-            if (expression instanceof InPredicate predicate) {
+            if (expression instanceof ApplyNode.In predicate) {
                 unwrapped = unwrapSingleColumnRow(
                         context,
-                        predicate.getValue(),
-                        predicate.getValueList(),
-                        (value, list) -> new InPredicate(value.toSymbolReference(), list.toSymbolReference()));
+                        predicate.value().toSymbolReference(),
+                        predicate.reference().toSymbolReference(),
+                        ApplyNode.In::new);
             }
-            else if (expression instanceof QuantifiedComparisonExpression comparison) {
+            else if (expression instanceof ApplyNode.QuantifiedComparison comparison) {
                 unwrapped = unwrapSingleColumnRow(
                         context,
-                        comparison.getValue(),
-                        comparison.getSubquery(),
-                        (value, list) -> new QuantifiedComparisonExpression(comparison.getOperator(), comparison.getQuantifier(), value.toSymbolReference(), list.toSymbolReference()));
+                        comparison.value().toSymbolReference(),
+                        comparison.reference().toSymbolReference(),
+                        (value, list) -> new ApplyNode.QuantifiedComparison(comparison.operator(), comparison.quantifier(), value, list));
             }
 
             if (unwrapped.isPresent()) {
@@ -140,13 +139,13 @@ public class UnwrapSingleColumnRowInApply
                                 node.getId(),
                                 new ProjectNode(context.getIdAllocator().getNextId(), node.getInput(), inputAssignments.build()),
                                 new ProjectNode(context.getIdAllocator().getNextId(), node.getSubquery(), nestedPlanAssignments.build()),
-                                applyAssignments.build(),
+                                applyAssignments.buildOrThrow(),
                                 node.getCorrelation(),
                                 node.getOriginSubquery()),
                         Assignments.identity(node.getOutputSymbols())));
     }
 
-    private Optional<Unwrapping> unwrapSingleColumnRow(Context context, Expression value, Expression list, BiFunction<Symbol, Symbol, Expression> function)
+    private Optional<Unwrapping> unwrapSingleColumnRow(Context context, Expression value, Expression list, BiFunction<Symbol, Symbol, ApplyNode.SetExpression> function)
     {
         Type type = typeAnalyzer.getType(context.getSession(), context.getSymbolAllocator().getTypes(), value);
         if (type instanceof RowType rowType) {
@@ -158,7 +157,7 @@ public class UnwrapSingleColumnRowInApply
 
                 Assignment inputAssignment = new Assignment(valueSymbol, new SubscriptExpression(value, new LongLiteral("1")));
                 Assignment nestedPlanAssignment = new Assignment(listSymbol, new SubscriptExpression(list, new LongLiteral("1")));
-                Expression comparison = function.apply(valueSymbol, listSymbol);
+                ApplyNode.SetExpression comparison = function.apply(valueSymbol, listSymbol);
 
                 return Optional.of(new Unwrapping(comparison, inputAssignment, nestedPlanAssignment));
             }
@@ -169,18 +168,18 @@ public class UnwrapSingleColumnRowInApply
 
     private static class Unwrapping
     {
-        private final Expression expression;
+        private final ApplyNode.SetExpression expression;
         private final Assignment inputAssignment;
         private final Assignment nestedPlanAssignment;
 
-        public Unwrapping(Expression expression, Assignment inputAssignment, Assignment nestedPlanAssignment)
+        public Unwrapping(ApplyNode.SetExpression expression, Assignment inputAssignment, Assignment nestedPlanAssignment)
         {
             this.expression = requireNonNull(expression, "expression is null");
             this.inputAssignment = requireNonNull(inputAssignment, "inputAssignment is null");
             this.nestedPlanAssignment = requireNonNull(nestedPlanAssignment, "nestedPlanAssignment is null");
         }
 
-        public Expression getExpression()
+        public ApplyNode.SetExpression getExpression()
         {
             return expression;
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -22,6 +22,7 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.SymbolAllocator;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.AggregationNode.Aggregation;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.DataOrganizationSpecification;
 import io.trino.sql.planner.plan.DistinctLimitNode;
 import io.trino.sql.planner.plan.GroupIdNode;
@@ -113,6 +114,19 @@ public class SymbolMapper
     public Symbol map(Symbol symbol)
     {
         return mappingFunction.apply(symbol);
+    }
+
+    public ApplyNode.SetExpression map(ApplyNode.SetExpression expression)
+    {
+        return switch (expression) {
+            case ApplyNode.Exists exists -> exists;
+            case ApplyNode.In in -> new ApplyNode.In(map(in.value()), map(in.reference()));
+            case ApplyNode.QuantifiedComparison comparison -> new ApplyNode.QuantifiedComparison(
+                    comparison.operator(),
+                    comparison.quantifier(),
+                    map(comparison.value()),
+                    map(comparison.reference()));
+        };
     }
 
     public List<Symbol> map(List<Symbol> symbols)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/TransformQuantifiedComparisonApplyToCorrelatedJoin.java
@@ -37,7 +37,6 @@ import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GenericLiteral;
 import io.trino.sql.tree.NullLiteral;
-import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SimpleCaseExpression;
 import io.trino.sql.tree.WhenClause;
@@ -55,6 +54,7 @@ import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.plan.AggregationNode.globalAggregation;
 import static io.trino.sql.planner.plan.AggregationNode.singleAggregation;
+import static io.trino.sql.planner.plan.ApplyNode.Quantifier.ALL;
 import static io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith;
 import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
@@ -64,7 +64,6 @@ import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQ
 import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN;
 import static io.trino.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.NOT_EQUAL;
-import static io.trino.sql.tree.QuantifiedComparisonExpression.Quantifier.ALL;
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
@@ -107,15 +106,15 @@ public class TransformQuantifiedComparisonApplyToCorrelatedJoin
                 return context.defaultRewrite(node);
             }
 
-            Expression expression = getOnlyElement(node.getSubqueryAssignments().getExpressions());
-            if (!(expression instanceof QuantifiedComparisonExpression quantifiedComparison)) {
-                return context.defaultRewrite(node);
+            ApplyNode.SetExpression expression = getOnlyElement(node.getSubqueryAssignments().values());
+            if (expression instanceof ApplyNode.QuantifiedComparison comparison) {
+                return rewriteQuantifiedApplyNode(node, comparison, context);
             }
 
-            return rewriteQuantifiedApplyNode(node, quantifiedComparison, context);
+            return context.defaultRewrite(node);
         }
 
-        private PlanNode rewriteQuantifiedApplyNode(ApplyNode node, QuantifiedComparisonExpression quantifiedComparison, RewriteContext<PlanNode> context)
+        private PlanNode rewriteQuantifiedApplyNode(ApplyNode node, ApplyNode.QuantifiedComparison quantifiedComparison, RewriteContext<PlanNode> context)
         {
             PlanNode subqueryPlan = context.rewrite(node.getSubquery());
 
@@ -175,16 +174,16 @@ public class TransformQuantifiedComparisonApplyToCorrelatedJoin
 
             Expression valueComparedToSubquery = rewriteUsingBounds(quantifiedComparison, minValue, maxValue, countAllValue, countNonNullValue);
 
-            Symbol quantifiedComparisonSymbol = getOnlyElement(node.getSubqueryAssignments().getSymbols());
+            Symbol quantifiedComparisonSymbol = getOnlyElement(node.getSubqueryAssignments().keySet());
 
             return projectExpressions(join, Assignments.of(quantifiedComparisonSymbol, valueComparedToSubquery));
         }
 
-        public Expression rewriteUsingBounds(QuantifiedComparisonExpression quantifiedComparison, Symbol minValue, Symbol maxValue, Symbol countAllValue, Symbol countNonNullValue)
+        public Expression rewriteUsingBounds(ApplyNode.QuantifiedComparison quantifiedComparison, Symbol minValue, Symbol maxValue, Symbol countAllValue, Symbol countNonNullValue)
         {
             BooleanLiteral emptySetResult;
             Function<List<Expression>, Expression> quantifier;
-            if (quantifiedComparison.getQuantifier() == ALL) {
+            if (quantifiedComparison.quantifier() == ALL) {
                 emptySetResult = TRUE_LITERAL;
                 quantifier = expressions -> ExpressionUtils.combineConjuncts(metadata, expressions);
             }
@@ -209,39 +208,51 @@ public class TransformQuantifiedComparisonApplyToCorrelatedJoin
                                     Optional.of(emptySetResult))))));
         }
 
-        private Expression getBoundComparisons(QuantifiedComparisonExpression quantifiedComparison, Symbol minValue, Symbol maxValue)
+        private Expression getBoundComparisons(ApplyNode.QuantifiedComparison quantifiedComparison, Symbol minValue, Symbol maxValue)
         {
-            if (quantifiedComparison.getOperator() == EQUAL && quantifiedComparison.getQuantifier() == ALL) {
+            if (mapOperator(quantifiedComparison) == EQUAL && quantifiedComparison.quantifier() == ALL) {
                 // A = ALL B <=> min B = max B && A = min B
                 return combineConjuncts(
                         metadata,
                         new ComparisonExpression(EQUAL, minValue.toSymbolReference(), maxValue.toSymbolReference()),
-                        new ComparisonExpression(EQUAL, quantifiedComparison.getValue(), maxValue.toSymbolReference()));
+                        new ComparisonExpression(EQUAL, quantifiedComparison.value().toSymbolReference(), maxValue.toSymbolReference()));
             }
 
-            if (EnumSet.of(LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL).contains(quantifiedComparison.getOperator())) {
+            if (EnumSet.of(LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL).contains(mapOperator(quantifiedComparison))) {
                 // A < ALL B <=> A < min B
                 // A > ALL B <=> A > max B
                 // A < ANY B <=> A < max B
                 // A > ANY B <=> A > min B
                 Symbol boundValue = shouldCompareValueWithLowerBound(quantifiedComparison) ? minValue : maxValue;
-                return new ComparisonExpression(quantifiedComparison.getOperator(), quantifiedComparison.getValue(), boundValue.toSymbolReference());
+                return new ComparisonExpression(mapOperator(quantifiedComparison), quantifiedComparison.value().toSymbolReference(), boundValue.toSymbolReference());
             }
             throw new IllegalArgumentException("Unsupported quantified comparison: " + quantifiedComparison);
         }
 
-        private static boolean shouldCompareValueWithLowerBound(QuantifiedComparisonExpression quantifiedComparison)
+        private static ComparisonExpression.Operator mapOperator(ApplyNode.QuantifiedComparison quantifiedComparison)
         {
-            return switch (quantifiedComparison.getQuantifier()) {
-                case ALL -> switch (quantifiedComparison.getOperator()) {
+            return switch (quantifiedComparison.operator()) {
+                case EQUAL -> EQUAL;
+                case NOT_EQUAL -> NOT_EQUAL;
+                case LESS_THAN -> LESS_THAN;
+                case LESS_THAN_OR_EQUAL -> LESS_THAN_OR_EQUAL;
+                case GREATER_THAN -> GREATER_THAN;
+                case GREATER_THAN_OR_EQUAL -> GREATER_THAN_OR_EQUAL;
+            };
+        }
+
+        private static boolean shouldCompareValueWithLowerBound(ApplyNode.QuantifiedComparison quantifiedComparison)
+        {
+            return switch (quantifiedComparison.quantifier()) {
+                case ALL -> switch (mapOperator(quantifiedComparison)) {
                     case LESS_THAN, LESS_THAN_OR_EQUAL -> true;
                     case GREATER_THAN, GREATER_THAN_OR_EQUAL -> false;
-                    default -> throw new IllegalArgumentException("Unexpected value: " + quantifiedComparison.getOperator());
+                    default -> throw new IllegalArgumentException("Unexpected value: " + mapOperator(quantifiedComparison));
                 };
-                case ANY, SOME -> switch (quantifiedComparison.getOperator()) {
+                case ANY, SOME -> switch (mapOperator(quantifiedComparison)) {
                     case LESS_THAN, LESS_THAN_OR_EQUAL -> false;
                     case GREATER_THAN, GREATER_THAN_OR_EQUAL -> true;
-                    default -> throw new IllegalArgumentException("Unexpected value: " + quantifiedComparison.getOperator());
+                    default -> throw new IllegalArgumentException("Unexpected value: " + mapOperator(quantifiedComparison));
                 };
             };
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -147,7 +147,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
@@ -262,7 +261,7 @@ public class PlanPrinter
     {
         TypeProvider typeProvider = TypeProvider.copyOf(symbols.entrySet().stream()
                 .distinct()
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue)));
 
         TableInfoSupplier tableInfoSupplier = new TableInfoSupplier(metadata, session);
         ValuePrinter valuePrinter = new ValuePrinter(metadata, functionManager, session);
@@ -315,7 +314,7 @@ public class PlanPrinter
                 .map(StageInfo::getTables)
                 .map(Map::entrySet)
                 .flatMap(Collection::stream)
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
 
         ValuePrinter valuePrinter = new ValuePrinter(metadata, functionManager, session);
         List<PlanFragment> planFragments = allStages.stream()
@@ -635,7 +634,7 @@ public class PlanPrinter
         return TypeProvider.copyOf(fragments.stream()
                 .flatMap(f -> f.getSymbols().entrySet().stream())
                 .distinct()
-                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue)));
     }
 
     public static String graphvizLogicalPlan(PlanNode plan, TypeProvider types)
@@ -771,7 +770,7 @@ public class PlanPrinter
                             "lookup", formatSymbols(node.getLookupSymbols())),
                     context);
 
-            for (Map.Entry<Symbol, ColumnHandle> entry : node.getAssignments().entrySet()) {
+            for (Entry<Symbol, ColumnHandle> entry : node.getAssignments().entrySet()) {
                 if (node.getOutputSymbols().contains(entry.getKey())) {
                     nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(entry.getKey()), anonymizer.anonymize(entry.getValue()));
                 }
@@ -880,7 +879,7 @@ public class PlanPrinter
                     ImmutableMap.of("symbols", formatCollection(anonymizedInputGroupingSetSymbols, Objects::toString)),
                     context);
 
-            for (Map.Entry<Symbol, Symbol> mapping : node.getGroupingColumns().entrySet()) {
+            for (Entry<Symbol, Symbol> mapping : node.getGroupingColumns().entrySet()) {
                 nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(mapping.getKey()), anonymizer.anonymize(mapping.getValue()));
             }
 
@@ -938,7 +937,7 @@ public class PlanPrinter
                     descriptor.put("hash", formatHash(node.getHashSymbol())).buildOrThrow(),
                     context);
 
-            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
+            for (Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 WindowNode.Function function = entry.getValue();
                 String frameInfo = formatFrame(function.getFrame());
 
@@ -992,7 +991,7 @@ public class PlanPrinter
             if (node.getCommonBaseFrame().isPresent()) {
                 nodeOutput.appendDetails("base frame: %s", formatFrame(node.getCommonBaseFrame().get()));
             }
-            for (Map.Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
+            for (Entry<Symbol, WindowNode.Function> entry : node.getWindowFunctions().entrySet()) {
                 WindowNode.Function function = entry.getValue();
                 nodeOutput.appendDetails(
                         "%s := %s(%s)",
@@ -1001,7 +1000,7 @@ public class PlanPrinter
                         Joiner.on(", ").join(anonymizeExpressions(function.getArguments())));
             }
 
-            for (Map.Entry<Symbol, Measure> entry : node.getMeasures().entrySet()) {
+            for (Entry<Symbol, Measure> entry : node.getMeasures().entrySet()) {
                 nodeOutput.appendDetails(
                         "%s := %s",
                         anonymizer.anonymize(entry.getKey()),
@@ -1018,9 +1017,9 @@ public class PlanPrinter
                             " := " +
                             subset.getValue().stream()
                                     .map(IrLabel::getName)
-                                    .collect(Collectors.joining(", ", "{", "}")))
+                                    .collect(joining(", ", "{", "}")))
                     .collect(joining(", ")));
-            for (Map.Entry<IrLabel, ExpressionAndValuePointers> entry : node.getVariableDefinitions().entrySet()) {
+            for (Entry<IrLabel, ExpressionAndValuePointers> entry : node.getVariableDefinitions().entrySet()) {
                 nodeOutput.appendDetails("%s := %s", entry.getKey().getName(), anonymizer.anonymize(unresolveFunctions(entry.getValue().getExpression())));
                 appendValuePointers(nodeOutput, entry.getValue());
             }
@@ -1383,14 +1382,14 @@ public class PlanPrinter
         {
             return filters.stream()
                     .map(filter -> anonymizer.anonymize(filter.getInput()) + " " + filter.getOperator().getValue() + " #" + filter.getId())
-                    .collect(Collectors.joining(", ", "{", "}"));
+                    .collect(joining(", ", "{", "}"));
         }
 
         private String printDynamicFilterAssignments(Map<DynamicFilterId, Symbol> filters)
         {
             return filters.entrySet().stream()
                     .map(filter -> anonymizer.anonymize(filter.getValue()) + " -> #" + filter.getKey())
-                    .collect(Collectors.joining(", ", "{", "}"));
+                    .collect(joining(", ", "{", "}"));
         }
 
         private void printTableScanInfo(NodeRepresentation nodeOutput, TableScanNode node, TableInfo tableInfo)
@@ -1402,7 +1401,7 @@ public class PlanPrinter
             }
             else {
                 // first, print output columns and their constraints
-                for (Map.Entry<Symbol, ColumnHandle> assignment : node.getAssignments().entrySet()) {
+                for (Entry<Symbol, ColumnHandle> assignment : node.getAssignments().entrySet()) {
                     ColumnHandle column = assignment.getValue();
                     nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(assignment.getKey()), anonymizer.anonymize(column));
                     printConstraint(nodeOutput, column, predicate);
@@ -1616,10 +1615,10 @@ public class PlanPrinter
                 NodeRepresentation nodeOutput,
                 Map<TableStatisticType, Symbol> tableStatistics,
                 Map<ColumnStatisticMetadata, Symbol> columnStatistics,
-                Map<Symbol, AggregationNode.Aggregation> aggregations)
+                Map<Symbol, Aggregation> aggregations)
         {
             nodeOutput.appendDetails("aggregations =>");
-            for (Map.Entry<TableStatisticType, Symbol> tableStatistic : tableStatistics.entrySet()) {
+            for (Entry<TableStatisticType, Symbol> tableStatistic : tableStatistics.entrySet()) {
                 nodeOutput.appendDetails("%s%s => [%s := %s]",
                         indentString(1),
                         anonymizer.anonymize(tableStatistic.getValue()),
@@ -1627,7 +1626,7 @@ public class PlanPrinter
                         formatAggregation(anonymizer, aggregations.get(tableStatistic.getValue())));
             }
 
-            for (Map.Entry<ColumnStatisticMetadata, Symbol> columnStatistic : columnStatistics.entrySet()) {
+            for (Entry<ColumnStatisticMetadata, Symbol> columnStatistic : columnStatistics.entrySet()) {
                 String aggregationName;
                 if (columnStatistic.getKey().getStatisticTypeIfPresent().isPresent()) {
                     aggregationName = columnStatistic.getKey().getStatisticType().name();
@@ -1839,7 +1838,7 @@ public class PlanPrinter
 
                 if (!node.getCopartitioningLists().isEmpty()) {
                     nodeOutput.appendDetails("%s", node.getCopartitioningLists().stream()
-                            .map(list -> list.stream().collect(Collectors.joining(", ", "(", ")")))
+                            .map(list -> list.stream().collect(joining(", ", "(", ")")))
                             .collect(joining(", ", "Co-partition: [", "]")));
                 }
             }
@@ -1976,12 +1975,36 @@ public class PlanPrinter
 
         private void printAssignments(NodeRepresentation nodeOutput, Assignments assignments)
         {
-            for (Map.Entry<Symbol, Expression> entry : assignments.getMap().entrySet()) {
+            for (Entry<Symbol, Expression> entry : assignments.getMap().entrySet()) {
                 if (entry.getValue() instanceof SymbolReference && ((SymbolReference) entry.getValue()).getName().equals(entry.getKey().getName())) {
                     // skip identity assignments
                     continue;
                 }
                 nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(entry.getKey()), anonymizer.anonymize(unresolveFunctions(entry.getValue())));
+            }
+        }
+
+        private void printAssignments(NodeRepresentation nodeOutput, Map<Symbol, ApplyNode.SetExpression> assignments)
+        {
+            for (Entry<Symbol, ApplyNode.SetExpression> entry : assignments.entrySet()) {
+                String assignment = switch (entry.getValue()) {
+                    case ApplyNode.In in -> "%s IN %s".formatted(anonymizer.anonymize(in.value()), anonymizer.anonymize(in.reference()));
+                    case ApplyNode.Exists unused -> "EXISTS";
+                    case ApplyNode.QuantifiedComparison comparison -> "%s %s %s %s".formatted(
+                            anonymizer.anonymize(comparison.value()),
+                            switch (comparison.operator()) {
+                                case EQUAL -> "=";
+                                case NOT_EQUAL -> "<>";
+                                case LESS_THAN -> "<";
+                                case LESS_THAN_OR_EQUAL -> "<=";
+                                case GREATER_THAN -> ">";
+                                case GREATER_THAN_OR_EQUAL -> ">=";
+                            },
+                            comparison.quantifier(),
+                            anonymizer.anonymize(comparison.reference()));
+                };
+
+                nodeOutput.appendDetails("%s := %s", anonymizer.anonymize(entry.getKey()), assignment);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -892,10 +893,15 @@ public final class ValidateDependenciesChecker
                     .addAll(createInputs(node.getInput(), boundSymbols))
                     .build();
 
-            for (Expression expression : node.getSubqueryAssignments().getExpressions()) {
-                Set<Symbol> dependencies = extractUnique(expression);
-                checkDependencies(inputs, dependencies, "Invalid node. Expression dependencies (%s) not in source plan output (%s)", dependencies, inputs);
-            }
+            List<Symbol> dependencies = node.getSubqueryAssignments().values().stream()
+                    .flatMap(assignment -> switch (assignment) {
+                        case ApplyNode.In in -> Stream.of(in.value(), in.reference());
+                        case ApplyNode.QuantifiedComparison comparison -> Stream.of(comparison.value(), comparison.reference());
+                        case ApplyNode.Exists unused -> Stream.empty();
+                    })
+                    .toList();
+
+            checkDependencies(inputs, dependencies, "Invalid node. Expression dependencies (%s) not in source plan output (%s)", dependencies, inputs);
 
             return null;
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -122,6 +122,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.patternRecognitio
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.rowNumber;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.setExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.sort;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.specification;
@@ -995,7 +996,7 @@ public class TestLogicalPlanner
                         filter("OUTER_FILTER",
                                 project(
                                         apply(ImmutableList.of("O", "C"),
-                                                ImmutableMap.of("OUTER_FILTER", expression("THREE IN (C)")),
+                                                ImmutableMap.of("OUTER_FILTER", setExpression(new ApplyNode.In(new Symbol("THREE"), new Symbol("C")))),
                                                 project(ImmutableMap.of("THREE", expression("BIGINT '3'")),
                                                         tableScan("orders", ImmutableMap.of(
                                                                 "O", "orderkey",

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
@@ -18,7 +18,6 @@ import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.tree.Expression;
@@ -92,9 +91,6 @@ public class ExpressionMatcher
     {
         if (node instanceof ProjectNode projectNode) {
             return projectNode.getAssignments().getMap();
-        }
-        if (node instanceof ApplyNode applyNode) {
-            return applyNode.getSubqueryAssignments().getMap();
         }
         return null;
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -727,7 +727,7 @@ public final class PlanMatchPattern
         return node(FilterNode.class, source).with(new FilterMatcher(expectedPredicate, Optional.of(dynamicFilter)));
     }
 
-    public static PlanMatchPattern apply(List<String> correlationSymbolAliases, Map<String, ExpressionMatcher> subqueryAssignments, PlanMatchPattern inputPattern, PlanMatchPattern subqueryPattern)
+    public static PlanMatchPattern apply(List<String> correlationSymbolAliases, Map<String, SetExpressionMatcher> subqueryAssignments, PlanMatchPattern inputPattern, PlanMatchPattern subqueryPattern)
     {
         PlanMatchPattern result = node(ApplyNode.class, inputPattern, subqueryPattern)
                 .with(new CorrelationMatcher(correlationSymbolAliases));
@@ -1049,6 +1049,11 @@ public final class PlanMatchPattern
     public static RvalueMatcher columnReference(String tableName, String columnName)
     {
         return new ColumnReference(tableName, columnName);
+    }
+
+    public static SetExpressionMatcher setExpression(ApplyNode.SetExpression expression)
+    {
+        return new SetExpressionMatcher(expression);
     }
 
     public static ExpressionMatcher expression(@Language("SQL") String expression)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SetExpressionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/SetExpressionMatcher.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.assertions;
+
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.ApplyNode;
+import io.trino.sql.planner.plan.PlanNode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class SetExpressionMatcher
+        implements RvalueMatcher
+{
+    private final ApplyNode.SetExpression expression;
+
+    SetExpressionMatcher(ApplyNode.SetExpression expression)
+    {
+        this.expression = requireNonNull(expression, "expression is null");
+    }
+
+    @Override
+    public Optional<Symbol> getAssignedSymbol(PlanNode node, Session session, Metadata metadata, SymbolAliases aliases)
+    {
+        if (!(node instanceof ApplyNode applyNode)) {
+            return Optional.empty();
+        }
+
+        List<Map.Entry<Symbol, ApplyNode.SetExpression>> matches = new ArrayList<>();
+
+        for (Map.Entry<Symbol, ApplyNode.SetExpression> entry : applyNode.getSubqueryAssignments().entrySet()) {
+            Map.Entry<Symbol, ApplyNode.SetExpression> match = switch (expression) {
+                case ApplyNode.Exists unused when entry.getValue() instanceof ApplyNode.Exists -> entry;
+                case ApplyNode.In expected
+                        when entry.getValue() instanceof ApplyNode.In actual &&
+                        matches(aliases, expected.value(), actual.value()) &&
+                        matches(aliases, expected.reference(), actual.reference()) -> entry;
+                case ApplyNode.QuantifiedComparison expected
+                        when entry.getValue() instanceof ApplyNode.QuantifiedComparison actual &&
+                        expected.operator().equals(actual.operator()) &&
+                        expected.quantifier().equals(actual.quantifier()) &&
+                        matches(aliases, expected.value(), actual.value()) &&
+                        matches(aliases, expected.reference(), actual.reference()) -> entry;
+                default -> null;
+            };
+
+            if (match != null) {
+                matches.add(match);
+            }
+        }
+
+        checkState(matches.size() <= 1, "Ambiguous expression %s matches multiple assignments: %s", expression, matches);
+
+        return matches.stream().map(Map.Entry::getKey).findFirst();
+    }
+
+    private boolean matches(SymbolAliases aliases, Symbol expected, Symbol actual)
+    {
+        return aliases.get(expected.getName()).getName().equals(actual.getName());
+    }
+
+    @Override
+    public String toString()
+    {
+        return expression.toString();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/StrictAssignedSymbolsMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/StrictAssignedSymbolsMatcher.java
@@ -63,7 +63,7 @@ public class StrictAssignedSymbolsMatcher
 
     public static Function<PlanNode, Set<Symbol>> actualSubqueryAssignments()
     {
-        return node -> ((ApplyNode) node).getSubqueryAssignments().getSymbols();
+        return node -> ((ApplyNode) node).getSubqueryAssignments().keySet();
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplyColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplyColumns.java
@@ -16,19 +16,18 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.tree.ComparisonExpression;
-import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.SymbolReference;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.apply;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.setExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
 
@@ -47,7 +46,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.filter(
@@ -75,9 +74,9 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a, inResult1),
                             p.apply(
-                                    Assignments.of(
-                                            inResult1, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference()),
-                                            inResult2, new InPredicate(b.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(
+                                            inResult1, new ApplyNode.In(a, subquerySymbol),
+                                            inResult2, new ApplyNode.In(b, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, b, correlationSymbol),
                                     p.filter(
@@ -89,7 +88,7 @@ public class TestPruneApplyColumns
                                 ImmutableMap.of("a", PlanMatchPattern.expression("a"), "in_result_1", PlanMatchPattern.expression("in_result_1")),
                                 apply(
                                         ImmutableList.of("correlation_symbol"),
-                                        ImmutableMap.of("in_result_1", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
+                                        ImmutableMap.of("in_result_1", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol")))),
                                         project(
                                                 ImmutableMap.of("a", PlanMatchPattern.expression("a"), "correlation_symbol", PlanMatchPattern.expression("correlation_symbol")),
                                                 values("a", "b", "correlation_symbol")),
@@ -109,9 +108,9 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a, inResult1),
                             p.apply(
-                                    Assignments.of(
-                                            inResult1, new InPredicate(a.toSymbolReference(), subquerySymbol1.toSymbolReference()),
-                                            inResult2, new InPredicate(a.toSymbolReference(), subquerySymbol2.toSymbolReference())),
+                                    ImmutableMap.of(
+                                            inResult1, new ApplyNode.In(a, subquerySymbol1),
+                                            inResult2, new ApplyNode.In(a, subquerySymbol2)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.filter(
@@ -123,7 +122,7 @@ public class TestPruneApplyColumns
                                 ImmutableMap.of("a", PlanMatchPattern.expression("a"), "in_result_1", PlanMatchPattern.expression("in_result_1")),
                                 apply(
                                         ImmutableList.of("correlation_symbol"),
-                                        ImmutableMap.of("in_result_1", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol_1"))),
+                                        ImmutableMap.of("in_result_1", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol_1")))),
                                         values("a", "correlation_symbol"),
                                         project(
                                                 ImmutableMap.of("subquery_symbol_1", PlanMatchPattern.expression("subquery_symbol_1")),
@@ -145,7 +144,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(correlationSymbol, inResult),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.filter(
@@ -157,7 +156,7 @@ public class TestPruneApplyColumns
                                 ImmutableMap.of("correlation_symbol", PlanMatchPattern.expression("correlation_symbol"), "in_result", PlanMatchPattern.expression("in_result")),
                                 apply(
                                         ImmutableList.of("correlation_symbol"),
-                                        ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
+                                        ImmutableMap.of("in_result", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol")))),
                                         values("a", "correlation_symbol"),
                                         project(
                                                 ImmutableMap.of("subquery_symbol", PlanMatchPattern.expression("subquery_symbol")),
@@ -179,7 +178,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(correlationSymbol, inResult),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, unreferenced, correlationSymbol),
                                     p.filter(
@@ -191,7 +190,7 @@ public class TestPruneApplyColumns
                                 ImmutableMap.of("correlation_symbol", PlanMatchPattern.expression("correlation_symbol"), "in_result", PlanMatchPattern.expression("in_result")),
                                 apply(
                                         ImmutableList.of("correlation_symbol"),
-                                        ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
+                                        ImmutableMap.of("in_result", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol")))),
                                         project(
                                                 ImmutableMap.of("a", PlanMatchPattern.expression("a"), "correlation_symbol", PlanMatchPattern.expression("correlation_symbol")),
                                                 values("a", "unreferenced", "correlation_symbol")),
@@ -212,7 +211,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a, inResult),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.filter(
@@ -234,7 +233,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a, inResult),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.values(subquerySymbol)));
@@ -254,7 +253,7 @@ public class TestPruneApplyColumns
                     return p.project(
                             Assignments.identity(a, correlationSymbol, inResult),
                             p.apply(
-                                    Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                                    ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                                     ImmutableList.of(correlationSymbol),
                                     p.values(a, correlationSymbol),
                                     p.filter(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplyCorrelation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplyCorrelation.java
@@ -16,15 +16,13 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.tree.ComparisonExpression;
-import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.SymbolReference;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.apply;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.setExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN;
 
@@ -41,7 +39,7 @@ public class TestPruneApplyCorrelation
                     Symbol subquerySymbol = p.symbol("subquery_symbol");
                     Symbol inResult = p.symbol("in_result");
                     return p.apply(
-                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                            ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                             ImmutableList.of(inputSymbol),
                             p.values(a, inputSymbol),
                             p.values(subquerySymbol));
@@ -49,7 +47,7 @@ public class TestPruneApplyCorrelation
                 .matches(
                         apply(
                                 ImmutableList.of(),
-                                ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol"))),
+                                ImmutableMap.of("in_result", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol")))),
                                 values("a", "input_symbol"),
                                 values("subquery_symbol")));
     }
@@ -64,7 +62,7 @@ public class TestPruneApplyCorrelation
                     Symbol subquerySymbol = p.symbol("subquery_symbol");
                     Symbol inResult = p.symbol("in_result");
                     return p.apply(
-                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol.toSymbolReference())),
+                            ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol)),
                             ImmutableList.of(inputSymbol),
                             p.values(a, inputSymbol),
                             p.filter(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplySourceColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneApplySourceColumns.java
@@ -16,16 +16,14 @@ package io.trino.sql.planner.iterative.rule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.assertions.ExpressionMatcher;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.SymbolReference;
+import io.trino.sql.planner.plan.ApplyNode;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.apply;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.setExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 
 public class TestPruneApplySourceColumns
@@ -41,7 +39,7 @@ public class TestPruneApplySourceColumns
                     Symbol subquerySymbol2 = p.symbol("subquery_symbol_2");
                     Symbol inResult = p.symbol("in_result");
                     return p.apply(
-                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), subquerySymbol1.toSymbolReference())),
+                            ImmutableMap.of(inResult, new ApplyNode.In(a, subquerySymbol1)),
                             ImmutableList.of(),
                             p.values(a),
                             p.values(subquerySymbol1, subquerySymbol2));
@@ -49,7 +47,7 @@ public class TestPruneApplySourceColumns
                 .matches(
                         apply(
                                 ImmutableList.of(),
-                                ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("subquery_symbol_1"))),
+                                ImmutableMap.of("in_result", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("subquery_symbol_1")))),
                                 values("a"),
                                 project(
                                         ImmutableMap.of("subquery_symbol_1", PlanMatchPattern.expression("subquery_symbol_1")),
@@ -67,9 +65,9 @@ public class TestPruneApplySourceColumns
                     Symbol inResult1 = p.symbol("in_result_1");
                     Symbol inResult2 = p.symbol("in_result_2");
                     return p.apply(
-                            Assignments.of(
-                                    inResult1, new InPredicate(a.toSymbolReference(), subquerySymbol1.toSymbolReference()),
-                                    inResult2, new InPredicate(a.toSymbolReference(), subquerySymbol2.toSymbolReference())),
+                            ImmutableMap.of(
+                                    inResult1, new ApplyNode.In(a, subquerySymbol1),
+                                    inResult2, new ApplyNode.In(a, subquerySymbol2)),
                             ImmutableList.of(),
                             p.values(a),
                             p.values(subquerySymbol1, subquerySymbol2));
@@ -86,7 +84,7 @@ public class TestPruneApplySourceColumns
                     Symbol subquerySymbol = p.symbol("subquery_symbol");
                     Symbol inResult = p.symbol("in_result");
                     return p.apply(
-                            Assignments.of(inResult, new InPredicate(a.toSymbolReference(), a.toSymbolReference())),
+                            ImmutableMap.of(inResult, new ApplyNode.In(a, a)),
                             ImmutableList.of(),
                             p.values(a),
                             p.values(subquerySymbol));
@@ -94,7 +92,7 @@ public class TestPruneApplySourceColumns
                 .matches(
                         apply(
                                 ImmutableList.of(),
-                                ImmutableMap.of("in_result", ExpressionMatcher.inPredicate(new SymbolReference("a"), new SymbolReference("a"))),
+                                ImmutableMap.of("in_result", setExpression(new ApplyNode.In(new Symbol("a"), new Symbol("a")))),
                                 values("a"),
                                 project(
                                         ImmutableMap.of(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantExists.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantExists.java
@@ -15,18 +15,15 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.Assignments;
-import io.trino.sql.tree.ExistsPredicate;
-import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.SymbolReference;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.testing.TestingMetadata;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 public class TestRemoveRedundantExists
         extends BaseRuleTest
@@ -35,7 +32,7 @@ public class TestRemoveRedundantExists
     public void testExistsFalse()
     {
         tester().assertThat(new RemoveRedundantExists())
-                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                .on(p -> p.apply(ImmutableMap.of(p.symbol("exists"), new ApplyNode.Exists()),
                         ImmutableList.of(),
                         p.values(1),
                         p.values(0)))
@@ -49,7 +46,7 @@ public class TestRemoveRedundantExists
     public void testExistsTrue()
     {
         tester().assertThat(new RemoveRedundantExists())
-                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                .on(p -> p.apply(ImmutableMap.of(p.symbol("exists"), new ApplyNode.Exists()),
                         ImmutableList.of(),
                         p.values(1),
                         p.values(1)))
@@ -63,7 +60,7 @@ public class TestRemoveRedundantExists
     public void testDoesNotFire()
     {
         tester().assertThat(new RemoveRedundantExists())
-                .on(p -> p.apply(Assignments.of(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL)),
+                .on(p -> p.apply(ImmutableMap.of(p.symbol("exists"), new ApplyNode.Exists()),
                         ImmutableList.of(),
                         p.values(1),
                         p.tableScan(ImmutableList.of(), ImmutableMap.of())))
@@ -71,10 +68,10 @@ public class TestRemoveRedundantExists
 
         tester().assertThat(new RemoveRedundantExists())
                 .on(p -> p.apply(
-                        Assignments.builder()
-                                .put(p.symbol("exists"), new ExistsPredicate(TRUE_LITERAL))
-                                .put(p.symbol("other"), new InPredicate(new SymbolReference("value"), new SymbolReference("list")))
-                                .build(),
+                        ImmutableMap.<Symbol, ApplyNode.SetExpression>builder()
+                                .put(p.symbol("exists"), new ApplyNode.Exists())
+                                .put(p.symbol("other"), new ApplyNode.In(p.symbol("value"), p.symbol("list")))
+                                .buildOrThrow(),
                         ImmutableList.of(),
                         p.values(1, p.symbol("value")),
                         p.tableScan(ImmutableList.of(p.symbol("list")), ImmutableMap.of(p.symbol("list"), new TestingMetadata.TestingColumnHandle("list")))))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveUnreferencedScalarApplyNodes.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveUnreferencedScalarApplyNodes.java
@@ -15,12 +15,12 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ApplyNode;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
-import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
 
 public class TestRemoveUnreferencedScalarApplyNodes
         extends BaseRuleTest
@@ -30,7 +30,7 @@ public class TestRemoveUnreferencedScalarApplyNodes
     {
         tester().assertThat(new RemoveUnreferencedScalarApplyNodes())
                 .on(p -> p.apply(
-                        Assignments.of(p.symbol("z"), expression("x IN (y)")),
+                        ImmutableMap.of(p.symbol("z"), new ApplyNode.In(p.symbol("x"), p.symbol("y"))),
                         ImmutableList.of(),
                         p.values(p.symbol("x")),
                         p.values(p.symbol("y"))))
@@ -42,7 +42,7 @@ public class TestRemoveUnreferencedScalarApplyNodes
     {
         tester().assertThat(new RemoveUnreferencedScalarApplyNodes())
                 .on(p -> p.apply(
-                        Assignments.of(),
+                        ImmutableMap.of(),
                         ImmutableList.of(),
                         p.values(p.symbol("x")),
                         p.values(p.symbol("y"))))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformExistsApplyToCorrelatedJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformExistsApplyToCorrelatedJoin.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.FilterNode;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,6 @@ public class TestTransformExistsApplyToCorrelatedJoin
         tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getPlannerContext()))
                 .on(p -> p.values(p.symbol("a")))
                 .doesNotFire();
-
         tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getPlannerContext()))
                 .on(p ->
                         p.correlatedJoin(
@@ -56,7 +56,7 @@ public class TestTransformExistsApplyToCorrelatedJoin
         tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getPlannerContext()))
                 .on(p ->
                         p.apply(
-                                Assignments.of(p.symbol("b", BOOLEAN), expression("EXISTS(SELECT TRUE)")),
+                                ImmutableMap.of(p.symbol("b", BOOLEAN), new ApplyNode.Exists()),
                                 ImmutableList.of(),
                                 p.values(),
                                 p.values()))
@@ -75,7 +75,7 @@ public class TestTransformExistsApplyToCorrelatedJoin
         tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getPlannerContext()))
                 .on(p ->
                         p.apply(
-                                Assignments.of(p.symbol("b", BOOLEAN), expression("EXISTS(SELECT TRUE)")),
+                                ImmutableMap.of(p.symbol("b", BOOLEAN), new ApplyNode.Exists()),
                                 ImmutableList.of(p.symbol("corr")),
                                 p.values(p.symbol("corr")),
                                 p.project(Assignments.of(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformUncorrelatedInPredicateSubqueryToSemiJoin.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformUncorrelatedInPredicateSubqueryToSemiJoin.java
@@ -13,13 +13,10 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.ApplyNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
-import io.trino.sql.tree.ExistsPredicate;
-import io.trino.sql.tree.InPredicate;
-import io.trino.sql.tree.LongLiteral;
-import io.trino.sql.tree.SymbolReference;
 import org.junit.jupiter.api.Test;
 
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
@@ -34,7 +31,7 @@ public class TestTransformUncorrelatedInPredicateSubqueryToSemiJoin
     {
         tester().assertThat(new TransformUncorrelatedInPredicateSubqueryToSemiJoin())
                 .on(p -> p.apply(
-                        Assignments.of(),
+                        ImmutableMap.of(),
                         emptyList(),
                         p.values(),
                         p.values()))
@@ -46,7 +43,7 @@ public class TestTransformUncorrelatedInPredicateSubqueryToSemiJoin
     {
         tester().assertThat(new TransformUncorrelatedInPredicateSubqueryToSemiJoin())
                 .on(p -> p.apply(
-                        Assignments.of(p.symbol("x"), new ExistsPredicate(new LongLiteral("1"))),
+                        ImmutableMap.of(p.symbol("x"), new ApplyNode.Exists()),
                         emptyList(),
                         p.values(),
                         p.values()))
@@ -58,11 +55,11 @@ public class TestTransformUncorrelatedInPredicateSubqueryToSemiJoin
     {
         tester().assertThat(new TransformUncorrelatedInPredicateSubqueryToSemiJoin())
                 .on(p -> p.apply(
-                        Assignments.of(
+                        ImmutableMap.of(
                                 p.symbol("x"),
-                                new InPredicate(
-                                        new SymbolReference("y"),
-                                        new SymbolReference("z"))),
+                                new ApplyNode.In(
+                                        p.symbol("y"),
+                                        p.symbol("z"))),
                         emptyList(),
                         p.values(p.symbol("y")),
                         p.values(p.symbol("z"))))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -526,7 +526,7 @@ public class PlanBuilder
         }
     }
 
-    public ApplyNode apply(Assignments subqueryAssignments, List<Symbol> correlation, PlanNode input, PlanNode subquery)
+    public ApplyNode apply(Map<Symbol, ApplyNode.SetExpression> subqueryAssignments, List<Symbol> correlation, PlanNode input, PlanNode subquery)
     {
         NullLiteral originSubquery = new NullLiteral(); // does not matter for tests
         return new ApplyNode(idAllocator.getNextId(), input, subquery, subqueryAssignments, correlation, originSubquery);


### PR DESCRIPTION
The set expressions in ApplyNode (IN, EXISTS and quantified comparisons) are currently modeled using AST nodes. This is not appropriate, as the expressions are not regular scalar expression -- the right hand side represents a set of values.

In this change, we introduce a new dedicated IR-specific abstraction within ApplyNode to model those expressions.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
