### PR TITLE
Remove redundant lambdas from test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
@@ -25,7 +25,6 @@ import io.trino.metadata.SessionPropertyManager;
 import io.trino.sql.planner.OptimizerConfig;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestFilterHideInacessibleColumnsSession
@@ -46,7 +45,7 @@ public class TestFilterHideInacessibleColumnsSession
         FeaturesConfig featuresConfig = new FeaturesConfig();
         featuresConfig.setHideInaccessibleColumns(true);
         SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
-        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
+        sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true");
     }
 
     @Test
@@ -54,7 +53,7 @@ public class TestFilterHideInacessibleColumnsSession
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
         SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
-        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false"));
+        sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false");
     }
 
     @Test
@@ -62,7 +61,7 @@ public class TestFilterHideInacessibleColumnsSession
     {
         FeaturesConfig featuresConfig = new FeaturesConfig();
         SessionPropertyManager sessionPropertyManager = createSessionPropertyManager(featuresConfig);
-        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
+        sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true");
     }
 
     private SessionPropertyManager createSessionPropertyManager(FeaturesConfig featuresConfig)

--- a/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemGcs.java
+++ b/lib/trino-filesystem-gcs/src/test/java/io/trino/filesystem/gcs/TestGcsFileSystemGcs.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestGcsFileSystemGcs
@@ -37,17 +36,17 @@ public class TestGcsFileSystemGcs
 
     @Test
     void testCreateFileRetry()
+            throws Exception
     {
         // Note: this test is meant to expose flakiness
         // Without retries it may fail non-deterministically.
         // Retries are enabled in the default GcsFileSystemConfig.
         // In practice this may happen between 7 and 20 retries.
-        assertThatNoException().isThrownBy(() -> {
-            for (int i = 1; i <= 30; i++) {
-                TrinoOutputFile outputFile = getFileSystem().newOutputFile(getRootLocation().appendPath("testFile"));
-                try (OutputStream out = outputFile.createOrOverwrite()) {
-                    out.write("test".getBytes(UTF_8));
-                }
-            }});
+        for (int i = 1; i <= 30; i++) {
+            TrinoOutputFile outputFile = getFileSystem().newOutputFile(getRootLocation().appendPath("testFile"));
+            try (OutputStream out = outputFile.createOrOverwrite()) {
+                out.write("test".getBytes(UTF_8));
+            }
+        }
     }
 }

--- a/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
+++ b/testing/trino-product-tests-launcher/src/test/java/io/trino/tests/product/launcher/local/TestManuallyJdbcOauth2.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -27,20 +26,18 @@ import java.util.Properties;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class TestManuallyJdbcOauth2
 {
     private static void verifyEtcHostsEntries()
-            throws UnknownHostException
+            throws Exception
     {
         assertThat(InetAddress.getByName("presto-master").isLoopbackAddress()).isTrue();
         assertThat(InetAddress.getByName("hydra").isLoopbackAddress()).isTrue();
         assertThat(InetAddress.getByName("hydra-consent").isLoopbackAddress()).isTrue();
 
-        assertThatNoException()
-                .describedAs("Trino server is not available under 7778 port")
-                .isThrownBy(() -> new Socket("presto-master", 7778).close());
+        // Trino server should be available under 7778 port
+        new Socket("presto-master", 7778).close();
     }
 
     /**

--- a/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
+++ b/testing/trino-testing-services/src/test/java/io/trino/testng/services/TestReportAfterMethodNotAlwaysRun.java
@@ -20,7 +20,6 @@ import org.testng.annotations.AfterSuite;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestReportAfterMethodNotAlwaysRun
@@ -28,7 +27,7 @@ public class TestReportAfterMethodNotAlwaysRun
     @Test(dataProvider = "correctCases")
     public void testCorrectCases(Class<?> testClass)
     {
-        assertThatNoException().isThrownBy(() -> ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass));
+        ReportAfterMethodNotAlwaysRun.checkHasAfterMethodsNotAlwaysRun(testClass);
     }
 
     @DataProvider


### PR DESCRIPTION
Whole test method asserts that every line of it succeeds, so using `assertThatNoException` is redundant. Of course there could be convention to clearly separate test setup and test assertions (given-when-then), but that's not a convention we use, thuse `assertThatNoException()` is redundant.
