### PR TITLE
Update aircompressor to 0.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.25</version>
+                <version>0.26</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes a potential JVM crash when decompressing corrupted Snappy data.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# All connectors that support parquet & ORC
* Fixes potential crash when decompressing corrupted Snappy data. ({issue}`20631`)
```
