### PR TITLE
Fix incorrect deny message in FileBasedSystemAccessControl

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -81,11 +81,13 @@ import static io.trino.spi.security.AccessDeniedException.denyDropSchema;
 import static io.trino.spi.security.AccessDeniedException.denyDropTable;
 import static io.trino.spi.security.AccessDeniedException.denyDropView;
 import static io.trino.spi.security.AccessDeniedException.denyExecuteProcedure;
+import static io.trino.spi.security.AccessDeniedException.denyExecuteQuery;
 import static io.trino.spi.security.AccessDeniedException.denyGrantRoles;
 import static io.trino.spi.security.AccessDeniedException.denyGrantSchemaPrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyGrantTablePrivilege;
 import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
 import static io.trino.spi.security.AccessDeniedException.denyInsertTable;
+import static io.trino.spi.security.AccessDeniedException.denyKillQuery;
 import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
 import static io.trino.spi.security.AccessDeniedException.denyRefreshMaterializedView;
 import static io.trino.spi.security.AccessDeniedException.denyRenameColumn;
@@ -294,7 +296,7 @@ public class FileBasedSystemAccessControl
     public void checkCanExecuteQuery(Identity identity)
     {
         if (!canAccessQuery(identity, Optional.empty(), QueryAccessRule.AccessMode.EXECUTE)) {
-            denyViewQuery();
+            denyExecuteQuery();
         }
     }
 
@@ -321,7 +323,7 @@ public class FileBasedSystemAccessControl
     public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         if (!canAccessQuery(identity, Optional.of(queryOwner.getUser()), QueryAccessRule.AccessMode.KILL)) {
-            denyViewQuery();
+            denyKillQuery();
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/BaseFileBasedSystemAccessControlTest.java
@@ -860,11 +860,11 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertThat(accessControlManager.filterViewQueryOwnedBy(alice, ImmutableSet.of(Identity.ofUser("a"), Identity.ofUser("b")))).isEqualTo(ImmutableSet.of(Identity.ofUser("a"), Identity.ofUser("b")));
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(alice, any),
-                "Cannot view query");
+                "Cannot kill query");
 
         assertAccessDenied(
                 () -> accessControlManager.checkCanExecuteQuery(bob),
-                "Cannot view query");
+                "Cannot execute query");
         assertAccessDenied(
                 () -> accessControlManager.checkCanViewQueryOwnedBy(bob, any),
                 "Cannot view query");
@@ -877,10 +877,10 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertThat(accessControlManager.filterViewQueryOwnedBy(dave, ImmutableSet.of(Identity.ofUser("alice"), Identity.ofUser("bob"), Identity.ofUser("dave"), Identity.ofUser("admin")))).isEqualTo(ImmutableSet.of(Identity.ofUser("alice"), Identity.ofUser("dave")));
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(dave, alice),
-                "Cannot view query");
+                "Cannot kill query");
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(dave, bob),
-                "Cannot view query");
+                "Cannot kill query");
         assertAccessDenied(
                 () -> accessControlManager.checkCanViewQueryOwnedBy(dave, bob),
                 "Cannot view query");
@@ -893,7 +893,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
         accessControlManager.checkCanViewQueryOwnedBy(contractor, dave);
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(contractor, dave),
-                "Cannot view query");
+                "Cannot kill query");
 
         accessControlManager.checkCanExecuteQuery(nonAsciiUser);
         accessControlManager.checkCanViewQueryOwnedBy(nonAsciiUser, any);
@@ -944,7 +944,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertThat(accessControlManager.filterViewQueryOwnedBy(bob, ImmutableSet.of(Identity.ofUser("a"), Identity.ofUser("b")))).isEqualTo(ImmutableSet.of());
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(bob, any),
-                "Cannot view query");
+                "Cannot kill query");
 
         accessControlManager.checkCanExecuteQuery(dave);
         accessControlManager.checkCanViewQueryOwnedBy(dave, alice);
@@ -952,9 +952,9 @@ public abstract class BaseFileBasedSystemAccessControlTest
         assertThat(accessControlManager.filterViewQueryOwnedBy(dave, ImmutableSet.of(Identity.ofUser("alice"), Identity.ofUser("bob"), Identity.ofUser("dave"), Identity.ofUser("admin")))).isEqualTo(ImmutableSet.of(Identity.ofUser("alice"), Identity.ofUser("dave")));
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(dave, alice),
-                "Cannot view query");
+                "Cannot kill query");
         assertAccessDenied(() -> accessControlManager.checkCanKillQueryOwnedBy(dave, bob),
-                "Cannot view query");
+                "Cannot kill query");
         assertAccessDenied(
                 () -> accessControlManager.checkCanViewQueryOwnedBy(dave, bob),
                 "Cannot view query");
@@ -967,7 +967,7 @@ public abstract class BaseFileBasedSystemAccessControlTest
         accessControlManager.checkCanViewQueryOwnedBy(contractor, dave);
         assertAccessDenied(
                 () -> accessControlManager.checkCanKillQueryOwnedBy(contractor, dave),
-                "Cannot view query");
+                "Cannot kill query");
     }
 
     @Test


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If we using FileBasedSystemAccessControl and execute or kill query using a user which is not match rule, FileBasedSystemAccessControl will throw `Cannot view query` rather than `Cannot execute query` or `Cannot kill query`


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

![image](https://github.com/trinodb/trino/assets/37698246/c1b7112c-4755-42bd-a198-7d5d5a14657a)

```
io.trino.spi.security.AccessDeniedException: Access Denied: Cannot view query
	at io.trino.spi.security.AccessDeniedException.denyViewQuery(AccessDeniedException.java:98)
	at io.trino.spi.security.AccessDeniedException.denyViewQuery(AccessDeniedException.java:93)
	at io.trino.plugin.base.security.FileBasedSystemAccessControl.checkCanExecuteQuery(FileBasedSystemAccessControl.java:338)
	at io.trino.security.AccessControlManager.lambda$checkCanExecuteQuery$6(AccessControlManager.java:266)
	at io.trino.security.AccessControlManager.systemAuthorizationCheck(AccessControlManager.java:1263)
	at io.trino.security.AccessControlManager.checkCanExecuteQuery(AccessControlManager.java:266)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.trino.plugin.base.util.LoggingInvocationHandler.handleInvocation(LoggingInvocationHandler.java:60)
	at com.google.common.reflect.AbstractInvocationHandler.invoke(AbstractInvocationHandler.java:87)
	at com.sun.proxy.$Proxy115.checkCanExecuteQuery(Unknown Source)
	at io.trino.security.ForwardingAccessControl.checkCanExecuteQuery(ForwardingAccessControl.java:83)
	at io.trino.dispatcher.DispatchManager.createQueryInternal(DispatchManager.java:181)
	at io.trino.dispatcher.DispatchManager.lambda$createQuery$0(DispatchManager.java:153)
	at io.trino.$gen.Trino_dev____20240206_032701_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

