### PR TITLE
Ignore nested delta directories for Hive ACID

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/AcidTables.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/AcidTables.java
@@ -26,7 +26,6 @@ import io.trino.filesystem.Location;
 import io.trino.filesystem.TrinoFileSystem;
 import io.trino.filesystem.TrinoInputFile;
 import io.trino.filesystem.TrinoOutputFile;
-import io.trino.spi.TrinoException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Multimaps.asMap;
 import static io.trino.hive.thrift.metastore.hive_metastoreConstants.TABLE_IS_TRANSACTIONAL;
 import static io.trino.hive.thrift.metastore.hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES;
-import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
 import static java.lang.Integer.parseInt;
 import static java.lang.Long.parseLong;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -133,7 +131,8 @@ public final class AcidTables
 
             if (name.startsWith("base_") || name.startsWith("delta_") || name.startsWith("delete_delta_")) {
                 if (suffix.indexOf('/', slash + 1) != -1) {
-                    throw new TrinoException(HIVE_INVALID_BUCKET_FILES, "Found file in sub-directory of ACID directory: " + file.location());
+                    // Ignore nested delta directories
+                    continue;
                 }
                 groupedFiles.put(name, file);
             }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -90,23 +90,18 @@ public class TestHiveTransactionalTable
     // Older Trino path ends look like /20210416_190616_00000_fsymd_af6f0a3d-5449-4478-a53d-9f9f99c07ed9
     private static final Pattern ORIGINAL_FILE_MATCHER = Pattern.compile(".*/\\d+_\\d+(_[^/]+)?$");
 
-    private static final String ACID_CORRUPTION_DIRECTORY_ISSUE = "https://github.com/trinodb/trino/issues/16315";
-    private static final String ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN = "Found file in sub-directory of ACID directory";
-
     @Inject
     private TestHiveMetastoreClientFactory testHiveMetastoreClientFactory;
 
     @Inject
     private HdfsClient hdfsClient;
 
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
     public void testReadFullAcid()
     {
         doTestReadFullAcid(false, BucketingType.NONE);
     }
 
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
     public void testReadFullAcidBucketed()
     {
@@ -114,7 +109,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadFullAcidPartitioned()
     {
         doTestReadFullAcid(true, BucketingType.NONE);
@@ -123,20 +117,17 @@ public class TestHiveTransactionalTable
     // This test is in STORAGE_FORMATS group to ensure test coverage of transactional tables with various
     // metastore and HDFS setups (kerberized or not, impersonation or not).
     @Test(groups = {HIVE_TRANSACTIONAL, STORAGE_FORMATS, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadFullAcidPartitionedBucketed()
     {
         doTestReadFullAcid(true, BucketingType.BUCKETED_DEFAULT);
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadFullAcidBucketedV1()
     {
         doTestReadFullAcid(false, BucketingType.BUCKETED_V1);
     }
 
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
     public void testReadFullAcidBucketedV2()
     {
@@ -198,29 +189,48 @@ public class TestHiveTransactionalTable
         }
     }
 
+    @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
+    public void testTwoMinorCompactions()
+    {
+        try (TemporaryHiveTable table = TemporaryHiveTable.temporaryHiveTable("test_two_minor_compactions_" + randomNameSuffix())) {
+            String tableName = table.getName();
+            onHive().executeQuery("CREATE TABLE " + tableName + " (col INT, fcol INT) " +
+                    "STORED AS ORC " +
+                    hiveTableProperties(ACID, NONE));
+
+            onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES (22, 2)");
+            String selectFromOnePartitionsSql = "SELECT col, fcol FROM " + tableName + " ORDER BY col";
+            assertThat(onTrino().executeQuery(selectFromOnePartitionsSql)).containsExactlyInOrder(row(22, 2));
+
+            compactTableAndWait(MINOR, tableName, "", new Duration(6, MINUTES));
+            compactTableAndWait(MINOR, tableName, "", new Duration(6, MINUTES));
+            // Second compact on Hive creates duplicated directories like:
+            // ./delta_0000001_0000001/bucket_00000
+            // ./delta_0000001_0000001/delta_0000001_0000001
+            // ./delta_0000001_0000001/delta_0000001_0000001/bucket_00000
+            assertThat(onTrino().executeQuery(selectFromOnePartitionsSql)).containsExactlyInOrder(row(22, 2));
+        }
+    }
+
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "partitioningAndBucketingTypeDataProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadInsertOnlyOrc(boolean isPartitioned, BucketingType bucketingType)
     {
         testReadInsertOnly(isPartitioned, bucketingType, "STORED AS ORC");
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "partitioningAndBucketingTypeSmokeDataProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadInsertOnlyParquet(boolean isPartitioned, BucketingType bucketingType)
     {
         testReadInsertOnly(isPartitioned, bucketingType, "STORED AS PARQUET");
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "partitioningAndBucketingTypeSmokeDataProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadInsertOnlyText(boolean isPartitioned, BucketingType bucketingType)
     {
         testReadInsertOnly(isPartitioned, bucketingType, "STORED AS TEXTFILE");
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadInsertOnlyTextWithCustomFormatProperties()
     {
         testReadInsertOnly(
@@ -276,14 +286,12 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {STORAGE_FORMATS, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadFullAcidWithOriginalFilesSmoke()
     {
         testReadFullAcidWithOriginalFiles(true, BUCKETED_DEFAULT);
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "partitioningAndBucketingTypeDataProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadFullAcidWithOriginalFiles(boolean isPartitioned, BucketingType bucketingType)
     {
         String tableName = "test_full_acid_acid_converted_table_read";
@@ -436,7 +444,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "partitioningAndBucketingTypeDataProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadInsertOnlyWithOriginalFiles(boolean isPartitioned, BucketingType bucketingType)
     {
         String tableName = "test_insert_only_acid_converted_table_read";
@@ -491,7 +498,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "testCreateAcidTableDataProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testCtasAcidTable(boolean isPartitioned, BucketingType bucketingType)
     {
         try (TemporaryHiveTable table = TemporaryHiveTable.temporaryHiveTable(format("ctas_transactional_%s", randomNameSuffix()))) {
@@ -511,7 +517,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "testCreateAcidTableDataProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testCreateAcidTable(boolean isPartitioned, BucketingType bucketingType)
     {
         withTemporaryTable("create_transactional", isPartitioned, bucketingType, tableName -> {
@@ -524,7 +529,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "acidFormatColumnNames")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidTableColumnNameConflict(String columnName)
     {
         withTemporaryTable("acid_column_name_conflict", true, NONE, tableName -> {
@@ -548,7 +552,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testSimpleUnpartitionedTransactionalInsert()
     {
         withTemporaryTable("unpartitioned_transactional_insert", false, NONE, tableName -> {
@@ -571,7 +574,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testTransactionalPartitionInsert()
     {
         withTemporaryTable("transactional_partition_insert", true, NONE, tableName -> {
@@ -605,14 +607,12 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testTransactionalBucketedPartitionedInsert()
     {
         testTransactionalBucketedPartitioned(false);
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testTransactionalBucketedPartitionedInsertOnly()
     {
         testTransactionalBucketedPartitioned(true);
@@ -645,7 +645,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testTransactionalUnpartitionedDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("unpartitioned_delete", false, NONE, tableName -> {
@@ -664,7 +663,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testMultiDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("unpartitioned_multi_delete", false, NONE, tableName -> {
@@ -679,7 +677,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testReadAfterMultiInsertAndDelete()
     {
         // Test reading from a table after Hive multi-insert. Multi-insert involves non-zero statement ID, encoded
@@ -709,7 +706,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testTransactionalMetadataDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("metadata_delete", true, NONE, tableName -> {
@@ -747,7 +743,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUnpartitionedDeleteAll(Engine inserter, Engine deleter)
     {
         withTemporaryTable("unpartitioned_delete_all", false, NONE, tableName -> {
@@ -759,7 +754,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testMultiColumnDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("multi_column_delete", false, NONE, tableName -> {
@@ -772,7 +766,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testPartitionAndRowsDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("partition_and_rows_delete", true, NONE, tableName -> {
@@ -786,7 +779,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testPartitionedInsertAndRowLevelDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("partitioned_row_level_delete", true, NONE, tableName -> {
@@ -841,7 +833,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteAllRowsInPartition()
     {
         withTemporaryTable("bucketed_partitioned_delete", true, NONE, tableName -> {
@@ -859,7 +850,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteAfterDelete()
     {
         withTemporaryTable("delete_after_delete", false, NONE, tableName -> {
@@ -878,7 +868,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteAfterDeleteWithPredicate()
     {
         withTemporaryTable("delete_after_delete_predicate", false, NONE, tableName -> {
@@ -898,7 +887,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testBucketedUnpartitionedDelete(Engine inserter, Engine deleter)
     {
         withTemporaryTable("bucketed_unpartitioned_delete", true, NONE, tableName -> {
@@ -929,7 +917,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteOverManySplits()
     {
         withTemporaryTable("delete_select", false, NONE, tableName -> {
@@ -943,7 +930,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testCorrectSelectCountStar(Engine inserter, Engine deleter)
     {
         withTemporaryTable("select_count_star_delete", true, NONE, tableName -> {
@@ -956,7 +942,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "insertersProvider", timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testInsertOnlyMultipleWriters(boolean bucketed, Engine inserter1, Engine inserter2)
     {
         log.info("testInsertOnlyMultipleWriters bucketed %s, inserter1 %s, inserter2 %s", bucketed, inserter1, inserter2);
@@ -981,7 +966,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testInsertFailsInExplicitTrinoTransaction()
     {
         withTemporaryTable("insert_fail_explicit_transaction", false, NONE, tableName -> {
@@ -993,7 +977,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUpdateFailsInExplicitTrinoTransaction()
     {
         withTemporaryTable("update_fail_explicit_transaction", false, NONE, tableName -> {
@@ -1005,7 +988,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteFailsInExplicitTrinoTransaction()
     {
         withTemporaryTable("delete_fail_explicit_transaction", false, NONE, tableName -> {
@@ -1017,7 +999,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testColumnRenamesOrcPartitioned(boolean transactional)
     {
         withTemporaryTable("test_column_renames_partitioned", false, NONE, tableName -> {
@@ -1032,7 +1013,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testColumnRenamesOrcNotPartitioned(boolean transactional)
     {
         withTemporaryTable("test_orc_column_renames_not_partitioned", false, NONE, tableName -> {
@@ -1065,7 +1045,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testOrcColumnSwap(boolean transactional)
     {
         withTemporaryTable("test_orc_column_renames", false, NONE, tableName -> {
@@ -1082,7 +1061,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testBehaviorOnParquetColumnRenames()
     {
         withTemporaryTable("test_parquet_column_renames", false, NONE, tableName -> {
@@ -1105,7 +1083,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testOrcColumnDropAdd(boolean transactional)
     {
         withTemporaryTable("test_orc_add_drop", false, NONE, tableName -> {
@@ -1127,7 +1104,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, dataProvider = "transactionModeProvider")
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testOrcColumnTypeChange(boolean transactional)
     {
         withTemporaryTable("test_orc_column_type_change", false, NONE, tableName -> {
@@ -1146,7 +1122,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testParquetColumnDropAdd()
     {
         withTemporaryTable("test_parquet_add_drop", false, NONE, tableName -> {
@@ -1182,7 +1157,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateFailNonTransactional()
     {
         withTemporaryTable("update_fail_nontransactional", true, NONE, tableName -> {
@@ -1198,7 +1172,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateFailInsertOnlyTable()
     {
         withTemporaryTable("update_fail_insert_only", false, NONE, tableName -> {
@@ -1216,7 +1189,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidDeleteFailNonTransactional()
     {
         withTemporaryTable("delete_fail_nontransactional", true, NONE, tableName -> {
@@ -1232,7 +1204,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidDeleteFailInsertOnlyTable()
     {
         withTemporaryTable("delete_fail_insert_only", false, NONE, tableName -> {
@@ -1250,7 +1221,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSucceedUpdatingPartitionKey()
     {
         withTemporaryTable("fail_update_partition_key", true, NONE, tableName -> {
@@ -1268,7 +1238,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSucceedUpdatingBucketColumn()
     {
         withTemporaryTable("fail_update_bucket_column", true, NONE, tableName -> {
@@ -1286,7 +1255,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateFailOnIllegalCast()
     {
         withTemporaryTable("fail_update_on_illegal_cast", true, NONE, tableName -> {
@@ -1302,7 +1270,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSimple()
     {
         withTemporaryTable("acid_update_simple", true, NONE, tableName -> {
@@ -1317,7 +1284,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSelectedValues()
     {
         withTemporaryTable("acid_update_simple_selected", true, NONE, tableName -> {
@@ -1332,7 +1298,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateCopyColumn()
     {
         withTemporaryTable("acid_update_copy_column", true, NONE, tableName -> {
@@ -1347,7 +1312,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSomeLiteralNullColumnValues()
     {
         withTemporaryTable("update_some_literal_null_columns", true, NONE, tableName -> {
@@ -1366,7 +1330,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateSomeComputedNullColumnValues()
     {
         withTemporaryTable("update_some_computed_null_columns", true, NONE, tableName -> {
@@ -1386,7 +1349,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateAllLiteralNullColumnValues()
     {
         withTemporaryTable("update_all_literal_null_columns", true, NONE, tableName -> {
@@ -1401,7 +1363,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateAllComputedNullColumnValues()
     {
         withTemporaryTable("update_all_computed_null_columns", true, NONE, tableName -> {
@@ -1417,7 +1378,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateReversed()
     {
         withTemporaryTable("update_reversed", true, NONE, tableName -> {
@@ -1432,7 +1392,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdatePermuted()
     {
         withTemporaryTable("update_permuted", true, NONE, tableName -> {
@@ -1447,7 +1406,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateAllColumnsSetAndDependencies()
     {
         withTemporaryTable("update_all_columns_set", true, NONE, tableName -> {
@@ -1462,7 +1420,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdatePartitioned()
     {
         withTemporaryTable("update_partitioned", true, NONE, tableName -> {
@@ -1479,7 +1436,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateBucketed()
     {
         withTemporaryTable("update_bucketed", true, NONE, tableName -> {
@@ -1496,7 +1452,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateMajorCompaction()
     {
         withTemporaryTable("schema_evolution_column_addition", false, NONE, tableName -> {
@@ -1518,7 +1473,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateWithSubqueryPredicate()
     {
         withTemporaryTable("test_update_subquery", false, NONE, tableName -> {
@@ -1549,7 +1503,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateWithSubqueryAssignment()
     {
         withTemporaryTable("test_update_subquery", false, NONE, tableName -> {
@@ -1580,7 +1533,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateDuplicateUpdateValue()
     {
         withTemporaryTable("test_update_bug", false, NONE, tableName -> {
@@ -1616,7 +1568,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testAcidUpdateMultipleDuplicateValues()
     {
         withTemporaryTable("test_update_multiple", false, NONE, tableName -> {
@@ -1680,7 +1631,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteFromOriginalFiles()
     {
         withTemporaryTable("delete_original_files", true, NONE, tableName -> {
@@ -1696,14 +1646,12 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteWholePartition()
     {
         testDeleteWholePartition(false);
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteWholePartitionWithOriginalFiles()
     {
         testDeleteWholePartition(true);
@@ -1743,7 +1691,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUpdateOriginalFilesPartitioned()
     {
         withTemporaryTable("update_original_files", true, NONE, tableName -> {
@@ -1757,7 +1704,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUpdateOriginalFilesUnpartitioned()
     {
         withTemporaryTable("update_original_files", true, NONE, tableName -> {
@@ -1771,7 +1717,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS}, timeOut = TEST_TIMEOUT)
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testInsertRowIdCorrectness()
     {
         withTemporaryTable("test_insert_row_id_correctness", false, NONE, tableName -> {
@@ -1907,7 +1852,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDoubleUpdateAndThenReadFromHive()
     {
         withTemporaryTable("test_double_update", false, NONE, tableName -> {
@@ -1928,7 +1872,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteWithOriginalFiles()
     {
         withTemporaryTable("test_delete_with_original_files", false, NONE, tableName -> {
@@ -1950,7 +1893,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteWithOriginalFilesWithWhereClause()
     {
         withTemporaryTable("test_delete_with_original_files_with_where_clause", false, NONE, tableName -> {
@@ -1988,7 +1930,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testDeleteAfterMajorCompaction()
     {
         withTemporaryTable("test_delete_after_major_compaction", false, NONE, tableName -> {
@@ -2000,14 +1941,12 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUnbucketedPartitionedTransactionalTableWithTaskWriterCountGreaterThanOne()
     {
         unbucketedTransactionalTableWithTaskWriterCountGreaterThanOne(true);
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testUnbucketedTransactionalTableWithTaskWriterCountGreaterThanOne()
     {
         unbucketedTransactionalTableWithTaskWriterCountGreaterThanOne(false);
@@ -2056,7 +1995,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testLargePartitionedDelete()
     {
         withTemporaryTable("large_delete_" + "stage1", false, NONE, tableStage1 -> {
@@ -2087,7 +2025,6 @@ public class TestHiveTransactionalTable
     }
 
     @Test(groups = {HIVE_TRANSACTIONAL, PROFILE_SPECIFIC_TESTS})
-    @Flaky(issue = ACID_CORRUPTION_DIRECTORY_ISSUE, match = ACID_CORRUPTION_DIRECTORY_RETRY_PATTERN)
     public void testLargePartitionedUpdate()
     {
         withTemporaryTable("large_update_" + "stage1", false, NONE, tableStage1 -> {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Fixes: https://github.com/trinodb/trino/issues/16315
Related: https://github.com/trinodb/trino/issues/8920

Multiple Hive minor compaction creates duplicated directoires like:
```
./delta_0000001_0000001/bucket_00000
./delta_0000001_0000001/delta_0000001_0000001
./delta_0000001_0000001/delta_0000001_0000001/bucket_00000
```
Hive is able to read such table without problem, ignoring nested delta directories. This change follows Hive behaviour.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
