### PR TITLE
Update pattern for Flaky ACID tests

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -91,7 +91,7 @@ public class TestHiveTransactionalTable
     private static final Pattern ORIGINAL_FILE_MATCHER = Pattern.compile(".*/\\d+_\\d+(_[^/]+)?$");
 
     private static final String ACID_CORRUPTION_DIRECTORY_ISSUE = "https://github.com/trinodb/trino/issues/16315";
-    private static final String ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN = "Hive table .* is corrupt. Found sub-directory in bucket directory for partition";
+    private static final String ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN = "Found file in sub-directory of ACID directory";
 
     @Inject
     private TestHiveMetastoreClientFactory testHiveMetastoreClientFactory;
@@ -99,6 +99,7 @@ public class TestHiveTransactionalTable
     @Inject
     private HdfsClient hdfsClient;
 
+    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
     public void testReadFullAcid()
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Exception message changed and currently tests are not retrying with warning:

`WARNING: not retrying; stacktrace does not match pattern 'Hive table .* is corrupt. Found sub-directory in bucket directory for partition': [io.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Query failed (#20240221_201727_00799_jrn62): Found file in sub-directory of ACID directory: hdfs://hadoop-master:9000/user/hive/warehouse/test_read_full_acid_true_none_p7a1xz1629/part_col=2/delete_delta_0000002_0000005/delete_delta_0000002_0000005/bucket_00000`

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

