### PR TITLE
Clarify decimal type handling behavior

### DIFF
--- a/docs/src/main/sphinx/connector/decimal-type-handling.fragment
+++ b/docs/src/main/sphinx/connector/decimal-type-handling.fragment
@@ -1,11 +1,11 @@
 ### Decimal type handling
 
-`DECIMAL` types with unspecified precision or scale are mapped to a Trino
-`DECIMAL` with a default precision of 38 and default scale of 0. The scale can
-be changed by setting the `decimal-mapping` configuration property or the
-`decimal_mapping` session property to `allow_overflow`. The scale of the
-resulting type is controlled via the `decimal-default-scale` configuration
-property or the `decimal-rounding-mode` session property. The precision is
+`DECIMAL` types with unspecified precision or scale are ignored unless the
+`decimal-mapping` configuration property or the `decimal_mapping` session
+property is set to `allow_overflow`. Then such types are mapped to a Trino
+`DECIMAL` with a default precision of 38 and default scale of 0. To change the
+scale of the resulting type, use the `decimal-default-scale` configuration
+property or the `decimal_default_scale` session property. The precision is
 always 38.
 
 By default, values that require rounding or truncation to fit will cause a


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* This PR clarifies the wording of the Decimal type handling fragment. Users should set the `decimal-mapping` config property or `decimal_mapping` session propery to `allow_overflow` to ensure that the default precision of 38 and scale of 0 are used. Failure to do so ignores `DECIMAL` types with unspecified precision.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
