### PR TITLE
Remove type-only coercion from planner layer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/json/JsonPathEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/json/JsonPathEvaluator.java
@@ -51,7 +51,7 @@ public class JsonPathEvaluator
 
         this.path = path;
         this.invoker = new Invoker(session, functionManager);
-        this.resolver = new CachingResolver(metadata, typeManager);
+        this.resolver = new CachingResolver(metadata);
     }
 
     public List<Object> evaluate(JsonNode input, Object[] parameters)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -207,7 +207,6 @@ public class Analysis
 
     private final Map<NodeRef<Expression>, Type> types = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, Type> coercions = new LinkedHashMap<>();
-    private final Set<NodeRef<Expression>> typeOnlyCoercions = new LinkedHashSet<>();
 
     private final Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundCalculation = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundComparison = new LinkedHashMap<>();
@@ -371,11 +370,6 @@ public class Analysis
         return unmodifiableMap(coercions);
     }
 
-    public Set<NodeRef<Expression>> getTypeOnlyCoercions()
-    {
-        return unmodifiableSet(typeOnlyCoercions);
-    }
-
     public Type getCoercion(Expression expression)
     {
         return coercions.get(NodeRef.of(expression));
@@ -404,11 +398,6 @@ public class Analysis
     public boolean isAggregation(QuerySpecification node)
     {
         return groupingSets.containsKey(NodeRef.of(node));
-    }
-
-    public boolean isTypeOnlyCoercion(Expression expression)
-    {
-        return typeOnlyCoercions.contains(NodeRef.of(expression));
     }
 
     public GroupingSetAnalysis getGroupingSets(QuerySpecification node)
@@ -712,22 +701,17 @@ public class Analysis
         this.types.putAll(types);
     }
 
-    public void addCoercion(Expression expression, Type type, boolean isTypeOnlyCoercion)
+    public void addCoercion(Expression expression, Type type)
     {
         this.coercions.put(NodeRef.of(expression), type);
-        if (isTypeOnlyCoercion) {
-            this.typeOnlyCoercions.add(NodeRef.of(expression));
-        }
     }
 
     public void addCoercions(
             Map<NodeRef<Expression>, Type> coercions,
-            Set<NodeRef<Expression>> typeOnlyCoercions,
             Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundCalculation,
             Map<NodeRef<Expression>, Type> sortKeyCoercionsForFrameBoundComparison)
     {
         this.coercions.putAll(coercions);
-        this.typeOnlyCoercions.addAll(typeOnlyCoercions);
         this.sortKeyCoercionsForFrameBoundCalculation.putAll(sortKeyCoercionsForFrameBoundCalculation);
         this.sortKeyCoercionsForFrameBoundComparison.putAll(sortKeyCoercionsForFrameBoundComparison);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
@@ -33,7 +33,6 @@ public class ExpressionAnalysis
 {
     private final Map<NodeRef<Expression>, Type> expressionTypes;
     private final Map<NodeRef<Expression>, Type> expressionCoercions;
-    private final Set<NodeRef<Expression>> typeOnlyCoercions;
     private final Map<NodeRef<Expression>, ResolvedField> columnReferences;
     private final Set<NodeRef<InPredicate>> subqueryInPredicates;
     private final Set<NodeRef<SubqueryExpression>> subqueries;
@@ -48,13 +47,11 @@ public class ExpressionAnalysis
             Set<NodeRef<SubqueryExpression>> subqueries,
             Set<NodeRef<ExistsPredicate>> existsSubqueries,
             Map<NodeRef<Expression>, ResolvedField> columnReferences,
-            Set<NodeRef<Expression>> typeOnlyCoercions,
             Set<NodeRef<QuantifiedComparisonExpression>> quantifiedComparisons,
             Set<NodeRef<FunctionCall>> windowFunctions)
     {
         this.expressionTypes = ImmutableMap.copyOf(requireNonNull(expressionTypes, "expressionTypes is null"));
         this.expressionCoercions = ImmutableMap.copyOf(requireNonNull(expressionCoercions, "expressionCoercions is null"));
-        this.typeOnlyCoercions = ImmutableSet.copyOf(requireNonNull(typeOnlyCoercions, "typeOnlyCoercions is null"));
         this.columnReferences = ImmutableMap.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
         this.subqueryInPredicates = ImmutableSet.copyOf(requireNonNull(subqueryInPredicates, "subqueryInPredicates is null"));
         this.subqueries = ImmutableSet.copyOf(requireNonNull(subqueries, "subqueries is null"));
@@ -76,11 +73,6 @@ public class ExpressionAnalysis
     public Type getCoercion(Expression expression)
     {
         return expressionCoercions.get(NodeRef.of(expression));
-    }
-
-    public boolean isTypeOnlyCoercion(Expression expression)
-    {
-        return typeOnlyCoercions.contains(NodeRef.of(expression));
     }
 
     public boolean isColumnReference(Expression node)

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionInterpreter.java
@@ -224,7 +224,7 @@ public class ExpressionInterpreter
                 .buildOrThrow();
 
         // add coercions
-        Expression rewrite = Coercer.addCoercions(expression, coercions, analyzer.getTypeOnlyCoercions());
+        Expression rewrite = Coercer.addCoercions(expression, coercions);
 
         // redo the analysis since above expression rewriter might create new expressions which do not have entries in the type map
         analyzer = createConstantAnalyzer(plannerContext, accessControl, session, parameters, WarningCollector.NOOP);
@@ -255,11 +255,7 @@ public class ExpressionInterpreter
             return rewritten;
         }
 
-        return new Cast(
-                rewritten,
-                toSqlType(coercion),
-                false,
-                analysis.isTypeOnlyCoercion(original));
+        return new Cast(rewritten, toSqlType(coercion), false);
     }
 
     private Object evaluate()
@@ -897,10 +893,6 @@ public class ExpressionInterpreter
             Object value = processWithExceptionHandling(node.getExpression(), context);
             Type targetType = plannerContext.getTypeManager().getType(toTypeSignature(node.getType()));
             Type sourceType = type(node.getExpression());
-
-            if (node.isTypeOnly()) {
-                return value;
-            }
 
             if (value == null) {
                 return null;

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2203,7 +2203,7 @@ class StatementAnalyzer
                             if (!typeCoercion.canCoerce(type, commonSuperType)) {
                                 throw semanticException(TYPE_MISMATCH, column, "Cannot coerce column of type %s to common supertype: %s", type.getDisplayName(), commonSuperType.getDisplayName());
                             }
-                            analysis.addCoercion(column, commonSuperType, typeCoercion.isTypeOnlyCoercion(type, commonSuperType));
+                            analysis.addCoercion(column, commonSuperType);
                         }
                     }
                 }
@@ -3329,7 +3329,7 @@ class StatementAnalyzer
                         throw semanticException(TYPE_MISMATCH, expression, "JOIN ON clause must evaluate to a boolean: actual type %s", clauseType);
                     }
                     // coerce expression to boolean
-                    analysis.addCoercion(expression, BOOLEAN, false);
+                    analysis.addCoercion(expression, BOOLEAN);
                 }
 
                 analysis.recordSubqueries(node, expressionAnalysis);
@@ -3448,7 +3448,7 @@ class StatementAnalyzer
                 Type expressionType = expressionTypes.get(index);
                 Type targetType = tableTypes.get(index);
                 if (!targetType.equals(expressionType)) {
-                    analysis.addCoercion(expression, targetType, typeCoercion.isTypeOnlyCoercion(expressionType, targetType));
+                    analysis.addCoercion(expression, targetType);
                 }
                 analysis.recordSubqueries(update, analyses.get(index));
             }
@@ -3548,7 +3548,7 @@ class StatementAnalyzer
                 throw semanticException(TYPE_MISMATCH, mergePredicate, "The MERGE predicate must evaluate to a boolean: actual type %s", mergePredicateType);
             }
             if (!mergePredicateType.equals(BOOLEAN)) {
-                analysis.addCoercion(mergePredicate, BOOLEAN, typeCoercion.isTypeOnlyCoercion(mergePredicateType, BOOLEAN));
+                analysis.addCoercion(mergePredicate, BOOLEAN);
             }
             analysis.recordSubqueries(merge, predicateAnalysis);
 
@@ -3584,7 +3584,7 @@ class StatementAnalyzer
                             throw semanticException(TYPE_MISMATCH, predicate, "WHERE clause predicate must evaluate to a boolean: actual type %s", predicateType);
                         }
                         // Coerce the predicate to boolean
-                        analysis.addCoercion(predicate, BOOLEAN, typeCoercion.isTypeOnlyCoercion(predicateType, BOOLEAN));
+                        analysis.addCoercion(predicate, BOOLEAN);
                     }
                 }
 
@@ -3614,7 +3614,7 @@ class StatementAnalyzer
                     Type targetType = dataColumnTypes.get(caseColumnNames.get(index));
                     Type expressionType = setExpressionTypes.get(index);
                     if (!targetType.equals(expressionType)) {
-                        analysis.addCoercion(expression, targetType, typeCoercion.isTypeOnlyCoercion(expressionType, targetType));
+                        analysis.addCoercion(expression, targetType);
                     }
                 }
             }
@@ -3890,21 +3890,21 @@ class StatementAnalyzer
                         Type actualItemType = actualType.getTypeParameters().get(i);
                         Type expectedItemType = commonSuperType.getTypeParameters().get(i);
                         if (!actualItemType.equals(expectedItemType)) {
-                            analysis.addCoercion(item, expectedItemType, typeCoercion.isTypeOnlyCoercion(actualItemType, expectedItemType));
+                            analysis.addCoercion(item, expectedItemType);
                         }
                     }
                 }
                 else if (actualType instanceof RowType) {
                     // coerce row-type expression as a whole
                     if (!actualType.equals(commonSuperType)) {
-                        analysis.addCoercion(row, commonSuperType, typeCoercion.isTypeOnlyCoercion(actualType, commonSuperType));
+                        analysis.addCoercion(row, commonSuperType);
                     }
                 }
                 else {
                     // coerce field. it will be wrapped in Row by Planner
                     Type superType = getOnlyElement(commonSuperType.getTypeParameters());
                     if (!actualType.equals(superType)) {
-                        analysis.addCoercion(row, superType, typeCoercion.isTypeOnlyCoercion(actualType, superType));
+                        analysis.addCoercion(row, superType);
                     }
                 }
             }
@@ -4867,7 +4867,7 @@ class StatementAnalyzer
                     throw semanticException(TYPE_MISMATCH, predicate, "WHERE clause must evaluate to a boolean: actual type %s", predicateType);
                 }
                 // coerce null to boolean
-                analysis.addCoercion(predicate, BOOLEAN, false);
+                analysis.addCoercion(predicate, BOOLEAN);
             }
 
             analysis.setWhere(node, predicate);
@@ -5115,7 +5115,7 @@ class StatementAnalyzer
                     throw new TrinoException(TYPE_MISMATCH, extractLocation(table), format("Expected row filter for '%s' to be of type BOOLEAN, but was %s", name, actualType), null);
                 }
 
-                analysis.addCoercion(expression, BOOLEAN, coercion.isTypeOnlyCoercion(actualType, BOOLEAN));
+                analysis.addCoercion(expression, BOOLEAN);
             }
 
             analysis.addRowFilter(table, expression);
@@ -5173,7 +5173,7 @@ class StatementAnalyzer
                     throw new TrinoException(TYPE_MISMATCH, extractLocation(table), format("Expected check constraint for '%s' to be of type BOOLEAN, but was %s", name, actualType), null);
                 }
 
-                analysis.addCoercion(expression, BOOLEAN, coercion.isTypeOnlyCoercion(actualType, BOOLEAN));
+                analysis.addCoercion(expression, BOOLEAN);
             }
 
             analysis.addCheckConstraints(table, expression);
@@ -5238,7 +5238,7 @@ class StatementAnalyzer
                 // due to the line "changeType(value, returnType)" in SqlToRowExpressionTranslator.visitCast. If there's an expression
                 // like CAST(CAST(x AS VARCHAR(1)) AS VARCHAR(2)), it determines that the outer cast is type-only and converts the expression
                 // to CAST(x AS VARCHAR(2)) by changing the type of the inner cast.
-                analysis.addCoercion(expression, expectedType, false);
+                analysis.addCoercion(expression, expectedType);
             }
 
             analysis.addColumnMask(table, column, expression);
@@ -5736,7 +5736,7 @@ class StatementAnalyzer
         {
             if (analysis.isDescribe()) {
                 analyzeExpression(parameter, scope);
-                analysis.addCoercion(parameter, BIGINT, false);
+                analysis.addCoercion(parameter, BIGINT);
                 return OptionalLong.empty();
             }
             // validate parameter index

--- a/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/IrExpressionInterpreter.java
@@ -921,11 +921,7 @@ public class IrExpressionInterpreter
                     return value;
                 }
 
-                return new Cast((Expression) value, node.getType(), node.isSafe(), node.isTypeOnly());
-            }
-
-            if (node.isTypeOnly()) {
-                return value;
+                return new Cast((Expression) value, node.getType(), node.isSafe());
             }
 
             if (value == null) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LiteralEncoder.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LiteralEncoder.java
@@ -111,7 +111,7 @@ public final class LiteralEncoder
             if (type.equals(UNKNOWN)) {
                 return new NullLiteral();
             }
-            return new Cast(new NullLiteral(), toSqlType(type), false, true);
+            return new Cast(new NullLiteral(), toSqlType(type), false);
         }
 
         checkArgument(Primitives.wrap(type.getJavaType()).isInstance(object), "object.getClass (%s) and type.getJavaType (%s) do not agree", object.getClass(), type.getJavaType());
@@ -205,14 +205,14 @@ public final class LiteralEncoder
                 return stringLiteral;
             }
             if (boundedLength > valueLength) {
-                return new Cast(stringLiteral, toSqlType(type), false, true);
+                return new Cast(stringLiteral, toSqlType(type), false);
             }
             throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value [%s] does not fit in type %s", value.toStringUtf8(), varcharType));
         }
 
         if (type instanceof CharType) {
             StringLiteral stringLiteral = new StringLiteral(((Slice) object).toStringUtf8());
-            return new Cast(stringLiteral, toSqlType(type), false, true);
+            return new Cast(stringLiteral, toSqlType(type), false);
         }
 
         if (type.equals(BOOLEAN)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2090,7 +2090,7 @@ public class LocalExecutionPlanner
 
         private RowExpression toRowExpression(Expression expression, Map<NodeRef<Expression>, Type> types, Map<Symbol, Integer> layout)
         {
-            return SqlToRowExpressionTranslator.translate(expression, types, layout, metadata, plannerContext.getFunctionManager(), session, true);
+            return SqlToRowExpressionTranslator.translate(expression, types, layout, metadata, plannerContext.getFunctionManager(), plannerContext.getTypeManager(), session, true);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -106,7 +106,6 @@ import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.Update;
 import io.trino.tracing.ScopedSpan;
 import io.trino.tracing.TrinoAttributes;
-import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
 import jakarta.annotation.Nonnull;
 
@@ -180,7 +179,6 @@ public class LogicalPlanner
     private final SymbolAllocator symbolAllocator = new SymbolAllocator();
     private final Metadata metadata;
     private final PlannerContext plannerContext;
-    private final TypeCoercion typeCoercion;
     private final IrTypeAnalyzer typeAnalyzer;
     private final StatisticsAggregationPlanner statisticsAggregationPlanner;
     private final StatsCalculator statsCalculator;
@@ -220,7 +218,6 @@ public class LogicalPlanner
         this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
         this.metadata = plannerContext.getMetadata();
-        this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
         this.statisticsAggregationPlanner = new StatisticsAggregationPlanner(symbolAllocator, plannerContext, session);
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
@@ -968,7 +965,7 @@ public class LogicalPlanner
         RelationPlan tableScanPlan = createRelationPlan(analysis, table);
         PlanBuilder sourcePlanBuilder = newPlanBuilder(tableScanPlan, analysis, ImmutableMap.of(), ImmutableMap.of(), session, plannerContext);
         if (statement.getWhere().isPresent()) {
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, buildLambdaDeclarationToSymbolMap(analysis, symbolAllocator), plannerContext, typeCoercion, Optional.empty(), session, ImmutableMap.of());
+            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, buildLambdaDeclarationToSymbolMap(analysis, symbolAllocator), plannerContext, Optional.empty(), session, ImmutableMap.of());
             Expression whereExpression = statement.getWhere().get();
             sourcePlanBuilder = subqueryPlanner.handleSubqueries(sourcePlanBuilder, whereExpression, analysis.getSubqueries(statement));
             sourcePlanBuilder = sourcePlanBuilder.withNewRoot(new FilterNode(idAllocator.getNextId(), sourcePlanBuilder.getRoot(), sourcePlanBuilder.rewrite(whereExpression)));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NullabilityAnalyzer.java
@@ -66,7 +66,7 @@ public final class NullabilityAnalyzer
             //
             // Also, try_cast (i.e., safe cast) can return null
             process(node.getExpression(), result);
-            result.compareAndSet(false, node.isSafe() || !node.isTypeOnly());
+            result.compareAndSet(false, node.isSafe());
             return null;
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ParameterRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ParameterRewriter.java
@@ -68,11 +68,7 @@ public class ParameterRewriter
 
         Type coercion = analysis.getCoercion(original);
         if (coercion != null) {
-            rewritten = new Cast(
-                    rewritten,
-                    toSqlType(coercion),
-                    false,
-                    analysis.isTypeOnlyCoercion(original));
+            rewritten = new Cast(rewritten, toSqlType(coercion), false);
         }
         return rewritten;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -221,7 +221,7 @@ class QueryPlanner
         this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
         this.session = session;
         this.outerContext = outerContext;
-        this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, typeCoercion, outerContext, session, recursiveSubqueries);
+        this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries);
         this.recursiveSubqueries = recursiveSubqueries;
     }
 
@@ -1559,8 +1559,7 @@ class QueryPlanner
                 Expression cast = new Cast(
                         coercions.get(sortKey).toSymbolReference(),
                         toSqlType(expectedType),
-                        false,
-                        typeCoercion.isTypeOnlyCoercion(analysis.getType(sortKey), expectedType));
+                        false);
                 sortKeyCoercedForFrameBoundCalculation = symbolAllocator.newSymbol(cast, expectedType);
                 sortKeyCoercions.put(expectedType, sortKeyCoercedForFrameBoundCalculation);
                 subPlan = subPlan.withNewRoot(new ProjectNode(
@@ -1603,8 +1602,7 @@ class QueryPlanner
                 Expression cast = new Cast(
                         coercions.get(sortKey).toSymbolReference(),
                         toSqlType(expectedType),
-                        false,
-                        typeCoercion.isTypeOnlyCoercion(analysis.getType(sortKey), expectedType));
+                        false);
                 Symbol castSymbol = symbolAllocator.newSymbol(cast, expectedType);
                 sortKeyCoercions.put(expectedType, castSymbol);
                 subPlan = subPlan.withNewRoot(new ProjectNode(
@@ -1674,8 +1672,7 @@ class QueryPlanner
             offsetToBigint = new Cast(
                     offsetSymbol.toSymbolReference(),
                     toSqlType(BIGINT),
-                    false,
-                    typeCoercion.isTypeOnlyCoercion(offsetType, BIGINT));
+                    false);
         }
 
         Symbol coercedOffsetSymbol = symbolAllocator.newSymbol(offsetToBigint, BIGINT);
@@ -2040,14 +2037,12 @@ class QueryPlanner
             // expressions may be repeated, for example, when resolving ordinal references in a GROUP BY clause
             if (!mappings.containsKey(NodeRef.of(expression))) {
                 if (coercion != null) {
-                    Type type = analysis.getType(expression);
                     Symbol symbol = symbolAllocator.newSymbol(expression, coercion);
 
                     assignments.put(symbol, new Cast(
                             subPlan.rewrite(expression),
                             toSqlType(coercion),
-                            false,
-                            typeCoercion.isTypeOnlyCoercion(type, coercion)));
+                            false));
 
                     mappings.put(NodeRef.of(expression), symbol);
                 }
@@ -2076,8 +2071,7 @@ class QueryPlanner
         return new Cast(
                 rewritten,
                 toSqlType(coercion),
-                false,
-                analysis.isTypeOnlyCoercion(original));
+                false);
     }
 
     public static NodeAndMappings coerce(RelationPlan plan, List<Type> types, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -227,7 +227,7 @@ class RelationPlanner
         this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
         this.outerContext = outerContext;
         this.session = session;
-        this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, typeCoercion, outerContext, session, recursiveSubqueries);
+        this.subqueryPlanner = new SubqueryPlanner(analysis, symbolAllocator, idAllocator, lambdaDeclarationToSymbolMap, plannerContext, outerContext, session, recursiveSubqueries);
         this.recursiveSubqueries = recursiveSubqueries;
     }
 
@@ -1016,8 +1016,7 @@ class RelationPlanner
             leftCoercions.put(leftOutput, new Cast(
                     left.getSymbol(leftField).toSymbolReference(),
                     toSqlType(type),
-                    false,
-                    typeCoercion.isTypeOnlyCoercion(left.getDescriptor().getFieldByIndex(leftField).getType(), type)));
+                    false));
             leftJoinColumns.put(identifier, leftOutput);
 
             // compute the coercion for the field on the right to the common supertype of left & right
@@ -1026,8 +1025,7 @@ class RelationPlanner
             rightCoercions.put(rightOutput, new Cast(
                     right.getSymbol(rightField).toSymbolReference(),
                     toSqlType(type),
-                    false,
-                    typeCoercion.isTypeOnlyCoercion(right.getDescriptor().getFieldByIndex(rightField).getType(), type)));
+                    false));
             rightJoinColumns.put(identifier, rightOutput);
 
             clauses.add(new JoinNode.EquiJoinClause(leftOutput, rightOutput));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
@@ -39,7 +39,6 @@ import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.tree.Cast;
-import io.trino.type.TypeCoercion;
 
 import java.util.Map;
 import java.util.Optional;
@@ -62,12 +61,10 @@ public class ApplyTableScanRedirection
             .matching(node -> !node.isUpdateTarget());
 
     private final PlannerContext plannerContext;
-    private final TypeCoercion typeCoercion;
 
     public ApplyTableScanRedirection(PlannerContext plannerContext)
     {
         this.plannerContext = requireNonNull(plannerContext, "plannerContext is null");
-        this.typeCoercion = new TypeCoercion(plannerContext.getTypeManager()::getType);
     }
 
     @Override
@@ -274,7 +271,6 @@ public class ApplyTableScanRedirection
         return new Cast(
                 destinationSymbol.toSymbolReference(),
                 toSqlType(sourceType),
-                false,
-                typeCoercion.isTypeOnlyCoercion(destinationType, sourceType));
+                false);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushCastIntoRow.java
@@ -79,7 +79,7 @@ public class PushCastIntoRow
                         Expression item = row.getItems().get(i);
                         DataType itemType = type.getFields().get(i).getType();
                         if (!(itemType instanceof GenericDataType) || !((GenericDataType) itemType).getName().getValue().equalsIgnoreCase(UnknownType.NAME)) {
-                            item = new Cast(item, itemType, node.isSafe(), node.isTypeOnly());
+                            item = new Cast(item, itemType, node.isSafe());
                         }
                         items.add(item);
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -566,11 +566,11 @@ public class UnwrapCastInComparison
 
     public static Expression falseIfNotNull(Expression argument)
     {
-        return and(new IsNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false, true));
+        return and(new IsNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false));
     }
 
     public static Expression trueIfNotNull(Expression argument)
     {
-        return or(new IsNotNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false, true));
+        return or(new IsNotNullPredicate(argument), new Cast(new NullLiteral(), toSqlType(BOOLEAN), false));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapRowSubscript.java
@@ -62,7 +62,7 @@ public class UnwrapRowSubscript
                 int index = (int) ((LongLiteral) node.getIndex()).getParsedValue();
                 DataType type = rowType.getFields().get(index - 1).getType();
                 if (!(type instanceof GenericDataType) || !((GenericDataType) type).getName().getValue().equalsIgnoreCase(UnknownType.NAME)) {
-                    coercions.push(new Coercion(type, cast.isTypeOnly(), cast.isSafe()));
+                    coercions.push(new Coercion(type, cast.isSafe()));
                 }
 
                 base = cast.getExpression();
@@ -74,7 +74,7 @@ public class UnwrapRowSubscript
 
                 while (!coercions.isEmpty()) {
                     Coercion coercion = coercions.pop();
-                    result = new Cast(result, coercion.getType(), coercion.isSafe(), coercion.isTypeOnly());
+                    result = new Cast(result, coercion.getType(), coercion.isSafe());
                 }
 
                 return result;
@@ -90,24 +90,17 @@ public class UnwrapRowSubscript
     private static class Coercion
     {
         private final DataType type;
-        private final boolean typeOnly;
         private final boolean safe;
 
-        public Coercion(DataType type, boolean typeOnly, boolean safe)
+        public Coercion(DataType type, boolean safe)
         {
             this.type = type;
-            this.typeOnly = typeOnly;
             this.safe = safe;
         }
 
         public DataType getType()
         {
             return type;
-        }
-
-        public boolean isTypeOnly()
-        {
-            return typeOnly;
         }
 
         public boolean isSafe()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ExpressionEquivalence.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ExpressionEquivalence.java
@@ -23,6 +23,7 @@ import io.trino.metadata.FunctionManager;
 import io.trino.metadata.Metadata;
 import io.trino.spi.function.CatalogSchemaFunctionName;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.planner.IrTypeAnalyzer;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeProvider;
@@ -61,13 +62,15 @@ public class ExpressionEquivalence
     private static final Ordering<RowExpression> ROW_EXPRESSION_ORDERING = Ordering.from(new RowExpressionComparator());
     private final Metadata metadata;
     private final FunctionManager functionManager;
+    private final TypeManager typeManager;
     private final IrTypeAnalyzer typeAnalyzer;
     private final CanonicalizationVisitor canonicalizationVisitor;
 
-    public ExpressionEquivalence(Metadata metadata, FunctionManager functionManager, IrTypeAnalyzer typeAnalyzer)
+    public ExpressionEquivalence(Metadata metadata, FunctionManager functionManager, TypeManager typeManager, IrTypeAnalyzer typeAnalyzer)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
         this.canonicalizationVisitor = new CanonicalizationVisitor();
     }
@@ -97,6 +100,7 @@ public class ExpressionEquivalence
                 symbolInput,
                 metadata,
                 functionManager,
+                typeManager,
                 session,
                 false);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -184,7 +184,7 @@ public class PredicatePushDown
             this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
             this.session = requireNonNull(session, "session is null");
             this.types = requireNonNull(types, "types is null");
-            this.expressionEquivalence = new ExpressionEquivalence(plannerContext.getMetadata(), plannerContext.getFunctionManager(), typeAnalyzer);
+            this.expressionEquivalence = new ExpressionEquivalence(plannerContext.getMetadata(), plannerContext.getFunctionManager(), plannerContext.getTypeManager(), typeAnalyzer);
             this.dynamicFiltering = dynamicFiltering;
 
             this.effectivePredicateExtractor = new EffectivePredicateExtractor(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/TypeValidator.java
@@ -17,8 +17,8 @@ import com.google.common.collect.ListMultimap;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.function.BoundSignature;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.planner.IrTypeAnalyzer;
 import io.trino.sql.planner.SimplePlanVisitor;
@@ -33,7 +33,6 @@ import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SymbolReference;
 import io.trino.type.FunctionType;
-import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
 
 import java.util.List;
@@ -56,21 +55,19 @@ public final class TypeValidator
             TypeProvider types,
             WarningCollector warningCollector)
     {
-        plan.accept(new Visitor(session, plannerContext.getTypeManager(), typeAnalyzer, types), null);
+        plan.accept(new Visitor(session, typeAnalyzer, types), null);
     }
 
     private static class Visitor
             extends SimplePlanVisitor<Void>
     {
         private final Session session;
-        private final TypeCoercion typeCoercion;
         private final IrTypeAnalyzer typeAnalyzer;
         private final TypeProvider types;
 
-        public Visitor(Session session, TypeManager typeManager, IrTypeAnalyzer typeAnalyzer, TypeProvider types)
+        public Visitor(Session session, IrTypeAnalyzer typeAnalyzer, TypeProvider types)
         {
             this.session = requireNonNull(session, "session is null");
-            this.typeCoercion = new TypeCoercion(typeManager::getType);
             this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
             this.types = requireNonNull(types, "types is null");
         }
@@ -183,8 +180,19 @@ public final class TypeValidator
 
         private void verifyTypeSignature(Symbol symbol, Type expected, Type actual)
         {
-            // UNKNOWN should be considered as a wildcard type, which matches all the other types
-            if (!(actual instanceof UnknownType) && !typeCoercion.isTypeOnlyCoercion(actual, expected)) {
+            if (actual instanceof RowType actualRowType && expected instanceof RowType expectedRowType) {
+                // ignore the field names when comparing row types -- TODO: maybe we should be more strict about this and require they match
+                List<Type> actualFieldTypes = actualRowType.getFields().stream()
+                        .map(RowType.Field::getType)
+                        .toList();
+
+                List<Type> expectedFieldType = expectedRowType.getFields().stream()
+                        .map(RowType.Field::getType)
+                        .toList();
+
+                checkArgument(expectedFieldType.equals(actualFieldTypes), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol, expected, actual);
+            }
+            else if (!(actual instanceof UnknownType)) { // UNKNOWN should be considered as a wildcard type, which matches all the other types
                 checkArgument(expected.equals(actual), "type of symbol '%s' is expected to be %s, but the actual type is %s", symbol, expected, actual);
             }
         }

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutineAnalyzer.java
@@ -423,7 +423,7 @@ public class SqlRoutineAnalyzer
                         throw semanticException(TYPE_MISMATCH, whenClause.getExpression(), "WHEN clause value must evaluate to CASE value type %s (actual: %s)", valueType, whenType);
                     }
                     if (!whenType.equals(superType.get())) {
-                        addCoercion(whenClause.getExpression(), whenType, superType.get());
+                        addCoercion(whenClause.getExpression(), superType.get());
                     }
                 }
             }
@@ -517,7 +517,7 @@ public class SqlRoutineAnalyzer
                 throw semanticException(TYPE_MISMATCH, expression, "%s must evaluate to %s (actual: %s)", message, expectedType, actualType);
             }
 
-            addCoercion(expression, actualType, expectedType);
+            addCoercion(expression, expectedType);
         }
 
         private Type analyzeExpression(Context context, Expression expression)
@@ -545,9 +545,9 @@ public class SqlRoutineAnalyzer
             return analysis.getType(expression);
         }
 
-        private void addCoercion(Expression expression, Type actualType, Type expectedType)
+        private void addCoercion(Expression expression, Type expectedType)
         {
-            analysis.addCoercion(expression, expectedType, typeCoercion.isTypeOnlyCoercion(actualType, expectedType));
+            analysis.addCoercion(expression, expectedType);
         }
 
         private void analyzeNodes(Context context, List<? extends Node> statements)

--- a/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/routine/SqlRoutinePlanner.java
@@ -22,6 +22,7 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import io.trino.sql.PlannerContext;
 import io.trino.sql.analyzer.Analysis;
 import io.trino.sql.analyzer.ExpressionAnalyzer;
@@ -371,7 +372,7 @@ public final class SqlRoutinePlanner
             analyzer.analyze(optimized, scope);
 
             // translate to RowExpression
-            TranslationVisitor translator = new TranslationVisitor(plannerContext.getMetadata(), analyzer.getExpressionTypes(), ImmutableMap.of(), context.variables());
+            TranslationVisitor translator = new TranslationVisitor(plannerContext.getMetadata(), plannerContext.getTypeManager(), analyzer.getExpressionTypes(), ImmutableMap.of(), context.variables());
             RowExpression rowExpression = translator.process(optimized, null);
 
             // optimize RowExpression
@@ -387,7 +388,7 @@ public final class SqlRoutinePlanner
             if (coercion == null) {
                 return rewritten;
             }
-            return new Cast(rewritten, toSqlType(coercion), false, analysis.isTypeOnlyCoercion(original));
+            return new Cast(rewritten, toSqlType(coercion), false);
         }
 
         private ExpressionAnalyzer createExpressionAnalyzer(Session session, TypeProvider typeProvider)
@@ -443,11 +444,12 @@ public final class SqlRoutinePlanner
 
         public TranslationVisitor(
                 Metadata metadata,
+                TypeManager typeManager,
                 Map<NodeRef<Expression>, Type> types,
                 Map<Symbol, Integer> layout,
                 Map<String, IrVariable> variables)
         {
-            super(metadata, types, layout);
+            super(metadata, typeManager, types, layout);
             this.variables = requireNonNull(variables, "variables is null");
         }
 

--- a/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
+++ b/core/trino-main/src/test/java/io/trino/json/TestJsonPathEvaluator.java
@@ -33,7 +33,6 @@ import io.trino.json.ir.IrPredicate;
 import io.trino.json.ir.TypedValue;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.LongTimestamp;
-import io.trino.spi.type.TestingTypeManager;
 import io.trino.spi.type.TypeSignature;
 import io.trino.sql.planner.PathNodes;
 import org.assertj.core.api.AssertProvider;
@@ -1480,7 +1479,7 @@ public class TestJsonPathEvaluator
                 input,
                 PARAMETERS.values().toArray(),
                 new JsonPathEvaluator.Invoker(testSessionBuilder().build().toConnectorSession(), createTestingFunctionManager()),
-                new CachingResolver(createTestMetadataManager(), new TestingTypeManager()));
+                new CachingResolver(createTestMetadataManager()));
     }
 
     private static PathPredicateEvaluationVisitor createPredicateVisitor(JsonNode input, boolean lax)
@@ -1489,6 +1488,6 @@ public class TestJsonPathEvaluator
                 lax,
                 createPathVisitor(input, lax),
                 new JsonPathEvaluator.Invoker(testSessionBuilder().build().toConnectorSession(), createTestingFunctionManager()),
-                new CachingResolver(createTestMetadataManager(), new TestingTypeManager()));
+                new CachingResolver(createTestMetadataManager()));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkScanFilterAndProjectOperator.java
@@ -237,6 +237,7 @@ public class BenchmarkScanFilterAndProjectOperator
                     sourceLayout,
                     PLANNER_CONTEXT.getMetadata(),
                     PLANNER_CONTEXT.getFunctionManager(),
+                    PLANNER_CONTEXT.getTypeManager(),
                     TEST_SESSION,
                     true);
         }

--- a/core/trino-main/src/test/java/io/trino/operator/project/TestPageFieldsToInputParametersRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/project/TestPageFieldsToInputParametersRewriter.java
@@ -146,6 +146,7 @@ public class TestPageFieldsToInputParametersRewriter
                     sourceLayout,
                     PLANNER_CONTEXT.getMetadata(),
                     PLANNER_CONTEXT.getFunctionManager(),
+                    PLANNER_CONTEXT.getTypeManager(),
                     TEST_SESSION,
                     true);
         }

--- a/core/trino-main/src/test/java/io/trino/sql/ExpressionTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/sql/ExpressionTestUtils.java
@@ -155,11 +155,7 @@ public final class ExpressionTestUtils
                 // cast expression if coercion is registered
                 Type coercion = analyzer.getExpressionCoercions().get(NodeRef.of(originalExpression));
                 if (coercion != null) {
-                    rewrittenExpression = new Cast(
-                            rewrittenExpression,
-                            toSqlType(coercion),
-                            false,
-                            analyzer.getTypeOnlyCoercions().contains(NodeRef.of(originalExpression)));
+                    rewrittenExpression = new Cast(rewrittenExpression, toSqlType(coercion), false);
                 }
                 return rewrittenExpression;
             }

--- a/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestSqlToRowExpressionTranslator.java
@@ -88,6 +88,7 @@ public class TestSqlToRowExpressionTranslator
                 ImmutableMap.of(),
                 PLANNER_CONTEXT.getMetadata(),
                 PLANNER_CONTEXT.getFunctionManager(),
+                PLANNER_CONTEXT.getTypeManager(),
                 TEST_SESSION,
                 true);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/BenchmarkPageProcessor2.java
@@ -186,6 +186,7 @@ public class BenchmarkPageProcessor2
                 sourceLayout,
                 PLANNER_CONTEXT.getMetadata(),
                 PLANNER_CONTEXT.getFunctionManager(),
+                PLANNER_CONTEXT.getTypeManager(),
                 TEST_SESSION,
                 true);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -427,26 +427,24 @@ public abstract class AbstractPredicatePushdownTest
     @Test
     public void testTablePredicateIsExtracted()
     {
-        PlanMatchPattern ordersTableScan = tableScan("orders", ImmutableMap.of("ORDERSTATUS", "orderstatus"));
-        if (enableDynamicFiltering) {
-            ordersTableScan = filter(TRUE_LITERAL, ordersTableScan);
-        }
         assertPlan(
                 "SELECT * FROM orders, nation WHERE orderstatus = CAST(nation.name AS varchar(1)) AND orderstatus BETWEEN 'A' AND 'O'",
                 anyTree(
                         node(JoinNode.class,
-                                ordersTableScan,
+                                filter("ORDERSTATUS IN ('F', 'O')",
+                                        tableScan("orders", ImmutableMap.of("ORDERSTATUS", "orderstatus"))),
                                 anyTree(
                                         filter("CAST(NAME AS varchar(1)) IN ('F', 'O')",
                                                 tableScan(
                                                         "nation",
                                                         ImmutableMap.of("NAME", "name")))))));
 
+        PlanMatchPattern ordersTableScan = tableScan("orders", ImmutableMap.of("ORDERSTATUS", "orderstatus"));
         assertPlan(
                 "SELECT * FROM orders JOIN nation ON orderstatus = CAST(nation.name AS varchar(1))",
                 anyTree(
                         node(JoinNode.class,
-                                ordersTableScan,
+                                enableDynamicFiltering ? filter(TRUE_LITERAL, ordersTableScan) : ordersTableScan,
                                 anyTree(
                                         filter("CAST(NAME AS varchar(1)) IN ('F', 'O', 'P')",
                                                 tableScan(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestConnectorExpressionTranslator.java
@@ -304,7 +304,6 @@ public class TestConnectorExpressionTranslator
                 new Cast(
                         new SymbolReference("varchar_symbol_1"),
                         toSqlType(BIGINT),
-                        true,
                         true),
                 Optional.empty());
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
@@ -270,7 +270,7 @@ public class TestDynamicFilter
 
     private Expression typeOnlyCast(String symbol, DataType asDataType)
     {
-        return new Cast(new Symbol(symbol).toSymbolReference(), asDataType, false, true);
+        return new Cast(new Symbol(symbol).toSymbolReference(), asDataType, false);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTypeValidator.java
@@ -48,7 +48,6 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.TestingPlannerContext.PLANNER_CONTEXT;
@@ -179,19 +178,6 @@ public class TestTypeValidator
                         Optional.empty(),
                         Optional.empty())),
                 singleGroupingSet(ImmutableList.of(columnA, columnB)));
-
-        assertTypesValid(node);
-    }
-
-    @Test
-    public void testValidTypeOnlyCoercion()
-    {
-        Expression expression = new Cast(columnB.toSymbolReference(), toSqlType(BIGINT));
-        Assignments assignments = Assignments.builder()
-                .put(symbolAllocator.newSymbol(expression, BIGINT), expression)
-                .put(symbolAllocator.newSymbol(columnE.toSymbolReference(), VARCHAR), columnE.toSymbolReference()) // implicit coercion from varchar(3) to varchar
-                .build();
-        PlanNode node = new ProjectNode(newId(), baseTableScan, assignments);
 
         assertTypesValid(node);
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -388,7 +388,7 @@ public class TestSimplifyExpressions
         {
             // the `expected` Cast expression comes out of the AstBuilder with the `typeOnly` flag set to false.
             // always set the `typeOnly` flag to false so that it does not break the comparison.
-            return new Cast(node.getExpression(), node.getType(), node.isSafe(), false);
+            return new Cast(node.getExpression(), node.getType(), node.isSafe());
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestExpressionEquivalence.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestExpressionEquivalence.java
@@ -57,6 +57,7 @@ public class TestExpressionEquivalence
     private static final ExpressionEquivalence EQUIVALENCE = new ExpressionEquivalence(
             PLANNER_CONTEXT.getMetadata(),
             PLANNER_CONTEXT.getFunctionManager(),
+            PLANNER_CONTEXT.getTypeManager(),
             new IrTypeAnalyzer(PLANNER_CONTEXT));
     private static final TypeProvider TYPE_PROVIDER = TypeProvider.copyOf(ImmutableMap.<Symbol, Type>builder()
             .put(new Symbol("a_boolean"), BOOLEAN)

--- a/core/trino-main/src/test/java/io/trino/type/BenchmarkDecimalOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/BenchmarkDecimalOperators.java
@@ -627,6 +627,7 @@ public class BenchmarkDecimalOperators
                     sourceLayout,
                     PLANNER_CONTEXT.getMetadata(),
                     PLANNER_CONTEXT.getFunctionManager(),
+                    PLANNER_CONTEXT.getTypeManager(),
                     TEST_SESSION,
                     true);
         }

--- a/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTypeCoercion.java
@@ -69,50 +69,6 @@ public class TestTypeCoercion
     private final Type re2jType = typeManager.getType(RE2J_REGEXP_SIGNATURE);
     private final TypeCoercion typeCoercion = new TypeCoercion(typeManager::getType);
 
-    @Test
-    public void testIsTypeOnlyCoercion()
-    {
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(BIGINT, BIGINT)).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createVarcharType(42), createVarcharType(44))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createVarcharType(44), createVarcharType(42))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createCharType(42), createVarcharType(42))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createVarcharType(42)), new ArrayType(createVarcharType(44)))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createVarcharType(44)), new ArrayType(createVarcharType(42)))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createDecimalType(22, 1), createDecimalType(23, 1))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createDecimalType(2, 1), createDecimalType(3, 1))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createDecimalType(23, 1), createDecimalType(22, 1))).isFalse();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createDecimalType(3, 1), createDecimalType(2, 1))).isFalse();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(createDecimalType(3, 1), createDecimalType(22, 1))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createDecimalType(22, 1)), new ArrayType(createDecimalType(23, 1)))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createDecimalType(2, 1)), new ArrayType(createDecimalType(3, 1)))).isTrue();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createDecimalType(23, 1)), new ArrayType(createDecimalType(22, 1)))).isFalse();
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(new ArrayType(createDecimalType(3, 1)), new ArrayType(createDecimalType(2, 1)))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(
-                mapType(createDecimalType(2, 1), createDecimalType(2, 1)),
-                mapType(createDecimalType(2, 1), createDecimalType(3, 1)))).isTrue();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(
-                mapType(createDecimalType(2, 1), createDecimalType(2, 1)),
-                mapType(createDecimalType(2, 1), createDecimalType(23, 1)))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(
-                mapType(createDecimalType(2, 1), createDecimalType(2, 1)),
-                mapType(createDecimalType(2, 1), createDecimalType(3, 2)))).isFalse();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(
-                mapType(createDecimalType(2, 1), createDecimalType(2, 1)),
-                mapType(createDecimalType(3, 1), createDecimalType(3, 1)))).isTrue();
-
-        Assertions.assertThat(typeCoercion.isTypeOnlyCoercion(
-                mapType(createDecimalType(3, 1), createDecimalType(3, 1)),
-                mapType(createDecimalType(2, 1), createDecimalType(2, 1)))).isFalse();
-    }
-
     private Type mapType(Type keyType, Type valueType)
     {
         return typeManager.getType(TypeSignature.mapType(keyType.getTypeSignature(), valueType.getTypeSignature()));

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Cast.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Cast.java
@@ -27,34 +27,28 @@ public final class Cast
     private final Expression expression;
     private final DataType type;
     private final boolean safe;
-    private final boolean typeOnly;
 
     public Cast(Expression expression, DataType type)
     {
-        this(Optional.empty(), expression, type, false, false);
+        this(Optional.empty(), expression, type, false);
     }
 
     public Cast(Expression expression, DataType type, boolean safe)
     {
-        this(Optional.empty(), expression, type, safe, false);
-    }
-
-    public Cast(Expression expression, DataType type, boolean safe, boolean typeOnly)
-    {
-        this(Optional.empty(), expression, type, safe, typeOnly);
+        this(Optional.empty(), expression, type, safe);
     }
 
     public Cast(NodeLocation location, Expression expression, DataType type)
     {
-        this(Optional.of(location), expression, type, false, false);
+        this(Optional.of(location), expression, type, false);
     }
 
     public Cast(NodeLocation location, Expression expression, DataType type, boolean safe)
     {
-        this(Optional.of(location), expression, type, safe, false);
+        this(Optional.of(location), expression, type, safe);
     }
 
-    private Cast(Optional<NodeLocation> location, Expression expression, DataType type, boolean safe, boolean typeOnly)
+    private Cast(Optional<NodeLocation> location, Expression expression, DataType type, boolean safe)
     {
         super(location);
         requireNonNull(expression, "expression is null");
@@ -62,7 +56,6 @@ public final class Cast
         this.expression = expression;
         this.type = type;
         this.safe = safe;
-        this.typeOnly = typeOnly;
     }
 
     public Expression getExpression()
@@ -78,11 +71,6 @@ public final class Cast
     public boolean isSafe()
     {
         return safe;
-    }
-
-    public boolean isTypeOnly()
-    {
-        return typeOnly;
     }
 
     @Override
@@ -108,7 +96,6 @@ public final class Cast
         }
         Cast cast = (Cast) o;
         return safe == cast.safe &&
-                typeOnly == cast.typeOnly &&
                 expression.equals(cast.expression) &&
                 type.equals(cast.type);
     }
@@ -116,7 +103,7 @@ public final class Cast
     @Override
     public int hashCode()
     {
-        return Objects.hash(expression, type, safe, typeOnly);
+        return Objects.hash(expression, type, safe);
     }
 
     @Override
@@ -127,7 +114,6 @@ public final class Cast
         }
 
         Cast otherCast = (Cast) other;
-        return safe == otherCast.safe &&
-                typeOnly == otherCast.typeOnly;
+        return safe == otherCast.safe;
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -892,7 +892,7 @@ public final class ExpressionTreeRewriter<C>
             DataType type = rewrite(node.getType(), context.get());
 
             if (node.getExpression() != expression || node.getType() != type) {
-                return new Cast(expression, type, node.isSafe(), node.isTypeOnly());
+                return new Cast(expression, type, node.isSafe());
             }
 
             return node;


### PR DESCRIPTION
Type-only coercion is a notion that only matters at code generation. It can be derived from the source and target types at that point in time instead of carrying that information in the AST and IR and throughout the planning and optimization process.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
