### PR TITLE
Limit parallelism on CI as test memory is capped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2727,6 +2727,31 @@
 
     <profiles>
         <profile>
+            <id>ci-auto-detection</id>
+            <activation>
+                <property>
+                    <name>env.CONTINUOUS_INTEGRATION</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- Limit parallelism on CI, since test resources are capped by ${air.test.jvmsize} -->
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>2</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>errorprone-compiler</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Limit parallelism on CI, since test resources are capped by `air.test.jvmsize`.