### PR TITLE
Remove redundant PositionsAppender reset loop

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
+++ b/core/trino-main/src/main/java/io/trino/operator/output/RowPositionsAppender.java
@@ -162,17 +162,12 @@ public class RowPositionsAppender
             }
             result = fromNotNullSuppressedFieldBlocks(positionCount, hasNullRow ? Optional.of(rowIsNull) : Optional.empty(), fieldBlocks);
         }
+        else if (hasNullRow) {
+            Block nullRowBlock = type.createBlockBuilder(null, 0).appendNull().build();
+            result = RunLengthEncodedBlock.create(nullRowBlock, positionCount);
+        }
         else {
-            for (UnnestingPositionsAppender fieldAppender : fieldAppenders) {
-                fieldAppender.reset();
-            }
-            if (hasNullRow) {
-                Block nullRowBlock = type.createBlockBuilder(null, 0).appendNull().build();
-                result = RunLengthEncodedBlock.create(nullRowBlock, positionCount);
-            }
-            else {
-                result = type.createBlockBuilder(null, 0).build();
-            }
+            result = type.createBlockBuilder(null, 0).build();
         }
 
         reset();


### PR DESCRIPTION
## Description
Removes a redundant loop over `UnnestingPositionAppenders#reset()` from `RowPositionsAppender#build()` since the subsequent call to `RowPositionsAppender#reset()` in the same method will itself perform a reset loop after https://github.com/trinodb/trino/pull/20529



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
