### PR TITLE
Add support for OpenTelemetry in Elasticsearch

### DIFF
--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-elasticsearch-rest-7.0</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -16,6 +16,7 @@ package io.trino.plugin.elasticsearch;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.TypeDeserializerModule;
 import io.trino.plugin.base.jmx.ConnectorObjectNameGeneratorModule;
@@ -59,6 +60,7 @@ public class ElasticsearchConnectorFactory
                 binder -> {
                     binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                     binder.bind(CatalogName.class).toInstance(new CatalogName(catalogName));
+                    binder.bind(OpenTelemetry.class).toInstance(context.getOpenTelemetry());
                 });
 
         Injector injector = app

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -33,6 +33,7 @@ import io.airlift.json.ObjectMapperProvider;
 import io.airlift.log.Logger;
 import io.airlift.stats.TimeStat;
 import io.airlift.units.Duration;
+import io.opentelemetry.api.OpenTelemetry;
 import io.trino.plugin.elasticsearch.AwsSecurityConfig;
 import io.trino.plugin.elasticsearch.ElasticsearchConfig;
 import io.trino.plugin.elasticsearch.PasswordConfig;
@@ -134,11 +135,12 @@ public class ElasticsearchClient
 
     @Inject
     public ElasticsearchClient(
+            OpenTelemetry openTelemetry,
             ElasticsearchConfig config,
             Optional<AwsSecurityConfig> awsSecurityConfig,
             Optional<PasswordConfig> passwordConfig)
     {
-        client = createClient(config, awsSecurityConfig, passwordConfig, backpressureStats);
+        client = createClient(openTelemetry, config, awsSecurityConfig, passwordConfig, backpressureStats);
 
         this.ignorePublishAddress = config.isIgnorePublishAddress();
         this.scrollSize = config.getScrollSize();
@@ -193,6 +195,7 @@ public class ElasticsearchClient
     }
 
     private static BackpressureRestHighLevelClient createClient(
+            OpenTelemetry openTelemetry,
             ElasticsearchConfig config,
             Optional<AwsSecurityConfig> awsSecurityConfig,
             Optional<PasswordConfig> passwordConfig,
@@ -242,7 +245,7 @@ public class ElasticsearchClient
             return clientBuilder;
         });
 
-        return new BackpressureRestHighLevelClient(builder, config, backpressureStats);
+        return new BackpressureRestHighLevelClient(builder, openTelemetry, config, backpressureStats);
     }
 
     private static AWSCredentialsProvider getAwsCredentialsProvider(AwsSecurityConfig config)


### PR DESCRIPTION
## Description

Add support for OpenTelemetry in Elasticsearch
![Screenshot 2024-02-13 at 22 16 14](https://github.com/trinodb/trino/assets/6237050/1f7455a8-3a0f-4c29-96ff-643c39fd1744)

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
