### PR TITLE
Add tenant id to configuration for Azure filesystem with OAuth

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOAuthConfig.java
@@ -20,6 +20,7 @@ import jakarta.validation.constraints.NotEmpty;
 public class AzureAuthOAuthConfig
 {
     private String clientEndpoint;
+    private String tenantId;
     private String clientId;
     private String clientSecret;
 
@@ -34,6 +35,20 @@ public class AzureAuthOAuthConfig
     public AzureAuthOAuthConfig setClientEndpoint(String clientEndpoint)
     {
         this.clientEndpoint = clientEndpoint;
+        return this;
+    }
+
+    @NotEmpty
+    public String getTenantId()
+    {
+        return tenantId;
+    }
+
+    @ConfigSecuritySensitive
+    @Config("azure.oauth.tenant-id")
+    public AzureAuthOAuthConfig setTenantId(String tenantId)
+    {
+        this.tenantId = tenantId;
         return this;
     }
 

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOauth.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthOauth.java
@@ -27,13 +27,14 @@ public class AzureAuthOauth
     @Inject
     public AzureAuthOauth(AzureAuthOAuthConfig config)
     {
-        this(config.getClientEndpoint(), config.getClientId(), config.getClientSecret());
+        this(config.getClientEndpoint(), config.getTenantId(), config.getClientId(), config.getClientSecret());
     }
 
-    public AzureAuthOauth(String clientEndpoint, String clientId, String clientSecret)
+    public AzureAuthOauth(String clientEndpoint, String tenantId, String clientId, String clientSecret)
     {
         credential = new ClientSecretCredentialBuilder()
                 .authorityHost(clientEndpoint)
+                .tenantId(tenantId)
                 .clientId(clientId)
                 .clientSecret(clientSecret)
                 .build();

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthOAuthConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureAuthOAuthConfig.java
@@ -29,6 +29,7 @@ class TestAzureAuthOAuthConfig
     {
         assertRecordedDefaults(recordDefaults(AzureAuthOAuthConfig.class)
                 .setClientEndpoint(null)
+                .setTenantId(null)
                 .setClientId(null)
                 .setClientSecret(null));
     }
@@ -38,12 +39,14 @@ class TestAzureAuthOAuthConfig
     {
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("azure.oauth.endpoint", "endpoint")
+                .put("azure.oauth.tenant-id", "tenantId")
                 .put("azure.oauth.client-id", "clientId")
                 .put("azure.oauth.secret", "secret")
                 .buildOrThrow();
 
         AzureAuthOAuthConfig expected = new AzureAuthOAuthConfig()
                 .setClientEndpoint("endpoint")
+                .setTenantId("tenantId")
                 .setClientId("clientId")
                 .setClientSecret("secret");
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The javadocs for `ClientSecretCredentialBuilder` used in `AzureAuthOauth` [say that](https://github.com/Azure/azure-sdk-for-java/blob/c9acfbacea3915edc04223f6a494e89dd288f365/sdk/identity/azure-identity/src/main/java/com/azure/identity/ClientSecretCredentialBuilder.java#L32-L46) the `tenantId` is required when configuring the azure sdk with oauth. This PR adds a config property for the `tenantId` and sets the `tenantId` in the `ClientSecretCredentialBuilder`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
