### PR TITLE
Verify user-visible message in assertQueryFails

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
+++ b/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
@@ -30,7 +30,6 @@ import io.trino.sql.parser.ParsingException;
 import io.trino.testing.QueryFailedException;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.assertj.core.internal.Failures;
 import org.assertj.core.util.CheckReturnValue;
 
 import java.util.Optional;
@@ -42,7 +41,6 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.assertj.core.error.ShouldHaveMessageMatchingRegex.shouldHaveMessageMatchingRegex;
 
 public final class TrinoExceptionAssert
         extends AbstractThrowableAssert<TrinoExceptionAssert, Throwable>
@@ -147,17 +145,5 @@ public final class TrinoExceptionAssert
             throw e;
         }
         return myself;
-    }
-
-    public TrinoExceptionAssert hasCauseMessageMatching(String regex)
-    {
-        Throwable cause = actual;
-        while (cause != null) {
-            if (cause.getMessage().matches(regex)) {
-                return myself;
-            }
-            cause = cause.getCause();
-        }
-        throw Failures.instance().failure(info, shouldHaveMessageMatchingRegex(actual, regex));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
+++ b/core/trino-main/src/main/java/io/trino/testing/assertions/TrinoExceptionAssert.java
@@ -16,6 +16,7 @@ package io.trino.testing.assertions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.trino.cache.SafeCaches;
 import io.trino.client.ErrorInfo;
 import io.trino.client.FailureException;
@@ -112,6 +113,7 @@ public final class TrinoExceptionAssert
         this.failureInfo = requireNonNull(failureInfo, "failureInfo is null");
     }
 
+    @CanIgnoreReturnValue
     public TrinoExceptionAssert hasErrorCode(ErrorCodeSupplier... errorCodeSupplier)
     {
         ErrorCode errorCode = null;
@@ -133,6 +135,7 @@ public final class TrinoExceptionAssert
         return myself;
     }
 
+    @CanIgnoreReturnValue
     public TrinoExceptionAssert hasLocation(int lineNumber, int columnNumber)
     {
         try {

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -468,7 +468,7 @@ public final class QueryAssertions
         catch (RuntimeException exception) {
             exception.addSuppressed(new Exception("Query: " + sql));
             assertThatTrinoException(exception)
-                    .hasCauseMessageMatching(expectedMessageRegExp);
+                    .hasMessageMatching(expectedMessageRegExp);
         }
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryAssertions.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryAssertions.java
@@ -148,16 +148,16 @@ public class TestQueryAssertions
         assertThatThrownBy(() -> queryAssert.matches("VALUES X'001299'"))
                 .hasMessageMatching(
                         "(?s).*" +
-                        "\\Q" +
-                        "Expecting actual:\n" +
-                        "  ([0, 18, 52])\n" +
-                        "to contain exactly in any order:\n" +
-                        "  [([0, 18, -103])]\n" +
-                        "elements not found:\n" +
-                        "  ([0, 18, -103])\n" +
-                        "and elements not expected:\n" +
-                        "  ([0, 18, 52])" +
-                        "\\E.*");
+                                "\\Q" +
+                                "Expecting actual:\n" +
+                                "  ([0, 18, 52])\n" +
+                                "to contain exactly in any order:\n" +
+                                "  [([0, 18, -103])]\n" +
+                                "elements not found:\n" +
+                                "  ([0, 18, -103])\n" +
+                                "and elements not expected:\n" +
+                                "  ([0, 18, 52])" +
+                                "\\E.*");
     }
 
     @Test
@@ -170,16 +170,16 @@ public class TestQueryAssertions
         assertThatThrownBy(() -> queryAssert.matches("SELECT CAST(ROW(X'001299') AS ROW(foo varbinary))"))
                 .hasMessageMatching(
                         "(?s).*" +
-                        "\\Q" +
-                        "Expecting actual:\n" +
-                        "  ([X'00 12 34'])\n" +
-                        "to contain exactly in any order:\n" +
-                        "  [([X'00 12 99'])]\n" +
-                        "elements not found:\n" +
-                        "  ([X'00 12 99'])\n" +
-                        "and elements not expected:\n" +
-                        "  ([X'00 12 34'])" +
-                        "\\E.*");
+                                "\\Q" +
+                                "Expecting actual:\n" +
+                                "  ([X'00 12 34'])\n" +
+                                "to contain exactly in any order:\n" +
+                                "  [([X'00 12 99'])]\n" +
+                                "elements not found:\n" +
+                                "  ([X'00 12 99'])\n" +
+                                "and elements not expected:\n" +
+                                "  ([X'00 12 34'])" +
+                                "\\E.*");
     }
 
     /**


### PR DESCRIPTION
Change `assertQueryFails` so that it verifies the message that the
end-user would see. Before the change, `assertQueryFails` would accept
any TrinoException that has expected message somewhere in the causal
chain. However, causal chain may or may not be visible to the end user,
depending on the tooling used. This restores the behavior that used to
be before commit https://github.com/trinodb/trino/commit/0a56d09d5b30ae882a61e4a5d26bf3cc054de9e5 (https://github.com/trinodb/trino/pull/20048).

Tests that want to verify causal message should do this explicitly.