### PR TITLE
Enable custom date format support for Elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -97,7 +97,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -322,10 +322,9 @@ public class ElasticsearchMetadata
             return new TypeAndDecoder(DOUBLE, new DoubleDecoder.Descriptor(path));
         }
         else if (type instanceof DateTimeType dateTimeType) {
-            if (dateTimeType.getFormats().isEmpty()) {
-                return new TypeAndDecoder(TIMESTAMP_MILLIS, new TimestampDecoder.Descriptor(path));
-            }
-            // otherwise, skip -- we don't support custom formats, yet
+            int precision = dateTimeType.getPrecision();
+            List<String> formats = dateTimeType.getFormats();
+            return new TypeAndDecoder(createTimestampType(precision), new TimestampDecoder.Descriptor(path, formats, precision));
         }
         else if (type instanceof ObjectType objectType) {
             ImmutableList.Builder<RowType.Field> rowFieldsBuilder = ImmutableList.builder();

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -503,7 +503,14 @@ public class ElasticsearchClient
                     if (value.has("format")) {
                         formats = Arrays.asList(value.get("format").asText().split("\\|\\|"));
                     }
-                    result.add(new IndexMetadata.Field(asRawJson, isArray, name, new IndexMetadata.DateTimeType(formats)));
+                    result.add(new IndexMetadata.Field(asRawJson, isArray, name, new IndexMetadata.DateTimeType(formats, 3)));
+                    break;
+                case "date_nanos":
+                    List<String> nanoFormats = ImmutableList.of();
+                    if (value.has("format")) {
+                        nanoFormats = Arrays.asList(value.get("format").asText().split("\\|\\|"));
+                    }
+                    result.add(new IndexMetadata.Field(asRawJson, isArray, name, new IndexMetadata.DateTimeType(nanoFormats, 9)));
                     break;
                 case "scaled_float":
                     result.add(new IndexMetadata.Field(asRawJson, isArray, name, new IndexMetadata.ScaledFloatType(value.get("scaling_factor").asDouble())));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
@@ -95,17 +95,23 @@ public class IndexMetadata
             implements Type
     {
         private final List<String> formats;
+        private int precision;
 
-        public DateTimeType(List<String> formats)
+        public DateTimeType(List<String> formats, int precision)
         {
             requireNonNull(formats, "formats is null");
-
             this.formats = ImmutableList.copyOf(formats);
+            this.precision = precision;
         }
 
         public List<String> getFormats()
         {
             return formats;
+        }
+
+        public int getPrecision()
+        {
+            return precision;
         }
     }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
@@ -15,34 +15,53 @@ package io.trino.plugin.elasticsearch.decoders;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.primitives.Longs;
 import io.trino.plugin.elasticsearch.DecoderDescriptor;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.LongTimestamp;
 import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.search.SearchHit;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.spi.type.TimestampType.MAX_SHORT_PRECISION;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static java.lang.String.format;
-import static java.time.ZoneOffset.UTC;
-import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.Objects.requireNonNull;
 
 public class TimestampDecoder
         implements Decoder
 {
     private final String path;
+    private final DateFormatter formatter;
 
-    public TimestampDecoder(String path)
+    private final int precision;
+
+    public TimestampDecoder(String path, List<String> formats, int precision)
     {
         this.path = requireNonNull(path, "path is null");
+        this.precision = precision;
+        if (formats.isEmpty()) {
+            this.formatter = DateFormatter.forPattern("strict_date_optional_time||epoch_millis");
+        }
+        else {
+            this.formatter = DateFormatter.forPattern(String.join("||", formats));
+        }
     }
 
     @Override
@@ -65,18 +84,42 @@ public class TimestampDecoder
             output.appendNull();
         }
         else {
-            LocalDateTime timestamp;
+            if (value instanceof Number) {
+                value = String.valueOf(value);
+            }
             if (value instanceof String valueString) {
-                Long epochMillis = Longs.tryParse(valueString);
-                if (epochMillis != null) {
-                    timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), UTC);
+                if (precision <= 3) {
+                    long epochMicros = formatter.parseMillis(valueString) * MICROSECONDS_PER_MILLISECOND;
+                    TIMESTAMP_MILLIS.writeLong(output, epochMicros);
+                }
+                else if (precision <= MAX_SHORT_PRECISION) {
+                    // Elasticsearch currently only support type 'date' and 'date_nanos' for date field.
                 }
                 else {
-                    timestamp = ISO_DATE_TIME.parse(valueString, LocalDateTime::from);
+                    Instant instant;
+                    TemporalAccessor temporalAccessor = formatter.parse(valueString);
+                    if (temporalAccessor.isSupported(ChronoField.INSTANT_SECONDS)) {
+                        instant = Instant.from(temporalAccessor);
+                    }
+                    else {
+                        // The case that Elasticsearch date format does not include time zone information
+                        LocalDateTime localDateTime = LocalDateTime.of(
+                                temporalAccessor.get(ChronoField.YEAR_OF_ERA),
+                                temporalAccessor.get(ChronoField.MONTH_OF_YEAR),
+                                temporalAccessor.get(ChronoField.DAY_OF_MONTH),
+                                temporalAccessor.get(ChronoField.HOUR_OF_DAY),
+                                temporalAccessor.get(ChronoField.MINUTE_OF_HOUR),
+                                temporalAccessor.get(ChronoField.SECOND_OF_MINUTE),
+                                temporalAccessor.get(ChronoField.NANO_OF_SECOND));
+                        ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, ZoneId.systemDefault());
+                        instant = Instant.from(zonedDateTime);
+                    }
+                    long epochMicros = instant.getLong(ChronoField.INSTANT_SECONDS) * MICROSECONDS_PER_SECOND
+                            + instant.getLong(ChronoField.MICRO_OF_SECOND);
+                    int picoOfMicros = instant.get(ChronoField.NANO_OF_SECOND) * PICOSECONDS_PER_NANOSECOND
+                            - instant.get(ChronoField.MICRO_OF_SECOND) * PICOSECONDS_PER_MICROSECOND;
+                    TIMESTAMP_NANOS.writeObject(output, new LongTimestamp(epochMicros, picoOfMicros));
                 }
-            }
-            else if (value instanceof Number) {
-                timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), UTC);
             }
             else {
                 throw new TrinoException(NOT_SUPPORTED, format(
@@ -85,10 +128,6 @@ public class TimestampDecoder
                         value,
                         value.getClass().getSimpleName()));
             }
-
-            long epochMicros = timestamp.atOffset(UTC).toInstant().toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
-
-            TIMESTAMP_MILLIS.writeLong(output, epochMicros);
         }
     }
 
@@ -96,11 +135,15 @@ public class TimestampDecoder
             implements DecoderDescriptor
     {
         private final String path;
+        private final List<String> formats;
+        private final int precision;
 
         @JsonCreator
-        public Descriptor(String path)
+        public Descriptor(String path, List<String> formats, int precision)
         {
             this.path = path;
+            this.formats = formats;
+            this.precision = precision;
         }
 
         @JsonProperty
@@ -109,10 +152,22 @@ public class TimestampDecoder
             return path;
         }
 
+        @JsonProperty
+        public List<String> getFormats()
+        {
+            return formats;
+        }
+
+        @JsonProperty
+        public int getPrecision()
+        {
+            return precision;
+        }
+
         @Override
         public Decoder createDecoder()
         {
-            return new TimestampDecoder(path);
+            return new TimestampDecoder(path, formats, precision);
         }
     }
 }


### PR DESCRIPTION
Custom date format for elasticsearch is not neccesseary to be ignore. DateFormatter from elasticsearch library can be used to decode values of date fields according to elasticsearch index mappings.
related to #11823
Update for #14925
