### PR TITLE
Add file-based access control documentation for procedure rules

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.md
+++ b/docs/src/main/sphinx/security/file-system-access-control.md
@@ -432,6 +432,67 @@ any catalog, and allows all users to create, drop, and execute functions (includ
 }
 ```
 
+(system-file-procedure-rules)=
+#### Procedure rules
+
+These rules control the ability of a user to execute procedures.
+
+Procedures are used for administrative operations on a specific catalog, such as
+registering external tables or flushing the connector's cache. Available
+procedures are detailed in the connector documentation pages.
+
+When procedure rules are present, the authorization is based on the first
+matching rule, processed from top to bottom. If no rules match, the
+authorization is denied. If procedure rules are not present, only procedures in
+`system.builtin` can be executed.
+
+Each procedure rule is composed of the following fields:
+
+- `user` (optional): regular expression to match against user name.
+  Defaults to `.*`.
+- `role` (optional): regular expression to match against role names.
+  Defaults to `.*`.
+- `group` (optional): regular expression to match against group names.
+  Defaults to `.*`.
+- `catalog` (optional): regular expression to match against catalog name.
+  Defaults to `.*`.
+- `schema` (optional): regular expression to match against schema name.
+  Defaults to `.*`.
+- `procedure` (optional): regular expression to match against procedure names.
+  Defaults to `.*`.
+- `privileges` (required): zero or more of `EXECUTE`, `GRANT_EXECUTE`.
+
+The following example allows the `admin` user to execute and grant execution
+rights to call `register_table` and `unregister_table` in the `system` schema of
+a catalog called  `delta`, that uses the [Delta Lake
+connector](/connector/delta-lake). It allows all users to execute the
+`delta.sytem.vacuum` procedure.
+
+```json
+{
+  "procedures": [
+    {
+      "user": "admin",
+      "catalog": "delta",
+      "schema": "system",
+      "procedure": "register_table|unregister_table",
+      "privileges": [
+        "EXECUTE",
+        "GRANT_EXECUTE"
+      ]
+    },
+    {
+      "catalog": "delta",
+      "schema": "system",
+      "procedure": "vacuum",
+      "privileges": [
+        "EXECUTE"
+      ]
+    }
+  ]
+}
+```
+
 (verify-rules)=
 
 #### Verify configuration


### PR DESCRIPTION
## Description

Adds a new section to the [File-based access control](https://trino.io/docs/current/security/file-system-access-control.html) documentation page, describing how to configure procedure rules.

#19488 added this feature, but missed updating the corresponding documentation.

Fixes https://github.com/trinodb/trino/issues/19593

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
