### PR TITLE
Do not copy node_modules in trino-main

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -528,6 +528,17 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <excludes>
+                    <exclude>**/node_modules/**</exclude>
+                </excludes>
+            </resource>
+        </resources>
+    </build>
+
     <profiles>
         <profile>
             <id>benchmarks</id>


### PR DESCRIPTION
If UI was built, maven will copy `node_modules` to target-classes which takes around 20-30s.

./mvnw clean resources:resources -pl ':trino-main' -DskipTests

Before:

`Copying 9969 resources from src/main/resources to target/classes`

After:

`Copying 107 resources from src/main/resources to target/classes`

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
