### PR TITLE
[Support]: S3 express bucket using a Switching Filesystem Logic

### DIFF
--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/Constants.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/Constants.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.filesystem.manager;
+
+final class Constants
+{
+    static final String S3_EXPRESS_FACTORY_KEY = "S3_EXPRESS_FACTORY_KEY";
+
+    private Constants()
+    {}
+}

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemConfig.java
@@ -25,6 +25,13 @@ public class FileSystemConfig
     private boolean nativeGcsEnabled;
     private CacheType cacheType = NONE;
 
+    // This enables us to communicate with S3Express buckets.
+    // Enabling `nativeS3Enabled` by default may lead to differences in behavior.
+    // This flag indicates the `FileSystemModule` to load `S3FileSystemModule` as well for
+    // accessing S3Express while `FileSystemModule` still passes `s3Enabled` to `HdfsFileSystemLoader` on the basis of `nativeS3Enabled`.
+    // This gives the benefit of the both -- we can have the calls routed to old FileSystem until `nativeS3Enabled` is true in OSS.
+    private boolean nativeS3ExpressEnabled = true;
+
     public boolean isHadoopEnabled()
     {
         return hadoopEnabled;
@@ -70,6 +77,18 @@ public class FileSystemConfig
     public FileSystemConfig setNativeGcsEnabled(boolean nativeGcsEnabled)
     {
         this.nativeGcsEnabled = nativeGcsEnabled;
+        return this;
+    }
+
+    public boolean isNativeS3ExpressEnabled()
+    {
+        return nativeS3ExpressEnabled;
+    }
+
+    @Config("fs.s3-express.enabled")
+    public FileSystemConfig setNativeS3ExpressEnabled(boolean nativeS3ExpressEnabled)
+    {
+        this.nativeS3ExpressEnabled = nativeS3ExpressEnabled;
         return this;
     }
 

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -83,6 +83,11 @@ public class FileSystemModule
 
         var factories = newMapBinder(binder, String.class, TrinoFileSystemFactory.class);
 
+        if (config.isNativeS3ExpressEnabled()) {
+            install(new S3FileSystemModule());
+            factories.addBinding(Constants.S3_EXPRESS_FACTORY_KEY).to(S3FileSystemFactory.class);
+        }
+
         if (config.isNativeAzureEnabled()) {
             install(new AzureFileSystemModule());
             factories.addBinding("abfs").to(AzureFileSystemFactory.class);

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/SwitchingFileSystem.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/SwitchingFileSystem.java
@@ -152,6 +152,13 @@ final class SwitchingFileSystem
 
     private TrinoFileSystemFactory determineFactory(Location location)
     {
+        if (isS3ExpressBucket(location)) {
+            return location.scheme()
+                    .map(scheme -> factories.get(Constants.S3_EXPRESS_FACTORY_KEY))
+                    .orElseThrow(() -> new IllegalStateException("No factory for S3 Express location: " + location
+                            + ". Please ensure that `fs.s3-express.enabled` is set"));
+        }
+
         return location.scheme()
                 .map(factories::get)
                 .or(() -> hdfsFactory)
@@ -162,5 +169,10 @@ final class SwitchingFileSystem
     {
         return session.map(factory::create).orElseGet(() ->
                 factory.create(identity.orElseThrow()));
+    }
+
+    private boolean isS3ExpressBucket(Location location)
+    {
+        return location.host().orElse("").endsWith("--x-s3");
     }
 }

--- a/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
+++ b/lib/trino-filesystem-manager/src/test/java/io/trino/filesystem/manager/TestFileSystemConfig.java
@@ -34,6 +34,7 @@ public class TestFileSystemConfig
                 .setNativeAzureEnabled(false)
                 .setNativeS3Enabled(false)
                 .setNativeGcsEnabled(false)
+                .setNativeS3ExpressEnabled(true)
                 .setCacheType(NONE));
     }
 
@@ -45,6 +46,7 @@ public class TestFileSystemConfig
                 .put("fs.native-azure.enabled", "true")
                 .put("fs.native-s3.enabled", "true")
                 .put("fs.native-gcs.enabled", "true")
+                .put("fs.s3-express.enabled", "false")
                 .put("fs.cache", "alluxio")
                 .buildOrThrow();
 
@@ -53,6 +55,7 @@ public class TestFileSystemConfig
                 .setNativeAzureEnabled(true)
                 .setNativeS3Enabled(true)
                 .setNativeGcsEnabled(true)
+                .setNativeS3ExpressEnabled(false)
                 .setCacheType(ALLUXIO);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

[Support]: S3 express bucket using a Switching Filesystem Logic

By Trino uses a file system which is built on sdkv1 to support s3 express buckets it needs a filesystem which uses sdkv2.
https://aws.amazon.com/s3/storage-classes/express-one-zone/

So a switching file system logic has been implemented.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
Testing 

```
Tested with hive, iceberg, delta -- scenarios below work fine.

Added fs.s3-express.enabled which is true by default. This can be turned off in case of any regressions on standard bucket path. This flag enables us to selectively enable S3 native filesystem only for S3Express.
Testing

trino:vinaydev_s3express_test> CREATE SCHEMA vinaydev_s3express_test_trino_435

                          ->   WITH
                          ->  (LOCATION = 's3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/');
CREATE SCHEMA

============================= Hive ============================ 

trino:vinaydev_s3express_test> use hive.vinaydev_s3express_test_trino_435; 
trino:vinaydev_s3express_test_trino_435> create table t1 as select 1 as c1, 'str' as c2; CREATE TABLE: 1 row
trino:vinaydev_s3express_test_trino_435> insert into t1 values (2, 'str'); 
trino:vinaydev_s3express_test_trino_435> select "$path", * from t1;

                                                                  $path                                                                    | c1 | c2

---------------------------------------------------------------------------------------------------------------------------------------------+----+----- s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1/20231214_104808_00011_pw5bz_1111ee1a-cb26-4e20-b3b9-dcd97ab4fb79 | 2 | str s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1/20231214_104347_00009_pw5bz_6433338a-31d2-49c5-9ac2-0e7485dc35ce | 1 | str (2 rows)

============================= Iceberg ============================

trino:vinaydev_s3express_test_trino_435> use iceberg.vinaydev_s3express_test; trino:vinaydev_s3express_test_trino_435> create table t1_iceberg_parquet as select from hive.vinaydev_s3express_test_trino_435.t1; trino:vinaydev_s3express_test_trino_435> select "$path", from t1_iceberg_parquet;

                                                                                                 $path                                                                                                   | c1 | c2

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--- -+----- s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1_iceberg_parquet-f1f0dee6ca644745bf41ffee391d9291/data/20231214_105110_00021_pw5bz-a956107a-5fb1-4e55-b8a4-8d3ac5d02bda.parquet | 2 | str s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1_iceberg_parquet-f1f0dee6ca644745bf41ffee391d9291/data/20231214_105110_00021_pw5bz-a956107a-5fb1-4e55-b8a4-8d3ac5d02bda.parquet | 1 | str (2 rows)

trino:vinaydev_s3express_test_trino_435> update t1_iceberg_parquet set c2 = 'up1' where c1 = 1; trino:vinaydev_s3express_test_trino_435> delete from t1_iceberg_parquet where c1 = 1; trino:vinaydev_s3express_test_trino_435> insert into t1_iceberg_parquet values (3, 'str'); trino:vinaydev_s3express_test_trino_435> select "$path", * from t1_iceberg_parquet;

                                                                                                 $path                                                                                                   | c1 | c2

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----+----- s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1_iceberg_parquet-f1f0dee6ca644745bf41ffee391d9291/data/20231214_105426_00026_pw5bz-6546d0c4-fa36-40ab-bc02-fbdd4bbd1390.parquet | 3 | str s3://vinaydev--use1-az6--x-s3/schemas/vinaydev_s3express_test_trino_435/t1_iceberg_parquet-f1f0dee6ca644745bf41ffee391d9291/data/20231214_105110_00021_pw5bz-a956107a-5fb1-4e55-b8a4-8d3ac5d02bda.parquet | 2 | str (2 rows)

============================= Delta ============================

trino:vinaydev_s3express_test_trino_435> use delta.vinaydev_s3express_test_trino_435; USE trino:vinaydev_s3express_test_trino_435> create table t1_delta_parquet as select from hive.vinaydev_s3express_test_trino_435.t1; trino:vinaydev_s3express_test_trino_435> select from t1_delta_parquet; c1 | c2 ----+-----

1 | str
2 | str

(2 rows)

trino:vinaydev_s3express_test_trino_435> update t1_delta_parquet set c2 = 'up1' where c1 = 1; trino:vinaydev_s3express_test_trino_435> select * from t1_delta_parquet; c1 | c2 ----+-----

2 | str
1 | up1

(2 rows)

trino:vinaydev_s3express_test_trino_435> delete from t1_delta_parquet where c1 = 1; trino:vinaydev_s3express_test_trino_435> select * from t1_delta_parquet; c1 | c2 ----+-----

2 | str

(1 row)

trino:vinaydev_s3express_test_trino_435> insert into t1_delta_parquet values (3, 'str'); trino:vinaydev_s3express_test_trino_435> select * from t1_delta_parquet; c1 | c2 ----+-----

3 | str
2 | str

(2 rows)

trino:vinaydev_s3express_test_trino_435> select "$path", * from t1_delta_parquet;

                                                                                         $path                                                                                            | c1 | c2
```

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
