### PR TITLE
Return DatasetId and TableId in BigQueryClient

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -88,7 +88,7 @@ public class BigQueryClient
     private final BigQueryTypeManager typeManager;
     private final ViewMaterializationCache materializationCache;
     private final boolean caseInsensitiveNameMatching;
-    private final LoadingCache<String, List<Dataset>> remoteDatasetCache;
+    private final LoadingCache<String, List<DatasetId>> remoteDatasetIdCache;
     private final Optional<String> configProjectId;
 
     public BigQueryClient(
@@ -105,10 +105,10 @@ public class BigQueryClient
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
         this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
-        this.remoteDatasetCache = EvictableCacheBuilder.newBuilder()
+        this.remoteDatasetIdCache = EvictableCacheBuilder.newBuilder()
                 .expireAfterWrite(metadataCacheTtl.toMillis(), MILLISECONDS)
                 .shareNothingWhenDisabled()
-                .build(CacheLoader.from(this::listDatasetsFromBigQuery));
+                .build(CacheLoader.from(this::listDatasetIdsFromBigQuery));
         this.configProjectId = requireNonNull(configProjectId, "projectId is null");
     }
 
@@ -127,10 +127,10 @@ public class BigQueryClient
         }
 
         Map<String, Optional<RemoteDatabaseObject>> mapping = new HashMap<>();
-        for (Dataset dataset : listDatasets(projectId)) {
+        for (DatasetId datasetId : listDatasetIds(projectId)) {
             mapping.merge(
-                    dataset.getDatasetId().getDataset().toLowerCase(ENGLISH),
-                    Optional.of(RemoteDatabaseObject.of(dataset.getDatasetId().getDataset())),
+                    datasetId.getDataset().toLowerCase(ENGLISH),
+                    Optional.of(RemoteDatabaseObject.of(datasetId.getDataset())),
                     (currentValue, collision) -> currentValue.map(current -> current.registerCollision(collision.get().getOnlyRemoteName())));
         }
 
@@ -145,15 +145,15 @@ public class BigQueryClient
 
     public Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName)
     {
-        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> listTables(DatasetId.of(projectId, remoteDatasetName)));
+        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> listTableIds(DatasetId.of(projectId, remoteDatasetName)));
     }
 
-    public Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Iterable<Table> tables)
+    public Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Iterable<TableId> tableIds)
     {
-        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> tables);
+        return toRemoteTable(projectId, remoteDatasetName, tableName, () -> tableIds);
     }
 
-    private Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Supplier<Iterable<Table>> tables)
+    private Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Supplier<Iterable<TableId>> tableIds)
     {
         requireNonNull(projectId, "projectId is null");
         requireNonNull(remoteDatasetName, "remoteDatasetName is null");
@@ -166,10 +166,10 @@ public class BigQueryClient
         TableId cacheKey = TableId.of(projectId, remoteDatasetName, tableName);
 
         Map<TableId, Optional<RemoteDatabaseObject>> mapping = new HashMap<>();
-        for (Table table : tables.get()) {
+        for (TableId tableId : tableIds.get()) {
             mapping.merge(
-                    tableIdToLowerCase(table.getTableId()),
-                    Optional.of(RemoteDatabaseObject.of(table.getTableId().getTable())),
+                    tableIdToLowerCase(tableId),
+                    Optional.of(RemoteDatabaseObject.of(tableId.getTable())),
                     (currentValue, collision) -> currentValue.map(current -> current.registerCollision(collision.get().getOnlyRemoteName())));
         }
 
@@ -236,27 +236,31 @@ public class BigQueryClient
         return datasetId.getDataset();
     }
 
-    public Iterable<Dataset> listDatasets(String projectId)
+    public Iterable<DatasetId> listDatasetIds(String projectId)
     {
         try {
-            return remoteDatasetCache.get(projectId);
+            return remoteDatasetIdCache.get(projectId);
         }
         catch (ExecutionException e) {
             throw new TrinoException(BIGQUERY_LISTING_DATASET_ERROR, "Failed to retrieve datasets from BigQuery", e);
         }
     }
 
-    private List<Dataset> listDatasetsFromBigQuery(String projectId)
+    private List<DatasetId> listDatasetIdsFromBigQuery(String projectId)
     {
+        // BigQuery.listDatasets returns partial information on each dataset. See javadoc for more details.
         return stream(bigQuery.listDatasets(projectId).iterateAll())
+                .map(Dataset::getDatasetId)
                 .collect(toImmutableList());
     }
 
-    public Iterable<Table> listTables(DatasetId remoteDatasetId)
+    public Iterable<TableId> listTableIds(DatasetId remoteDatasetId)
     {
+        // BigQuery.listTables returns partial information on each table. See javadoc for more details.
         Iterable<Table> allTables = bigQuery.listTables(remoteDatasetId).iterateAll();
         return stream(allTables)
                 .filter(table -> TABLE_TYPES.contains(table.getDefinition().getType()))
+                .map(TableInfo::getTableId)
                 .collect(toImmutableList());
     }
 


### PR DESCRIPTION
## Description

Return DatasetId and TableId lists in BigQueryClient to avoid misusage. 

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
