### PR TITLE
Move RN entry to connector

### DIFF
--- a/docs/src/main/sphinx/release/release-437.md
+++ b/docs/src/main/sphinx/release/release-437.md
@@ -12,8 +12,6 @@
   with [the `spill-compression-codec` property](prop-spill-compression-codec). ({issue}`20274`)
 * {{breaking}} Remove the deprecated `experimental.spill-compression-enabled`
   configuration property. ({issue}`20274`)
-* Fix materialized views being permanently stale when they reference
-  [table functions](/functions/table). ({issue}`19904`)
 * Fix failure when invoking functions that may return null values. ({issue}`18456`)
 * Fix `ArrayIndexOutOfBoundsException` with RowBlockBuilder during output
   operations. ({issue}`20426`)
@@ -29,5 +27,7 @@
 
 ## Iceberg connector
 
+* Fix materialized views being permanently stale when they reference
+  [table functions](/functions/table). ({issue}`19904`)
 * Improve performance of queries with filters on `ROW` columns stored in Parquet
   files. ({issue}`17133`)


### PR DESCRIPTION
The behavior described is Iceberg connector-specific. We cannot determine what would be the behavior of a connector if it implemented materialized views support, so the wording was not generally appropriate.
