### PR TITLE
Enable caching metadata files in iceberg filesystem cache

### DIFF
--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioFileSystemCacheModule.java
@@ -48,7 +48,7 @@ public class AlluxioFileSystemCacheModule
         newExporter(binder).export(AlluxioCacheStats.class).as(generator -> generator.generatedNameOf(AlluxioCacheStats.class));
 
         if (isCoordinator) {
-            binder.bind(TrinoFileSystemCache.class).to(AlluxioCoordinatorNoOpFileSystemCache.class).in(SINGLETON);
+            binder.bind(TrinoFileSystemCache.class).to(AlluxioCoordinatorFileSystemCache.class).in(SINGLETON);
             newOptionalBinder(binder, CachingHostAddressProvider.class).setBinding().to(ConsistentHashingHostAddressProvider.class).in(SINGLETON);
         }
         else {

--- a/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
+++ b/lib/trino-filesystem-cache-alluxio/src/main/java/io/trino/filesystem/alluxio/AlluxioInputStream.java
@@ -36,6 +36,7 @@ import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_KEY;
 import static java.lang.Integer.max;
 import static java.lang.Math.addExact;
 import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.checkFromIndexSize;
 import static java.util.Objects.requireNonNull;
@@ -119,7 +120,7 @@ public class AlluxioInputStream
         if (position >= fileLength) {
             return -1;
         }
-        int bytesRead = doRead(bytes, offset, length);
+        int bytesRead = doRead(bytes, offset, toIntExact(min(fileLength - position, length)));
         position += bytesRead;
         return bytesRead;
     }

--- a/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
+++ b/lib/trino-filesystem-manager/src/main/java/io/trino/filesystem/manager/FileSystemModule.java
@@ -14,6 +14,7 @@
 package io.trino.filesystem.manager;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
@@ -25,6 +26,7 @@ import io.trino.filesystem.TrinoFileSystemFactory;
 import io.trino.filesystem.alluxio.AlluxioFileSystemCacheModule;
 import io.trino.filesystem.azure.AzureFileSystemFactory;
 import io.trino.filesystem.azure.AzureFileSystemModule;
+import io.trino.filesystem.cache.AllowFilesystemCacheOnCoordinator;
 import io.trino.filesystem.cache.CacheFileSystemFactory;
 import io.trino.filesystem.cache.CacheKeyProvider;
 import io.trino.filesystem.cache.CachingHostAddressProvider;
@@ -102,6 +104,7 @@ public class FileSystemModule
 
         newOptionalBinder(binder, CachingHostAddressProvider.class).setDefault().to(DefaultCachingHostAddressProvider.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, CacheKeyProvider.class).setDefault().to(DefaultCacheKeyProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, Key.get(boolean.class, AllowFilesystemCacheOnCoordinator.class)).setDefault().toInstance(false);
 
         newOptionalBinder(binder, TrinoFileSystemCache.class);
 

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/AllowFilesystemCacheOnCoordinator.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/cache/AllowFilesystemCacheOnCoordinator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.cache;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@BindingAnnotation
+public @interface AllowFilesystemCacheOnCoordinator
+{
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
+import io.trino.filesystem.cache.AllowFilesystemCacheOnCoordinator;
 import io.trino.filesystem.cache.CacheKeyProvider;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
@@ -117,6 +118,7 @@ public class IcebergModule
 
         newOptionalBinder(binder, IcebergFileSystemFactory.class).setDefault().to(DefaultIcebergFileSystemFactory.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, CacheKeyProvider.class).setBinding().to(IcebergCacheKeyProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, Key.get(boolean.class, AllowFilesystemCacheOnCoordinator.class)).setBinding().toInstance(true);
     }
 
     @Provides

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/cache/IcebergCacheKeyProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/cache/IcebergCacheKeyProvider.java
@@ -16,7 +16,6 @@ package io.trino.plugin.iceberg.cache;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.cache.CacheKeyProvider;
 
-import java.io.IOException;
 import java.util.Optional;
 
 public class IcebergCacheKeyProvider
@@ -24,8 +23,13 @@ public class IcebergCacheKeyProvider
 {
     @Override
     public Optional<String> getCacheKey(TrinoInputFile delegate)
-            throws IOException
     {
-        return Optional.of(delegate.location().path());
+        String path = delegate.location().path();
+        if (path.endsWith(".trinoSchema") || path.contains("/.trinoPermissions/")) {
+            // Needed to avoid caching files from FileHiveMetastore on coordinator during tests
+            return Optional.empty();
+        }
+        // Iceberg data and metadata files are immutable
+        return Optional.of(path);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergAlluxioCacheFileOperations.java
@@ -33,6 +33,9 @@ import java.util.Map;
 import static io.trino.filesystem.tracing.CacheSystemAttributes.CACHE_FILE_LOCATION;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
 import static io.trino.plugin.iceberg.TestIcebergFileOperations.FileType.DATA;
+import static io.trino.plugin.iceberg.TestIcebergFileOperations.FileType.MANIFEST;
+import static io.trino.plugin.iceberg.TestIcebergFileOperations.FileType.METADATA_JSON;
+import static io.trino.plugin.iceberg.TestIcebergFileOperations.FileType.SNAPSHOT;
 import static io.trino.testing.MultisetAssertions.assertMultisetsEqual;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toCollection;
@@ -61,12 +64,11 @@ public class TestIcebergAlluxioCacheFileOperations
                 .buildOrThrow();
 
         DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
-                .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
                 .setSchemaInitializer(SchemaInitializer.builder()
                         .withSchemaName(TEST_SCHEMA)
                         .build())
                 .setIcebergProperties(icebergProperties)
-                .setNodeCount(2)
+                .setNodeCount(1)
                 .build();
         queryRunner.execute("CREATE SCHEMA IF NOT EXISTS " + TEST_SCHEMA);
         return queryRunner;
@@ -85,12 +87,22 @@ public class TestIcebergAlluxioCacheFileOperations
                         .addCopies(new CacheOperation("Alluxio.readExternal", DATA), 2)
                         .addCopies(new CacheOperation("Alluxio.readCached", DATA), 2)
                         .addCopies(new CacheOperation("Alluxio.writeCache", DATA), 2)
+                        .add(new CacheOperation("Alluxio.readExternal", METADATA_JSON))
+                        .add(new CacheOperation("Alluxio.readCached", METADATA_JSON))
+                        .add(new CacheOperation("Alluxio.writeCache", METADATA_JSON))
+                        .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
+                        .add(new CacheOperation("Alluxio.readExternal", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 4)
+                        .add(new CacheOperation("Alluxio.writeCache", MANIFEST))
                         .build());
 
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
                         .addCopies(new CacheOperation("Alluxio.readCached", DATA), 2)
+                        .add(new CacheOperation("Alluxio.readCached", METADATA_JSON))
+                        .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
+                        .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 4)
                         .build());
 
         assertUpdate("INSERT INTO test_cache_file_operations VALUES ('p3', '3-xyz')", 1);
@@ -103,11 +115,21 @@ public class TestIcebergAlluxioCacheFileOperations
                         .addCopies(new CacheOperation("Alluxio.readExternal", DATA), 3)
                         .addCopies(new CacheOperation("Alluxio.readCached", DATA), 5)
                         .addCopies(new CacheOperation("Alluxio.writeCache", DATA), 3)
+                        .add(new CacheOperation("Alluxio.readExternal", METADATA_JSON))
+                        .addCopies(new CacheOperation("Alluxio.readCached", METADATA_JSON), 2)
+                        .add(new CacheOperation("Alluxio.writeCache", METADATA_JSON))
+                        .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
+                        .add(new CacheOperation("Alluxio.readExternal", MANIFEST))
+                        .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 10)
+                        .add(new CacheOperation("Alluxio.writeCache", MANIFEST))
                         .build());
         assertFileSystemAccesses(
                 "SELECT * FROM test_cache_file_operations",
                 ImmutableMultiset.<CacheOperation>builder()
                         .addCopies(new CacheOperation("Alluxio.readCached", DATA), 5)
+                        .addCopies(new CacheOperation("Alluxio.readCached", METADATA_JSON), 2)
+                        .addCopies(new CacheOperation("Alluxio.readCached", SNAPSHOT), 2)
+                        .addCopies(new CacheOperation("Alluxio.readCached", MANIFEST), 10)
                         .build());
     }
 


### PR DESCRIPTION
## Description
Enable caching metadata files in iceberg filesystem cache

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Improve latency of queries when filesystem caching is enabled. ({issue}`20803`)
```
