### PR TITLE
Hive stats adaptation from metastore implementations to SPI conversion layer

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -98,18 +98,18 @@ public class HiveMetastoreClosure
         return delegate.getSupportedColumnStatistics(type);
     }
 
-    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
-        return delegate.getTableColumnStatistics(databaseName, tableName, columnNames, rowCount);
+        return delegate.getTableColumnStatistics(databaseName, tableName, columnNames);
     }
 
     public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(
             String databaseName,
             String tableName,
-            Map<String, OptionalLong> partitionNamesWithRowCount,
+            Set<String> partitionNames,
             Set<String> columnNames)
     {
-        return delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNamesWithRowCount, columnNames);
+        return delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNames, columnNames);
     }
 
     public boolean useSparkTableStatistics()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveColumnStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveColumnStatistics.java
@@ -44,7 +44,7 @@ public class HiveColumnStatistics
     private final OptionalLong maxValueSizeInBytes;
     private final OptionalLong totalSizeInBytes;
     private final OptionalLong nullsCount;
-    private final OptionalLong distinctValuesCount;
+    private final OptionalLong distinctValuesWithNullCount;
 
     public static HiveColumnStatistics empty()
     {
@@ -61,7 +61,7 @@ public class HiveColumnStatistics
             @JsonProperty("maxValueSizeInBytes") OptionalLong maxValueSizeInBytes,
             @JsonProperty("totalSizeInBytes") OptionalLong totalSizeInBytes,
             @JsonProperty("nullsCount") OptionalLong nullsCount,
-            @JsonProperty("distinctValuesCount") OptionalLong distinctValuesCount)
+            @JsonProperty("distinctValuesWithNullCount") OptionalLong distinctValuesWithNullCount)
     {
         this.integerStatistics = requireNonNull(integerStatistics, "integerStatistics is null");
         this.doubleStatistics = requireNonNull(doubleStatistics, "doubleStatistics is null");
@@ -71,7 +71,7 @@ public class HiveColumnStatistics
         this.maxValueSizeInBytes = requireNonNull(maxValueSizeInBytes, "maxValueSizeInBytes is null");
         this.totalSizeInBytes = requireNonNull(totalSizeInBytes, "totalSizeInBytes is null");
         this.nullsCount = requireNonNull(nullsCount, "nullsCount is null");
-        this.distinctValuesCount = requireNonNull(distinctValuesCount, "distinctValuesCount is null");
+        this.distinctValuesWithNullCount = requireNonNull(distinctValuesWithNullCount, "distinctValuesWithNullCount is null");
 
         List<String> presentStatistics = new ArrayList<>();
         integerStatistics.ifPresent(s -> presentStatistics.add("integerStatistics"));
@@ -131,9 +131,9 @@ public class HiveColumnStatistics
     }
 
     @JsonProperty
-    public OptionalLong getDistinctValuesCount()
+    public OptionalLong getDistinctValuesWithNullCount()
     {
-        return distinctValuesCount;
+        return distinctValuesWithNullCount;
     }
 
     @Override
@@ -154,7 +154,7 @@ public class HiveColumnStatistics
                 Objects.equals(maxValueSizeInBytes, that.maxValueSizeInBytes) &&
                 Objects.equals(totalSizeInBytes, that.totalSizeInBytes) &&
                 Objects.equals(nullsCount, that.nullsCount) &&
-                Objects.equals(distinctValuesCount, that.distinctValuesCount);
+                Objects.equals(distinctValuesWithNullCount, that.distinctValuesWithNullCount);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class HiveColumnStatistics
                 maxValueSizeInBytes,
                 totalSizeInBytes,
                 nullsCount,
-                distinctValuesCount);
+                distinctValuesWithNullCount);
     }
 
     @Override
@@ -184,43 +184,43 @@ public class HiveColumnStatistics
         maxValueSizeInBytes.ifPresent(stats -> toStringHelper.add("maxValueSizeInBytes", stats));
         totalSizeInBytes.ifPresent(stats -> toStringHelper.add("totalSizeInBytes", stats));
         nullsCount.ifPresent(stats -> toStringHelper.add("nullsCount", stats));
-        distinctValuesCount.ifPresent(stats -> toStringHelper.add("distinctValuesCount", stats));
+        distinctValuesWithNullCount.ifPresent(stats -> toStringHelper.add("distinctValuesWithNullCount", stats));
         return toStringHelper.toString();
     }
 
-    public static HiveColumnStatistics createIntegerColumnStatistics(OptionalLong min, OptionalLong max, OptionalLong nullsCount, OptionalLong distinctValuesCount)
+    public static HiveColumnStatistics createIntegerColumnStatistics(OptionalLong min, OptionalLong max, OptionalLong nullsCount, OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setIntegerStatistics(new IntegerStatistics(min, max))
                 .setNullsCount(nullsCount)
-                .setDistinctValuesCount(distinctValuesCount)
+                .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
-    public static HiveColumnStatistics createDoubleColumnStatistics(OptionalDouble min, OptionalDouble max, OptionalLong nullsCount, OptionalLong distinctValuesCount)
+    public static HiveColumnStatistics createDoubleColumnStatistics(OptionalDouble min, OptionalDouble max, OptionalLong nullsCount, OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setDoubleStatistics(new DoubleStatistics(min, max))
                 .setNullsCount(nullsCount)
-                .setDistinctValuesCount(distinctValuesCount)
+                .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
-    public static HiveColumnStatistics createDecimalColumnStatistics(Optional<BigDecimal> min, Optional<BigDecimal> max, OptionalLong nullsCount, OptionalLong distinctValuesCount)
+    public static HiveColumnStatistics createDecimalColumnStatistics(Optional<BigDecimal> min, Optional<BigDecimal> max, OptionalLong nullsCount, OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setDecimalStatistics(new DecimalStatistics(min, max))
                 .setNullsCount(nullsCount)
-                .setDistinctValuesCount(distinctValuesCount)
+                .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
-    public static HiveColumnStatistics createDateColumnStatistics(Optional<LocalDate> min, Optional<LocalDate> max, OptionalLong nullsCount, OptionalLong distinctValuesCount)
+    public static HiveColumnStatistics createDateColumnStatistics(Optional<LocalDate> min, Optional<LocalDate> max, OptionalLong nullsCount, OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setDateStatistics(new DateStatistics(min, max))
                 .setNullsCount(nullsCount)
-                .setDistinctValuesCount(distinctValuesCount)
+                .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
@@ -236,13 +236,13 @@ public class HiveColumnStatistics
             OptionalLong maxValueSizeInBytes,
             OptionalLong totalSizeInBytes,
             OptionalLong nullsCount,
-            OptionalLong distinctValuesCount)
+            OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setMaxValueSizeInBytes(maxValueSizeInBytes)
                 .setTotalSizeInBytes(totalSizeInBytes)
                 .setNullsCount(nullsCount)
-                .setDistinctValuesCount(distinctValuesCount)
+                .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
@@ -270,7 +270,7 @@ public class HiveColumnStatistics
         private OptionalLong maxValueSizeInBytes = OptionalLong.empty();
         private OptionalLong totalSizeInBytes = OptionalLong.empty();
         private OptionalLong nullsCount = OptionalLong.empty();
-        private OptionalLong distinctValuesCount = OptionalLong.empty();
+        private OptionalLong distinctValuesWithNullCount = OptionalLong.empty();
 
         private Builder() {}
 
@@ -340,15 +340,15 @@ public class HiveColumnStatistics
             return this;
         }
 
-        public Builder setDistinctValuesCount(OptionalLong distinctValuesCount)
+        public Builder setDistinctValuesWithNullCount(OptionalLong distinctValuesWithNullCount)
         {
-            this.distinctValuesCount = distinctValuesCount;
+            this.distinctValuesWithNullCount = distinctValuesWithNullCount;
             return this;
         }
 
-        public Builder setDistinctValuesCount(long distinctValuesCount)
+        public Builder setDistinctValuesWithNullCount(long distinctValuesWithNullCount)
         {
-            this.distinctValuesCount = OptionalLong.of(distinctValuesCount);
+            this.distinctValuesWithNullCount = OptionalLong.of(distinctValuesWithNullCount);
             return this;
         }
 
@@ -363,7 +363,7 @@ public class HiveColumnStatistics
                     maxValueSizeInBytes,
                     totalSizeInBytes,
                     nullsCount,
-                    distinctValuesCount);
+                    distinctValuesWithNullCount);
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveColumnStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveColumnStatistics.java
@@ -42,7 +42,7 @@ public class HiveColumnStatistics
     private final Optional<DateStatistics> dateStatistics;
     private final Optional<BooleanStatistics> booleanStatistics;
     private final OptionalLong maxValueSizeInBytes;
-    private final OptionalLong totalSizeInBytes;
+    private final OptionalDouble averageColumnLength;
     private final OptionalLong nullsCount;
     private final OptionalLong distinctValuesWithNullCount;
 
@@ -59,7 +59,7 @@ public class HiveColumnStatistics
             @JsonProperty("dateStatistics") Optional<DateStatistics> dateStatistics,
             @JsonProperty("booleanStatistics") Optional<BooleanStatistics> booleanStatistics,
             @JsonProperty("maxValueSizeInBytes") OptionalLong maxValueSizeInBytes,
-            @JsonProperty("totalSizeInBytes") OptionalLong totalSizeInBytes,
+            @JsonProperty("averageColumnLength") OptionalDouble averageColumnLength,
             @JsonProperty("nullsCount") OptionalLong nullsCount,
             @JsonProperty("distinctValuesWithNullCount") OptionalLong distinctValuesWithNullCount)
     {
@@ -69,7 +69,7 @@ public class HiveColumnStatistics
         this.dateStatistics = requireNonNull(dateStatistics, "dateStatistics is null");
         this.booleanStatistics = requireNonNull(booleanStatistics, "booleanStatistics is null");
         this.maxValueSizeInBytes = requireNonNull(maxValueSizeInBytes, "maxValueSizeInBytes is null");
-        this.totalSizeInBytes = requireNonNull(totalSizeInBytes, "totalSizeInBytes is null");
+        this.averageColumnLength = requireNonNull(averageColumnLength, "averageColumnLength is null");
         this.nullsCount = requireNonNull(nullsCount, "nullsCount is null");
         this.distinctValuesWithNullCount = requireNonNull(distinctValuesWithNullCount, "distinctValuesWithNullCount is null");
 
@@ -119,9 +119,9 @@ public class HiveColumnStatistics
     }
 
     @JsonProperty
-    public OptionalLong getTotalSizeInBytes()
+    public OptionalDouble getAverageColumnLength()
     {
-        return totalSizeInBytes;
+        return averageColumnLength;
     }
 
     @JsonProperty
@@ -152,7 +152,7 @@ public class HiveColumnStatistics
                 Objects.equals(dateStatistics, that.dateStatistics) &&
                 Objects.equals(booleanStatistics, that.booleanStatistics) &&
                 Objects.equals(maxValueSizeInBytes, that.maxValueSizeInBytes) &&
-                Objects.equals(totalSizeInBytes, that.totalSizeInBytes) &&
+                Objects.equals(averageColumnLength, that.averageColumnLength) &&
                 Objects.equals(nullsCount, that.nullsCount) &&
                 Objects.equals(distinctValuesWithNullCount, that.distinctValuesWithNullCount);
     }
@@ -167,7 +167,7 @@ public class HiveColumnStatistics
                 dateStatistics,
                 booleanStatistics,
                 maxValueSizeInBytes,
-                totalSizeInBytes,
+                averageColumnLength,
                 nullsCount,
                 distinctValuesWithNullCount);
     }
@@ -182,7 +182,7 @@ public class HiveColumnStatistics
         dateStatistics.ifPresent(stats -> toStringHelper.add("dateStatistics", stats));
         booleanStatistics.ifPresent(stats -> toStringHelper.add("booleanStatistics", stats));
         maxValueSizeInBytes.ifPresent(stats -> toStringHelper.add("maxValueSizeInBytes", stats));
-        totalSizeInBytes.ifPresent(stats -> toStringHelper.add("totalSizeInBytes", stats));
+        averageColumnLength.ifPresent(stats -> toStringHelper.add("averageColumnLength", stats));
         nullsCount.ifPresent(stats -> toStringHelper.add("nullsCount", stats));
         distinctValuesWithNullCount.ifPresent(stats -> toStringHelper.add("distinctValuesWithNullCount", stats));
         return toStringHelper.toString();
@@ -234,23 +234,23 @@ public class HiveColumnStatistics
 
     public static HiveColumnStatistics createStringColumnStatistics(
             OptionalLong maxValueSizeInBytes,
-            OptionalLong totalSizeInBytes,
+            OptionalDouble averageColumnLength,
             OptionalLong nullsCount,
             OptionalLong distinctValuesWithNullCount)
     {
         return builder()
                 .setMaxValueSizeInBytes(maxValueSizeInBytes)
-                .setTotalSizeInBytes(totalSizeInBytes)
+                .setAverageColumnLength(averageColumnLength)
                 .setNullsCount(nullsCount)
                 .setDistinctValuesWithNullCount(distinctValuesWithNullCount)
                 .build();
     }
 
-    public static HiveColumnStatistics createBinaryColumnStatistics(OptionalLong maxValueSizeInBytes, OptionalLong totalSizeInBytes, OptionalLong nullsCount)
+    public static HiveColumnStatistics createBinaryColumnStatistics(OptionalLong maxValueSizeInBytes, OptionalDouble averageColumnLength, OptionalLong nullsCount)
     {
         return builder()
                 .setMaxValueSizeInBytes(maxValueSizeInBytes)
-                .setTotalSizeInBytes(totalSizeInBytes)
+                .setAverageColumnLength(averageColumnLength)
                 .setNullsCount(nullsCount)
                 .build();
     }
@@ -268,7 +268,7 @@ public class HiveColumnStatistics
         private Optional<DateStatistics> dateStatistics = Optional.empty();
         private Optional<BooleanStatistics> booleanStatistics = Optional.empty();
         private OptionalLong maxValueSizeInBytes = OptionalLong.empty();
-        private OptionalLong totalSizeInBytes = OptionalLong.empty();
+        private OptionalDouble averageColumnLength = OptionalDouble.empty();
         private OptionalLong nullsCount = OptionalLong.empty();
         private OptionalLong distinctValuesWithNullCount = OptionalLong.empty();
 
@@ -316,15 +316,15 @@ public class HiveColumnStatistics
             return this;
         }
 
-        public Builder setTotalSizeInBytes(long totalSizeInBytes)
+        public Builder setAverageColumnLength(double averageColumnLength)
         {
-            this.totalSizeInBytes = OptionalLong.of(totalSizeInBytes);
+            this.averageColumnLength = OptionalDouble.of(averageColumnLength);
             return this;
         }
 
-        public Builder setTotalSizeInBytes(OptionalLong totalSizeInBytes)
+        public Builder setAverageColumnLength(OptionalDouble averageColumnLength)
         {
-            this.totalSizeInBytes = totalSizeInBytes;
+            this.averageColumnLength = averageColumnLength;
             return this;
         }
 
@@ -361,7 +361,7 @@ public class HiveColumnStatistics
                     dateStatistics,
                     booleanStatistics,
                     maxValueSizeInBytes,
-                    totalSizeInBytes,
+                    averageColumnLength,
                     nullsCount,
                     distinctValuesWithNullCount);
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -50,19 +50,16 @@ public interface HiveMetastore
 
     /**
      * @param columnNames Must not be empty.
-     * @param rowCount row count is required to calculate the number of distinct values, because Hive treats a NULL as a distinct value resulting in a count that is off by one
      */
-    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount);
+    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
 
     /**
      * @param columnNames Must not be empty.
-     * @param partitionNamesWithRowCount row count for each partition is required to calculate the number of distinct values, because
-     * Hive treats a NULL as a distinct value resulting in a count that is off by one
      */
     Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(
             String databaseName,
             String tableName,
-            Map<String, OptionalLong> partitionNamesWithRowCount,
+            Set<String> partitionNames,
             Set<String> columnNames);
 
     /**

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SparkMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SparkMetastoreUtil.java
@@ -40,7 +40,6 @@ import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createDoubleCo
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createStringColumnStatistics;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.NUM_ROWS;
-import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getTotalSizeInBytes;
 import static io.trino.plugin.hive.type.Category.PRIMITIVE;
 
 public final class SparkMetastoreUtil
@@ -121,7 +120,7 @@ public final class SparkMetastoreUtil
                     distinctValuesWithNullCount);
             case STRING, VARCHAR, CHAR -> createStringColumnStatistics(
                     maxLength,
-                    getTotalSizeInBytes(avgLength, OptionalLong.of(rowCount), nullsCount),
+                    avgLength,
                     nullsCount,
                     distinctValuesWithNullCount);
             case DATE -> createDateColumnStatistics(
@@ -131,7 +130,7 @@ public final class SparkMetastoreUtil
                     distinctValuesWithNullCount);
             case BINARY -> createBinaryColumnStatistics(
                     maxLength,
-                    getTotalSizeInBytes(avgLength, OptionalLong.of(rowCount), nullsCount),
+                    avgLength,
                     nullsCount);
             case DECIMAL -> createDecimalColumnStatistics(
                     toDecimal(parameters.get(field + COLUMN_MIN)),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/StatisticsUpdateMode.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/StatisticsUpdateMode.java
@@ -98,12 +98,10 @@ public enum StatisticsUpdateMode
         var mergedTableStatistics = reduce(existingStatistics.getBasicStatistics(), incrementalStatistics.getBasicStatistics(), Operator.ADD);
 
         // only keep columns that have statistics in old and new
-        var existingColumnStatistics = existingStatistics.getColumnStatistics();
-        var incrementalColumnStatistics = incrementalStatistics.getColumnStatistics();
-        var mergedColumnStatistics = intersection(existingColumnStatistics.keySet(), incrementalColumnStatistics.keySet()).stream()
+        var mergedColumnStatistics = intersection(existingStatistics.getColumnStatistics().keySet(), incrementalStatistics.getColumnStatistics().keySet()).stream()
                 .collect(toImmutableMap(
                         column -> column,
-                        column -> merge(existingColumnStatistics.get(column), incrementalColumnStatistics.get(column))));
+                        column -> merge(column, existingStatistics, incrementalStatistics)));
 
         return new PartitionStatistics(mergedTableStatistics, mergedColumnStatistics);
     }
@@ -117,8 +115,11 @@ public enum StatisticsUpdateMode
                 reduce(first.getOnDiskDataSizeInBytes(), second.getOnDiskDataSizeInBytes(), operator, false));
     }
 
-    private static HiveColumnStatistics merge(HiveColumnStatistics first, HiveColumnStatistics second)
+    private static HiveColumnStatistics merge(String column, PartitionStatistics firstStats, PartitionStatistics secondStats)
     {
+        HiveColumnStatistics first = firstStats.getColumnStatistics().get(column);
+        HiveColumnStatistics second = secondStats.getColumnStatistics().get(column);
+
         return new HiveColumnStatistics(
                 mergeIntegerStatistics(first.getIntegerStatistics(), second.getIntegerStatistics()),
                 mergeDoubleStatistics(first.getDoubleStatistics(), second.getDoubleStatistics()),
@@ -128,7 +129,45 @@ public enum StatisticsUpdateMode
                 reduce(first.getMaxValueSizeInBytes(), second.getMaxValueSizeInBytes(), Operator.MAX, true),
                 reduce(first.getTotalSizeInBytes(), second.getTotalSizeInBytes(), Operator.ADD, true),
                 reduce(first.getNullsCount(), second.getNullsCount(), Operator.ADD, false),
-                reduce(first.getDistinctValuesCount(), second.getDistinctValuesCount(), Operator.MAX, false));
+                mergeDistinctValueCount(column, firstStats, secondStats));
+    }
+
+    private static OptionalLong mergeDistinctValueCount(String column, PartitionStatistics first, PartitionStatistics second)
+    {
+        HiveColumnStatistics firstColumn = first.getColumnStatistics().get(column);
+        HiveColumnStatistics secondColumn = second.getColumnStatistics().get(column);
+
+        OptionalLong firstDistinct = firstColumn.getDistinctValuesWithNullCount();
+        OptionalLong secondDistinct = secondColumn.getDistinctValuesWithNullCount();
+
+        // if one column is entirely non-null and the other is entirely null
+        if (firstDistinct.isPresent() && noNulls(firstColumn) && isAllNull(second, secondColumn)) {
+            return OptionalLong.of(firstDistinct.getAsLong() + 1);
+        }
+        if (secondDistinct.isPresent() && noNulls(secondColumn) && isAllNull(first, firstColumn)) {
+            return OptionalLong.of(secondDistinct.getAsLong() + 1);
+        }
+
+        if (firstDistinct.isPresent() && secondDistinct.isPresent()) {
+            return OptionalLong.of(max(firstDistinct.getAsLong(), secondDistinct.getAsLong()));
+        }
+        return OptionalLong.empty();
+    }
+
+    private static boolean noNulls(HiveColumnStatistics columnStats)
+    {
+        if (columnStats.getNullsCount().isEmpty()) {
+            return false;
+        }
+        return columnStats.getNullsCount().orElse(-1) == 0;
+    }
+
+    private static boolean isAllNull(PartitionStatistics stats, HiveColumnStatistics columnStats)
+    {
+        if (stats.getBasicStatistics().getRowCount().isEmpty() || columnStats.getNullsCount().isEmpty()) {
+            return false;
+        }
+        return stats.getBasicStatistics().getRowCount().getAsLong() == columnStats.getNullsCount().getAsLong();
     }
 
     private static Optional<IntegerStatistics> mergeIntegerStatistics(Optional<IntegerStatistics> first, Optional<IntegerStatistics> second)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/ColumnStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/ColumnStatistics.java
@@ -71,7 +71,7 @@ public record ColumnStatistics(
                 hiveColumnStatistics.getMaxValueSizeInBytes(),
                 hiveColumnStatistics.getTotalSizeInBytes(),
                 hiveColumnStatistics.getNullsCount(),
-                hiveColumnStatistics.getDistinctValuesCount());
+                hiveColumnStatistics.getDistinctValuesWithNullCount());
     }
 
     public HiveColumnStatistics toHiveColumnStatistics()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/ColumnStatistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/ColumnStatistics.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.file;
+
+import com.google.errorprone.annotations.Immutable;
+import io.trino.plugin.hive.metastore.HiveColumnStatistics;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public record ColumnStatistics(
+        Optional<IntegerStatistics> integerStatistics,
+        Optional<DoubleStatistics> doubleStatistics,
+        Optional<DecimalStatistics> decimalStatistics,
+        Optional<DateStatistics> dateStatistics,
+        Optional<BooleanStatistics> booleanStatistics,
+        OptionalLong maxValueSizeInBytes,
+        OptionalLong totalSizeInBytes,
+        OptionalLong nullsCount,
+        OptionalLong distinctValuesCount)
+{
+    public ColumnStatistics
+    {
+        requireNonNull(integerStatistics, "integerStatistics is null");
+        requireNonNull(doubleStatistics, "doubleStatistics is null");
+        requireNonNull(decimalStatistics, "decimalStatistics is null");
+        requireNonNull(dateStatistics, "dateStatistics is null");
+        requireNonNull(booleanStatistics, "booleanStatistics is null");
+        requireNonNull(maxValueSizeInBytes, "maxValueSizeInBytes is null");
+        requireNonNull(totalSizeInBytes, "totalSizeInBytes is null");
+        requireNonNull(nullsCount, "nullsCount is null");
+        requireNonNull(distinctValuesCount, "distinctValuesCount is null");
+
+        Set<String> presentStatistics = new LinkedHashSet<>();
+        integerStatistics.ifPresent(ignored -> presentStatistics.add("integerStatistics"));
+        doubleStatistics.ifPresent(ignored -> presentStatistics.add("doubleStatistics"));
+        decimalStatistics.ifPresent(ignored -> presentStatistics.add("decimalStatistics"));
+        dateStatistics.ifPresent(ignored -> presentStatistics.add("dateStatistics"));
+        booleanStatistics.ifPresent(ignored -> presentStatistics.add("booleanStatistics"));
+        checkArgument(presentStatistics.size() <= 1, "multiple type specific statistic objects are present: %s", presentStatistics);
+    }
+
+    public static ColumnStatistics fromHiveColumnStatistics(HiveColumnStatistics hiveColumnStatistics)
+    {
+        return new ColumnStatistics(
+                hiveColumnStatistics.getIntegerStatistics().map(stat -> new IntegerStatistics(stat.getMin(), stat.getMax())),
+                hiveColumnStatistics.getDoubleStatistics().map(stat -> new DoubleStatistics(stat.getMin(), stat.getMax())),
+                hiveColumnStatistics.getDecimalStatistics().map(stat -> new DecimalStatistics(stat.getMin(), stat.getMax())),
+                hiveColumnStatistics.getDateStatistics().map(stat -> new DateStatistics(stat.getMin(), stat.getMax())),
+                hiveColumnStatistics.getBooleanStatistics().map(stat -> new BooleanStatistics(stat.getTrueCount(), stat.getFalseCount())),
+                hiveColumnStatistics.getMaxValueSizeInBytes(),
+                hiveColumnStatistics.getTotalSizeInBytes(),
+                hiveColumnStatistics.getNullsCount(),
+                hiveColumnStatistics.getDistinctValuesCount());
+    }
+
+    public HiveColumnStatistics toHiveColumnStatistics()
+    {
+        return new HiveColumnStatistics(
+                integerStatistics.map(stat -> new io.trino.plugin.hive.metastore.IntegerStatistics(stat.min(), stat.max())),
+                doubleStatistics.map(stat -> new io.trino.plugin.hive.metastore.DoubleStatistics(stat.min(), stat.max())),
+                decimalStatistics.map(stat -> new io.trino.plugin.hive.metastore.DecimalStatistics(stat.min(), stat.max())),
+                dateStatistics.map(stat -> new io.trino.plugin.hive.metastore.DateStatistics(stat.min(), stat.max())),
+                booleanStatistics.map(stat -> new io.trino.plugin.hive.metastore.BooleanStatistics(stat.trueCount(), stat.falseCount())),
+                maxValueSizeInBytes,
+                totalSizeInBytes,
+                nullsCount,
+                distinctValuesCount);
+    }
+
+    public record IntegerStatistics(OptionalLong min, OptionalLong max)
+    {
+        public IntegerStatistics
+        {
+            requireNonNull(min, "min is null");
+            requireNonNull(max, "max is null");
+        }
+    }
+
+    public record DoubleStatistics(OptionalDouble min, OptionalDouble max)
+    {
+        public DoubleStatistics
+        {
+            requireNonNull(min, "min is null");
+            requireNonNull(max, "max is null");
+        }
+    }
+
+    public record DecimalStatistics(Optional<BigDecimal> min, Optional<BigDecimal> max)
+    {
+        public DecimalStatistics
+        {
+            requireNonNull(min, "min is null");
+            requireNonNull(max, "max is null");
+        }
+    }
+
+    public record DateStatistics(Optional<LocalDate> min, Optional<LocalDate> max)
+    {
+        public DateStatistics
+        {
+            requireNonNull(min, "min is null");
+            requireNonNull(max, "max is null");
+        }
+    }
+
+    public record BooleanStatistics(OptionalLong trueCount, OptionalLong falseCount)
+    {
+        public BooleanStatistics
+        {
+            requireNonNull(trueCount, "trueCount is null");
+            requireNonNull(falseCount, "falseCount is null");
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -84,7 +84,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -446,7 +445,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount)
+    public synchronized Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         checkArgument(!columnNames.isEmpty(), "columnNames is empty");
         Location tableMetadataDirectory = getTableMetadataDirectory(databaseName, tableName);
@@ -457,11 +456,11 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Map<String, OptionalLong> partitionNamesWithRowCount, Set<String> columnNames)
+    public synchronized Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         checkArgument(!columnNames.isEmpty(), "columnNames is empty");
         ImmutableMap.Builder<String, Map<String, HiveColumnStatistics>> result = ImmutableMap.builder();
-        for (String partitionName : partitionNamesWithRowCount.keySet()) {
+        for (String partitionName : partitionNames) {
             result.put(partitionName, getPartitionStatisticsInternal(databaseName, tableName, partitionName, columnNames));
         }
         return result.buildOrThrow();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -31,6 +31,7 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.TrinoOutputFile;
+import io.trino.plugin.hive.HiveBasicStatistics;
 import io.trino.plugin.hive.HiveColumnStatisticType;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.NodeVersion;
@@ -452,7 +453,7 @@ public class FileHiveMetastore
         TableMetadata tableMetadata = readSchemaFile(TABLE, tableMetadataDirectory, tableCodec)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         checkVersion(tableMetadata.getWriterVersion());
-        return toHiveColumnStats(columnNames, tableMetadata.getColumnStatistics());
+        return toHiveColumnStats(columnNames, tableMetadata.getParameters(), tableMetadata.getColumnStatistics());
     }
 
     @Override
@@ -471,7 +472,7 @@ public class FileHiveMetastore
         Location partitionDirectory = getPartitionMetadataDirectory(databaseName, tableName, partitionName);
         PartitionMetadata partitionMetadata = readSchemaFile(PARTITION, partitionDirectory, partitionCodec)
                 .orElseThrow(() -> new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), extractPartitionValues(partitionName)));
-        return toHiveColumnStats(columnNames, partitionMetadata.getColumnStatistics());
+        return toHiveColumnStats(columnNames, partitionMetadata.getParameters(), partitionMetadata.getColumnStatistics());
     }
 
     private Table getRequiredTable(String databaseName, String tableName)
@@ -1622,7 +1623,10 @@ public class FileHiveMetastore
 
     private static PartitionStatistics toHivePartitionStatistics(Map<String, String> parameters, Map<String, ColumnStatistics> columnStatistics)
     {
-        return new PartitionStatistics(getHiveBasicStatistics(parameters), toHiveColumnStats(columnStatistics.keySet(), columnStatistics));
+        HiveBasicStatistics basicStatistics = getHiveBasicStatistics(parameters);
+        Map<String, HiveColumnStatistics> hiveColumnStatistics = columnStatistics.entrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, column -> column.getValue().toHiveColumnStatistics(basicStatistics)));
+        return new PartitionStatistics(basicStatistics, hiveColumnStatistics);
     }
 
     private static Map<String, ColumnStatistics> fromHiveColumnStats(Map<String, HiveColumnStatistics> columnStatistics)
@@ -1631,11 +1635,12 @@ public class FileHiveMetastore
                 .collect(toImmutableMap(Entry::getKey, entry -> fromHiveColumnStatistics(entry.getValue())));
     }
 
-    private static Map<String, HiveColumnStatistics> toHiveColumnStats(Set<String> columnNames, Map<String, ColumnStatistics> columnStatistics)
+    private static Map<String, HiveColumnStatistics> toHiveColumnStats(Set<String> columnNames, Map<String, String> partitionMetadata, Map<String, ColumnStatistics> columnStatistics)
     {
+        HiveBasicStatistics basicStatistics = getHiveBasicStatistics(partitionMetadata);
         return columnStatistics.entrySet().stream()
                 .filter(entry -> columnNames.contains(entry.getKey()))
-                .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().toHiveColumnStatistics()));
+                .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().toHiveColumnStatistics(basicStatistics)));
     }
 
     private record RoleGrantee(String role, HivePrincipal grantee)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -107,6 +107,7 @@ import static io.trino.plugin.hive.ViewReaderUtil.isSomeKindOfAView;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.makePartitionName;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.verifyCanDropColumn;
+import static io.trino.plugin.hive.metastore.file.ColumnStatistics.fromHiveColumnStatistics;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.SchemaType.DATABASE;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.SchemaType.PARTITION;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.SchemaType.TABLE;
@@ -451,9 +452,7 @@ public class FileHiveMetastore
         TableMetadata tableMetadata = readSchemaFile(TABLE, tableMetadataDirectory, tableCodec)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         checkVersion(tableMetadata.getWriterVersion());
-        return tableMetadata.getColumnStatistics().entrySet().stream()
-                .filter(entry -> columnNames.contains(entry.getKey()))
-                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+        return toHiveColumnStats(columnNames, tableMetadata.getColumnStatistics());
     }
 
     @Override
@@ -472,9 +471,7 @@ public class FileHiveMetastore
         Location partitionDirectory = getPartitionMetadataDirectory(databaseName, tableName, partitionName);
         PartitionMetadata partitionMetadata = readSchemaFile(PARTITION, partitionDirectory, partitionCodec)
                 .orElseThrow(() -> new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), extractPartitionValues(partitionName)));
-        return partitionMetadata.getColumnStatistics().entrySet().stream()
-                .filter(entry -> columnNames.contains(entry.getKey()))
-                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+        return toHiveColumnStats(columnNames, partitionMetadata.getColumnStatistics());
     }
 
     private Table getRequiredTable(String databaseName, String tableName)
@@ -505,12 +502,12 @@ public class FileHiveMetastore
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         checkVersion(tableMetadata.getWriterVersion());
 
-        PartitionStatistics originalStatistics = new PartitionStatistics(getHiveBasicStatistics(tableMetadata.getParameters()), tableMetadata.getColumnStatistics());
+        PartitionStatistics originalStatistics = toHivePartitionStatistics(tableMetadata.getParameters(), tableMetadata.getColumnStatistics());
         PartitionStatistics updatedStatistics = mode.updatePartitionStatistics(originalStatistics, statisticsUpdate);
 
         TableMetadata updatedMetadata = tableMetadata
                 .withParameters(currentVersion, updateStatisticsParameters(tableMetadata.getParameters(), updatedStatistics.getBasicStatistics()))
-                .withColumnStatistics(currentVersion, updatedStatistics.getColumnStatistics());
+                .withColumnStatistics(currentVersion, fromHiveColumnStats(updatedStatistics.getColumnStatistics()));
 
         writeSchemaFile(TABLE, tableMetadataDirectory, tableCodec, updatedMetadata, true);
     }
@@ -522,13 +519,13 @@ public class FileHiveMetastore
             Location partitionDirectory = getPartitionMetadataDirectory(table, partitionName);
             PartitionMetadata partitionMetadata = readSchemaFile(PARTITION, partitionDirectory, partitionCodec)
                     .orElseThrow(() -> new PartitionNotFoundException(table.getSchemaTableName(), extractPartitionValues(partitionName)));
-            PartitionStatistics originalStatistics = new PartitionStatistics(getHiveBasicStatistics(partitionMetadata.getParameters()), partitionMetadata.getColumnStatistics());
+            PartitionStatistics originalStatistics = toHivePartitionStatistics(partitionMetadata.getParameters(), partitionMetadata.getColumnStatistics());
 
             PartitionStatistics updatedStatistics = mode.updatePartitionStatistics(originalStatistics, partitionUpdate);
 
             PartitionMetadata updatedMetadata = partitionMetadata
                     .withParameters(updateStatisticsParameters(partitionMetadata.getParameters(), updatedStatistics.getBasicStatistics()))
-                    .withColumnStatistics(updatedStatistics.getColumnStatistics());
+                    .withColumnStatistics(fromHiveColumnStats(updatedStatistics.getColumnStatistics()));
 
             writeSchemaFile(PARTITION, partitionDirectory, partitionCodec, updatedMetadata, true);
         });
@@ -727,7 +724,7 @@ public class FileHiveMetastore
         alterTable(databaseName, tableName, oldTable -> {
             Map<String, String> parameters = oldTable.getParameters().entrySet().stream()
                     .filter(entry -> !entry.getKey().equals(TABLE_COMMENT))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
             comment.ifPresent(value -> parameters.put(TABLE_COMMENT, value));
 
             return oldTable.withParameters(currentVersion, parameters);
@@ -1621,6 +1618,24 @@ public class FileHiveMetastore
         return directory.appendPath("%s=%s".formatted(
                 escapePathName(functionName),
                 sha256().hashUnencodedChars(signatureToken)));
+    }
+
+    private static PartitionStatistics toHivePartitionStatistics(Map<String, String> parameters, Map<String, ColumnStatistics> columnStatistics)
+    {
+        return new PartitionStatistics(getHiveBasicStatistics(parameters), toHiveColumnStats(columnStatistics.keySet(), columnStatistics));
+    }
+
+    private static Map<String, ColumnStatistics> fromHiveColumnStats(Map<String, HiveColumnStatistics> columnStatistics)
+    {
+        return columnStatistics.entrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> fromHiveColumnStatistics(entry.getValue())));
+    }
+
+    private static Map<String, HiveColumnStatistics> toHiveColumnStats(Set<String> columnNames, Map<String, ColumnStatistics> columnStatistics)
+    {
+        return columnStatistics.entrySet().stream()
+                .filter(entry -> columnNames.contains(entry.getKey()))
+                .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().toHiveColumnStatistics()));
     }
 
     private record RoleGrantee(String role, HivePrincipal grantee)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/PartitionMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/PartitionMetadata.java
@@ -21,7 +21,6 @@ import io.trino.plugin.hive.HiveBucketProperty;
 import io.trino.plugin.hive.HiveStorageFormat;
 import io.trino.plugin.hive.PartitionStatistics;
 import io.trino.plugin.hive.metastore.Column;
-import io.trino.plugin.hive.metastore.HiveColumnStatistics;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.Storage;
@@ -33,8 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.TableType.EXTERNAL_TABLE;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
+import static io.trino.plugin.hive.metastore.file.ColumnStatistics.fromHiveColumnStatistics;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.updateStatisticsParameters;
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +50,7 @@ public class PartitionMetadata
 
     private final Optional<String> externalLocation;
 
-    private final Map<String, HiveColumnStatistics> columnStatistics;
+    private final Map<String, ColumnStatistics> columnStatistics;
 
     @JsonCreator
     public PartitionMetadata(
@@ -59,7 +60,7 @@ public class PartitionMetadata
             @JsonProperty("bucketProperty") Optional<HiveBucketProperty> bucketProperty,
             @JsonProperty("serdeParameters") Map<String, String> serdeParameters,
             @JsonProperty("externalLocation") Optional<String> externalLocation,
-            @JsonProperty("columnStatistics") Map<String, HiveColumnStatistics> columnStatistics)
+            @JsonProperty("columnStatistics") Map<String, ColumnStatistics> columnStatistics)
     {
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
@@ -94,7 +95,8 @@ public class PartitionMetadata
 
         bucketProperty = partition.getStorage().getBucketProperty();
         serdeParameters = partition.getStorage().getSerdeParameters();
-        columnStatistics = ImmutableMap.copyOf(statistics.getColumnStatistics());
+        columnStatistics = statistics.getColumnStatistics().entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> fromHiveColumnStatistics(entry.getValue())));
     }
 
     @JsonProperty
@@ -134,7 +136,7 @@ public class PartitionMetadata
     }
 
     @JsonProperty
-    public Map<String, HiveColumnStatistics> getColumnStatistics()
+    public Map<String, ColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;
     }
@@ -144,7 +146,7 @@ public class PartitionMetadata
         return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, serdeParameters, externalLocation, columnStatistics);
     }
 
-    public PartitionMetadata withColumnStatistics(Map<String, HiveColumnStatistics> columnStatistics)
+    public PartitionMetadata withColumnStatistics(Map<String, ColumnStatistics> columnStatistics)
     {
         return new PartitionMetadata(columns, parameters, storageFormat, bucketProperty, serdeParameters, externalLocation, columnStatistics);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HiveBucketProperty;
 import io.trino.plugin.hive.HiveStorageFormat;
-import io.trino.plugin.hive.metastore.HiveColumnStatistics;
 import io.trino.plugin.hive.metastore.Storage;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.metastore.Table;
@@ -55,7 +54,7 @@ public class TableMetadata
     private final Optional<String> viewOriginalText;
     private final Optional<String> viewExpandedText;
 
-    private final Map<String, HiveColumnStatistics> columnStatistics;
+    private final Map<String, ColumnStatistics> columnStatistics;
 
     @JsonCreator
     public TableMetadata(
@@ -72,7 +71,7 @@ public class TableMetadata
             @JsonProperty("externalLocation") Optional<String> externalLocation,
             @JsonProperty("viewOriginalText") Optional<String> viewOriginalText,
             @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
-            @JsonProperty("columnStatistics") Map<String, HiveColumnStatistics> columnStatistics)
+            @JsonProperty("columnStatistics") Map<String, ColumnStatistics> columnStatistics)
     {
         this.writerVersion = requireNonNull(writerVersion, "writerVersion is null");
         this.owner = requireNonNull(owner, "owner is null");
@@ -227,7 +226,7 @@ public class TableMetadata
     }
 
     @JsonProperty
-    public Map<String, HiveColumnStatistics> getColumnStatistics()
+    public Map<String, ColumnStatistics> getColumnStatistics()
     {
         return columnStatistics;
     }
@@ -270,7 +269,7 @@ public class TableMetadata
                 columnStatistics);
     }
 
-    public TableMetadata withColumnStatistics(String currentVersion, Map<String, HiveColumnStatistics> columnStatistics)
+    public TableMetadata withColumnStatistics(String currentVersion, Map<String, ColumnStatistics> columnStatistics)
     {
         return new TableMetadata(
                 Optional.of(requireNonNull(currentVersion, "currentVersion is null")),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/DefaultGlueColumnStatisticsProvider.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import io.trino.plugin.hive.HiveBasicStatistics;
 import io.trino.plugin.hive.HiveColumnStatisticType;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.HiveColumnStatistics;
@@ -48,7 +47,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -61,7 +59,6 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_PARTITION_NOT_FOUND;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueStatConverter.fromGlueColumnStatistics;
 import static io.trino.plugin.hive.metastore.glue.converter.GlueStatConverter.toGlueColumnStatistics;
-import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.getHiveBasicStatistics;
 import static java.util.concurrent.CompletableFuture.allOf;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
@@ -98,7 +95,7 @@ public class DefaultGlueColumnStatisticsProvider
     }
 
     @Override
-    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         try {
             List<List<String>> columnChunks = Lists.partition(ImmutableList.copyOf(columnNames), GLUE_COLUMN_READ_STAT_PAGE_SIZE);
@@ -117,7 +114,7 @@ public class DefaultGlueColumnStatisticsProvider
                 for (ColumnStatistics columnStatistics : tableColumnsStats.getColumnStatisticsList()) {
                     columnStatsMapBuilder.put(
                             columnStatistics.getColumnName(),
-                            fromGlueColumnStatistics(columnStatistics.getStatisticsData(), rowCount));
+                            fromGlueColumnStatistics(columnStatistics.getStatisticsData()));
                 }
             }
             return columnStatsMapBuilder.buildOrThrow();
@@ -131,11 +128,11 @@ public class DefaultGlueColumnStatisticsProvider
     public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(
             String databaseName,
             String tableName,
-            Map<String, OptionalLong> partitionNamesWithRowCount,
+            Set<String> partitionNames,
             Set<String> columnNames)
     {
         Map<String, List<CompletableFuture<GetColumnStatisticsForPartitionResult>>> resultsForPartition = new HashMap<>();
-        for (String partitionName : partitionNamesWithRowCount.keySet()) {
+        for (String partitionName : partitionNames) {
             ImmutableList.Builder<CompletableFuture<GetColumnStatisticsForPartitionResult>> futures = ImmutableList.builder();
             for (List<String> columnBatch : Lists.partition(ImmutableList.copyOf(columnNames), GLUE_COLUMN_READ_STAT_PAGE_SIZE)) {
                 GetColumnStatisticsForPartitionRequest request = new GetColumnStatisticsForPartitionRequest()
@@ -152,13 +149,12 @@ public class DefaultGlueColumnStatisticsProvider
             ImmutableMap.Builder<String, Map<String, HiveColumnStatistics>> partitionStatistics = ImmutableMap.builder();
             resultsForPartition.forEach((partitionName, futures) -> {
                 ImmutableMap.Builder<String, HiveColumnStatistics> columnStatsMapBuilder = ImmutableMap.builder();
-                OptionalLong rowCount = partitionNamesWithRowCount.get(partitionName);
                 for (CompletableFuture<GetColumnStatisticsForPartitionResult> getColumnStatisticsResultFuture : futures) {
                     GetColumnStatisticsForPartitionResult getColumnStatisticsResult = getFutureValue(getColumnStatisticsResultFuture);
                     getColumnStatisticsResult.getColumnStatisticsList().forEach(columnStatistics ->
                             columnStatsMapBuilder.put(
                                     columnStatistics.getColumnName(),
-                                    fromGlueColumnStatistics(columnStatistics.getStatisticsData(), rowCount)));
+                                    fromGlueColumnStatistics(columnStatistics.getStatisticsData())));
                 }
 
                 partitionStatistics.put(partitionName, columnStatsMapBuilder.buildOrThrow());
@@ -204,8 +200,7 @@ public class DefaultGlueColumnStatisticsProvider
     public void updateTableColumnStatistics(Table table, Map<String, HiveColumnStatistics> updatedTableColumnStatistics)
     {
         try {
-            HiveBasicStatistics tableStats = getHiveBasicStatistics(table.getParameters());
-            List<ColumnStatistics> columnStats = toGlueColumnStatistics(table, updatedTableColumnStatistics, tableStats.getRowCount()).stream()
+            List<ColumnStatistics> columnStats = toGlueColumnStatistics(table, updatedTableColumnStatistics).stream()
                     .filter(this::isGlueWritable)
                     .collect(toUnmodifiableList());
 
@@ -255,8 +250,7 @@ public class DefaultGlueColumnStatisticsProvider
             Partition partition = update.getPartition();
             Map<String, HiveColumnStatistics> updatedColumnStatistics = update.getColumnStatistics();
 
-            HiveBasicStatistics partitionStats = getHiveBasicStatistics(partition.getParameters());
-            List<ColumnStatistics> columnStats = toGlueColumnStatistics(partition, updatedColumnStatistics, partitionStats.getRowCount()).stream()
+            List<ColumnStatistics> columnStats = toGlueColumnStatistics(partition, updatedColumnStatistics).stream()
                     .filter(this::isGlueWritable)
                     .collect(toUnmodifiableList());
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueColumnStatisticsProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueColumnStatisticsProvider.java
@@ -22,7 +22,6 @@ import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.type.Type;
 
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -31,12 +30,12 @@ public interface GlueColumnStatisticsProvider
 {
     Set<HiveColumnStatisticType> getSupportedColumnStatistics(Type type);
 
-    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount);
+    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
 
     Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(
             String databaseName,
             String tableName,
-            Map<String, OptionalLong> partitionNamesWithRowCount,
+            Set<String> partitionNames,
             Set<String> columns);
 
     void updateTableColumnStatistics(Table table, Map<String, HiveColumnStatistics> columnStatistics);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -118,17 +118,17 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         checkArgument(!columnNames.isEmpty(), "columnNames is empty");
-        return delegate.getTableColumnStatistics(databaseName, tableName, columnNames, rowCount);
+        return delegate.getTableColumnStatistics(databaseName, tableName, columnNames);
     }
 
     @Override
-    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Map<String, OptionalLong> partitionNamesWithRowCount, Set<String> columnNames)
+    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         checkArgument(!columnNames.isEmpty(), "columnNames is empty");
-        return delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNamesWithRowCount, columnNames);
+        return delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNames, columnNames);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -94,9 +94,9 @@ public sealed interface ThriftMetastore
 
     Set<HiveColumnStatisticType> getSupportedColumnStatistics(Type type);
 
-    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount);
+    Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames);
 
-    Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Map<String, OptionalLong> partitionNamesWithRowCount, Set<String> columnNames);
+    Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames);
 
     boolean useSparkTableStatistics();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -500,7 +500,7 @@ public final class ThriftMetastoreUtil
         return partitionBuilder.build();
     }
 
-    public static HiveColumnStatistics fromMetastoreApiColumnStatistics(ColumnStatisticsObj columnStatistics, OptionalLong rowCount)
+    public static HiveColumnStatistics fromMetastoreApiColumnStatistics(ColumnStatisticsObj columnStatistics)
     {
         if (columnStatistics.getStatsData().isSetLongStats()) {
             LongColumnStatsData longStatsData = columnStatistics.getStatsData().getLongStats();
@@ -764,7 +764,7 @@ public final class ThriftMetastoreUtil
         return result.buildOrThrow();
     }
 
-    public static ColumnStatisticsObj createMetastoreColumnStatistics(String columnName, HiveType columnType, HiveColumnStatistics statistics, OptionalLong rowCount)
+    public static ColumnStatisticsObj createMetastoreColumnStatistics(String columnName, HiveType columnType, HiveColumnStatistics statistics)
     {
         TypeInfo typeInfo = columnType.getTypeInfo();
         checkArgument(typeInfo.getCategory() == PRIMITIVE, "unsupported type: %s", columnType);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/tracing/TracingHiveMetastore.java
@@ -111,25 +111,25 @@ public class TracingHiveMetastore
     }
 
     @Override
-    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames, OptionalLong rowCount)
+    public Map<String, HiveColumnStatistics> getTableColumnStatistics(String databaseName, String tableName, Set<String> columnNames)
     {
         Span span = tracer.spanBuilder("HiveMetastore.getTableColumnStatistics")
                 .setAttribute(SCHEMA, databaseName)
                 .setAttribute(TABLE, tableName)
                 .startSpan();
-        return withTracing(span, () -> delegate.getTableColumnStatistics(databaseName, tableName, columnNames, rowCount));
+        return withTracing(span, () -> delegate.getTableColumnStatistics(databaseName, tableName, columnNames));
     }
 
     @Override
-    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Map<String, OptionalLong> partitionNamesWithRowCount, Set<String> columnNames)
+    public Map<String, Map<String, HiveColumnStatistics>> getPartitionColumnStatistics(String databaseName, String tableName, Set<String> partitionNames, Set<String> columnNames)
     {
         Span span = tracer.spanBuilder("HiveMetastore.getPartitionColumnStatistics")
                 .setAttribute(SCHEMA, databaseName)
                 .setAttribute(TABLE, tableName)
-                .setAttribute(PARTITION_REQUEST_COUNT, (long) partitionNamesWithRowCount.size())
+                .setAttribute(PARTITION_REQUEST_COUNT, (long) partitionNames.size())
                 .startSpan();
         return withTracing(span, () -> {
-            var partitionColumnStatistics = delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNamesWithRowCount, columnNames);
+            var partitionColumnStatistics = delegate.getPartitionColumnStatistics(databaseName, tableName, partitionNames, columnNames);
             span.setAttribute(PARTITION_RESPONSE_COUNT, partitionColumnStatistics.size());
             return partitionColumnStatistics;
         });

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/statistics/AbstractHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/statistics/AbstractHiveStatisticsProvider.java
@@ -84,6 +84,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static java.lang.Double.isFinite;
 import static java.lang.Double.isNaN;
+import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Collections.unmodifiableList;
 
@@ -222,29 +223,8 @@ public abstract class AbstractHiveStatisticsProvider
                         rowCount.getAsLong());
             }
         });
-        columnStatistics.getDistinctValuesCount().ifPresent(distinctValuesCount -> {
+        columnStatistics.getDistinctValuesWithNullCount().ifPresent(distinctValuesCount -> {
             checkStatistics(distinctValuesCount >= 0, table, partition, column, "distinctValuesCount must be greater than or equal to zero: %s", distinctValuesCount);
-            if (rowCount.isPresent()) {
-                checkStatistics(
-                        distinctValuesCount <= rowCount.getAsLong(),
-                        table,
-                        partition,
-                        column,
-                        "distinctValuesCount must be less than or equal to rowCount. distinctValuesCount: %s. rowCount: %s.",
-                        distinctValuesCount,
-                        rowCount.getAsLong());
-            }
-            if (rowCount.isPresent() && columnStatistics.getNullsCount().isPresent()) {
-                long nonNullsCount = rowCount.getAsLong() - columnStatistics.getNullsCount().getAsLong();
-                checkStatistics(
-                        distinctValuesCount <= nonNullsCount,
-                        table,
-                        partition,
-                        column,
-                        "distinctValuesCount must be less than or equal to nonNullsCount. distinctValuesCount: %s. nonNullsCount: %s.",
-                        distinctValuesCount,
-                        nonNullsCount);
-            }
         });
 
         columnStatistics.getIntegerStatistics().ifPresent(integerStatistics -> {
@@ -686,7 +666,7 @@ public abstract class AbstractHiveStatisticsProvider
         }
 
         return ColumnStatistics.builder()
-                .setDistinctValuesCount(calculateDistinctValuesCount(columnStatistics))
+                .setDistinctValuesCount(calculateDistinctValuesCount(column, partitionStatistics))
                 .setNullsFraction(calculateNullsFraction(column, partitionStatistics))
                 .setDataSize(calculateDataSize(column, partitionStatistics, rowsCount))
                 .setRange(calculateRange(type, columnStatistics))
@@ -694,10 +674,10 @@ public abstract class AbstractHiveStatisticsProvider
     }
 
     @VisibleForTesting
-    static Estimate calculateDistinctValuesCount(List<HiveColumnStatistics> columnStatistics)
+    static Estimate calculateDistinctValuesCount(String column, Collection<PartitionStatistics> partitionStatistics)
     {
-        return columnStatistics.stream()
-                .map(AbstractHiveStatisticsProvider::getDistinctValuesCount)
+        return partitionStatistics.stream()
+                .map(statistics -> getDistinctValuesCount(column, statistics))
                 .filter(OptionalLong::isPresent)
                 .map(OptionalLong::getAsLong)
                 .peek(distinctValuesCount -> verify(distinctValuesCount >= 0, "distinctValuesCount must be greater than or equal to zero"))
@@ -706,8 +686,14 @@ public abstract class AbstractHiveStatisticsProvider
                 .orElse(Estimate.unknown());
     }
 
-    private static OptionalLong getDistinctValuesCount(HiveColumnStatistics statistics)
+    @VisibleForTesting
+    static OptionalLong getDistinctValuesCount(String column, PartitionStatistics partitionStatistics)
     {
+        HiveColumnStatistics statistics = partitionStatistics.getColumnStatistics().get(column);
+        if (statistics == null) {
+            return OptionalLong.empty();
+        }
+
         if (statistics.getBooleanStatistics().isPresent() &&
                 statistics.getBooleanStatistics().get().getFalseCount().isPresent() &&
                 statistics.getBooleanStatistics().get().getTrueCount().isPresent()) {
@@ -715,10 +701,27 @@ public abstract class AbstractHiveStatisticsProvider
             long trueCount = statistics.getBooleanStatistics().get().getTrueCount().getAsLong();
             return OptionalLong.of((falseCount > 0 ? 1 : 0) + (trueCount > 0 ? 1 : 0));
         }
-        if (statistics.getDistinctValuesCount().isPresent()) {
-            return statistics.getDistinctValuesCount();
+
+        if (statistics.getDistinctValuesWithNullCount().isEmpty()) {
+            return OptionalLong.empty();
         }
-        return OptionalLong.empty();
+
+        long distinctValuesCount = statistics.getDistinctValuesWithNullCount().getAsLong();
+
+        // Hive includes nulls in the distinct values count, but Trino does not
+        long nullsCount = statistics.getNullsCount().orElse(0);
+        if (distinctValuesCount > 0 && nullsCount > 0) {
+            distinctValuesCount--;
+        }
+
+        // if there is non-null row the distinct values count should be at least 1
+        if (distinctValuesCount == 0 && nullsCount < partitionStatistics.getBasicStatistics().getRowCount().orElse(0)) {
+            distinctValuesCount = 1;
+        }
+
+        // Hive can produce distinct values that are much larger than the actual number of rows in the partition
+        distinctValuesCount = min(distinctValuesCount, partitionStatistics.getBasicStatistics().getRowCount().orElse(Long.MAX_VALUE) - nullsCount);
+        return OptionalLong.of(distinctValuesCount);
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/Statistics.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/Statistics.java
@@ -101,7 +101,7 @@ public final class Statistics
                 result.setTotalSizeInBytes(0);
                 return;
             case NUMBER_OF_DISTINCT_VALUES:
-                result.setDistinctValuesCount(0);
+                result.setDistinctValuesWithNullCount(0);
                 return;
             case NUMBER_OF_NON_NULL_VALUES:
                 result.setNullsCount(0);
@@ -214,7 +214,8 @@ public final class Statistics
             // number of distinct value is estimated using HLL, and can be higher than the number of non null values
             long numberOfNonNullValues = BIGINT.getLong(computedStatistics.get(NUMBER_OF_NON_NULL_VALUES), 0);
             long numberOfDistinctValues = BIGINT.getLong(computedStatistics.get(NUMBER_OF_DISTINCT_VALUES), 0);
-            result.setDistinctValuesCount(Math.min(numberOfDistinctValues, numberOfNonNullValues));
+            // Hive expects NDV to be one greater when column has a null
+            result.setDistinctValuesWithNullCount(Math.min(numberOfDistinctValues, numberOfNonNullValues) + (rowCount > numberOfNonNullValues ? 1 : 0));
         }
 
         // NUMBER OF FALSE, NUMBER OF TRUE

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3OnDataLake.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.plugin.hive.containers.HiveHadoop;
@@ -48,7 +49,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -1977,7 +1977,7 @@ public class TestHive3OnDataLake
         Map<String, Map<String, HiveColumnStatistics>> partitionStatistics = metastoreClient.getPartitionColumnStatistics(
                 HIVE_TEST_SCHEMA,
                 tableName,
-                Map.of(partitionName, OptionalLong.empty()),
+                ImmutableSet.of(partitionName),
                 partition.getColumns().stream().map(Column::getName).collect(toSet()));
 
         metastoreClient.dropPartition(HIVE_TEST_SCHEMA, tableName, List.of(regionKey), true);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSparkMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSparkMetastoreUtil.java
@@ -160,7 +160,7 @@ public class TestSparkMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setNullsCount(7)
                 .setDistinctValuesWithNullCount(3)
-                .setTotalSizeInBytes(30)
+                .setAverageColumnLength(10)
                 .build());
     }
 
@@ -179,7 +179,7 @@ public class TestSparkMetastoreUtil
         HiveColumnStatistics actual = fromMetastoreColumnStatistics("c_bin", HiveType.HIVE_BINARY, columnStatistics, 10);
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setNullsCount(3)
-                .setTotalSizeInBytes(70)
+                .setAverageColumnLength(10)
                 .setMaxValueSizeInBytes(10)
                 .build());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSparkMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSparkMetastoreUtil.java
@@ -48,7 +48,7 @@ public class TestSparkMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(4)))
                 .setNullsCount(0)
-                .setDistinctValuesCount(4)
+                .setDistinctValuesWithNullCount(4)
                 .build());
     }
 
@@ -71,7 +71,7 @@ public class TestSparkMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(0.3), OptionalDouble.of(3.3)))
                 .setNullsCount(1)
-                .setDistinctValuesCount(9)
+                .setDistinctValuesWithNullCount(10)
                 .build());
     }
 
@@ -95,7 +95,7 @@ public class TestSparkMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDecimalStatistics(new DecimalStatistics(Optional.of(new BigDecimal("0.3")), Optional.of(new BigDecimal("3.3"))))
                 .setNullsCount(1)
-                .setDistinctValuesCount(9)
+                .setDistinctValuesWithNullCount(10)
                 .build());
     }
 
@@ -140,7 +140,7 @@ public class TestSparkMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDateStatistics(new DateStatistics(Optional.of(LocalDate.of(2000, 1, 1)), Optional.of(LocalDate.of(2030, 12, 31))))
                 .setNullsCount(3)
-                .setDistinctValuesCount(7)
+                .setDistinctValuesWithNullCount(10)
                 .build());
     }
 
@@ -159,7 +159,7 @@ public class TestSparkMetastoreUtil
         HiveColumnStatistics actual = fromMetastoreColumnStatistics("c_char", HiveType.HIVE_STRING, columnStatistics, 10);
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setNullsCount(7)
-                .setDistinctValuesCount(3)
+                .setDistinctValuesWithNullCount(3)
                 .setTotalSizeInBytes(30)
                 .build());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestStatisticsUpdateMode.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestStatisticsUpdateMode.java
@@ -271,17 +271,17 @@ class TestStatisticsUpdateMode
     void testMergeGenericColumnStatistics()
     {
         assertMergeIncrementalColumnStatistics(
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build());
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.empty()).build());
         assertMergeIncrementalColumnStatistics(
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(1)).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.empty()).build());
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.empty()).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.empty()).build());
         assertMergeIncrementalColumnStatistics(
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(1)).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(2)).build(),
-                HiveColumnStatistics.builder().setDistinctValuesCount(OptionalLong.of(2)).build());
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.of(1)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.of(2)).build(),
+                HiveColumnStatistics.builder().setDistinctValuesWithNullCount(OptionalLong.of(2)).build());
 
         assertMergeIncrementalColumnStatistics(
                 HiveColumnStatistics.builder().setNullsCount(OptionalLong.empty()).build(),
@@ -344,7 +344,7 @@ class TestStatisticsUpdateMode
         assertThat(columnStatistics).containsEntry("a_column", HiveColumnStatistics.builder()
                         .setIntegerStatistics(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(5)))
                         .setNullsCount(0)
-                        .setDistinctValuesCount(5)
+                        .setDistinctValuesWithNullCount(5)
                         .build());
         assertThat(columnStatistics).containsEntry("b_column", HiveColumnStatistics.builder()
                         .setNullsCount(1)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -559,7 +559,7 @@ public class TestCachingHiveMetastore
                         OptionalLong.empty(),
                         OptionalLong.empty(),
                         OptionalLong.of(newStats.getLongStats().getNumNulls()),
-                        OptionalLong.of(newStats.getLongStats().getNumDVs() - 1))));
+                        OptionalLong.of(newStats.getLongStats().getNumDVs()))));
         assertThat(mockClient.getAccessCount()).isEqualTo(6);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -520,10 +520,10 @@ public class TestCachingHiveMetastore
         assertThat(metastore.getTable(TEST_DATABASE, TEST_TABLE)).isPresent();
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
 
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet(), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet())).isEqualTo(TEST_COLUMN_STATS);
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet(), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet())).isEqualTo(TEST_COLUMN_STATS);
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
         assertThat(metastore.getTableColumnStatisticsStats().getRequestCount()).isEqualTo(2);
@@ -533,7 +533,7 @@ public class TestCachingHiveMetastore
         assertThat(metastore.getTableStats().getHitRate()).isEqualTo(0.0);
 
         // check empty column list does not trigger the call
-        assertThatThrownBy(() -> metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(), TEST_BASIC_STATS.getRowCount()))
+        assertThatThrownBy(() -> metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of()))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThat(metastore.getTableColumnStatisticsStats().getRequestCount()).isEqualTo(2);
         assertThat(metastore.getTableColumnStatisticsStats().getHitRate()).isEqualTo(0.5);
@@ -542,19 +542,19 @@ public class TestCachingHiveMetastore
                 "col1", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(1)),
                 "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(2)),
                 "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(3))));
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col1"), TEST_BASIC_STATS.getRowCount())).containsEntry("col1", intColumnStats(1));
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col2"), TEST_BASIC_STATS.getRowCount())).containsEntry("col2", intColumnStats(2));
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col2", "col3"), TEST_BASIC_STATS.getRowCount()))
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col1"))).containsEntry("col1", intColumnStats(1));
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col2"))).containsEntry("col2", intColumnStats(2));
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of("col2", "col3")))
                 .containsEntry("col2", intColumnStats(2))
                 .containsEntry("col3", intColumnStats(3));
 
-        metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount()); // ensure cached
+        metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN)); // ensure cached
         assertThat(mockClient.getAccessCount()).isEqualTo(5);
         ColumnStatisticsData newStats = new ColumnStatisticsData();
         newStats.setLongStats(new LongColumnStatsData(327843, 4324));
         mockClient.mockColumnStats(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_COLUMN, newStats));
         metastore.invalidateTable(TEST_DATABASE, TEST_TABLE);
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount()))
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_COLUMN, createIntegerColumnStatistics(
                         OptionalLong.empty(),
                         OptionalLong.empty(),
@@ -573,11 +573,11 @@ public class TestCachingHiveMetastore
 
         // Force TEST_TABLE to not have column statistics available
         mockClient.mockColumnStats(TEST_DATABASE, TEST_TABLE, ImmutableMap.of());
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEmpty();
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEmpty();
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
         // Absence of column statistics should get cached and metastore client access count should stay the same
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEmpty();
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEmpty();
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
     }
 
@@ -593,11 +593,11 @@ public class TestCachingHiveMetastore
 
         // Force TEST_TABLE to not have column statistics available
         mockClient.mockColumnStats(TEST_DATABASE, TEST_TABLE, ImmutableMap.of());
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEmpty();
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEmpty();
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
         // Absence of column statistics does not get cached and metastore client access count increases
-        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEmpty();
+        assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEmpty();
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
     }
 
@@ -609,10 +609,10 @@ public class TestCachingHiveMetastore
         assertThat(statsOnlyCacheMetastore.getTable(TEST_DATABASE, TEST_TABLE)).isPresent();
         assertThat(mockClient.getAccessCount()).isEqualTo(1);
 
-        assertThat(statsOnlyCacheMetastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+        assertThat(statsOnlyCacheMetastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEqualTo(TEST_COLUMN_STATS);
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
-        assertThat(statsOnlyCacheMetastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+        assertThat(statsOnlyCacheMetastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_COLUMN))).isEqualTo(TEST_COLUMN_STATS);
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
         assertThat(statsOnlyCacheMetastore.getTableColumnStatisticsStats().getRequestCount()).isEqualTo(2);
@@ -666,10 +666,10 @@ public class TestCachingHiveMetastore
                     });
 
             // start get stats before the invalidation, it will wait until invalidation is done to finish
-            assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet(), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+            assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet())).isEqualTo(TEST_COLUMN_STATS);
             assertThat(mockClient.getAccessCount()).isEqualTo(2);
             // get stats after invalidate
-            assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet(), TEST_BASIC_STATS.getRowCount())).isEqualTo(TEST_COLUMN_STATS);
+            assertThat(metastore.getTableColumnStatistics(TEST_DATABASE, TEST_TABLE, TEST_COLUMN_STATS.keySet())).isEqualTo(TEST_COLUMN_STATS);
             // the value was not cached
             assertThat(mockClient.getAccessCount()).isEqualTo(3);
             // make sure invalidateFuture is done
@@ -696,12 +696,12 @@ public class TestCachingHiveMetastore
         String partition3Name = makePartitionName(table, partition3);
         assertThat(mockClient.getAccessCount()).isEqualTo(4);
 
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(5);
 
         assertThat(metastore.getPartitionStatisticsStats().getRequestCount()).isEqualTo(1);
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(5);
 
@@ -715,7 +715,7 @@ public class TestCachingHiveMetastore
         assertThat(metastore.getPartitionStats().getHitRate()).isEqualTo(0.0);
 
         // check empty column list does not trigger the call
-        assertThatThrownBy(() -> metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of()))
+        assertThatThrownBy(() -> metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of()))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThat(metastore.getPartitionStatisticsStats().getRequestCount()).isEqualTo(2);
         assertThat(metastore.getPartitionStatisticsStats().getHitRate()).isEqualTo(0.5);
@@ -725,13 +725,13 @@ public class TestCachingHiveMetastore
                 "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(2)),
                 "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(3))));
 
-        var tableCol1PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(partitionName, OptionalLong.empty()), ImmutableSet.of("col1"));
+        var tableCol1PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(partitionName), ImmutableSet.of("col1"));
         assertThat(tableCol1PartitionStatistics).containsOnlyKeys(partitionName);
         assertThat(tableCol1PartitionStatistics.get(partitionName)).containsEntry("col1", intColumnStats(1));
-        var tableCol2PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(partitionName, OptionalLong.empty()), ImmutableSet.of("col2"));
+        var tableCol2PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(partitionName), ImmutableSet.of("col2"));
         assertThat(tableCol2PartitionStatistics).containsOnlyKeys(partitionName);
         assertThat(tableCol2PartitionStatistics.get(partitionName)).containsEntry("col2", intColumnStats(2));
-        var tableCol23PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(partitionName, OptionalLong.empty()), ImmutableSet.of("col2", "col3"));
+        var tableCol23PartitionStatistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(partitionName), ImmutableSet.of("col2", "col3"));
         assertThat(tableCol23PartitionStatistics).containsOnlyKeys(partitionName);
         assertThat(tableCol23PartitionStatistics.get(partitionName))
                 .containsEntry("col2", intColumnStats(2))
@@ -747,14 +747,14 @@ public class TestCachingHiveMetastore
                 "col2", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(32)),
                 "col3", ColumnStatisticsData.longStats(new LongColumnStatsData().setNumNulls(33))));
 
-        var tableCol2Partition2Statistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(partition2Name, OptionalLong.empty()), ImmutableSet.of("col2"));
+        var tableCol2Partition2Statistics = metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(partition2Name), ImmutableSet.of("col2"));
         assertThat(tableCol2Partition2Statistics).containsOnlyKeys(partition2Name);
         assertThat(tableCol2Partition2Statistics.get(partition2Name)).containsEntry("col2", intColumnStats(22));
 
         var tableCol23Partition123Statistics = metastore.getPartitionColumnStatistics(
                 TEST_DATABASE,
                 TEST_TABLE,
-                ImmutableMap.of(partitionName, OptionalLong.empty(), partition2Name, OptionalLong.empty(), partition3Name, OptionalLong.empty()),
+                ImmutableSet.of(partitionName, partition2Name, partition3Name),
                 ImmutableSet.of("col2", "col3"));
         assertThat(tableCol23Partition123Statistics).containsOnlyKeys(partitionName, partition2Name, partition3Name);
         assertThat(tableCol23Partition123Statistics.get(partitionName))
@@ -784,12 +784,12 @@ public class TestCachingHiveMetastore
                 .setBasicStatistics(TEST_BASIC_STATS)
                 .setColumnStatistics(ImmutableMap.of())
                 .build();
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION2, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION2), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION2, expectedStats.getColumnStatistics()));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
 
         // Absence of column statistics should get cached and metastore client access count should stay the same
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION2, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION2), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION2, expectedStats.getColumnStatistics()));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
     }
@@ -812,12 +812,12 @@ public class TestCachingHiveMetastore
                 .setBasicStatistics(TEST_BASIC_STATS)
                 .setColumnStatistics(ImmutableMap.of())
                 .build();
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION2, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION2), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION2, expectedStats.getColumnStatistics()));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
 
         // Absence of column statistics does not get cached and metastore client access count increases
-        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION2, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION2), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION2, expectedStats.getColumnStatistics()));
         assertThat(mockClient.getAccessCount()).isEqualTo(4);
     }
@@ -833,11 +833,11 @@ public class TestCachingHiveMetastore
         assertThat(statsOnlyCacheMetastore.getPartition(table, TEST_PARTITION_VALUES1)).isPresent();
         assertThat(mockClient.getAccessCount()).isEqualTo(2);
 
-        assertThat(statsOnlyCacheMetastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(statsOnlyCacheMetastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
 
-        assertThat(statsOnlyCacheMetastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+        assertThat(statsOnlyCacheMetastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                 .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
         assertThat(mockClient.getAccessCount()).isEqualTo(3);
 
@@ -897,11 +897,11 @@ public class TestCachingHiveMetastore
                     });
 
             // start get stats before the invalidation, it will wait until invalidation is done to finish
-            assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+            assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                     .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
             assertThat(mockClient.getAccessCount()).isEqualTo(3);
             // get stats after invalidate
-            assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableMap.of(TEST_PARTITION1, OptionalLong.empty()), ImmutableSet.of(TEST_COLUMN)))
+            assertThat(metastore.getPartitionColumnStatistics(TEST_DATABASE, TEST_TABLE, ImmutableSet.of(TEST_PARTITION1), ImmutableSet.of(TEST_COLUMN)))
                     .isEqualTo(ImmutableMap.of(TEST_PARTITION1, TEST_COLUMN_STATS));
             // the value was not cached
             assertThat(mockClient.getAccessCount()).isEqualTo(4);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestColumnStatistics.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestColumnStatistics.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.file;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.trino.plugin.hive.metastore.BooleanStatistics;
+import io.trino.plugin.hive.metastore.DateStatistics;
+import io.trino.plugin.hive.metastore.DecimalStatistics;
+import io.trino.plugin.hive.metastore.DoubleStatistics;
+import io.trino.plugin.hive.metastore.HiveColumnStatistics;
+import io.trino.plugin.hive.metastore.IntegerStatistics;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestColumnStatistics
+{
+    private static final JsonCodec<Map<String, ColumnStatistics>> MAP_COLUMN_STATISTICS_CODEC = JsonCodec.mapJsonCodec(String.class, ColumnStatistics.class);
+
+    @Test
+    void testRoundTrip()
+    {
+        assertThat(MAP_COLUMN_STATISTICS_CODEC.fromJson(MAP_COLUMN_STATISTICS_CODEC.toJson(ALL_KINDS)))
+                .isEqualTo(ALL_KINDS);
+    }
+
+    @Test
+    void testDeserialize()
+    {
+        assertThat(MAP_COLUMN_STATISTICS_CODEC.fromJson(ALL_KINDS_JSON))
+                .isEqualTo(ALL_KINDS);
+    }
+
+    @Test
+    void testRoundHive()
+    {
+        Map<String, ColumnStatistics> fromHive = HIVE_ALL_KINDS.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, e -> ColumnStatistics.fromHiveColumnStatistics(e.getValue())));
+        assertThat(fromHive).isEqualTo(ALL_KINDS);
+
+        assertThat(fromHive.entrySet().stream()
+                .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().toHiveColumnStatistics())))
+                .isEqualTo(HIVE_ALL_KINDS);
+    }
+
+    private static final String ALL_KINDS_JSON =
+            """
+            {
+                "empty": {},
+                "integer": {
+                    "integerStatistics": {
+                        "min": 1,
+                        "max": 11
+                    },
+                    "maxValueSizeInBytes": 1,
+                    "totalSizeInBytes": 110,
+                    "nullsCount": 11,
+                    "distinctValuesCount": 111
+                },
+                "double": {
+                    "doubleStatistics": {
+                        "min": 2.0,
+                        "max": 12.0
+                    },
+                    "maxValueSizeInBytes": 2,
+                    "totalSizeInBytes": 220,
+                    "nullsCount": 22,
+                    "distinctValuesCount": 222
+                },
+                "decimal": {
+                    "decimalStatistics": {
+                        "min": 3.0,
+                        "max": 13.0
+                    },
+                    "maxValueSizeInBytes": 3,
+                    "totalSizeInBytes": 330,
+                    "nullsCount": 33,
+                    "distinctValuesCount": 333
+                },
+                "date": {
+                    "dateStatistics": {
+                        "min": "0004-04-04",
+                        "max": "0014-04-04"
+                    },
+                    "maxValueSizeInBytes": 4,
+                    "totalSizeInBytes": 440,
+                    "nullsCount": 44,
+                    "distinctValuesCount": 444
+                },
+                "boolean": {
+                    "booleanStatistics": {
+                        "trueCount": 5,
+                        "falseCount": 5
+                    },
+                    "maxValueSizeInBytes": 5,
+                    "totalSizeInBytes": 550,
+                    "nullsCount": 55,
+                    "distinctValuesCount": 555
+                },
+                "basic": {
+                    "maxValueSizeInBytes": 6,
+                    "totalSizeInBytes": 660,
+                    "nullsCount": 66,
+                    "distinctValuesCount": 666
+                }
+            }
+            """;
+
+    private static final Map<String, ColumnStatistics> ALL_KINDS = ImmutableMap.<String, ColumnStatistics>builder()
+            .put("empty", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty()))
+            .put("integer", new ColumnStatistics(
+                    Optional.of(new ColumnStatistics.IntegerStatistics(OptionalLong.of(1), OptionalLong.of(11))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(1),
+                    OptionalLong.of(110),
+                    OptionalLong.of(11),
+                    OptionalLong.of(111)))
+            .put("double", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.of(new ColumnStatistics.DoubleStatistics(OptionalDouble.of(2.0), OptionalDouble.of(12.0))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(2),
+                    OptionalLong.of(220),
+                    OptionalLong.of(22),
+                    OptionalLong.of(222)))
+            .put("decimal", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new ColumnStatistics.DecimalStatistics(Optional.of(new BigDecimal("3.0")), Optional.of(new BigDecimal("13.0")))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(3),
+                    OptionalLong.of(330),
+                    OptionalLong.of(33),
+                    OptionalLong.of(333)))
+            .put("date", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new ColumnStatistics.DateStatistics(Optional.of(LocalDate.of(4, 4, 4)), Optional.of(LocalDate.of(14, 4, 4)))),
+                    Optional.empty(),
+                    OptionalLong.of(4),
+                    OptionalLong.of(440),
+                    OptionalLong.of(44),
+                    OptionalLong.of(444)))
+            .put("boolean", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new ColumnStatistics.BooleanStatistics(OptionalLong.of(5), OptionalLong.of(5))),
+                    OptionalLong.of(5),
+                    OptionalLong.of(550),
+                    OptionalLong.of(55),
+                    OptionalLong.of(555)))
+            .put("basic", new ColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(6),
+                    OptionalLong.of(660),
+                    OptionalLong.of(66),
+                    OptionalLong.of(666)))
+            .buildOrThrow();
+
+    private static final Map<String, HiveColumnStatistics> HIVE_ALL_KINDS = ImmutableMap.<String, HiveColumnStatistics>builder()
+            .put("empty", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty(),
+                    OptionalLong.empty()))
+            .put("integer", new HiveColumnStatistics(
+                    Optional.of(new IntegerStatistics(OptionalLong.of(1), OptionalLong.of(11))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(1),
+                    OptionalLong.of(110),
+                    OptionalLong.of(11),
+                    OptionalLong.of(111)))
+            .put("double", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.of(new DoubleStatistics(OptionalDouble.of(2.0), OptionalDouble.of(12.0))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(2),
+                    OptionalLong.of(220),
+                    OptionalLong.of(22),
+                    OptionalLong.of(222)))
+            .put("decimal", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new DecimalStatistics(Optional.of(new BigDecimal("3.0")), Optional.of(new BigDecimal("13.0")))),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(3),
+                    OptionalLong.of(330),
+                    OptionalLong.of(33),
+                    OptionalLong.of(333)))
+            .put("date", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new DateStatistics(Optional.of(LocalDate.of(4, 4, 4)), Optional.of(LocalDate.of(14, 4, 4)))),
+                    Optional.empty(),
+                    OptionalLong.of(4),
+                    OptionalLong.of(440),
+                    OptionalLong.of(44),
+                    OptionalLong.of(444)))
+            .put("boolean", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.of(new BooleanStatistics(OptionalLong.of(5), OptionalLong.of(5))),
+                    OptionalLong.of(5),
+                    OptionalLong.of(550),
+                    OptionalLong.of(55),
+                    OptionalLong.of(555)))
+            .put("basic", new HiveColumnStatistics(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    OptionalLong.of(6),
+                    OptionalLong.of(660),
+                    OptionalLong.of(66),
+                    OptionalLong.of(666)))
+            .buildOrThrow();
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -246,7 +246,7 @@ public class TestThriftMetastoreUtil
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setMaxValueSizeInBytes(100)
-                .setTotalSizeInBytes(23)
+                .setAverageColumnLength(23.333)
                 .setNullsCount(1)
                 .setDistinctValuesWithNullCount(20)
                 .build());
@@ -274,7 +274,7 @@ public class TestThriftMetastoreUtil
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setMaxValueSizeInBytes(100)
-                .setTotalSizeInBytes(44)
+                .setAverageColumnLength(22.2)
                 .setNullsCount(2)
                 .build());
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -79,7 +79,7 @@ public class TestThriftMetastoreUtil
         longColumnStatsData.setNumNulls(1);
         longColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BIGINT_TYPE_NAME, longStats(longColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(1000));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setIntegerStatistics(new IntegerStatistics(OptionalLong.of(0), OptionalLong.of(100)))
@@ -93,7 +93,7 @@ public class TestThriftMetastoreUtil
     {
         LongColumnStatsData emptyLongColumnStatsData = new LongColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BIGINT_TYPE_NAME, longStats(emptyLongColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setIntegerStatistics(new IntegerStatistics(OptionalLong.empty(), OptionalLong.empty()))
@@ -109,7 +109,7 @@ public class TestThriftMetastoreUtil
         doubleColumnStatsData.setNumNulls(1);
         doubleColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(doubleColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(1000));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(0), OptionalDouble.of(100)))
@@ -123,7 +123,7 @@ public class TestThriftMetastoreUtil
     {
         DoubleColumnStatsData emptyDoubleColumnStatsData = new DoubleColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(emptyDoubleColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDoubleStatistics(new DoubleStatistics(OptionalDouble.empty(), OptionalDouble.empty()))
@@ -141,7 +141,7 @@ public class TestThriftMetastoreUtil
         decimalColumnStatsData.setNumNulls(1);
         decimalColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DECIMAL_TYPE_NAME, decimalStats(decimalColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(1000));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDecimalStatistics(new DecimalStatistics(Optional.of(low), Optional.of(high)))
@@ -155,7 +155,7 @@ public class TestThriftMetastoreUtil
     {
         DecimalColumnStatsData emptyDecimalColumnStatsData = new DecimalColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DECIMAL_TYPE_NAME, decimalStats(emptyDecimalColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDecimalStatistics(new DecimalStatistics(Optional.empty(), Optional.empty()))
@@ -170,7 +170,7 @@ public class TestThriftMetastoreUtil
         booleanColumnStatsData.setNumFalses(10);
         booleanColumnStatsData.setNumNulls(0);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BOOLEAN_TYPE_NAME, booleanStats(booleanColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setBooleanStatistics(new BooleanStatistics(OptionalLong.of(100), OptionalLong.of(10)))
@@ -183,7 +183,7 @@ public class TestThriftMetastoreUtil
     {
         BooleanColumnStatsData statsData = new BooleanColumnStatsData(1L, -1L, 2L);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BOOLEAN_TYPE_NAME, booleanStats(statsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty()))
@@ -196,7 +196,7 @@ public class TestThriftMetastoreUtil
     {
         BooleanColumnStatsData emptyBooleanColumnStatsData = new BooleanColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BOOLEAN_TYPE_NAME, booleanStats(emptyBooleanColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setBooleanStatistics(new BooleanStatistics(OptionalLong.empty(), OptionalLong.empty()))
@@ -212,7 +212,7 @@ public class TestThriftMetastoreUtil
         dateColumnStatsData.setNumNulls(1);
         dateColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DATE_TYPE_NAME, dateStats(dateColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(1000));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(1000)), Optional.of(LocalDate.ofEpochDay(2000))))
@@ -226,7 +226,7 @@ public class TestThriftMetastoreUtil
     {
         DateColumnStatsData emptyDateColumnStatsData = new DateColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DATE_TYPE_NAME, dateStats(emptyDateColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDateStatistics(new DateStatistics(Optional.empty(), Optional.empty()))
@@ -242,7 +242,7 @@ public class TestThriftMetastoreUtil
         stringColumnStatsData.setNumNulls(1);
         stringColumnStatsData.setNumDVs(20);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", STRING_TYPE_NAME, stringStats(stringColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(2));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setMaxValueSizeInBytes(100)
@@ -257,7 +257,7 @@ public class TestThriftMetastoreUtil
     {
         StringColumnStatsData emptyStringColumnStatsData = new StringColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", STRING_TYPE_NAME, stringStats(emptyStringColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder().build());
     }
@@ -270,7 +270,7 @@ public class TestThriftMetastoreUtil
         binaryColumnStatsData.setAvgColLen(22.2);
         binaryColumnStatsData.setNumNulls(2);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BINARY_TYPE_NAME, binaryStats(binaryColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(4));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setMaxValueSizeInBytes(100)
@@ -284,7 +284,7 @@ public class TestThriftMetastoreUtil
     {
         BinaryColumnStatsData emptyBinaryColumnStatsData = new BinaryColumnStatsData();
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", BINARY_TYPE_NAME, binaryStats(emptyBinaryColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.empty());
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder().build());
     }
@@ -296,7 +296,7 @@ public class TestThriftMetastoreUtil
         doubleColumnStatsData.setNumNulls(10);
         doubleColumnStatsData.setNumDVs(1);
         ColumnStatisticsObj columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(doubleColumnStatsData));
-        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(10));
+        HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual.getNullsCount()).isEqualTo(OptionalLong.of(10));
         assertThat(actual.getDistinctValuesWithNullCount()).isEqualTo(OptionalLong.of(1));
@@ -305,7 +305,7 @@ public class TestThriftMetastoreUtil
         doubleColumnStatsData.setNumNulls(10);
         doubleColumnStatsData.setNumDVs(1);
         columnStatisticsObj = new ColumnStatisticsObj("my_col", DOUBLE_TYPE_NAME, doubleStats(doubleColumnStatsData));
-        actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(11));
+        actual = fromMetastoreApiColumnStatistics(columnStatisticsObj);
 
         assertThat(actual.getNullsCount()).isEqualTo(OptionalLong.of(10));
         assertThat(actual.getDistinctValuesWithNullCount()).isEqualTo(OptionalLong.of(1));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/TestThriftMetastoreUtil.java
@@ -84,7 +84,7 @@ public class TestThriftMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setIntegerStatistics(new IntegerStatistics(OptionalLong.of(0), OptionalLong.of(100)))
                 .setNullsCount(1)
-                .setDistinctValuesCount(19)
+                .setDistinctValuesWithNullCount(20)
                 .build());
     }
 
@@ -114,7 +114,7 @@ public class TestThriftMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDoubleStatistics(new DoubleStatistics(OptionalDouble.of(0), OptionalDouble.of(100)))
                 .setNullsCount(1)
-                .setDistinctValuesCount(19)
+                .setDistinctValuesWithNullCount(20)
                 .build());
     }
 
@@ -146,7 +146,7 @@ public class TestThriftMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDecimalStatistics(new DecimalStatistics(Optional.of(low), Optional.of(high)))
                 .setNullsCount(1)
-                .setDistinctValuesCount(19)
+                .setDistinctValuesWithNullCount(20)
                 .build());
     }
 
@@ -217,7 +217,7 @@ public class TestThriftMetastoreUtil
         assertThat(actual).isEqualTo(HiveColumnStatistics.builder()
                 .setDateStatistics(new DateStatistics(Optional.of(LocalDate.ofEpochDay(1000)), Optional.of(LocalDate.ofEpochDay(2000))))
                 .setNullsCount(1)
-                .setDistinctValuesCount(19)
+                .setDistinctValuesWithNullCount(20)
                 .build());
     }
 
@@ -248,7 +248,7 @@ public class TestThriftMetastoreUtil
                 .setMaxValueSizeInBytes(100)
                 .setTotalSizeInBytes(23)
                 .setNullsCount(1)
-                .setDistinctValuesCount(1)
+                .setDistinctValuesWithNullCount(20)
                 .build());
     }
 
@@ -299,7 +299,7 @@ public class TestThriftMetastoreUtil
         HiveColumnStatistics actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(10));
 
         assertThat(actual.getNullsCount()).isEqualTo(OptionalLong.of(10));
-        assertThat(actual.getDistinctValuesCount()).isEqualTo(OptionalLong.of(0));
+        assertThat(actual.getDistinctValuesWithNullCount()).isEqualTo(OptionalLong.of(1));
 
         doubleColumnStatsData = new DoubleColumnStatsData();
         doubleColumnStatsData.setNumNulls(10);
@@ -308,7 +308,7 @@ public class TestThriftMetastoreUtil
         actual = fromMetastoreApiColumnStatistics(columnStatisticsObj, OptionalLong.of(11));
 
         assertThat(actual.getNullsCount()).isEqualTo(OptionalLong.of(10));
-        assertThat(actual.getDistinctValuesCount()).isEqualTo(OptionalLong.of(1));
+        assertThat(actual.getDistinctValuesWithNullCount()).isEqualTo(OptionalLong.of(1));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -73,6 +73,7 @@ import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.cal
 import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.calculateRangeForPartitioningKey;
 import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.convertPartitionValueToDouble;
 import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.createDataColumnStatistics;
+import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.getDistinctValuesCount;
 import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.getPartitionsSample;
 import static io.trino.plugin.hive.statistics.AbstractHiveStatisticsProvider.validatePartitionStatistics;
 import static io.trino.plugin.hive.util.HiveUtil.parsePartitionValue;
@@ -169,21 +170,9 @@ public class TestMetastoreHiveStatisticsProvider
         assertInvalidStatistics(
                 PartitionStatistics.builder()
                         .setBasicStatistics(new HiveBasicStatistics(0, 0, 0, 0))
-                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setDistinctValuesCount(-1).build()))
+                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setDistinctValuesWithNullCount(-1).build()))
                         .build(),
                 invalidColumnStatistics("distinctValuesCount must be greater than or equal to zero: -1"));
-        assertInvalidStatistics(
-                PartitionStatistics.builder()
-                        .setBasicStatistics(new HiveBasicStatistics(0, 0, 0, 0))
-                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setDistinctValuesCount(1).build()))
-                        .build(),
-                invalidColumnStatistics("distinctValuesCount must be less than or equal to rowCount. distinctValuesCount: 1. rowCount: 0."));
-        assertInvalidStatistics(
-                PartitionStatistics.builder()
-                        .setBasicStatistics(new HiveBasicStatistics(0, 1, 0, 0))
-                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setDistinctValuesCount(1).setNullsCount(1).build()))
-                        .build(),
-                invalidColumnStatistics("distinctValuesCount must be less than or equal to nonNullsCount. distinctValuesCount: 1. nonNullsCount: 0."));
         assertInvalidStatistics(
                 PartitionStatistics.builder()
                         .setBasicStatistics(new HiveBasicStatistics(0, 0, 0, 0))
@@ -460,22 +449,65 @@ public class TestMetastoreHiveStatisticsProvider
     @Test
     public void testCalculateDistinctValuesCount()
     {
-        assertThat(calculateDistinctValuesCount(ImmutableList.of())).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(HiveColumnStatistics.empty()))).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(HiveColumnStatistics.empty(), HiveColumnStatistics.empty()))).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(distinctValuesCount(1)))).isEqualTo(Estimate.of(1));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(distinctValuesCount(1), distinctValuesCount(2)))).isEqualTo(Estimate.of(2));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(distinctValuesCount(1), HiveColumnStatistics.empty()))).isEqualTo(Estimate.of(1));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty())))).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.of(1), OptionalLong.of(0), OptionalLong.empty())))).isEqualTo(Estimate.of(1));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.of(10), OptionalLong.empty(), OptionalLong.empty())))).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.of(10), OptionalLong.of(10), OptionalLong.empty())))).isEqualTo(Estimate.of(2));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.empty(), OptionalLong.of(10), OptionalLong.empty())))).isEqualTo(Estimate.unknown());
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.of(0), OptionalLong.of(10), OptionalLong.empty())))).isEqualTo(Estimate.of(1));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(createBooleanColumnStatistics(OptionalLong.of(0), OptionalLong.of(0), OptionalLong.empty())))).isEqualTo(Estimate.of(0));
-        assertThat(calculateDistinctValuesCount(ImmutableList.of(
-                createBooleanColumnStatistics(OptionalLong.of(0), OptionalLong.of(10), OptionalLong.empty()),
-                createBooleanColumnStatistics(OptionalLong.of(1), OptionalLong.of(10), OptionalLong.empty())))).isEqualTo(Estimate.of(2));
+        assertThat(getDistinctValuesCount(COLUMN, PartitionStatistics.empty())).isEmpty();
+        assertThat(getDistinctValuesCount(COLUMN, distinctValuesCount(1))).hasValue(1);
+
+        // Hive includes null in distinct values count. If column has nulls, decrease distinct values count by 1.
+        assertThat(getDistinctValuesCount(
+                COLUMN,
+                new PartitionStatistics(
+                        new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(10), OptionalLong.empty(), OptionalLong.empty()),
+                        ImmutableMap.of(COLUMN, HiveColumnStatistics.builder()
+                                .setNullsCount(3)
+                                .setDistinctValuesWithNullCount(5)
+                                .build()))))
+                .hasValue(4);
+
+        // if column only has a non-null row, count should not be zero
+        assertThat(getDistinctValuesCount(
+                COLUMN,
+                new PartitionStatistics(
+                        new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(10), OptionalLong.empty(), OptionalLong.empty()),
+                        ImmutableMap.of(COLUMN, HiveColumnStatistics.builder()
+                                .setNullsCount(3)
+                                .setDistinctValuesWithNullCount(1)
+                                .build()))))
+                .hasValue(1);
+
+        // Hive may have a distinct value much larger than the row count
+        assertThat(getDistinctValuesCount(
+                COLUMN,
+                new PartitionStatistics(
+                        new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(5), OptionalLong.empty(), OptionalLong.empty()),
+                        ImmutableMap.of(COLUMN, HiveColumnStatistics.builder()
+                                .setDistinctValuesWithNullCount(10)
+                                .build()))))
+                .hasValue(5);
+        assertThat(getDistinctValuesCount(
+                COLUMN,
+                new PartitionStatistics(
+                        new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(5), OptionalLong.empty(), OptionalLong.empty()),
+                        ImmutableMap.of(COLUMN, HiveColumnStatistics.builder()
+                                .setNullsCount(3)
+                                .setDistinctValuesWithNullCount(10)
+                                .build()))))
+                .hasValue(2);
+
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty()))).isEmpty();
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.of(1), OptionalLong.of(0), OptionalLong.empty()))).hasValue(1);
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.of(10), OptionalLong.empty(), OptionalLong.empty()))).isEmpty();
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.of(10), OptionalLong.of(10), OptionalLong.empty()))).hasValue(2);
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.empty(), OptionalLong.of(10), OptionalLong.empty()))).isEmpty();
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.of(0), OptionalLong.of(10), OptionalLong.empty()))).hasValue(1);
+        assertThat(getDistinctValuesCount(COLUMN, booleanDistinctValuesCount(OptionalLong.of(0), OptionalLong.of(0), OptionalLong.empty()))).hasValue(0);
+
+        assertThat(calculateDistinctValuesCount(COLUMN, ImmutableList.of())).isEqualTo(Estimate.unknown());
+        assertThat(calculateDistinctValuesCount(COLUMN, ImmutableList.of(PartitionStatistics.empty(), PartitionStatistics.empty()))).isEqualTo(Estimate.unknown());
+        assertThat(calculateDistinctValuesCount(COLUMN, ImmutableList.of(distinctValuesCount(1), distinctValuesCount(2)))).isEqualTo(Estimate.of(2));
+        assertThat(calculateDistinctValuesCount(COLUMN, ImmutableList.of(distinctValuesCount(1), PartitionStatistics.empty()))).isEqualTo(Estimate.of(1));
+        assertThat(calculateDistinctValuesCount(COLUMN, ImmutableList.of(
+                booleanDistinctValuesCount(OptionalLong.of(0), OptionalLong.of(10), OptionalLong.empty()),
+                booleanDistinctValuesCount(OptionalLong.of(1), OptionalLong.of(10), OptionalLong.empty())))).isEqualTo(Estimate.of(2));
     }
 
     @Test
@@ -564,9 +596,10 @@ public class TestMetastoreHiveStatisticsProvider
     public void testGetTableStatistics()
     {
         String partitionName = "p1=string1/p2=1234";
+        // Hive includes the null in distinct count, so provided value is 301, but actual distinct count is 300
         PartitionStatistics statistics = PartitionStatistics.builder()
                 .setBasicStatistics(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(1000), OptionalLong.empty(), OptionalLong.empty()))
-                .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
+                .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(301))))
                 .build();
         HiveStatisticsProvider statisticsProvider = new AbstractHiveStatisticsProvider()
         {
@@ -618,9 +651,10 @@ public class TestMetastoreHiveStatisticsProvider
     @Test
     public void testGetTableStatisticsUnpartitioned()
     {
+        // Hive includes the null in distinct count, so provided value is 301, but actual distinct count is 300
         PartitionStatistics statistics = PartitionStatistics.builder()
                 .setBasicStatistics(new HiveBasicStatistics(OptionalLong.empty(), OptionalLong.of(1000), OptionalLong.empty(), OptionalLong.empty()))
-                .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(300))))
+                .setColumnStatistics(ImmutableMap.of(COLUMN, createIntegerColumnStatistics(OptionalLong.of(-100), OptionalLong.of(100), OptionalLong.of(500), OptionalLong.of(301))))
                 .build();
         HiveStatisticsProvider statisticsProvider = new AbstractHiveStatisticsProvider()
         {
@@ -851,11 +885,17 @@ public class TestMetastoreHiveStatisticsProvider
                 ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setTotalSizeInBytes(dataSize).build()));
     }
 
-    private static HiveColumnStatistics distinctValuesCount(long count)
+    private static PartitionStatistics distinctValuesCount(long count)
     {
-        return HiveColumnStatistics.builder()
-                .setDistinctValuesCount(count)
-                .build();
+        return new PartitionStatistics(HiveBasicStatistics.createEmptyStatistics(), ImmutableMap.of(COLUMN, HiveColumnStatistics.builder()
+                .setDistinctValuesWithNullCount(count)
+                .build()));
+    }
+
+    private static PartitionStatistics booleanDistinctValuesCount(OptionalLong trueCount, OptionalLong falseCount, OptionalLong nullsCount)
+    {
+        return new PartitionStatistics(HiveBasicStatistics.createEmptyStatistics(),
+                ImmutableMap.of(COLUMN, createBooleanColumnStatistics(trueCount, falseCount, nullsCount)));
     }
 
     private static HiveColumnStatistics integerRange(long min, long max)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/statistics/TestMetastoreHiveStatisticsProvider.java
@@ -152,9 +152,9 @@ public class TestMetastoreHiveStatisticsProvider
         assertInvalidStatistics(
                 PartitionStatistics.builder()
                         .setBasicStatistics(new HiveBasicStatistics(0, 0, 0, 0))
-                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setTotalSizeInBytes(-1).build()))
+                        .setColumnStatistics(ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setAverageColumnLength(-1).build()))
                         .build(),
-                invalidColumnStatistics("totalSizeInBytes must be greater than or equal to zero: -1"));
+                invalidColumnStatistics("averageColumnLength must be greater than or equal to zero: -1.0"));
         assertInvalidStatistics(
                 PartitionStatistics.builder()
                         .setBasicStatistics(new HiveBasicStatistics(0, 0, 0, 0))
@@ -531,23 +531,23 @@ public class TestMetastoreHiveStatisticsProvider
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCount(1000)), 1000)).isEqualTo(Estimate.unknown());
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(dataSize(1000)), 1000)).isEqualTo(Estimate.unknown());
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(dataSize(1000), rowsCount(1000)), 1000)).isEqualTo(Estimate.unknown());
-        assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCountAndDataSize(500, 1000)), 2000)).isEqualTo(Estimate.of(4000));
+        assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCountAndDataSize(500, 2)), 2000)).isEqualTo(Estimate.of(4000));
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCountAndDataSize(0, 0)), 2000)).isEqualTo(Estimate.unknown());
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCountAndDataSize(0, 0)), 0)).isEqualTo(Estimate.zero());
         assertThat(calculateDataSize(COLUMN, ImmutableList.of(rowsCountAndDataSize(1000, 0)), 2000)).isEqualTo(Estimate.of(0));
         assertThat(calculateDataSize(
                 COLUMN,
                 ImmutableList.of(
-                        rowsCountAndDataSize(500, 1000),
-                        rowsCountAndDataSize(1000, 5000)),
+                        rowsCountAndDataSize(500, 2),
+                        rowsCountAndDataSize(1000, 5)),
                 5000)).isEqualTo(Estimate.of(20000));
         assertThat(calculateDataSize(
                 COLUMN,
                 ImmutableList.of(
                         dataSize(1000),
-                        rowsCountAndDataSize(500, 1000),
+                        rowsCountAndDataSize(500, 2),
                         rowsCount(3000),
-                        rowsCountAndDataSize(1000, 5000)),
+                        rowsCountAndDataSize(1000, 5)),
                 5000)).isEqualTo(Estimate.of(20000));
     }
 
@@ -868,7 +868,7 @@ public class TestMetastoreHiveStatisticsProvider
 
     private static PartitionStatistics dataSize(long dataSize)
     {
-        return new PartitionStatistics(HiveBasicStatistics.createEmptyStatistics(), ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setTotalSizeInBytes(dataSize).build()));
+        return new PartitionStatistics(HiveBasicStatistics.createEmptyStatistics(), ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setAverageColumnLength(dataSize).build()));
     }
 
     private static PartitionStatistics rowsCountAndNullsCount(long rowsCount, long nullsCount)
@@ -878,11 +878,11 @@ public class TestMetastoreHiveStatisticsProvider
                 ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setNullsCount(nullsCount).build()));
     }
 
-    private static PartitionStatistics rowsCountAndDataSize(long rowsCount, long dataSize)
+    private static PartitionStatistics rowsCountAndDataSize(long rowsCount, long averageColumnLength)
     {
         return new PartitionStatistics(
                 new HiveBasicStatistics(0, rowsCount, 0, 0),
-                ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setTotalSizeInBytes(dataSize).build()));
+                ImmutableMap.of(COLUMN, HiveColumnStatistics.builder().setAverageColumnLength(averageColumnLength).build()));
     }
 
     private static PartitionStatistics distinctValuesCount(long count)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
@@ -334,12 +334,12 @@ public class TestHiveTableStatistics
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
         onTrino().executeQuery("CALL system.flush_metadata_cache()");
 
-        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
-                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
-                row("p_name", 109.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
-                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 15.0, null, null));
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
+                row("p_nationkey", null, anyOf(4., 5.), 0.0, null, "8", "21"),
+                row("p_name", 31.0, 5.0, 0.0, null, null, null),
+                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
+                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
+                row(null, null, null, null, 5.0, null, null));
 
         assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -348,12 +348,12 @@ public class TestHiveTableStatistics
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
-                row("p_nationkey", null, anyOf(4., 5.), 0.0, null, "8", "21"),
-                row("p_name", 31.0, 5.0, 0.0, null, null, null),
-                row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
-                row("p_comment", 351.0, 5.0, 0.0, null, null, null),
-                row(null, null, null, null, 5.0, null, null));
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
+                row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
+                row("p_name", 109.0, 5.0, 0.0, null, null, null),
+                row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
+                row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
+                row(null, null, null, null, 15.0, null, null));
     }
 
     @Test
@@ -1090,9 +1090,9 @@ public class TestHiveTableStatistics
                     row("c_decimal_w_params", null, 2.0, 0.4, null, "345.67", "345.678"),
                     row("c_timestamp", null, 2.0, 0.4, null, null, null),
                     row("c_date", null, 2.0, 0.4, null, "2015-05-08", "2015-06-10"),
-                    row("c_string", 32.0, 2.0, 0.4, null, null, null),
-                    row("c_varchar", 29.0, 2.0, 0.4, null, null, null),
-                    row("c_char", 17.0, 2.0, 0.4, null, null, null),
+                    row("c_string", 32.0001, 2.0, 0.4, null, null, null),
+                    row("c_varchar", 29.0001, 2.0, 0.4, null, null, null),
+                    row("c_char", 17.0001, 2.0, 0.4, null, null, null),
                     row("c_boolean", null, 2.0, 0.4, null, null, null),
                     row("c_binary", 39.0, null, 0.4, null, null, null),
                     row(null, null, null, null, 5.0, null, null)));


### PR DESCRIPTION
## Description

Trino and Hive have different stats for number of distinct values and average size.  Currently this translation is happening inside of each Hive metastore implementation, which is complex and redundant. Instead this PR moves translation to
the layer that translate connector stats to and from engine stats.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
