### PR TITLE
Ensure complete TaskInfo/Status for FINISHED tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -73,6 +73,7 @@ import static io.trino.execution.DynamicFiltersCollector.INITIAL_DYNAMIC_FILTERS
 import static io.trino.execution.DynamicFiltersCollector.INITIAL_DYNAMIC_FILTER_DOMAINS;
 import static io.trino.execution.TaskState.FAILED;
 import static io.trino.execution.TaskState.FAILING;
+import static io.trino.execution.TaskState.FINISHED;
 import static io.trino.execution.TaskState.RUNNING;
 import static io.trino.util.Failures.toFailures;
 import static java.lang.String.format;
@@ -371,6 +372,16 @@ public class SqlTask
             fullGcTime = taskContext.getFullGcTime();
             dynamicFiltersVersion = taskContext.getDynamicFiltersVersion();
         }
+        else {
+            if (state == FINISHED) {
+                // if task FINISHED successfully but taskHolder is not yet updated with SqlTaskExecution or FinalTaskInfo
+                // we are masking the state and return RUNNING. This is important so coordinator would not consider incomplete
+                // task information (e.g. missing proper dynamicFiltersVersion as final).
+                // This covers only short time window between call to SqlTaskExecution.start() and updating taskHolder reference in tryCreateSqlTaskExecution,
+                // so it will not add any noticable delays.
+                state = RUNNING;
+            }
+        }
 
         return new TaskStatus(
                 taskStateMachine.getTaskId(),
@@ -519,13 +530,14 @@ public class SqlTask
     @Nullable
     private SqlTaskExecution tryCreateSqlTaskExecution(Session session, Span stageSpan, PlanFragment fragment)
     {
+        SqlTaskExecution execution;
         synchronized (taskHolderLock) {
             // Recheck holder for task execution after acquiring the lock
             TaskHolder taskHolder = taskHolderReference.get();
             if (taskHolder.isFinished()) {
                 return null;
             }
-            SqlTaskExecution execution = taskHolder.getTaskExecution();
+            execution = taskHolder.getTaskExecution();
             if (execution != null) {
                 return execution;
             }
@@ -555,8 +567,14 @@ public class SqlTask
             // this must happen after taskExecution.start(), otherwise it could become visible to a
             // concurrent update without being fully initialized
             checkState(taskHolderReference.compareAndSet(taskHolder, new TaskHolder(execution)), "unsynchronized concurrent task holder update");
-            return execution;
         }
+        if (taskStateMachine.getState() == FINISHED) {
+            // Bump task status version as otherwise it could not be observed by coordinator due to
+            // status masking logic in createTaskStatus for case when neither SqlExecution nor
+            // FinalTaskInfo is set in TaskHolder.
+            notifyStatusChanged();
+        }
+        return execution;
     }
 
     public ListenableFuture<BufferResult> getTaskResults(PipelinedOutputBuffers.OutputBufferId bufferId, long startingSequenceId, DataSize maxSize)


### PR DESCRIPTION
Commit ensures that for tasks which completed successfuly (task state is set to FINISHED) we construct TaskInfo/TasksStatus with state set to FINISHED only when TaskHolder transtions out of initial state when it is not referencing SqlTaskExecution.

Otherwise it is possible that coordinator would get incomplete information about the task, which is already marked as FINISHED. In such case no longer ask for updates for updates. This may happen for very short lived tasks.

One of the important things which would be missing in such a case is dynamic filter information.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix rare condition where queries could have worse performance due to dynamic filters not delivered to consumer. ({issue}`20709`)
```
