### PR TITLE
Remove optimize failure RN entry

### DIFF
--- a/docs/src/main/sphinx/release/release-438.md
+++ b/docs/src/main/sphinx/release/release-438.md
@@ -35,7 +35,6 @@
   property or the `parquet_writer_page_value_count` session property. ({issue}`20171`)
 * Add support for `array`, `map` and `row` types in the `migrate` table
   procedure. ({issue}`17583`)
-* Fix potential query failure when running the `optimize` table procedure. ({issue}`20490`)
 
 ## Pinot connector
 


### PR DESCRIPTION
The original PR was not supposed to fix a query failure (otherwise it would have regression tests for that.)
