### PR TITLE
Elasticsearch connector supports custom date formats

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -322,10 +322,8 @@ public class ElasticsearchMetadata
             return new TypeAndDecoder(DOUBLE, new DoubleDecoder.Descriptor(path));
         }
         else if (type instanceof DateTimeType dateTimeType) {
-            if (dateTimeType.getFormats().isEmpty()) {
-                return new TypeAndDecoder(TIMESTAMP_MILLIS, new TimestampDecoder.Descriptor(path));
-            }
-            // otherwise, skip -- we don't support custom formats, yet
+            // decoder supports custom formats already
+            return new TypeAndDecoder(TIMESTAMP_MILLIS, new TimestampDecoder.Descriptor(path, dateTimeType.getFormats()));
         }
         else if (type instanceof ObjectType objectType) {
             ImmutableList.Builder<RowType.Field> rowFieldsBuilder = ImmutableList.builder();


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The current Elasticsearch Connector does not support custom date formats. When query such types, they are automatically skipped. This PR supports custom date formats.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Please review the previous code comments below:
class: io.trino.plugin.elasticsearch.ElasticsearchMetadata
function: TypeAndDecoder toTrino(String prefix, IndexMetadata.Field field)
line: 328
comments:  // otherwise, skip -- we don't support custom formats, yet
![image](https://github.com/trinodb/trino/assets/19464348/218e6ec7-8c39-46cc-ae3b-b9e3cd897385)



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. Elasticsearch connector supports custom date type formats
```
