### PR TITLE
Remove non-existing config property

### DIFF
--- a/testing/trino-server-dev/etc/catalog/delta.properties
+++ b/testing/trino-server-dev/etc/catalog/delta.properties
@@ -14,7 +14,6 @@ fs.native-s3.enabled=true
 s3.region=us-east-1
 s3.endpoint=http://localhost:9080
 s3.path-style-access=true
-s3.ssl.enabled=false
 s3.aws-access-key=minio-access-key
 s3.aws-secret-key=minio-secret-key
 

--- a/testing/trino-server-dev/etc/catalog/hudi.properties
+++ b/testing/trino-server-dev/etc/catalog/hudi.properties
@@ -20,6 +20,5 @@ fs.native-s3.enabled=true
 s3.region=us-east-1
 s3.endpoint=http://localhost:9080
 s3.path-style-access=true
-s3.ssl.enabled=false
 s3.aws-access-key=minio-access-key
 s3.aws-secret-key=minio-secret-key


### PR DESCRIPTION
## Description

[S3FileSystemConfig](https://github.com/trinodb/trino/blob/master/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystemConfig.java) doesn't support `s3.ssl.enabled` property. 