### PR TITLE
Remove deprecation from Standard environment extender

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -61,12 +61,6 @@ import static org.testcontainers.containers.wait.strategy.Wait.forHealthcheck;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
-/**
- * @deprecated Product tests should mimic production like use case.
- * Single node environment does not do it well enough and some issues are
- * only exposed with multi node installations. Use {@link StandardMultinode} instead.
- */
-@Deprecated
 public final class Standard
         implements EnvironmentExtender
 {


### PR DESCRIPTION
The suggested replacement, the `StandardMultinode`, relies on `Standard`, so we cannot remove the class. It also provides number of constants shared across. Having it deprecated triggers many warnings in the code, with no clear intention to have them resolved.
