### PR TITLE
Revert "Update gib to 4.5.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2878,7 +2878,7 @@
                     <plugin>
                         <groupId>io.github.gitflow-incremental-builder</groupId>
                         <artifactId>gitflow-incremental-builder</artifactId>
-                        <version>4.5.2</version>
+                        <version>4.5.1</version>
                         <extensions>true</extensions>
                         <configuration>
                             <disableIfBranchMatches>master</disableIfBranchMatches>


### PR DESCRIPTION
Reverts trinodb/trino#20689

Causing a lot of noise in the CI due to the incompatible jgit version with `git-commit-id` plugin.

<img width="1250" alt="Screenshot 2024-02-14 at 16 51 14" src="https://github.com/trinodb/trino/assets/66972/8d4dbce6-e236-437e-864c-e400fe9b10d5">
