### PR TITLE
Populate the cache in the Maven Checks job

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -47,9 +47,7 @@ runs:
         if: ${{ format('{0}', inputs.cache) == 'true' }}
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.m2/repository
-            /tmp/pt_java_downloads
+          path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,13 @@ concurrency:
 jobs:
   maven-checks:
     runs-on: ubuntu-latest
+    name: maven-checks ${{ matrix.java-version }}
     strategy:
       fail-fast: false
       matrix:
-        java-version:
-          - 21
-          - 22-ea
+        include:
+          - { java-version: 21, cache: 'true', cleanup-node: 'false' }
+          - { java-version: 22-ea, cache: 'restore', cleanup-node: 'true' }
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -67,9 +68,9 @@ jobs:
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
         with:
-          cache: ${{ matrix.java-version == '21' && 'true' || 'restore' }}
+          cache: ${{ matrix.cache }}
           java-version: ${{ matrix.java-version }}
-          cleanup-node: true
+          cleanup-node: ${{ matrix.cleanup-node }}
       - name: Check SPI backward compatibility
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -81,7 +82,7 @@ jobs:
           $MAVEN clean verify -B --strict-checksums -V -T 1C -b smart -DskipTests -P ci -pl '!:trino-server-rpm'
       - name: Remove Trino from local Maven repo to avoid caching it
         # Avoid caching artifacts built in this job, cache should only include dependencies
-        if: steps.cache.outputs.cache-hit != 'true' && matrix.java-version == '21'
+        if: steps.cache.outputs.cache-hit != 'true' && matrix.cache == 'true'
         run: rm -rf ~/.m2/repository/io/trino/trino-*
 
   artifact-checks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
         with:
-          cache: 'restore'
+          cache: ${{ matrix.java-version == '21' && 'true' || 'restore' }}
           java-version: ${{ matrix.java-version }}
           cleanup-node: true
       - name: Check SPI backward compatibility
@@ -81,7 +81,7 @@ jobs:
           $MAVEN clean verify -B --strict-checksums -V -T 1C -b smart -DskipTests -P ci -pl '!:trino-server-rpm'
       - name: Remove Trino from local Maven repo to avoid caching it
         # Avoid caching artifacts built in this job, cache should only include dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true' && matrix.java-version == '21'
         run: rm -rf ~/.m2/repository/io/trino/trino-*
 
   artifact-checks:
@@ -119,10 +119,6 @@ jobs:
           platforms: arm64,ppc64le
       - name: Build and Test Docker Image
         run: core/docker/build.sh
-      - name: Remove Trino from local Maven repo to avoid caching it
-        # Avoid caching artifacts built in this job, cache should only include dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: rm -rf ~/.m2/repository/io/trino/trino-*
 
   check-commits-dispatcher:
     runs-on: ubuntu-latest
@@ -960,7 +956,7 @@ jobs:
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
         with:
-          cache: restore
+          cache: 'false'
       - name: Product tests artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

* Populate the cache in the Maven Checks job
* Revert to not restoring the cache in product tests job, as it doesn't build anything and restores all required blobs from an artifact
* Only cleanup the node for JDK 22

Follow-up to f133a42e4e1df7c7dc8777edf45df71b3fa0d1b6 (merged manually from #20504)

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
