### PR TITLE
Refactor TableReferenceInfo implementing classes

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/BaseViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/BaseViewReferenceInfo.java
@@ -13,42 +13,16 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import static java.util.Objects.requireNonNull;
-
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public abstract class BaseViewReferenceInfo
-        implements TableReferenceInfo
+public sealed interface BaseViewReferenceInfo
+        extends TableReferenceInfo
+        permits ViewReferenceInfo, MaterializedViewReferenceInfo
 {
-    private final String catalogName;
-    private final String schemaName;
-    private final String viewName;
+    String catalogName();
 
-    protected BaseViewReferenceInfo(String catalogName, String schemaName, String viewName)
-    {
-        this.catalogName = requireNonNull(catalogName, "catalogName is null");
-        this.schemaName = requireNonNull(schemaName, "schemaName is null");
-        this.viewName = requireNonNull(viewName, "viewName is null");
-    }
+    String schemaName();
 
-    @JsonProperty
-    public String getCatalogName()
-    {
-        return catalogName;
-    }
-
-    @JsonProperty
-    public String getSchemaName()
-    {
-        return schemaName;
-    }
-
-    @JsonProperty
-    public String getViewName()
-    {
-        return viewName;
-    }
+    String viewName();
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnMaskReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnMaskReferenceInfo.java
@@ -13,27 +13,20 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public class ColumnMaskReferenceInfo
-        extends FilterMaskReferenceInfo
+public record ColumnMaskReferenceInfo(@Override String expression, @Override String targetCatalogName, @Override String targetSchemaName, @Override String targetTableName, String targetColumnName)
+        implements FilterMaskReferenceInfo
 {
-    private final String columnName;
-
-    @JsonCreator
-    public ColumnMaskReferenceInfo(String maskExpression, String targetCatalogName, String targetSchemaName, String targetTableName, String targetColumnName)
+    public ColumnMaskReferenceInfo
     {
-        super(maskExpression, targetCatalogName, targetSchemaName, targetTableName);
-        this.columnName = targetColumnName;
-    }
-
-    @JsonProperty
-    public String getTargetColumnName()
-    {
-        return columnName;
+        requireNonNull(expression, "expression is null");
+        requireNonNull(targetCatalogName, "targetCatalogName is null");
+        requireNonNull(targetSchemaName, "targetSchemaName is null");
+        requireNonNull(targetTableName, "targetTableName is null");
+        requireNonNull(targetColumnName, "targetColumnName is null");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/FilterMaskReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/FilterMaskReferenceInfo.java
@@ -13,48 +13,19 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public abstract class FilterMaskReferenceInfo
-        implements TableReferenceInfo
+public sealed interface FilterMaskReferenceInfo
+        extends TableReferenceInfo
+        permits RowFilterReferenceInfo, ColumnMaskReferenceInfo
+
 {
-    private final String expression;
-    private final String targetCatalogName;
-    private final String targetSchemaName;
-    private final String targetTableName;
+    String expression();
 
-    protected FilterMaskReferenceInfo(String expression, String targetCatalogName, String targetSchemaName, String targetTableName)
-    {
-        this.expression = expression;
-        this.targetCatalogName = targetCatalogName;
-        this.targetSchemaName = targetSchemaName;
-        this.targetTableName = targetTableName;
-    }
+    String targetCatalogName();
 
-    @JsonProperty
-    public String getExpression()
-    {
-        return expression;
-    }
+    String targetSchemaName();
 
-    @JsonProperty
-    public String getTargetCatalogName()
-    {
-        return targetCatalogName;
-    }
-
-    @JsonProperty
-    public String getTargetSchemaName()
-    {
-        return targetSchemaName;
-    }
-
-    @JsonProperty
-    public String getTargetTableName()
-    {
-        return targetTableName;
-    }
+    String targetTableName();
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/MaterializedViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/MaterializedViewReferenceInfo.java
@@ -13,17 +13,18 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public class MaterializedViewReferenceInfo
-        extends BaseViewReferenceInfo
+public record MaterializedViewReferenceInfo(@Override String catalogName, @Override String schemaName, @Override String viewName)
+        implements BaseViewReferenceInfo
 {
-    @JsonCreator
-    public MaterializedViewReferenceInfo(String catalogName, String schemaName, String viewName)
+    public MaterializedViewReferenceInfo
     {
-        super(catalogName, schemaName, viewName);
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(schemaName, "schemaName is null");
+        requireNonNull(viewName, "viewName is null");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RowFilterReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RowFilterReferenceInfo.java
@@ -13,17 +13,19 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public class RowFilterReferenceInfo
-        extends FilterMaskReferenceInfo
+public record RowFilterReferenceInfo(@Override String expression, @Override String targetCatalogName, @Override String targetSchemaName, @Override String targetTableName)
+        implements FilterMaskReferenceInfo
 {
-    @JsonCreator
-    public RowFilterReferenceInfo(String filterExpression, String targetCatalogName, String targetSchemaName, String targetTableName)
+    public RowFilterReferenceInfo
     {
-        super(filterExpression, targetCatalogName, targetSchemaName, targetTableName);
+        requireNonNull(expression, "expression is null");
+        requireNonNull(targetCatalogName, "targetCatalogName is null");
+        requireNonNull(targetSchemaName, "targetSchemaName is null");
+        requireNonNull(targetTableName, "targetTableName is null");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableReferenceInfo.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = MaterializedViewReferenceInfo.class, name = "materializedView"),
         @JsonSubTypes.Type(value = RowFilterReferenceInfo.class, name = "rowFilter"),
         @JsonSubTypes.Type(value = ColumnMaskReferenceInfo.class, name = "columnMask")})
-public interface TableReferenceInfo
+public sealed interface TableReferenceInfo
+        permits BaseViewReferenceInfo, FilterMaskReferenceInfo
 {
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ViewReferenceInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ViewReferenceInfo.java
@@ -13,17 +13,18 @@
  */
 package io.trino.spi.eventlistener;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
+import static java.util.Objects.requireNonNull;
 
 /**
  * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
  */
-public class ViewReferenceInfo
-        extends BaseViewReferenceInfo
+public record ViewReferenceInfo(@Override String catalogName, @Override String schemaName, @Override String viewName)
+        implements BaseViewReferenceInfo
 {
-    @JsonCreator
-    public ViewReferenceInfo(String catalogName, String schemaName, String viewName)
+    public ViewReferenceInfo
     {
-        super(catalogName, schemaName, viewName);
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(schemaName, "schemaName is null");
+        requireNonNull(viewName, "viewName is null");
     }
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestTableReferenceInfo.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/eventlistener/TestTableReferenceInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.eventlistener;
+
+import io.airlift.json.JsonCodec;
+import org.junit.jupiter.api.Test;
+
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestTableReferenceInfo
+{
+    private final JsonCodec<TableReferenceInfo> codec = jsonCodec(TableReferenceInfo.class);
+
+    @Test
+    public void testJsonRoundTrip()
+    {
+        assertRoundTrip(new ViewReferenceInfo("catalogName", "schemaName", "viewName"));
+        assertRoundTrip(new MaterializedViewReferenceInfo("catalogName", "schemaName", "materializedViewName"));
+        assertRoundTrip(new RowFilterReferenceInfo("expression", "targetCatalogName", "targetSchemaName", "targetTableName"));
+        assertRoundTrip(new ColumnMaskReferenceInfo("expression", "targetCatalogName", "targetSchemaName", "targetTableName", "targetColumnName"));
+    }
+
+    private void assertRoundTrip(TableReferenceInfo info)
+    {
+        assertThat(codec.fromJson(codec.toJson(info))).isEqualTo(info);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/BaseViewReferenceInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/BaseViewReferenceInfoAssert.java
@@ -28,9 +28,9 @@ public class BaseViewReferenceInfoAssert
 
     public BaseViewReferenceInfoAssert hasCatalogSchemaView(String catalogName, String schemaName, String viewName)
     {
-        assertThat(actual.getCatalogName()).isEqualTo(catalogName);
-        assertThat(actual.getSchemaName()).isEqualTo(schemaName);
-        assertThat(actual.getViewName()).isEqualTo(viewName);
+        assertThat(actual.catalogName()).isEqualTo(catalogName);
+        assertThat(actual.schemaName()).isEqualTo(schemaName);
+        assertThat(actual.viewName()).isEqualTo(viewName);
         return this;
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/common/assertions/FilterMaskReferenceInfoAssert.java
+++ b/testing/trino-tests/src/test/java/io/trino/common/assertions/FilterMaskReferenceInfoAssert.java
@@ -29,15 +29,15 @@ public class FilterMaskReferenceInfoAssert
 
     public FilterMaskReferenceInfoAssert hasExpression(String expression)
     {
-        assertThat(actual.getExpression()).isEqualToIgnoringWhitespace(expression);
+        assertThat(actual.expression()).isEqualToIgnoringWhitespace(expression);
         return this;
     }
 
     public FilterMaskReferenceInfoAssert hasTargetCatalogSchemaTable(String catalogName, String schemaName, String tableName)
     {
-        assertThat(actual.getTargetCatalogName()).isEqualTo(catalogName);
-        assertThat(actual.getTargetSchemaName()).isEqualTo(schemaName);
-        assertThat(actual.getTargetTableName()).isEqualTo(tableName);
+        assertThat(actual.targetCatalogName()).isEqualTo(catalogName);
+        assertThat(actual.targetSchemaName()).isEqualTo(schemaName);
+        assertThat(actual.targetTableName()).isEqualTo(tableName);
         return this;
     }
 
@@ -45,7 +45,7 @@ public class FilterMaskReferenceInfoAssert
     {
         TrinoAssertions.assertThat(actual).isInstanceOfSatisfying(
                 ColumnMaskReferenceInfo.class,
-                columnMaskInfo -> assertThat(columnMaskInfo.getTargetColumnName()).isEqualTo(maskedColumnName));
+                columnMaskInfo -> assertThat(columnMaskInfo.targetColumnName()).isEqualTo(maskedColumnName));
         return this;
     }
 }


### PR DESCRIPTION
## Description
Refactors `TableReferenceInfo` implementations into sealed interfaces and record classes to reduce boilerplate and the risk of implementation bugs such as mismatches between getter field names and concrete class class constructor arguments (such as was previously the case between `RowFilterReferenceInfo` and `FilterMaskReferenceInfo`).


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Follows up from https://github.com/trinodb/trino/pull/18871


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
