### PR TITLE
Add OpenTracing support to product tests

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
@@ -56,6 +56,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -69,12 +70,16 @@ import static io.trino.tests.product.launcher.env.DockerContainer.ensurePathExis
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.isTrinoContainer;
+import static io.trino.tests.product.launcher.env.EnvironmentListener.compose;
+import static io.trino.tests.product.launcher.env.EnvironmentListener.printStartupLogs;
 import static io.trino.tests.product.launcher.env.Environments.pruneEnvironment;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TRINO_ETC;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Duration.ofMinutes;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.function.UnaryOperator.identity;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public final class Environment
@@ -103,12 +108,13 @@ public final class Environment
             Map<String, DockerContainer> containers,
             EnvironmentListener listener,
             boolean attached,
-            Map<String, List<String>> configuredFeatures)
+            Map<String, List<String>> configuredFeatures,
+            List<Supplier<String>> startupLogs)
     {
         this.name = requireNonNull(name, "name is null");
         this.startupRetries = startupRetries;
         this.containers = requireNonNull(containers, "containers is null");
-        this.listener = requireNonNull(listener, "listener is null");
+        this.listener = compose(requireNonNull(listener, "listener is null"), printStartupLogs(startupLogs));
         this.attached = attached;
         this.configuredFeatures = requireNonNull(configuredFeatures, "configuredFeatures is null");
     }
@@ -370,6 +376,8 @@ public final class Environment
         private final Map<String, DockerContainer> containers = new HashMap<>();
         private final PrintStream printStream;
         private final Multimap<String, String> configuredFeatures = HashMultimap.create();
+        private final ImmutableList.Builder<Supplier<String>> startupLogs = ImmutableList.builder();
+        private Function<String, String> logTransformer = Function.identity();
 
         private DockerContainer.OutputMode outputMode;
         private int startupRetries = 1;
@@ -483,6 +491,18 @@ public final class Environment
             return this;
         }
 
+        public Builder addStartupLogs(Supplier<String> line)
+        {
+            startupLogs.add(line);
+            return this;
+        }
+
+        public Builder addLogsTransformer(Function<String, String> transformer)
+        {
+            logTransformer = logTransformer.compose(transformer);
+            return this;
+        }
+
         private static void updateContainerHostConfig(CreateContainerCmd createContainerCmd)
         {
             HostConfig hostConfig = requireNonNull(createContainerCmd.getHostConfig(), "hostConfig is null");
@@ -575,18 +595,18 @@ public final class Environment
             switch (outputMode) {
                 case DISCARD -> {
                     log.warn("Containers logs are not printed to stdout");
-                    setContainerOutputConsumer(Builder::discardContainerLogs);
+                    setContainerOutputConsumer(identity(), Builder::discardContainerLogs);
                 }
-                case PRINT -> setContainerOutputConsumer(frame -> printContainerLogs(printStream, frame));
+                case PRINT -> setContainerOutputConsumer(logTransformer, frame -> printContainerLogs(printStream, frame));
                 case PRINT_WRITE -> {
                     verify(logsBaseDir.isPresent(), "--logs-dir must be set with --output WRITE");
-                    setContainerOutputConsumer(container -> combineConsumers(
+                    setContainerOutputConsumer(logTransformer, container -> combineConsumers(
                             writeContainerLogs(container, logsBaseDir.get()),
                             printContainerLogs(printStream, container)));
                 }
                 case WRITE -> {
                     verify(logsBaseDir.isPresent(), "--logs-dir must be set with --output WRITE");
-                    setContainerOutputConsumer(container -> writeContainerLogs(container, logsBaseDir.get()));
+                    setContainerOutputConsumer(logTransformer, container -> writeContainerLogs(container, logsBaseDir.get()));
                 }
             }
 
@@ -613,7 +633,8 @@ public final class Environment
                     containers,
                     listener,
                     attached,
-                    configuredFeatures);
+                    configuredFeatures,
+                    startupLogs.build());
         }
 
         private static Consumer<OutputFrame> writeContainerLogs(DockerContainer container, Path path)
@@ -682,9 +703,12 @@ public final class Environment
             return outputFrame -> Arrays.stream(consumers).forEach(consumer -> consumer.accept(outputFrame));
         }
 
-        private void setContainerOutputConsumer(Function<DockerContainer, Consumer<OutputFrame>> consumer)
+        private void setContainerOutputConsumer(Function<String, String> logTransformer, Function<DockerContainer, Consumer<OutputFrame>> consumer)
         {
-            configureContainers(container -> container.withLogConsumer(consumer.apply(container)));
+            configureContainers(container -> container.withLogConsumer(frame -> {
+                String line = logTransformer.apply(frame.getUtf8StringWithoutLineEnding());
+                consumer.apply(container).accept(new OutputFrame(frame.getType(), line.getBytes(UTF_8)));
+            }));
         }
 
         public Builder setLogsBaseDir(Optional<Path> baseDir)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentContainers.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentContainers.java
@@ -29,6 +29,7 @@ public final class EnvironmentContainers
     public static final String WORKER_NTH = WORKER + "-";
     public static final String HADOOP = "hadoop-master";
     public static final String TESTS = "tests";
+    public static final String OPENTRACING_COLLECTOR = "opentracing-collector";
     public static final String LDAP = "ldapserver";
 
     private EnvironmentContainers() {}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentListener.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentListener.java
@@ -22,6 +22,7 @@ import io.trino.tests.product.launcher.util.ConsoleTable;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -29,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.tests.product.launcher.env.StatisticsFetcher.Stats.HEADER;
@@ -259,6 +261,34 @@ public interface EnvironmentListener
                 catch (Exception e) {
                     e.printStackTrace();
                 }
+            }
+        };
+    }
+
+    static EnvironmentListener printStartupLogs(List<Supplier<String>> lines)
+    {
+        return new EnvironmentListener()
+        {
+            @Override
+            public void environmentStarted(Environment environment)
+            {
+                if (lines.isEmpty()) {
+                    return;
+                }
+
+                String separator = "=".repeat(80);
+                StringBuilder startupInfo = new StringBuilder()
+                        .append("\n".repeat(3))
+                        .append(separator)
+                        .append("\n");
+
+                for (Supplier<String> line : lines) {
+                    startupInfo.append("\n").append(line.get());
+                }
+                startupInfo.append("\n".repeat(2))
+                        .append(separator)
+                        .append("\n".repeat(3));
+                log.info(startupInfo.toString());
             }
         };
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentModule.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentModule.java
@@ -142,4 +142,12 @@ public final class EnvironmentModule
     {
         return options.debug;
     }
+
+    @Provides
+    @Singleton
+    @Tracing
+    public boolean provideTracing(EnvironmentOptions options)
+    {
+        return options.tracing;
+    }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
@@ -50,6 +50,9 @@ public final class EnvironmentOptions
     @Option(names = "--debug", description = "Open Java debug ports")
     public boolean debug;
 
+    @Option(names = "--tracing", description = "Automatic collection of OpenTracing data")
+    public boolean tracing;
+
     @Option(names = "--output", description = "Container output handling mode: ${COMPLETION-CANDIDATES} " + DEFAULT_VALUE, defaultValue = "PRINT")
     public DockerContainer.OutputMode output;
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Tracing.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Tracing.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.env;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface Tracing
+{
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -13,6 +13,7 @@
  */
 package io.trino.tests.product.launcher.env.common;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
 import io.trino.tests.product.launcher.docker.DockerFiles;
@@ -22,6 +23,7 @@ import io.trino.tests.product.launcher.env.Environment;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentContainers;
 import io.trino.tests.product.launcher.env.ServerPackage;
+import io.trino.tests.product.launcher.env.Tracing;
 import io.trino.tests.product.launcher.env.jdk.JdkProvider;
 import io.trino.tests.product.launcher.testcontainers.PortBinder;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
@@ -30,6 +32,7 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -37,9 +40,14 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.net.UrlEscapers.urlFragmentEscaper;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
+import static io.trino.tests.product.launcher.env.EnvironmentContainers.OPENTRACING_COLLECTOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER_NTH;
@@ -63,6 +71,8 @@ public final class Standard
         implements EnvironmentExtender
 {
     private static final Logger log = Logger.get(Standard.class);
+    private static final int COLLECTOR_UI_PORT = 16686;
+    private static final int COLLECTOR_GRPC_PORT = 4317;
 
     public static final String CONTAINER_HEALTH_D = "/etc/health.d/";
     public static final String CONTAINER_CONF_ROOT = "/docker/presto-product-tests/";
@@ -82,6 +92,7 @@ public final class Standard
     private final JdkProvider jdkProvider;
     private final File serverPackage;
     private final boolean debug;
+    private final boolean tracing;
 
     @Inject
     public Standard(
@@ -90,7 +101,8 @@ public final class Standard
             EnvironmentConfig environmentConfig,
             @ServerPackage File serverPackage,
             JdkProvider jdkProvider,
-            @Debug boolean debug)
+            @Debug boolean debug,
+            @Tracing boolean tracing)
     {
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
         this.portBinder = requireNonNull(portBinder, "portBinder is null");
@@ -98,12 +110,20 @@ public final class Standard
         this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
         this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
         this.debug = debug;
+        this.tracing = tracing;
         checkArgument(serverPackage.getName().endsWith(".tar.gz"), "Currently only server .tar.gz package is supported");
     }
 
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
+        if (tracing) {
+            DockerContainer tracingContainer = createTracingCollector();
+            builder.addContainer(tracingContainer);
+            builder.addLogsTransformer(addTracingLink(tracingContainer));
+            builder.addStartupLogs(() -> "Tracing collector available at http://localhost:" + tracingContainer.getMappedPort(COLLECTOR_UI_PORT));
+        }
+
         builder.addContainers(createTrinoCoordinator(), createTestsContainer());
         // default catalogs copied from /docker/presto-product-tests
         builder.addConnector("blackhole");
@@ -112,11 +132,46 @@ public final class Standard
         builder.addConnector("tpch");
     }
 
+    private Function<String, String> addTracingLink(DockerContainer tracingContainer)
+    {
+        Pattern pattern = Pattern.compile(".*TIMELINE: Query ([a-z0-9_]+) ::.*");
+
+        return line -> {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.matches()) {
+                String queryId = matcher.group(1);
+                String query = "{\"trino.query_id\": \"%s\"}".formatted(queryId);
+                URI searchLink = URI.create("http://localhost:%d/search?operation=query&service=trino&tags=%s".formatted(
+                        tracingContainer.getMappedPort(COLLECTOR_UI_PORT),
+                        urlFragmentEscaper().escape(query)));
+                return line + " :: TRACING :: " + searchLink;
+            }
+            return line;
+        };
+    }
+
+    private DockerContainer createTracingCollector()
+    {
+        DockerContainer container = new DockerContainer("jaegertracing/all-in-one:latest", OPENTRACING_COLLECTOR)
+                .withEnv(ImmutableMap.of(
+                        "COLLECTOR_OTLP_ENABLED", "true",
+                        "SPAN_STORAGE_TYPE", "badger",
+                        "GOMAXPROCS", "2"))
+                .withNetworkAliases(OPENTRACING_COLLECTOR + ".docker.cluster")
+                .withCreateContainerCmdModifier(createContainerCmd -> {
+                    createContainerCmd.getHostConfig().withMemory(2 * 1024 * 1024 * 1024L); // 2GB limit
+                });
+
+        portBinder.exposePort(container, COLLECTOR_UI_PORT); // UI port
+        portBinder.exposePort(container, COLLECTOR_GRPC_PORT);  // OpenTelemetry over gRPC
+        return container;
+    }
+
     @SuppressWarnings("resource")
     private DockerContainer createTrinoCoordinator()
     {
         DockerContainer container =
-                createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, COORDINATOR)
+                createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, COORDINATOR)
                         .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/standard/access-control.properties")), CONTAINER_TRINO_ACCESS_CONTROL_PROPERTIES)
                         .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/standard/config.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES);
 
@@ -135,7 +190,7 @@ public final class Standard
     }
 
     @SuppressWarnings("resource")
-    public static DockerContainer createTrinoContainer(DockerFiles dockerFiles, File serverPackage, JdkProvider jdkProvider, boolean debug, String dockerImageName, String logicalName)
+    public static DockerContainer createTrinoContainer(DockerFiles dockerFiles, File serverPackage, JdkProvider jdkProvider, boolean debug, boolean tracing, String dockerImageName, String logicalName)
     {
         DockerContainer container = new DockerContainer(dockerImageName, logicalName)
                 .withNetworkAliases(logicalName + ".docker.cluster")
@@ -156,6 +211,10 @@ public final class Standard
         }
         else {
             container.withHealthCheck(dockerFiles.getDockerFilesHostPath("health-checks/health.sh"));
+        }
+
+        if (tracing) {
+            enableTrinoTracing(container);
         }
 
         return jdkProvider.applyTo(container);
@@ -203,6 +262,29 @@ public final class Standard
 
             // expose debug port unconditionally when debug is enabled
             unsafelyExposePort(container, debugPort);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void enableTrinoTracing(DockerContainer container)
+    {
+        log.info("Enabling tracing collection for container %s", container.getLogicalName());
+
+        try {
+            FileAttribute<Set<PosixFilePermission>> rwx = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx"));
+            Path script = Files.createTempFile("enable-tracing", ".sh", rwx);
+            script.toFile().deleteOnExit();
+            Files.writeString(
+                    script,
+                    """
+                    #!/bin/bash
+                    echo 'tracing.enabled=true' >> '%1$s'
+                    echo 'tracing.exporter.endpoint=http://opentracing-collector.docker.cluster:%2$d' >> '%1$s'
+                    """.formatted(CONTAINER_TRINO_CONFIG_PROPERTIES, COLLECTOR_GRPC_PORT),
+                    UTF_8);
+            container.withCopyFileToContainer(forHostPath(script), "/docker/presto-init.d/enable-tracing.sh");
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -117,6 +117,7 @@ public final class Standard
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
+        builder.addStartupLogs(() -> "Trino running with JDK: " + jdkProvider.getDescription());
         if (tracing) {
             DockerContainer tracingContainer = createTracingCollector();
             builder.addContainer(tracingContainer);

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/StandardMultinode.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/StandardMultinode.java
@@ -21,6 +21,7 @@ import io.trino.tests.product.launcher.env.DockerContainer;
 import io.trino.tests.product.launcher.env.Environment;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.ServerPackage;
+import io.trino.tests.product.launcher.env.Tracing;
 import io.trino.tests.product.launcher.env.jdk.JdkProvider;
 
 import java.io.File;
@@ -44,6 +45,7 @@ public class StandardMultinode
     private final File serverPackage;
     private final JdkProvider jdkProvider;
     private final boolean debug;
+    private final boolean tracing;
 
     @Inject
     public StandardMultinode(
@@ -52,7 +54,8 @@ public class StandardMultinode
             EnvironmentConfig environmentConfig,
             @ServerPackage File serverPackage,
             JdkProvider jdkProvider,
-            @Debug boolean debug)
+            @Debug boolean debug,
+            @Tracing boolean tracing)
     {
         this.standard = requireNonNull(standard, "standard is null");
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
@@ -61,6 +64,7 @@ public class StandardMultinode
         this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
         this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
         this.debug = debug;
+        this.tracing = tracing;
         checkArgument(serverPackage.getName().endsWith(".tar.gz"), "Currently only server .tar.gz package is supported");
     }
 
@@ -81,7 +85,7 @@ public class StandardMultinode
     @SuppressWarnings("resource")
     private DockerContainer createTrinoWorker()
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, WORKER)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, WORKER)
                 .withCopyFileToContainer(forHostPath(configDir.getPath("multinode-worker-config.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES);
     }
 }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTls.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTls.java
@@ -22,6 +22,7 @@ import io.trino.tests.product.launcher.env.Environment;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentProvider;
 import io.trino.tests.product.launcher.env.ServerPackage;
+import io.trino.tests.product.launcher.env.Tracing;
 import io.trino.tests.product.launcher.env.common.Hadoop;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
@@ -51,6 +52,7 @@ public final class EnvMultinodeTls
     private final String imagesVersion;
     private final File serverPackage;
     private final boolean debug;
+    private final boolean tracing;
     private final JdkProvider jdkProvider;
 
     @Inject
@@ -62,7 +64,8 @@ public final class EnvMultinodeTls
             EnvironmentConfig environmentConfig,
             @ServerPackage File serverPackage,
             JdkProvider jdkProvider,
-            @Debug boolean debug)
+            @Debug boolean debug,
+            @Tracing boolean tracing)
     {
         super(ImmutableList.of(standard, hadoop));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
@@ -71,6 +74,7 @@ public final class EnvMultinodeTls
         this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
         this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
         this.debug = debug;
+        this.tracing = tracing;
     }
 
     @Override
@@ -93,7 +97,7 @@ public final class EnvMultinodeTls
 
     private DockerContainer createTrinoWorker(String workerName)
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, workerName)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, "ghcr.io/trinodb/testing/centos7-oj17:" + imagesVersion, workerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls/config-worker.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("common/hadoop/hive.properties")), CONTAINER_TRINO_HIVE_PROPERTIES)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTlsKerberos.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTlsKerberos.java
@@ -22,6 +22,7 @@ import io.trino.tests.product.launcher.env.Environment;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentProvider;
 import io.trino.tests.product.launcher.env.ServerPackage;
+import io.trino.tests.product.launcher.env.Tracing;
 import io.trino.tests.product.launcher.env.common.HadoopKerberos;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
@@ -50,6 +51,7 @@ public final class EnvMultinodeTlsKerberos
     private final JdkProvider jdkProvider;
     private final File serverPackage;
     private final boolean debug;
+    private final boolean tracing;
 
     @Inject
     public EnvMultinodeTlsKerberos(
@@ -59,7 +61,8 @@ public final class EnvMultinodeTlsKerberos
             EnvironmentConfig config,
             @ServerPackage File serverPackage,
             JdkProvider jdkProvider,
-            @Debug boolean debug)
+            @Debug boolean debug,
+            @Tracing boolean tracing)
     {
         super(ImmutableList.of(standard, hadoopKerberos));
         this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
@@ -69,6 +72,7 @@ public final class EnvMultinodeTlsKerberos
         this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
         this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
         this.debug = debug;
+        this.tracing = tracing;
     }
 
     @Override
@@ -89,7 +93,7 @@ public final class EnvMultinodeTlsKerberos
     @SuppressWarnings("resource")
     private DockerContainer createTrinoWorker(String workerName)
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, trinoDockerImageName, workerName)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, trinoDockerImageName, workerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls-kerberos/config-worker.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls-kerberos/hive.properties")), CONTAINER_TRINO_HIVE_PROPERTIES)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTlsKerberosDelegation.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvMultinodeTlsKerberosDelegation.java
@@ -22,6 +22,7 @@ import io.trino.tests.product.launcher.env.Environment;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentProvider;
 import io.trino.tests.product.launcher.env.ServerPackage;
+import io.trino.tests.product.launcher.env.Tracing;
 import io.trino.tests.product.launcher.env.common.HadoopKerberos;
 import io.trino.tests.product.launcher.env.common.Standard;
 import io.trino.tests.product.launcher.env.common.TestsEnvironment;
@@ -53,6 +54,7 @@ public final class EnvMultinodeTlsKerberosDelegation
     private final JdkProvider jdkProvider;
     private final File serverPackage;
     private final boolean debug;
+    private final boolean tracing;
 
     @Inject
     public EnvMultinodeTlsKerberosDelegation(
@@ -62,7 +64,8 @@ public final class EnvMultinodeTlsKerberosDelegation
             EnvironmentConfig config,
             @ServerPackage File serverPackage,
             JdkProvider jdkProvider,
-            @Debug boolean debug)
+            @Debug boolean debug,
+            @Tracing boolean tracing)
     {
         super(ImmutableList.of(standard, hadoopKerberos));
         this.configDir = dockerFiles.getDockerFilesHostDirectory("conf/environment/multinode-tls-kerberos-delegation");
@@ -73,6 +76,7 @@ public final class EnvMultinodeTlsKerberosDelegation
         this.jdkProvider = requireNonNull(jdkProvider, "jdkProvider is null");
         this.serverPackage = requireNonNull(serverPackage, "serverPackage is null");
         this.debug = debug;
+        this.tracing = tracing;
     }
 
     @Override
@@ -98,7 +102,7 @@ public final class EnvMultinodeTlsKerberosDelegation
     @SuppressWarnings("resource")
     private DockerContainer createTrinoWorker(String workerName)
     {
-        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, trinoDockerImageName, workerName)
+        return createTrinoContainer(dockerFiles, serverPackage, jdkProvider, debug, tracing, trinoDockerImageName, workerName)
                 .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withDomainName("docker.cluster"))
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls-kerberos/config-worker.properties")), CONTAINER_TRINO_CONFIG_PROPERTIES)
                 .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/multinode-tls-kerberos/hive.properties")), CONTAINER_TRINO_HIVE_PROPERTIES)


### PR DESCRIPTION
It's an opt-in featured activated with `--tracing` flag added to either `test run` or `env up` launcher commands.

When environment is started, little message is printed to the console, that makes it easier to navigate to a collector UI:

<img width="1652" alt="Screenshot 2024-02-14 at 10 30 59" src="https://github.com/trinodb/trino/assets/66972/68a79d98-e033-47d6-998f-a9f51d2877a7">
