### PR TITLE
Add cache invalidation for testHiveViewsCannotBeAccessed

### DIFF
--- a/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
+++ b/plugin/trino-delta-lake/src/test/java/io/trino/plugin/deltalake/BaseDeltaLakeConnectorSmokeTest.java
@@ -519,7 +519,7 @@ public abstract class BaseDeltaLakeConnectorSmokeTest
     {
         String schemaName = "test_schema" + randomNameSuffix();
         String viewName = "dummy_view";
-        hiveHadoop.runOnHive("CREATE DATABASE " + schemaName);
+        assertUpdate("CREATE SCHEMA " + schemaName);
         hiveHadoop.runOnHive(format("CREATE VIEW %s.%s AS SELECT * FROM %s.customer", schemaName, viewName, SCHEMA));
         assertThat(computeScalar(format("SHOW TABLES FROM %s LIKE '%s'", schemaName, viewName))).isEqualTo(viewName);
         assertThatThrownBy(() -> computeActual("DESCRIBE " + schemaName + "." + viewName)).hasMessageContaining(format("%s.%s is not a Delta Lake table", schemaName, viewName));


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes https://github.com/trinodb/trino/issues/19799

Test was flaky because sometimes cache was invalidated due expiring TTL or not. It is failing continuously when for testing TTL is set to 60s and additional SHOW TABLE is added to fill cache before hive direct calls.

Change schema creation origin to Trino will make sure that cache is updated.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
