### PR TITLE
Implement global target concurrency for thread-per-driver scheduler

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ConcurrencyController.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/dedicated/ConcurrencyController.java
@@ -19,15 +19,12 @@ class ConcurrencyController
 {
     private static final double TARGET_UTILIZATION = 0.5;
 
-    private final int maxConcurrency;
     private int targetConcurrency;
 
-    public ConcurrencyController(int initialConcurrency, int maxConcurrency)
+    public ConcurrencyController(int initialConcurrency)
     {
         checkArgument(initialConcurrency > 0, "initial concurrency must be positive");
-        checkArgument(initialConcurrency <= maxConcurrency, "initial concurrency must be <= maxConcurrency>");
         this.targetConcurrency = initialConcurrency;
-        this.maxConcurrency = maxConcurrency;
     }
 
     public void update(double utilization, int currentConcurrency)
@@ -38,8 +35,6 @@ class ConcurrencyController
         else if (utilization < TARGET_UTILIZATION && currentConcurrency >= targetConcurrency) {
             targetConcurrency++;
         }
-
-        targetConcurrency = Math.min(maxConcurrency, targetConcurrency);
     }
 
     public int targetConcurrency()

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerThreadPerDriver.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManagerThreadPerDriver.java
@@ -31,6 +31,8 @@ public class TestSqlTaskManagerThreadPerDriver
                 Tracing.noopTracer(),
                 testingVersionEmbedder(),
                 new FairScheduler(8, "Runner-%d", Ticker.systemTicker()),
-                Integer.MAX_VALUE);
+                1,
+                Integer.MAX_VALUE,
+                8);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/dedicated/TestThreadPerDriverTaskExecutor.java
@@ -121,7 +121,7 @@ public class TestThreadPerDriverTaskExecutor
     {
         TestingTicker ticker = new TestingTicker();
         FairScheduler scheduler = new FairScheduler(1, "Runner-%d", ticker);
-        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, Integer.MAX_VALUE);
+        ThreadPerDriverTaskExecutor executor = new ThreadPerDriverTaskExecutor(noopTracer(), testingVersionEmbedder(), scheduler, 1, Integer.MAX_VALUE, Integer.MAX_VALUE);
         executor.start();
 
         try {


### PR DESCRIPTION
Concurrency for running leaf tasks is controlled according to the following:
* Each task is guaranteed a minimum number of leaf drivers to be running at a time (controlled by task.min-drivers-per-task)
* Once the minimum is satisfied, additional leaf drivers can get scheduled up to a maximum global target concurrency (controlled by task.min-drivers) Splits get chosen from all available tasks in a round-robin manner.
* A dynamic per-task controller calculates the desired concurrency based on output buffer utilization. We call this "target concurrency". The number of leaf drivers is capped by the lowest of target concurrency and the maximum number of drivers per task (controlled by task.max-drivers-per-task)





<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* TBD. ({issue}`issuenumber`)
```
