### PR TITLE
Enable JMX metrics for resource groups by default

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
+++ b/core/trino-main/src/main/java/io/trino/execution/resourcegroups/InternalResourceGroup.java
@@ -105,7 +105,7 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private SchedulingPolicy schedulingPolicy = FAIR;
     @GuardedBy("root")
-    private boolean jmxExport;
+    private boolean jmxExport = true;
 
     // Live data structures
     // ====================

--- a/docs/src/main/sphinx/admin/resource-groups.md
+++ b/docs/src/main/sphinx/admin/resource-groups.md
@@ -132,7 +132,7 @@ are reflected automatically for incoming queries.
   {ref}`scheduleweight-example`.
 
 - `jmxExport` (optional): If true, group statistics are exported to JMX for monitoring.
-  Defaults to `false`.
+  Defaults to `true`.
 
 - `subGroups` (optional): list of sub-groups.
 

--- a/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
+++ b/plugin/trino-resource-group-managers/src/test/java/io/trino/plugin/resourcegroups/db/TestDbResourceGroupConfigurationManager.java
@@ -118,7 +118,7 @@ public class TestDbResourceGroupConfigurationManager
         assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, Duration.ofHours(1), Duration.ofDays(1));
         InternalResourceGroup sub = global.getOrCreateSubGroup("sub");
         manager.configure(sub, new SelectionContext<>(sub.getId(), new ResourceGroupIdTemplate("global.sub")));
-        assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, false, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(Long.MAX_VALUE));
+        assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, true, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(Long.MAX_VALUE));
     }
 
     @Test
@@ -197,14 +197,14 @@ public class TestDbResourceGroupConfigurationManager
         InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub");
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new ResourceGroupIdTemplate("global.sub")));
         // Verify record exists
-        assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(Long.MAX_VALUE));
-        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", 1L, ENVIRONMENT);
+        assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, true, Duration.ofMillis(Long.MAX_VALUE), Duration.ofMillis(Long.MAX_VALUE));
+        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, false, "1h", "1d", 1L, ENVIRONMENT);
         do {
             MILLISECONDS.sleep(500);
         }
-        while (globalSub.getJmxExport() == false);
+        while (globalSub.getJmxExport() == true);
         // Verify update
-        assertEqualsResourceGroup(globalSub, "3MB", 2, 1, 1, WEIGHTED, 6, true, Duration.ofHours(1), Duration.ofDays(1));
+        assertEqualsResourceGroup(globalSub, "3MB", 2, 1, 1, WEIGHTED, 6, false, Duration.ofHours(1), Duration.ofDays(1));
         // Verify delete
         dao.deleteSelectors(2);
         dao.deleteResourceGroup(2);

--- a/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
+++ b/plugin/trino-resource-group-managers/src/test/resources/resource_groups_config.json
@@ -15,7 +15,8 @@
           "softMemoryLimit": "2MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 4,
-          "schedulingWeight": 5
+          "schedulingWeight": 5,
+          "jmxExport": false
         }
       ]
     }


### PR DESCRIPTION
<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text: "Expose resource groups metrics by default"
