### PR TITLE
Supplement HiveBlockEncodingSerde

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBlockEncodingSerde.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBlockEncodingSerde.java
@@ -23,10 +23,12 @@ import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.block.BlockEncodingSerde;
 import io.trino.spi.block.ByteArrayBlockEncoding;
 import io.trino.spi.block.DictionaryBlockEncoding;
+import io.trino.spi.block.Fixed12BlockEncoding;
 import io.trino.spi.block.Int128ArrayBlockEncoding;
 import io.trino.spi.block.IntArrayBlockEncoding;
 import io.trino.spi.block.LazyBlockEncoding;
 import io.trino.spi.block.LongArrayBlockEncoding;
+import io.trino.spi.block.MapBlockEncoding;
 import io.trino.spi.block.RowBlockEncoding;
 import io.trino.spi.block.RunLengthBlockEncoding;
 import io.trino.spi.block.ShortArrayBlockEncoding;
@@ -68,9 +70,11 @@ public final class HiveBlockEncodingSerde
         addBlockEncoding(new ShortArrayBlockEncoding());
         addBlockEncoding(new IntArrayBlockEncoding());
         addBlockEncoding(new LongArrayBlockEncoding());
+        addBlockEncoding(new Fixed12BlockEncoding());
         addBlockEncoding(new Int128ArrayBlockEncoding());
         addBlockEncoding(new DictionaryBlockEncoding());
         addBlockEncoding(new ArrayBlockEncoding());
+        addBlockEncoding(new MapBlockEncoding());
         addBlockEncoding(new RowBlockEncoding());
         addBlockEncoding(new RunLengthBlockEncoding());
         addBlockEncoding(new LazyBlockEncoding());
@@ -104,6 +108,7 @@ public final class HiveBlockEncodingSerde
 
             // look up the encoding factory
             BlockEncoding blockEncoding = blockEncodings.get(encodingName);
+            checkArgument(blockEncoding != null, "Cannot write block %s with encoding %s", block, encodingName);
 
             // see if a replacement block should be written instead
             Optional<Block> replacementBlock = blockEncoding.replacementBlockForWrite(block);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveBlockEncodingSerde.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveBlockEncodingSerde.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.util;
+
+import io.airlift.slice.BasicSliceInput;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceOutput;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.CharType.createCharType;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHiveBlockEncodingSerde
+{
+    @Test
+    public void testSerialization()
+    {
+        testSerialization(BOOLEAN);
+        testSerialization(TINYINT);
+        testSerialization(SMALLINT);
+        testSerialization(INTEGER);
+        testSerialization(BIGINT);
+        testSerialization(REAL);
+        testSerialization(DOUBLE);
+        testSerialization(createDecimalType(7, 2));
+        testSerialization(createDecimalType(37, 2));
+        testSerialization(createCharType(10));
+        testSerialization(createVarcharType(10));
+        testSerialization(createUnboundedVarcharType());
+        testSerialization(DATE);
+        testSerialization(createTimeType(0));
+        testSerialization(createTimeType(3));
+        testSerialization(createTimeType(12));
+        testSerialization(createTimeWithTimeZoneType(0));
+        testSerialization(createTimeWithTimeZoneType(3));
+        testSerialization(createTimeWithTimeZoneType(12));
+        testSerialization(createTimestampType(0));
+        testSerialization(createTimestampType(3));
+        testSerialization(createTimestampType(12));
+        testSerialization(createTimestampWithTimeZoneType(0));
+        testSerialization(createTimestampWithTimeZoneType(3));
+        testSerialization(createTimestampWithTimeZoneType(12));
+    }
+
+    private void testSerialization(Type type)
+    {
+        Slice serialized;
+        try (SliceOutput sliceOutput = new DynamicSliceOutput(0)) {
+            Block block = type.createBlockBuilder(null, 0).build();
+            new HiveBlockEncodingSerde().writeBlock(sliceOutput, block);
+            serialized = sliceOutput.slice();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        try (BasicSliceInput input = serialized.getInput()) {
+            Block read = new HiveBlockEncodingSerde().readBlock(input);
+            assertThat(read.getPositionCount()).isEqualTo(0);
+        }
+    }
+}


### PR DESCRIPTION
Per the class level code comment, `HiveBlockEncodingSerde` is supposed to provide same encodings as the `BlockEncodingManager`.
