### PR TITLE
[WIP] Avoid fetching all trees when checking out repo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
+          filter: 'tree:0'
           ref: |
             ${{ github.event_name == 'repository_dispatch' &&
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
@@ -90,6 +91,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
+          filter: 'tree:0'
           ref: |
             ${{ github.event_name == 'repository_dispatch' &&
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
@@ -131,6 +133,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base
+          filter: 'tree:0'
       - name: Block illegal commits
         uses: trinodb/github-actions/block-commits@c2991972560c5219d9ae5fb68c0c9d687ffcdd10
         with:
@@ -164,6 +167,7 @@ jobs:
         if: matrix.commit != ''
         with:
           fetch-depth: 0 # checkout all commits to be able to determine merge base
+          filter: 'tree:0'
           ref: ${{ matrix.commit }}
       # This composite job must be entirely standalone, and checked out from the correct commit before being executed.
       # It can't accept any parameters defined in this workflow, because the values of those parameters would always be taken from
@@ -206,6 +210,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all commits: it's not needed here, but it's needed almost always, so let's do this for completeness
+          filter: 'tree:0'
           ref: |
             ${{ github.event_name == 'repository_dispatch' &&
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&
@@ -951,6 +956,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # checkout all commits, as the build result depends on `git describe` equivalent
+          filter: 'tree:0'
           ref: |
             ${{ github.event_name == 'repository_dispatch' &&
                 github.event.client_payload.pull_request.head.sha == github.event.client_payload.slash_command.args.named.sha &&


### PR DESCRIPTION
A regular checkout fetches trees all the way to the beginning of history. With the tree:0 filter, trees aren't fetched until git needs them (i.e., when checking out a branch), which should reduce the amount of data and time it takes to switch to the PR branch to build.

See https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/#
