### PR TITLE
Add `$partitions` system table to Delta Lake Connector

### DIFF
--- a/docs/src/main/sphinx/connector/delta-lake.md
+++ b/docs/src/main/sphinx/connector/delta-lake.md
@@ -687,6 +687,47 @@ The output of the query has the following history columns:
   - Whether or not the operation appended data
 :::
 
+#### `$partitions` table
+
+The `$partitions` table provides access to a specified Delta Lake Table's partitions keys and values.
+Each table row is a unique partition value, with the columns being the partition keys.
+
+For example, provided a table with the `regionkey` column set as a partition key:
+
+```
+CREATE TABLE example.default.example_partitioned_table
+WITH (
+  location = 's3://my-bucket/a/path',
+  partitioned_by = ARRAY['regionkey'],
+)
+AS SELECT name, comment, regionkey FROM tpch.tiny.nation;
+```
+
+With the following values:
+
+```
+name | comment | regionkey |
+-----+---------+-----------+
+foo  | foo     | east      |
+bar  | bar     | west      |
+baz  | baz     | west      |
+```
+
+Querying the partitions table:
+
+```
+SELECT * from example.default."example_partitioned_table$partitions"
+```
+
+Will return the following:
+
+```text
+regionkey |
+----------+
+east      |
+west      |
+```
+
 ##### `$properties` table
 
 The `$properties` table provides access to Delta Lake table configuration,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeMetadata.java
@@ -3521,10 +3521,10 @@ public class DeltaLakeMetadata
     @Override
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
-        return getRawSystemTable(tableName).map(systemTable -> new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
+        return getRawSystemTable(session, tableName).map(systemTable -> new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
     }
 
-    private Optional<SystemTable> getRawSystemTable(SchemaTableName systemTableName)
+    private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName systemTableName)
     {
         Optional<DeltaLakeTableType> tableType = DeltaLakeTableName.tableTypeFrom(systemTableName.getTableName());
         if (tableType.isEmpty() || tableType.get() == DeltaLakeTableType.DATA) {
@@ -3554,6 +3554,7 @@ public class DeltaLakeMetadata
                     transactionLogAccess,
                     typeManager));
             case PROPERTIES -> Optional.of(new DeltaLakePropertiesTable(systemTableName, tableLocation, transactionLogAccess));
+            case PARTITIONS -> Optional.of(new DeltaLakePartitionsTable(session, systemTableName, tableLocation, transactionLogAccess, typeManager));
         };
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
@@ -134,11 +134,10 @@ public class DeltaLakePartitionsTable
         if (partitionColumns.isEmpty()) {
             return new EmptyPageSource();
         }
-        return new FixedPageSource(buildPages(session, tableSnapshot, metadataEntry, constraint));
+        return new FixedPageSource(buildPages(session, tableSnapshot, metadataEntry));
     }
 
-    private List<Page> buildPages(ConnectorSession session, TableSnapshot tableSnapshot, MetadataEntry metadataEntry,
-                                  TupleDomain<Integer> constraint)
+    private List<Page> buildPages(ConnectorSession session, TableSnapshot tableSnapshot, MetadataEntry metadataEntry)
     {
         PageListBuilder pageListBuilder = PageListBuilder.forTable(tableMetadata);
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakePartitionsTable.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.deltalake;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.deltalake.transactionlog.AddFileEntry;
+import io.trino.plugin.deltalake.transactionlog.MetadataEntry;
+import io.trino.plugin.deltalake.transactionlog.TableSnapshot;
+import io.trino.plugin.deltalake.transactionlog.TransactionLogAccess;
+import io.trino.plugin.deltalake.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.EmptyPageSource;
+import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.TimestampWithTimeZoneType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarcharType;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.deltalake.DeltaLakeErrorCode.DELTA_LAKE_INVALID_SCHEMA;
+import static io.trino.plugin.deltalake.transactionlog.DeltaLakeSchemaSupport.extractPartitionColumns;
+import static java.util.Objects.requireNonNull;
+
+public class DeltaLakePartitionsTable
+        implements SystemTable
+{
+    private final SchemaTableName tableName;
+    private final String tableLocation;
+    private final TransactionLogAccess transactionLogAccess;
+    private final TypeManager typeManager;
+    private final ConnectorTableMetadata tableMetadata;
+    private final List<DeltaLakeColumnHandle> partitionColumns;
+    private static final DateTimeFormatter DELTA_TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+            .optionalStart().appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true).optionalEnd()
+            .toFormatter();
+
+    public DeltaLakePartitionsTable(
+            ConnectorSession session,
+            SchemaTableName tableName,
+            String tableLocation,
+            TransactionLogAccess transactionLogAccess,
+            TypeManager typeManager)
+    {
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.tableLocation = requireNonNull(tableLocation, "tableLocation is null");
+        this.transactionLogAccess = requireNonNull(transactionLogAccess, "transactionLogAccess is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+
+        this.partitionColumns = getPartitionColumns(new SchemaTableName(tableName.getSchemaName(), DeltaLakeTableName.tableNameFrom(tableName.getTableName())), this.tableLocation, session);
+
+        List<ColumnMetadata> columns = partitionColumns.stream()
+                .map(column -> new ColumnMetadata(column.getBaseColumnName(), column.getType()))
+                .collect(toImmutableList());
+
+        this.tableMetadata = new ConnectorTableMetadata(tableName, columns);
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session,
+                                          TupleDomain<Integer> constraint)
+    {
+        TableSnapshot tableSnapshot;
+        MetadataEntry metadataEntry;
+        try {
+            // Verify the transaction log is readable
+            SchemaTableName baseTableName = new SchemaTableName(tableName.getSchemaName(),
+                    DeltaLakeTableName.tableNameFrom(tableName.getTableName()));
+            tableSnapshot = transactionLogAccess.loadSnapshot(session, baseTableName, tableLocation);
+            metadataEntry = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
+        }
+        catch (IOException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA,
+                    "Unable to load table metadata from location: " + tableLocation, e);
+        }
+        if (partitionColumns.isEmpty()) {
+            return new EmptyPageSource();
+        }
+        return new FixedPageSource(buildPages(session, tableSnapshot, metadataEntry, constraint));
+    }
+
+    private List<Page> buildPages(ConnectorSession session, TableSnapshot tableSnapshot, MetadataEntry metadataEntry,
+                                  TupleDomain<Integer> constraint)
+    {
+        PageListBuilder pageListBuilder = PageListBuilder.forTable(tableMetadata);
+
+        Stream<AddFileEntry> activeFiles = transactionLogAccess.loadActiveFiles(tableSnapshot, metadataEntry,
+                transactionLogAccess.getProtocolEntry(session, tableSnapshot), TupleDomain.all(), alwaysTrue(), session);
+
+        for (Map<String, Optional<String>> partitionValue : getDedupedPartitionValues(activeFiles)) {
+            if (partitionValue.isEmpty()) {
+                pageListBuilder.beginRow();
+                pageListBuilder.appendNull();
+                pageListBuilder.endRow();
+                continue;
+            }
+
+            pageListBuilder.beginRow();
+            for (DeltaLakeColumnHandle column : partitionColumns) {
+                String actualPartitionValue = partitionValue.get(column.getBaseColumnName()).orElse(null);
+
+                if (actualPartitionValue == null) {
+                    pageListBuilder.appendNull();
+                }
+                else {
+                    Type columnType = column.getType();
+                    switch (columnType) {
+                        case BooleanType booleanType ->
+                                pageListBuilder.appendBoolean(Boolean.parseBoolean(actualPartitionValue));
+                        case TimestampWithTimeZoneType timestampType ->
+                                pageListBuilder.appendTimestampTzMillis(DELTA_TIMESTAMP_FORMATTER.parse(actualPartitionValue, LocalDateTime::from).toInstant(ZoneOffset.UTC).toEpochMilli(), TimeZoneKey.UTC_KEY);
+                        case IntegerType integerType ->
+                                pageListBuilder.appendInteger(Long.parseLong(actualPartitionValue));
+                        case TinyintType tinyintType ->
+                                pageListBuilder.appendTinyint(Long.parseLong(actualPartitionValue));
+                        case SmallintType smallintType ->
+                                pageListBuilder.appendSmallint(Long.parseLong(actualPartitionValue));
+                        case BigintType bigintType ->
+                                pageListBuilder.appendBigint(Long.parseLong(actualPartitionValue));
+                        case DecimalType decimalType ->
+                                pageListBuilder.appendDecimal(decimalType.getPrecision(), decimalType.getScale(), Int128.valueOf(new BigDecimal(actualPartitionValue).unscaledValue()));
+                        case DoubleType doubleType ->
+                                pageListBuilder.appendDouble(Double.parseDouble(actualPartitionValue));
+                        case DateType dateType ->
+                                pageListBuilder.appendDate(LocalDate.parse(actualPartitionValue).toEpochDay());
+                        case RealType realType ->
+                                pageListBuilder.appendReal(Float.parseFloat(actualPartitionValue));
+                        case VarcharType varcharType ->
+                                pageListBuilder.appendVarchar(actualPartitionValue);
+                        case null, default -> pageListBuilder.appendNull();
+                    }
+                }
+            }
+            pageListBuilder.endRow();
+        }
+        return pageListBuilder.build();
+    }
+
+    private ImmutableList<Map<String, Optional<String>>> getDedupedPartitionValues(Stream<AddFileEntry> addFileEntries)
+    {
+        return addFileEntries
+                .map(AddFileEntry::getCanonicalPartitionValues)
+                .distinct()
+                .collect(toImmutableList());
+    }
+
+    private List<DeltaLakeColumnHandle> getPartitionColumns(SchemaTableName tableName, String tableLocation, ConnectorSession session)
+    {
+        try {
+            // Verify the transaction log is readable
+            SchemaTableName baseTableName = new SchemaTableName(tableName.getSchemaName(), DeltaLakeTableName.tableNameFrom(tableName.getTableName()));
+            TableSnapshot tableSnapshot = transactionLogAccess.loadSnapshot(session, baseTableName, tableLocation);
+            MetadataEntry metadata = transactionLogAccess.getMetadataEntry(tableSnapshot, session);
+            return extractPartitionColumns(metadata, transactionLogAccess.getProtocolEntry(session, tableSnapshot), typeManager);
+        }
+        catch (IOException e) {
+            throw new TrinoException(DELTA_LAKE_INVALID_SCHEMA, "Unable to load table metadata from location: " + tableLocation, e);
+        }
+    }
+}

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableType.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/DeltaLakeTableType.java
@@ -18,4 +18,5 @@ public enum DeltaLakeTableType
     DATA,
     HISTORY,
     PROPERTIES,
+    PARTITIONS,
 }

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogAccess.java
@@ -311,7 +311,7 @@ public class TransactionLogAccess
         }
     }
 
-    private Stream<AddFileEntry> loadActiveFiles(
+    public Stream<AddFileEntry> loadActiveFiles(
             TableSnapshot tableSnapshot,
             MetadataEntry metadataEntry,
             ProtocolEntry protocolEntry,

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/PageListBuilder.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/util/PageListBuilder.java
@@ -20,6 +20,8 @@ import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Int128;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.Type;
 
@@ -31,7 +33,13 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 
 public final class PageListBuilder
@@ -93,9 +101,44 @@ public final class PageListBuilder
         BIGINT.writeLong(nextColumn(), value);
     }
 
+    public void appendTinyint(long value)
+    {
+        TINYINT.writeLong(nextColumn(), value);
+    }
+
+    public void appendInteger(long value)
+    {
+        INTEGER.writeLong(nextColumn(), value);
+    }
+
     public void appendBoolean(boolean value)
     {
         BOOLEAN.writeBoolean(nextColumn(), value);
+    }
+
+    public void appendSmallint(long value)
+    {
+        SMALLINT.writeLong(nextColumn(), value);
+    }
+
+    public void appendDecimal(int precision, int scale, Int128 value)
+    {
+        DecimalType.createDecimalType(precision, scale).writeObject(nextColumn(), value);
+    }
+
+    public void appendDouble(double value)
+    {
+        DOUBLE.writeDouble(nextColumn(), value);
+    }
+
+    public void appendDate(long value)
+    {
+        DATE.writeLong(nextColumn(), value);
+    }
+
+    public void appendReal(float value)
+    {
+        REAL.writeFloat(nextColumn(), value);
     }
 
     public void appendTimestampTzMillis(long millisUtc, TimeZoneKey timeZoneKey)

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakePartitioning.java
@@ -140,11 +140,43 @@ public class TestDeltaLakePartitioning
     }
 
     @Test
-    public void testPartitionsSystemTableDoesNotExist()
+    public void testPartitionsSystemTableExists()
     {
-        assertQueryFails(
-                "SELECT * FROM \"partitions$partitions\"",
-                ".*'delta\\.tpch\\.\"partitions\\$partitions\"' does not exist");
+        assertQuerySucceeds("SELECT * FROM \"partitions$partitions\"");
+    }
+
+    @Test
+    public void testReadAllTypesPartitionsSystemTable()
+    {
+        assertQuery(
+                "SELECT " +
+                        "p_string, " +
+                        "p_byte, " +
+                        "p_short, " +
+                        "p_int, " +
+                        "p_long, " +
+                        "p_decimal, " +
+                        "p_boolean, " +
+                        "p_float, " +
+                        "p_double, " +
+                        "p_date, " +
+                        // H2QueryRunner does not support TIMESTAMP WITH TIME ZONE,
+                        // so instead we convert the TIMESTAMP WITH TIME ZONE from Delta to a string representation and compare that.
+                        "CAST(p_timestamp AS VARCHAR) " +
+                        "FROM \"partitions$partitions\" " +
+                        "LIMIT 1 ",
+                "VALUES (" +
+                        "'Alice', " +
+                        "123, " +
+                        "12345, " +
+                        "123456789, " +
+                        "1234567890123456789, " +
+                        "12345678901234567890.123456789012345678, " +
+                        "true, " +
+                        "3.1415927, " +
+                        "3.141592653589793, " +
+                        "DATE '2014-01-01', " +
+                        "'2014-01-01 23:00:01.123 UTC')");
     }
 
     @Test

--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/TestDeltaLakeTableName.java
@@ -32,6 +32,7 @@ public class TestDeltaLakeTableName
         assertParseNameAndType("abc", "abc", DATA);
         assertParseNameAndType("abc$history", "abc", DeltaLakeTableType.HISTORY);
         assertParseNameAndType("abc$properties", "abc", DeltaLakeTableType.PROPERTIES);
+        assertParseNameAndType("abc$partitions", "abc", DeltaLakeTableType.PARTITIONS);
 
         assertNoValidTableType("abc$data");
         assertInvalid("abc@123", "Invalid Delta Lake table name: abc@123");
@@ -48,6 +49,8 @@ public class TestDeltaLakeTableName
 
         assertThat(DeltaLakeTableName.isDataTable("abc$data")).isFalse(); // it's invalid
         assertThat(DeltaLakeTableName.isDataTable("abc$history")).isFalse();
+        assertThat(DeltaLakeTableName.isDataTable("abc$properties")).isFalse();
+        assertThat(DeltaLakeTableName.isDataTable("abc$partitions")).isFalse();
         assertThat(DeltaLakeTableName.isDataTable("abc$invalid")).isFalse();
     }
 
@@ -57,6 +60,7 @@ public class TestDeltaLakeTableName
         assertThat(DeltaLakeTableName.tableNameFrom("abc")).isEqualTo("abc");
         assertThat(DeltaLakeTableName.tableNameFrom("abc$data")).isEqualTo("abc");
         assertThat(DeltaLakeTableName.tableNameFrom("abc$history")).isEqualTo("abc");
+        assertThat(DeltaLakeTableName.tableNameFrom("abc$partitions")).isEqualTo("abc");
         assertThat(DeltaLakeTableName.tableNameFrom("abc$properties")).isEqualTo("abc");
         assertThat(DeltaLakeTableName.tableNameFrom("abc$invalid")).isEqualTo("abc");
     }


### PR DESCRIPTION

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

This PR implements the `$partitions` system table in the Delta Lake Connector.

This is another attempt at https://github.com/trinodb/trino/pull/19722, and takes into consideration the review comments left. This implementation:

* Does not use the Provider pattern
* Accurately persists partition column types to the System table


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Closes https://github.com/trinodb/trino/issues/18590

There is one part I don't love about this implementation, but wanted to get feedback about it here. 

The `TransactionLogAccess` class currently provides one non-deprecated public method to get active files from a table. The partitions table needs these files to get the partition values, but using this method causes the following error `unknown session property delta.checkpoint_filtering_enabled`.

I was unable to get this to work, even after manually setting the session variables in the test runners. When debugging it looks like calling to system tables uses a `ConnectorSession`that does not have catalog-specific session variables in it, thus this block throws the above error, specifically the `isCheckpointFilteringEnabled` call

```java
if (isCheckpointFilteringEnabled(session)) {
    return loadActiveFiles(tableSnapshot, metadataEntry, protocolEntry, partitionConstraint, addStatsMinMaxColumnFilter, session);
}
```

To get this PR into a working state, I made `loadActiveFiles` public, though I'm open to a better solution

cc @findinpath @ebyhr 


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Delta Lake
* Add `$partitions` system table to the Delta Connector ({issue}`18590`)
```
