### PR TITLE
Update docker-images version to 91

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
         <dep.aws-sdk.version>1.12.659</dep.aws-sdk.version>
         <dep.cassandra.version>4.17.0</dep.cassandra.version>
         <dep.confluent.version>7.5.1</dep.confluent.version>
-        <dep.docker.images.version>90</dep.docker.images.version>
+        <dep.docker.images.version>91</dep.docker.images.version>
         <dep.drift.version>1.21</dep.drift.version>
         <dep.duct-tape.version>1.0.8</dep.duct-tape.version>
         <dep.errorprone.version>2.25.0</dep.errorprone.version>


### PR DESCRIPTION
## Description

This updates Delta Lake version to 3.1.0. 
