### PR TITLE
Make OIDC end_session_endpoint optional

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OidcDiscovery.java
@@ -37,7 +37,6 @@ import static io.airlift.http.client.HttpStatus.REQUEST_TIMEOUT;
 import static io.airlift.http.client.HttpStatus.TOO_MANY_REQUESTS;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.ACCESS_TOKEN_ISSUER;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.AUTH_URL;
-import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.END_SESSION_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.JWKS_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.TOKEN_URL;
 import static io.trino.server.security.oauth2.StaticOAuth2ServerConfig.USERINFO_URL;
@@ -115,7 +114,7 @@ public class OidcDiscovery
             else {
                 userinfoEndpoint = Optional.empty();
             }
-            Optional<URI> endSessionEndpoint = Optional.of(getRequiredField("end_session_endpoint", metadata.getEndSessionEndpointURI(), END_SESSION_URL, Optional.empty()));
+            Optional<URI> endSessionEndpoint = Optional.ofNullable(metadata.getEndSessionEndpointURI());
             return new OAuth2ServerConfig(
                     // AD FS server can include "access_token_issuer" field in OpenID Provider Metadata.
                     // It's not a part of the OIDC standard thus have to be handled separately.

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOidcDiscovery.java
@@ -51,28 +51,31 @@ public class TestOidcDiscovery
     public void testStaticConfiguration()
             throws Exception
     {
-        testStaticConfiguration(Optional.empty(), Optional.empty());
-        testStaticConfiguration(Optional.of("/access-token-issuer"), Optional.of("/userinfo"));
+        testStaticConfiguration(Optional.empty(), Optional.empty(), Optional.empty());
+        testStaticConfiguration(Optional.of("/access-token-issuer"), Optional.of("/userinfo"), Optional.empty());
+        testStaticConfiguration(Optional.empty(), Optional.empty(), Optional.of("/connect/logout"));
+        testStaticConfiguration(Optional.of("/access-token-issuer"), Optional.of("/userinfo"), Optional.of("/connect/logout"));
     }
 
-    private void testStaticConfiguration(Optional<String> accessTokenPath, Optional<String> userinfoPath)
+    private void testStaticConfiguration(Optional<String> accessTokenPath, Optional<String> userinfoPath, Optional<String> endSessionPath)
             throws Exception
     {
         try (MetadataServer metadataServer = new MetadataServer(ImmutableMap.of("/jwks.json", "jwk/jwk-public.json"))) {
             URI issuer = metadataServer.getBaseUrl();
             Optional<URI> accessTokenIssuer = accessTokenPath.map(issuer::resolve);
             Optional<URI> userinfoUrl = userinfoPath.map(issuer::resolve);
+            Optional<URI> endSessionUrl = endSessionPath.map(issuer::resolve);
             ImmutableMap.Builder<String, String> properties = ImmutableMap.<String, String>builder()
                     .put("http-server.authentication.oauth2.issuer", metadataServer.getBaseUrl().toString())
                     .put("http-server.authentication.oauth2.oidc.discovery", "false")
                     .put("http-server.authentication.oauth2.auth-url", issuer.resolve("/connect/authorize").toString())
                     .put("http-server.authentication.oauth2.token-url", issuer.resolve("/connect/token").toString())
-                    .put("http-server.authentication.oauth2.jwks-url", issuer.resolve("/jwks.json").toString())
-                    .put("http-server.authentication.oauth2.end-session-url", issuer.resolve("/connect/logout").toString());
+                    .put("http-server.authentication.oauth2.jwks-url", issuer.resolve("/jwks.json").toString());
             accessTokenIssuer.map(URI::toString).ifPresent(uri -> properties.put("http-server.authentication.oauth2.access-token-issuer", uri));
             userinfoUrl.map(URI::toString).ifPresent(uri -> properties.put("http-server.authentication.oauth2.userinfo-url", uri));
+            endSessionUrl.map(URI::toString).ifPresent(uri -> properties.put("http-server.authentication.oauth2.end-session-url", uri));
             try (TestingTrinoServer server = createServer(properties.buildOrThrow())) {
-                assertConfiguration(server, issuer, accessTokenIssuer.map(issuer::resolve), userinfoUrl.map(issuer::resolve));
+                assertConfiguration(server, issuer, accessTokenIssuer.map(issuer::resolve), userinfoUrl.map(issuer::resolve), endSessionUrl.map(issuer::resolve));
             }
         }
     }
@@ -81,12 +84,25 @@ public class TestOidcDiscovery
     public void testOidcDiscovery()
             throws Exception
     {
-        testOidcDiscovery("openid-configuration.json", Optional.empty(), Optional.of("/connect/userinfo"));
-        testOidcDiscovery("openid-configuration-without-userinfo.json", Optional.empty(), Optional.empty());
-        testOidcDiscovery("openid-configuration-with-access-token-issuer.json", Optional.of("http://access-token-issuer.com/adfs/services/trust"), Optional.of("/connect/userinfo"));
+        testOidcDiscovery("openid-configuration.json",
+                Optional.empty(),
+                Optional.of("/connect/userinfo"),
+                Optional.of("/connect/end_session"));
+        testOidcDiscovery("openid-configuration-without-userinfo.json",
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of("/connect/end_session"));
+        testOidcDiscovery("openid-configuration-with-access-token-issuer.json",
+                Optional.of("http://access-token-issuer.com/adfs/services/trust"),
+                Optional.of("/connect/userinfo"),
+                Optional.of("/adfs/oauth2/logout"));
+        testOidcDiscovery("openid-configuration-without-end-session-url.json",
+                Optional.empty(),
+                Optional.of("/connect/userinfo"),
+                Optional.empty());
     }
 
-    private void testOidcDiscovery(String configuration, Optional<String> accessTokenIssuer, Optional<String> userinfoUrl)
+    private void testOidcDiscovery(String configuration, Optional<String> accessTokenIssuer, Optional<String> userinfoUrl, Optional<String> endSessionUrl)
             throws Exception
     {
         try (MetadataServer metadataServer = new MetadataServer(
@@ -100,7 +116,7 @@ public class TestOidcDiscovery
                                 .put("http-server.authentication.oauth2.oidc.discovery", "true")
                                 .buildOrThrow())) {
             URI issuer = metadataServer.getBaseUrl();
-            assertConfiguration(server, issuer, accessTokenIssuer.map(issuer::resolve), userinfoUrl.map(issuer::resolve));
+            assertConfiguration(server, issuer, accessTokenIssuer.map(issuer::resolve), userinfoUrl.map(issuer::resolve), endSessionUrl.map(issuer::resolve));
         }
     }
 
@@ -158,7 +174,7 @@ public class TestOidcDiscovery
                                 .put("http-server.authentication.oauth2.oidc.discovery.timeout", "10s")
                                 .buildOrThrow())) {
             URI issuer = metadataServer.getBaseUrl();
-            assertConfiguration(server, issuer, Optional.empty(), Optional.of(issuer.resolve("/connect/userinfo")));
+            assertConfiguration(server, issuer, Optional.empty(), Optional.of(issuer.resolve("/connect/userinfo")), Optional.of(issuer.resolve("/connect/end_session")));
         }
     }
 
@@ -199,7 +215,7 @@ public class TestOidcDiscovery
                                 .put("http-server.authentication.oauth2.oidc.use-userinfo-endpoint", "false")
                                 .buildOrThrow())) {
             URI issuer = metadataServer.getBaseUrl();
-            assertConfiguration(server, issuer, Optional.empty(), Optional.empty());
+            assertConfiguration(server, issuer, Optional.empty(), Optional.empty(), Optional.of(issuer.resolve("/connect/end_session")));
         }
     }
 
@@ -239,7 +255,7 @@ public class TestOidcDiscovery
         }
     }
 
-    private static void assertConfiguration(TestingTrinoServer server, URI issuer, Optional<URI> accessTokenIssuer, Optional<URI> userinfoUrl)
+    private static void assertConfiguration(TestingTrinoServer server, URI issuer, Optional<URI> accessTokenIssuer, Optional<URI> userinfoUrl, Optional<URI> endSessionUrl)
     {
         assertComponents(server);
         OAuth2ServerConfig config = server.getInstance(Key.get(OAuth2ServerConfigProvider.class)).get();
@@ -248,6 +264,7 @@ public class TestOidcDiscovery
         assertThat(config.tokenUrl()).isEqualTo(issuer.resolve("/connect/token"));
         assertThat(config.jwksUrl()).isEqualTo(issuer.resolve("/jwks.json"));
         assertThat(config.userinfoUrl()).isEqualTo(userinfoUrl);
+        assertThat(config.endSessionUrl()).isEqualTo(endSessionUrl);
     }
 
     private static void assertComponents(TestingTrinoServer server)

--- a/core/trino-main/src/test/resources/oidc/openid-configuration-without-end-session-url.json
+++ b/core/trino-main/src/test/resources/oidc/openid-configuration-without-end-session-url.json
@@ -1,0 +1,105 @@
+{
+    "issuer": "https://issuer.com",
+    "authorization_endpoint": "https://issuer.com/connect/authorize",
+    "token_endpoint": "https://issuer.com/connect/token",
+    "token_endpoint_auth_methods_supported": [
+        "client_secret_basic",
+        "private_key_jwt"
+    ],
+    "token_endpoint_auth_signing_alg_values_supported": [
+        "RS256",
+        "ES256"
+    ],
+    "userinfo_endpoint": "https://issuer.com/connect/userinfo",
+    "check_session_iframe": "https://issuer.com/connect/check_session",
+    "jwks_uri": "https://issuer.com/jwks.json",
+    "registration_endpoint": "https://issuer.com/connect/register",
+    "scopes_supported": [
+        "openid",
+        "profile",
+        "email",
+        "address",
+        "phone",
+        "offline_access"
+    ],
+    "response_types_supported": [
+        "code",
+        "code id_token",
+        "id_token",
+        "token id_token"
+    ],
+    "acr_values_supported": [
+        "urn:mace:incommon:iap:silver",
+        "urn:mace:incommon:iap:bronze"
+    ],
+    "subject_types_supported": [
+        "public",
+        "pairwise"
+    ],
+    "userinfo_signing_alg_values_supported": [
+        "RS256",
+        "ES256",
+        "HS256"
+    ],
+    "userinfo_encryption_alg_values_supported": [
+        "RSA1_5",
+        "A128KW"
+    ],
+    "userinfo_encryption_enc_values_supported": [
+        "A128CBC-HS256",
+        "A128GCM"
+    ],
+    "id_token_signing_alg_values_supported": [
+        "RS256",
+        "ES256",
+        "HS256"
+    ],
+    "id_token_encryption_alg_values_supported": [
+        "RSA1_5",
+        "A128KW"
+    ],
+    "id_token_encryption_enc_values_supported": [
+        "A128CBC-HS256",
+        "A128GCM"
+    ],
+    "request_object_signing_alg_values_supported": [
+        "none",
+        "RS256",
+        "ES256"
+    ],
+    "display_values_supported": [
+        "page",
+        "popup"
+    ],
+    "claim_types_supported": [
+        "normal",
+        "distributed"
+    ],
+    "claims_supported": [
+        "sub",
+        "iss",
+        "auth_time",
+        "acr",
+        "name",
+        "given_name",
+        "family_name",
+        "nickname",
+        "profile",
+        "picture",
+        "website",
+        "email",
+        "email_verified",
+        "locale",
+        "zoneinfo",
+        "http://example.info/claims/groups"
+    ],
+    "claims_parameter_supported": true,
+    "service_documentation": "http://issuer.com/connect/service_documentation.html",
+    "ui_locales_supported": [
+        "en-US",
+        "en-GB",
+        "en-CA",
+        "fr-FR",
+        "fr-CA"
+    ]
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Make OIDC `end_session_endpoint` optional.
Fix https://github.com/trinodb/trino/issues/19844

Although this field is mandatory in the spec [OpenID Connect RP-Initiated Logout 1.0 ](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), the spec itself is not mandatory.
Some providers do not implement it:
*  https://accounts.google.com/.well-known/openid-configuration
* https://github.com/dexidp/dex/issues/1697

https://openid.net/developers/how-connect-works/
![image](https://github.com/trinodb/trino/assets/2330687/26f812c3-3817-4111-a15c-a8503b2acd00)


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
