### PR TITLE
Do not append groupId/artifactId to the url in children

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" child.project.url.inherit.append.path="false" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -132,8 +132,9 @@
         <module>testing/trino-tests</module>
     </modules>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
         <connection>scm:git:git://github.com/trinodb/trino.git</connection>
+        <developerConnection>scm:git:git@github.com:trinodb/trino.git</developerConnection>
         <tag>HEAD</tag>
         <url>https://github.com/trinodb/trino</url>
     </scm>


### PR DESCRIPTION
Before:
```
./mvnw help:effective-pom -pl ':trino-mysql' | grep 'url>' | head -n 1
Running `/Users/mateuszgajewski/Projects/src/github.com/trinodb/trino/mvnw`...
  <url>https://trino.io/plugin/trino-mysql</url>
```

After:
```
./mvnw help:effective-pom -pl ':trino-mysql' | grep 'url>' | head -n 1
Running `/Users/mateuszgajewski/Projects/src/github.com/trinodb/trino/mvnw`...
  <url>https://trino.io</url>
```

According to the `project.url` documentation in the Maven xsd:

```
<xs:documentation source="description">
            The URL to the project's homepage.
            <br><b>Default value is</b>: parent value [+ path adjustment] + (artifactId or project.directory property), or just parent value if
            project's <code>child.project.url.inherit.append.path="false"</code>
          </xs:documentation>
```

This invalid url (https://trino.io/core/trino-server) was added to the RPM as `URL` metadata field.