### PR TITLE
Fix bug on streaming reads in Alluxio cache 

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -158,10 +158,11 @@ public class AlluxioInputStream
         }
         externalStream.seek(aligned.pageStart());
         byte[] readBuffer = new byte[aligned.length()];
-        int externalBytesRead = externalStream.read(readBuffer, 0, aligned.length());
+        int externalBytesRead = externalStream.readNBytes(readBuffer, 0, aligned.length());
         if (externalBytesRead < 0) {
             throw new IOException("Unexpected end of stream");
         }
+        verify(aligned.length() == externalBytesRead, "invalid number of external bytes read");
         helper.putCache(aligned.pageStart(), aligned.pageEnd(), readBuffer, externalBytesRead);
         int bytesToCopy = min(length, max(externalBytesRead - aligned.pageOffset(), 0));
         System.arraycopy(readBuffer, aligned.pageOffset(), buffer, offset, bytesToCopy);

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -113,6 +113,9 @@ public class AlluxioInputStream
         ensureOpen();
 
         checkFromIndexSize(offset, length, bytes.length);
+        if (length == 0) {
+            return 0;
+        }
         if (position >= fileLength) {
             return -1;
         }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite5.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite5.java
@@ -50,7 +50,7 @@ public class Suite5
                         .withGroups(CONFIGURED_FEATURES, STORAGE_FORMATS, HDFS_IMPERSONATION, AUTHORIZATION)
                         .build(),
                 testOnEnvironment(EnvMultinodeHiveCaching.class)
-                        .withGroups(CONFIGURED_FEATURES, HIVE_ALLUXIO_CACHING)
+                        .withGroups(CONFIGURED_FEATURES, HIVE_ALLUXIO_CACHING, STORAGE_FORMATS)
                         .withExcludedGroups(ICEBERG)
                         .build());
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fix a bug in `AlluxioInputStream.read` where we might repeatedly read 0 bytes, depending on the underlying file system, causing infinite loops. Thanks to @raunaqmorarka for reporting that this happens for RCBINARY and the Hadoop file system.

What happens is:
1. We want to read byte 100.
2. We align the read to the beginning of the page (0), the external stream only returns 99 bytes.
3. We put the 99 bytes in the cache (this is not even correct, as we assume pages are always complete).
4. We return 0 bytes read to the caller.
5. Go back to step 1. when caller attempts to read byte 100 again, and we make no progress.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
