### PR TITLE
Revert "Replace custom air.main.basedir property with built-in session.rootDirectory"

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,1 @@
 --strict-checksums
--Dmodernizer.violationsFile=${session.rootDirectory}/.mvn/modernizer/violations.xml

--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-cli</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <main-class>io.trino.cli.Trino</main-class>
         <dep.jline.version>3.25.1</dep.jline.version>

--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-client</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
     </properties>
 

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-jdbc</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <shadeBase>io.trino.jdbc.\$internal</shadeBase>
     </properties>

--- a/core/trino-grammar/pom.xml
+++ b/core/trino-grammar/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-grammar</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
     </properties>
 

--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-main</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.clearspring.analytics</groupId>

--- a/core/trino-parser/pom.xml
+++ b/core/trino-parser/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-parser</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-server-main</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- allow dependencies with newer bytecode versions -->
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
         <project.build.targetJdk>8</project.build.targetJdk>

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -13,6 +13,8 @@
     <packaging>rpm</packaging>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+
         <server.tar.package>trino-server-${project.version}</server.tar.package>
     </properties>
 

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -13,6 +13,8 @@
     <packaging>provisio</packaging>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+
         <air.check.skip-enforcer>false</air.check.skip-enforcer>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
         <air.check.skip-findbugs>true</air.check.skip-findbugs>

--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-spi</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <released-artifacts.dir>${project.build.directory}/released-artifacts</released-artifacts.dir>
         <trino.check.skip-revapi>${air.check.skip-basic}</trino.check.skip-revapi>
     </properties>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>trino-docs</artifactId>
     <packaging>pom</packaging>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/lib/trino-array/pom.xml
+++ b/lib/trino-array/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-array</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/lib/trino-cache/pom.xml
+++ b/lib/trino-cache/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-cache</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino Filesystem - Azure</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-filesystem-gcs/pom.xml
+++ b/lib/trino-filesystem-gcs/pom.xml
@@ -13,6 +13,10 @@
     <name>trino-filesystem-gcs</name>
     <description>Trino Filesystem - GCS</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.api</groupId>

--- a/lib/trino-filesystem-manager/pom.xml
+++ b/lib/trino-filesystem-manager/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-filesystem-manager</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-filesystem-s3/pom.xml
+++ b/lib/trino-filesystem-s3/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-filesystem-s3</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-filesystem/pom.xml
+++ b/lib/trino-filesystem/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-filesystem</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>trino-geospatial-toolkit</artifactId>
     <description>Trino - Geospatial utilities</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.esri.geometry</groupId>

--- a/lib/trino-hdfs/pom.xml
+++ b/lib/trino-hdfs/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-hdfs</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Hive Formats</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-matching/pom.xml
+++ b/lib/trino-matching/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-matching</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.compiler.fail-warnings>true</air.compiler.fail-warnings>
     </properties>
 

--- a/lib/trino-memory-context/pom.xml
+++ b/lib/trino-memory-context/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>trino-memory-context</artifactId>
     <description>Trino - Memory Tracking Framework</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/lib/trino-orc/pom.xml
+++ b/lib/trino-orc/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-orc</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-parquet</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/lib/trino-phoenix5-patched/pom.xml
+++ b/lib/trino-phoenix5-patched/pom.xml
@@ -13,6 +13,10 @@
     <artifactId>trino-phoenix5-patched</artifactId>
     <description>Trino - patched Phoenix5 client to work with JDK17</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.phoenix</groupId>

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>trino-plugin-toolkit</artifactId>
     <description>Trino - Plugin Toolkit</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/lib/trino-record-decoder/pom.xml
+++ b/lib/trino-record-decoder/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-record-decoder</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/plugin/trino-accumulo-iterators/pom.xml
+++ b/plugin/trino-accumulo-iterators/pom.xml
@@ -14,6 +14,7 @@
     <description>Accumulo Iterators for the Trino Accumulo Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
     </properties>
 

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Accumulo Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.curator.version>2.13.0</dep.curator.version>
     </properties>
 

--- a/plugin/trino-atop/pom.xml
+++ b/plugin/trino-atop/pom.xml
@@ -14,6 +14,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Atop Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>trino-base-jdbc</artifactId>
     <description>Trino - Base JDBC Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - BigQuery Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/plugin/trino-blackhole/pom.xml
+++ b/plugin/trino-blackhole/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Black Hole Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Cassandra Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.native-protocol.version>1.5.1</dep.native-protocol.version>
     </properties>
 

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - ClickHouse Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.clickhouse</groupId>

--- a/plugin/trino-delta-lake/pom.xml
+++ b/plugin/trino-delta-lake/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Delta Lake Connector Plugin</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/plugin/trino-druid/pom.xml
+++ b/plugin/trino-druid/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Druid Jdbc Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Elasticsearch Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.elasticsearch.version>7.17.18</dep.elasticsearch.version>
     </properties>
 

--- a/plugin/trino-example-http/pom.xml
+++ b/plugin/trino-example-http/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Example HTTP Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-example-jdbc/pom.xml
+++ b/plugin/trino-example-jdbc/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Example JDBC Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/plugin/trino-exchange-filesystem/pom.xml
+++ b/plugin/trino-exchange-filesystem/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Exchange</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.azure</groupId>

--- a/plugin/trino-exchange-hdfs/pom.xml
+++ b/plugin/trino-exchange-hdfs/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Exchange HDFS</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/plugin/trino-geospatial/pom.xml
+++ b/plugin/trino-geospatial/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Geospatial Plugin</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.esri.geometry</groupId>

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Google Sheets Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -14,6 +14,8 @@
     <description>Trino - Hive Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+
         <!--
           Project's default for air.test.parallel is 'methods'. By design, 'instances' runs all the methods in the same instance in the same thread,
           but two methods on two different instances will be running in different threads.

--- a/plugin/trino-http-event-listener/pom.xml
+++ b/plugin/trino-http-event-listener/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Http Query Listener</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-hudi/pom.xml
+++ b/plugin/trino-hudi/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Hudi Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.hudi.version>0.14.0</dep.hudi.version>
         <dep.hbase.version>2.4.9</dep.hbase.version>
     </properties>

--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Iceberg Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- Nessie version (matching to Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
         <dep.nessie.version>0.71.0</dep.nessie.version>
     </properties>

--- a/plugin/trino-ignite/pom.xml
+++ b/plugin/trino-ignite/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Ignite Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.test.jvm.additional-arguments>${air.test.jvm.additional-arguments.default} --add-opens=java.base/java.nio=ALL-UNNAMED</air.test.jvm.additional-arguments>
     </properties>
 

--- a/plugin/trino-jmx/pom.xml
+++ b/plugin/trino-jmx/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - JMX Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-kafka/pom.xml
+++ b/plugin/trino-kafka/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Kafka Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-kinesis/pom.xml
+++ b/plugin/trino-kinesis/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Kinesis Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/plugin/trino-kudu/pom.xml
+++ b/plugin/trino-kudu/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Kudu Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <kudu.version>1.17.0</kudu.version>
     </properties>
 

--- a/plugin/trino-local-file/pom.xml
+++ b/plugin/trino-local-file/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Local File Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-mariadb/pom.xml
+++ b/plugin/trino-mariadb/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - MariaDB Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Memory Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/plugin/trino-ml/pom.xml
+++ b/plugin/trino-ml/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Machine Learning Plugin</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.facebook.thirdparty</groupId>

--- a/plugin/trino-mongodb/pom.xml
+++ b/plugin/trino-mongodb/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - mongodb Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <mongo-java.version>4.11.1</mongo-java.version>
     </properties>
 

--- a/plugin/trino-mysql-event-listener/pom.xml
+++ b/plugin/trino-mysql-event-listener/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Mysql Event Listener</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - MySQL Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-opensearch/pom.xml
+++ b/plugin/trino-opensearch/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - OpenSearch Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.opensearch.version>2.11.1</dep.opensearch.version>
     </properties>
 

--- a/plugin/trino-oracle/pom.xml
+++ b/plugin/trino-oracle/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Oracle Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Password Authenticators</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>at.favre.lib</groupId>

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -14,6 +14,7 @@
     <description>Trino - Phoenix 5 Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.hbase.version>2.2.7</dep.hbase.version>
 
         <!-- This is required for JDK 17 to start HBase server due to illegal reflective access -->

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Pinot Connector</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.pinot.version>0.12.1</dep.pinot.version>
     </properties>
 

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - PostgreSQL Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-prometheus/pom.xml
+++ b/plugin/trino-prometheus/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Prometheus Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Raptor Legacy Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Redis Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Redshift Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.amazon.redshift</groupId>

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Resource Group Configuration Managers</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Session Property Managers</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-singlestore/pom.xml
+++ b/plugin/trino-singlestore/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - SingleStore Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - SQL Server Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-teradata-functions/pom.xml
+++ b/plugin/trino-teradata-functions/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Teradata's specific functions for Trino</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-thrift-api/pom.xml
+++ b/plugin/trino-thrift-api/pom.xml
@@ -13,6 +13,10 @@
     <packaging>jar</packaging>
     <description>Trino - Thrift Connector API</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-thrift-testing-server/pom.xml
+++ b/plugin/trino-thrift-testing-server/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Thrift Testing Server</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.plugin.thrift.server.ThriftTpchServer</main-class>
     </properties>
 

--- a/plugin/trino-thrift/pom.xml
+++ b/plugin/trino-thrift/pom.xml
@@ -13,6 +13,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - Thrift Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/plugin/trino-tpcds/pom.xml
+++ b/plugin/trino-tpcds/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - TPC-DS Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/plugin/trino-tpch/pom.xml
+++ b/plugin/trino-tpch/pom.xml
@@ -12,6 +12,10 @@
     <packaging>trino-plugin</packaging>
     <description>Trino - TPC-H Connector</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
         <air.java.version>21.0.1</air.java.version>
         <air.javadoc.lint>-missing</air.javadoc.lint>
+        <air.main.basedir>${project.basedir}</air.main.basedir>
         <air.modernizer.java-version>8</air.modernizer.java-version>
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
         <!--
@@ -2284,6 +2285,9 @@
                     <groupId>org.gaul</groupId>
                     <artifactId>modernizer-maven-plugin</artifactId>
                     <configuration>
+                        <violationsFiles>
+                            <violationsFile>${air.main.basedir}/.mvn/modernizer/violations.xml</violationsFile>
+                        </violationsFiles>
                         <exclusionPatterns>
                             <exclusionPattern>org/joda/time/.*</exclusionPattern>
                         </exclusionPatterns>

--- a/service/trino-proxy/pom.xml
+++ b/service/trino-proxy/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Proxy Service</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.proxy.TrinoProxy</main-class>
     </properties>
 

--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-verifier</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.verifier.TrinoVerifier</main-class>
     </properties>
 

--- a/testing/trino-benchmark-queries/pom.xml
+++ b/testing/trino-benchmark-queries/pom.xml
@@ -10,6 +10,10 @@
 
     <artifactId>trino-benchmark-queries</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.airlift</groupId>

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>trino-benchto-benchmarks</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <air.check.fail-duplicate-finder>false</air.check.fail-duplicate-finder>
     </properties>
 

--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-faulttolerant-tests</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/testing/trino-plugin-reader/pom.xml
+++ b/testing/trino-plugin-reader/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-plugin-reader</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.server.PluginReader</main-class>
     </properties>
 

--- a/testing/trino-product-tests-groups/pom.xml
+++ b/testing/trino-product-tests-groups/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-product-tests-groups</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/testing/trino-product-tests-launcher/pom.xml
+++ b/testing/trino-product-tests-launcher/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-product-tests-launcher</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.tests.product.launcher.cli.Launcher</main-class>
     </properties>
 

--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>trino-product-tests</artifactId>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <main-class>io.trino.tests.product.TemptoProductTestRunner</main-class>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>
     </properties>

--- a/testing/trino-server-dev/pom.xml
+++ b/testing/trino-server-dev/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-server-dev</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -13,6 +13,7 @@
     <description>Trino - Tests whether older Trino JDBC clients are compatible with current Trino server</description>
 
     <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- Version needs to be hardcoded for the release plugin to work. It will be updated by the release plugin. -->
         <dep.presto-jdbc-under-test>440-SNAPSHOT</dep.presto-jdbc-under-test>
     </properties>

--- a/testing/trino-test-jdbc-compatibility-old-server/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-server/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>trino-test-jdbc-compatibility-old-server</artifactId>
     <description>Trino - Tests whether current Trino JDBC clients are compatible with old Trino servers</description>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.github.docker-java</groupId>

--- a/testing/trino-testing-containers/pom.xml
+++ b/testing/trino-testing-containers/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-testing-containers</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.github.docker-java</groupId>

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-testing-kafka</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/testing/trino-testing-resources/pom.xml
+++ b/testing/trino-testing-resources/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-testing-resources</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
 
         <dependency>

--- a/testing/trino-testing-services/pom.xml
+++ b/testing/trino-testing-services/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-testing-services</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.google.errorprone</groupId>

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-testing</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>trino-tests</artifactId>
 
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Reverts commit ff1cddbd31d70610952922b19c13bd957e33f00f from trinodb/trino#20486

It doesn't work with `mvnd`:
```
[ERROR] Failed to execute goal org.gaul:modernizer-maven-plugin:2.7.0:modernizer (modernizer) on project trino-root: Error opening violation file: ${session.rootDirectory}/.mvn/modernizer/violations.xml: ${session.rootDirectory}/.mvn/modernizer/violations.xm
l (No such file or directory) -> [Help 1]
```

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
