### PR TITLE
Remove unused sqlite-jdbc from Iceberg

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -629,13 +629,6 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.xerial</groupId>
-            <artifactId>sqlite-jdbc</artifactId>
-            <version>3.45.1.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description

Remove unused sqlite-jdbc from Iceberg

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
