### PR TITLE
Update HTTP client config doc

### DIFF
--- a/docs/src/main/sphinx/admin/properties-exchange.md
+++ b/docs/src/main/sphinx/admin/properties-exchange.md
@@ -4,6 +4,8 @@ Exchanges transfer data between Trino nodes for different stages of
 a query. Adjusting these properties may help to resolve inter-node
 communication issues or improve network utilization.
 
+Additionally, you can configure the exchange [HTTP client usage](/admin/properties-http-client).
+
 ## `exchange.client-threads`
 
 - **Type:** {ref}`prop-type-integer`

--- a/docs/src/main/sphinx/admin/properties-http-client.md
+++ b/docs/src/main/sphinx/admin/properties-http-client.md
@@ -17,6 +17,8 @@ The following prefixes are supported:
 
 - `oauth2-jwk` for {doc}`/security/oauth2`
 - `jwk` for {doc}`/security/jwt`
+- `exchange` to configure data transfer between Trino nodes in addition to
+  [](/admin/properties-exchange)
 
 ## General properties
 
@@ -27,6 +29,13 @@ The following prefixes are supported:
 - **Minimum value:** `0ms`
 
 Timeout value for establishing the connection to the external service.
+
+### `max-content-length`
+
+- **Type:** [](prop-type-duration)
+- **Default value:** `16MB`
+
+Maximum content size for each HTTP request and response.
 
 ### `http-client.request-timeout`
 


### PR DESCRIPTION
## Description

- Add exchange prefix
- Add max content length property

This came up to be added in some discussion around `exchange.http-client.max-content-length` 
so I think it makes sense to add it to the list. 

However ... I am not sure if we want to add this property specifically as well. In the prior PR with @Jessie212 I think we decided NOT to add that property, but it seems to be used in the field.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

https://github.com/trinodb/trino/pull/12247

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
