### PR TITLE
Migrate concurrency control for JUnit test

### DIFF
--- a/testing/trino-faulttolerant-tests/pom.xml
+++ b/testing/trino-faulttolerant-tests/pom.xml
@@ -473,11 +473,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
-                            <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/hive/Test*FaultTolerant*.java</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -492,11 +496,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
-                            <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/delta/Test*.java</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -511,11 +519,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <!-- Failure recovery tests spend most of the time waiting for a retry -->
-                            <threadCount>4</threadCount>
                             <includes>
                                 <include>**/io/trino/faulttolerant/iceberg/Test*.java</include>
                             </includes>
+                            <systemPropertyVariables>
+                                <junit.jupiter.execution.parallel.enabled>true</junit.jupiter.execution.parallel.enabled>
+                                <junit.jupiter.execution.parallel.config.strategy>fixed</junit.jupiter.execution.parallel.config.strategy>
+                                <!-- Failure recovery tests spend most of the time waiting for a retry -->
+                                <junit.jupiter.execution.parallel.config.fixed.parallelism>4</junit.jupiter.execution.parallel.config.fixed.parallelism>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
<threadCount> is ignored by JUnit surefire runner. Migrating to relevant config options.

