### PR TITLE
Prevent view owner from being set when system security is used

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/glue/TrinoGlueCatalog.java
@@ -1151,7 +1151,7 @@ public class TrinoGlueCatalog
             TableInput materializedViewTableInput = getMaterializedViewTableInput(
                     viewName.getTableName(),
                     encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition)),
-                    session.getUser(),
+                    isUsingSystemSecurity ? null : session.getUser(),
                     createMaterializedViewProperties(session, storageMetadataLocation));
             if (existing.isPresent()) {
                 updateTable(viewName.getSchemaName(), materializedViewTableInput);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestTrinoGlueCatalog.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.glue.AWSGlueAsyncClientBuilder;
 import com.amazonaws.services.glue.model.CreateDatabaseRequest;
 import com.amazonaws.services.glue.model.DatabaseInput;
 import com.amazonaws.services.glue.model.DeleteDatabaseRequest;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.filesystem.TrinoFileSystemFactory;
@@ -31,7 +32,9 @@ import io.trino.plugin.iceberg.TableStatisticsWriter;
 import io.trino.plugin.iceberg.catalog.BaseTrinoCatalogTest;
 import io.trino.plugin.iceberg.catalog.TrinoCatalog;
 import io.trino.spi.connector.CatalogHandle;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.MaterializedViewNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
@@ -42,10 +45,17 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.airlift.json.JsonCodec.jsonCodec;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_FILE_SYSTEM_FACTORY;
+import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
+import static io.trino.plugin.iceberg.IcebergSchemaProperties.LOCATION_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROPERTY;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingNames.randomNameSuffix;
@@ -61,24 +71,28 @@ public class TestTrinoGlueCatalog
     @Override
     protected TrinoCatalog createTrinoCatalog(boolean useUniqueTableLocations)
     {
-        TrinoFileSystemFactory fileSystemFactory = HDFS_FILE_SYSTEM_FACTORY;
+        return createGlueTrinoCatalog(useUniqueTableLocations, false);
+    }
+
+    private TrinoCatalog createGlueTrinoCatalog(boolean useUniqueTableLocations, boolean useSystemSecurity)
+    {
         AWSGlueAsync glueClient = AWSGlueAsyncClientBuilder.defaultClient();
         IcebergGlueCatalogConfig catalogConfig = new IcebergGlueCatalogConfig();
         return new TrinoGlueCatalog(
                 new CatalogName("catalog_name"),
-                fileSystemFactory,
+                HDFS_FILE_SYSTEM_FACTORY,
                 new TestingTypeManager(),
                 catalogConfig.isCacheTableMetadata(),
                 new GlueIcebergTableOperationsProvider(
                         TESTING_TYPE_MANAGER,
                         catalogConfig,
-                        fileSystemFactory,
+                        HDFS_FILE_SYSTEM_FACTORY,
                         new GlueMetastoreStats(),
                         glueClient),
                 "test",
                 glueClient,
                 new GlueMetastoreStats(),
-                false,
+                useSystemSecurity,
                 Optional.empty(),
                 useUniqueTableLocations,
                 new IcebergConfig().isHideMaterializedViewStorageTable());
@@ -131,6 +145,55 @@ public class TestTrinoGlueCatalog
         finally {
             glueClient.deleteDatabase(new DeleteDatabaseRequest()
                     .withName(databaseName));
+        }
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSystemSecurity()
+    {
+        TrinoCatalog glueTrinoCatalog = createGlueTrinoCatalog(false, true);
+        String namespace = "test_create_mv_" + randomNameSuffix();
+        String table = "materialized_view_name";
+        SchemaTableName viewName = new SchemaTableName(namespace, table);
+        Map<String, Object> properties = ImmutableMap.of(LOCATION_PROPERTY, "file:///tmp/a/path/");
+        try {
+            glueTrinoCatalog.createNamespace(SESSION, namespace, properties, new TrinoPrincipal(PrincipalType.USER, SESSION.getUser()));
+            glueTrinoCatalog.createMaterializedView(
+                    SESSION,
+                    viewName,
+                    new ConnectorMaterializedViewDefinition(
+                            "CREATE * FROM tpch.tiny.nations",
+                            Optional.empty(),
+                            Optional.of("catalog_name"),
+                            Optional.of("schema_name"),
+                            ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("col1", INTEGER.getTypeId(), Optional.empty())),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.of("test_owner"),
+                            ImmutableList.of()),
+                    ImmutableMap.of(FILE_FORMAT_PROPERTY, PARQUET, FORMAT_VERSION_PROPERTY, 1),
+                    false,
+                    false);
+            List<SchemaTableName> materializedViews = glueTrinoCatalog.listMaterializedViews(SESSION, Optional.of(namespace));
+            assertThat(materializedViews.size()).isEqualTo(1);
+            assertThat(materializedViews.get(0).getTableName()).isEqualTo(table);
+            Optional<ConnectorMaterializedViewDefinition> returned = glueTrinoCatalog.getMaterializedView(SESSION, materializedViews.get(0));
+            assertThat(returned).isPresent();
+            assertThat(returned.get().getOwner()).isEmpty();
+        }
+        finally {
+            try {
+                glueTrinoCatalog.dropMaterializedView(SESSION, viewName);
+            }
+            catch (MaterializedViewNotFoundException e) {
+                LOG.warn("Failed to clean up view: %s", viewName);
+            }
+            try {
+                glueTrinoCatalog.dropNamespace(SESSION, namespace);
+            }
+            catch (Exception e) {
+                LOG.warn("Failed to clean up namespace: %s", namespace);
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
It is a security hole as user can have broader access to glue than to trino and can leverage this to get access to data he should not access


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Stop setting materialized view owner in glue catalog . ({issue}`issuenumber`)
```
