### PR TITLE
Handle TrinoException in CachingIdentifierMapping

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/CachingIdentifierMapping.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/mapping/CachingIdentifierMapping.java
@@ -105,6 +105,9 @@ public final class CachingIdentifierMapping
                 return remoteSchema;
             }
         }
+        catch (TrinoException e) {
+            throw e;
+        }
         catch (RuntimeException e) {
             throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote schema name: " + firstNonNull(e.getMessage(), e), e);
         }
@@ -133,6 +136,9 @@ public final class CachingIdentifierMapping
             if (remoteTable != null) {
                 return remoteTable;
             }
+        }
+        catch (TrinoException e) {
+            throw e;
         }
         catch (RuntimeException e) {
             throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to find remote table name: " + firstNonNull(e.getMessage(), e), e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

`RemoteIdentifiers.getRemoteTables` & `getRemoteTables` could throw a Trino `JDBC_ERROR`. This PR avoids wrapping them in another `TrinoException` with `GENERIC_INTERNAL_ERROR`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
