### PR TITLE
Fix character type truncation Hive LazySimpleSerDe

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ReadWriteUtils.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ReadWriteUtils.java
@@ -327,6 +327,8 @@ public final class ReadWriteUtils
         if (indexEnd < 0) {
             return length;
         }
-        return indexEnd - offset;
+        // end index could run over length because of large code points (e.g., 4-byte code points)
+        // or within length because of small code points (e.g., 1-byte code points)
+        return min(indexEnd - offset, length);
     }
 }


### PR DESCRIPTION
## Description
Truncation logic for VARCHAR and CHAR can return a value outside the bounds of the input field.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive
* Fix decoding of `VARCHAR` and `CHAR` with lengh in `TEXTFILE` and `SEQUENCEFILE ` formats. ({issue}`issuenumber`)
```
