### PR TITLE
Update kudu to 1.17.0

### DIFF
--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <kudu.version>1.15.0</kudu.version>
+        <kudu.version>1.17.0</kudu.version>
     </properties>
 
     <dependencies>

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestingKuduServer.java
@@ -32,7 +32,7 @@ public class TestingKuduServer
 {
     private static final String KUDU_IMAGE = "apache/kudu";
     public static final String EARLIEST_TAG = "1.13.0";
-    public static final String LATEST_TAG = "1.15.0";
+    public static final String LATEST_TAG = "1.17";
 
     private static final Integer KUDU_MASTER_PORT = 7051;
     private static final Integer KUDU_TSERVER_PORT = 7050;
@@ -61,14 +61,11 @@ public class TestingKuduServer
     public TestingKuduServer(String kuduVersion)
     {
         network = Network.newNetwork();
-
-        String hostIP = getHostIPAddress();
-
         String masterContainerAlias = "kudu-master";
         this.master = new GenericContainer<>(format("%s:%s", KUDU_IMAGE, kuduVersion))
                 .withExposedPorts(KUDU_MASTER_PORT)
                 .withCommand("master")
-                .withEnv("MASTER_ARGS", "--default_num_replicas=1")
+                .withEnv("MASTER_ARGS", "--default_num_replicas=1 --unlock_unsafe_flags --use_hybrid_clock=false")
                 .withNetwork(network)
                 .withNetworkAliases(masterContainerAlias);
 
@@ -83,7 +80,7 @@ public class TestingKuduServer
                 .withExposedPorts(KUDU_TSERVER_PORT)
                 .withCommand("tserver")
                 .withEnv("KUDU_MASTERS", format("%s:%s", masterContainerAlias, KUDU_MASTER_PORT))
-                .withEnv("TSERVER_ARGS", format("--fs_wal_dir=/var/lib/kudu/tserver --logtostderr --use_hybrid_clock=false --rpc_bind_addresses=%s:%s --rpc_advertised_addresses=%s:%s", instanceName, KUDU_TSERVER_PORT, hostIP, proxy.getProxyPort()))
+                .withEnv("TSERVER_ARGS", format("--fs_wal_dir=/var/lib/kudu/tserver --logtostderr --use_hybrid_clock=false --unlock_unsafe_flags --rpc_bind_addresses=%s:%s --rpc_advertised_addresses=%s:%s", instanceName, KUDU_TSERVER_PORT, TOXIPROXY_NETWORK_ALIAS, proxy.getOriginalProxyPort()))
                 .withNetwork(network)
                 .withNetworkAliases(instanceName)
                 .dependsOn(master);


### PR DESCRIPTION
This also works now locally.

This solves following CVE:

<img width="2363" alt="Screenshot 2024-02-14 at 17 54 17" src="https://github.com/trinodb/trino/assets/66972/65dd9654-818f-478c-97ae-6c8e34487957">

But there is one new instead:

<img width="1719" alt="Screenshot 2024-02-14 at 17 54 54" src="https://github.com/trinodb/trino/assets/66972/af841957-4cd1-4a1d-823a-2d66c2727101">


