### PR TITLE
Implement Query Info Pruned Endpoint

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -1364,7 +1364,12 @@ public class QueryStateMachine
             return;
         }
 
-        QueryInfo queryInfo = finalInfo.get();
+        QueryInfo prunedQueryInfo = QueryStateMachine.pruneQueryInfo(finalInfo.get(), version);
+        finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
+    }
+
+    public static QueryInfo pruneQueryInfo(QueryInfo queryInfo, NodeVersion version)
+    {
         Optional<StageInfo> prunedOutputStage = queryInfo.getOutputStage().map(outputStage -> new StageInfo(
                 outputStage.getStageId(),
                 outputStage.getState(),
@@ -1377,7 +1382,7 @@ public class QueryStateMachine
                 ImmutableMap.of(), // Remove tables
                 outputStage.getFailureCause()));
 
-        QueryInfo prunedQueryInfo = new QueryInfo(
+        return new QueryInfo(
                 queryInfo.getQueryId(),
                 queryInfo.getSession(),
                 queryInfo.getState(),
@@ -1413,7 +1418,6 @@ public class QueryStateMachine
                 queryInfo.getRetryPolicy(),
                 true,
                 version);
-        finalQueryInfo.compareAndSet(finalInfo, Optional.of(prunedQueryInfo));
     }
 
     private static QueryStats pruneQueryStats(QueryStats queryStats)

--- a/core/trino-main/src/main/java/io/trino/server/QueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryResource.java
@@ -25,6 +25,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.security.AccessDeniedException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.PUT;
@@ -43,6 +44,7 @@ import java.util.Optional;
 
 import static io.trino.connector.system.KillQueryProcedure.createKillQueryException;
 import static io.trino.connector.system.KillQueryProcedure.createPreemptQueryException;
+import static io.trino.execution.QueryStateMachine.pruneQueryInfo;
 import static io.trino.security.AccessControlUtil.checkCanKillQueryOwnedBy;
 import static io.trino.security.AccessControlUtil.checkCanViewQueryOwnedBy;
 import static io.trino.security.AccessControlUtil.filterQueries;
@@ -88,11 +90,12 @@ public class QueryResource
     @ResourceSecurity(AUTHENTICATED_USER)
     @GET
     @Path("{queryId}")
-    public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
+    public Response getQueryInfo(@PathParam("queryId") QueryId queryId, @QueryParam("pruned") @DefaultValue("false") boolean pruned, @Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
     {
         requireNonNull(queryId, "queryId is null");
 
-        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
+        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId)
+                .map(info -> pruned ? pruneQueryInfo(info, info.getVersion()) : info);
         if (queryInfo.isEmpty()) {
             return Response.status(Status.GONE).build();
         }

--- a/core/trino-main/src/main/resources/webapp/references.html
+++ b/core/trino-main/src/main/resources/webapp/references.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="References - Trino">
+    <title>References - Trino</title>
+
+    <link rel="icon" href="assets/favicon.ico">
+
+    <!-- Bootstrap core -->
+    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+
+    <!-- jQuery -->
+    <script type="text/javascript" src="vendor/jquery/jquery-3.5.1.min.js"></script>
+
+    <!-- Bootstrap JS -->
+    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+
+    <!-- Sparkline -->
+    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+
+    <!-- Code highlighting -->
+    <link rel="stylesheet" href="vendor/highlightjs/9.3/styles/solarized-dark.css">
+    <script src="vendor/highlightjs/9.3/highlight.pack.js"></script>
+
+    <!-- Clipboard -->
+    <script src="vendor/clipboardjs/clipboard.min.js"></script>
+
+    <!-- CSS loader -->
+    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="assets/trino.css" rel="stylesheet">
+</head>
+
+<body>
+
+<div class="container">
+    <div id="title"></div>
+
+    <div id="references"><div class="loader">Loading...</div></div>
+
+</div> <!-- /container -->
+
+<script type="text/javascript" src="dist/references.js"></script>
+
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+
+</body>
+</html>
+
+</html>

--- a/core/trino-main/src/main/resources/webapp/src/components/QueryHeader.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryHeader.jsx
@@ -102,6 +102,8 @@ export class QueryHeader extends React.Component {
                                     {this.renderTab("timeline.html", "Splits")}
                                     &nbsp;
                                     <a href={"/ui/api/query/" + query.queryId + "?pretty"} className="btn btn-info navbar-btn" target="_blank">JSON</a>
+                                    &nbsp;
+                                    {this.renderTab("references.html", "References")}
                                 </td>
                             </tr>
                             </tbody>

--- a/core/trino-main/src/main/resources/webapp/src/components/ReferenceDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/ReferenceDetail.jsx
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+import {
+    formatCount,
+    formatDataSize,
+    formatDuration,
+    getChildren,
+    getFirstParameter,
+    getTaskNumber,
+    initializeGraph,
+    initializeSvg,
+    isQueryEnded,
+    parseAndFormatDataSize,
+    parseDataSize,
+    parseDuration
+} from "../utils";
+import {QueryHeader} from "./QueryHeader";
+
+export class ReferenceDetail extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            initialized: false,
+            ended: false,
+            query: null,
+        };
+
+        this.refreshLoop = this.refreshLoop.bind(this);
+    }
+
+    resetTimer() {
+        clearTimeout(this.timeoutId);
+        // stop refreshing when query finishes or fails
+        if (this.state.query === null || !this.state.ended) {
+            this.timeoutId = setTimeout(this.refreshLoop, 1000);
+        }
+    }
+
+    refreshLoop() {
+        clearTimeout(this.timeoutId); // to stop multiple series of refreshLoop from going on simultaneously
+        const queryString = getFirstParameter(window.location.search).split('.');
+        const queryId = queryString[0];
+
+        $.get('/ui/api/query/' + queryId + "?pruned=true", query => {
+            this.setState({
+                initialized: true,
+                ended: query.finalQueryInfo,
+                query: query,
+            });
+            this.resetTimer();
+        }).fail(() => {
+            this.setState({
+                initialized: true,
+            });
+            this.resetTimer();
+        });
+    }
+
+    componentDidMount() {
+        this.refreshLoop();
+    }
+
+    renderReferencedTables(tables) {
+            if (!tables || tables.length === 0) {
+                return (
+                    <div>
+                        <h3>Referenced Tables</h3>
+                        <hr className="h3-hr"/>
+                        <tr>
+                            <td className="info-text wrap-text">
+                                <pr>No referenced tables.</pr>
+                            </td>
+                        </tr>
+                    </div>
+                );
+            }
+            return (
+                <div>
+                    <h3>Referenced Tables</h3>
+                    <hr className="h3-hr"/>
+                    <table className="table">
+                        <tbody>
+                        {tables.map(table => (
+                            <tr>
+                                <td className="info-text wrap-text">
+                                    <pr>{`${table.catalog}.${table.schema}.${table.table} (Authorization: ${table.authorization}, Directly Referenced: ${table.directlyReferenced})`}</pr>
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+                </div>
+            );
+        }
+
+        renderRoutines(routines) {
+            if (!routines || routines.length === 0) {
+                return (
+                    <div>
+                        <h3>Routines</h3>
+                        <hr className="h3-hr"/>
+                        <tr>
+                            <td className="info-text wrap-text">
+                                <pr>No referenced routines.</pr>
+                            </td>
+                        </tr>
+                    </div>
+                );
+            }
+            return (
+                <div>
+                    <h3>Routines</h3>
+                    <hr className="h3-hr"/>
+                    <table className="table">
+                        <tbody>
+                        {routines.map(routine => (
+                            <tr>
+                                <td className="info-text wrap-text">
+                                    <pr>{`${routine.routine} (Authorization: ${routine.authorization})`}</pr>
+                                </td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+                </div>
+            );
+        }
+
+        render() {
+            const { query, jsonData, initialized } = this.state;
+            if (!query) {
+                let label = initialized ? "Query not found" : <div className="loader">Loading...</div>;
+                return (
+                    <div className="row error-message">
+                        <div className="col-xs-12"><h4>{label}</h4></div>
+                    </div>
+                );
+            }
+
+            const referencedTables = query.referencedTables || [];
+            const routines = query.routines || [];
+
+            let referencesData = this.state.ended ? (
+                <div className="col-xs-12">
+                    {this.renderReferencedTables(referencedTables)}
+                    {this.renderRoutines(routines)}
+                </div>
+            ) : (
+                <div className="row error-message">
+                    <div className="col-xs-12">
+                        <h4>References will appear automatically when query completes.</h4>
+                        <div className="loader">Loading...</div>
+                    </div>
+                </div>
+            );
+
+            return (
+                <div>
+                    <QueryHeader query={query}/>
+                    <hr className="h3-hr"/>
+                    <div className="row">
+                        <div className="col-xs-12">
+                            {referencesData}
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+}

--- a/core/trino-main/src/main/resources/webapp/src/references.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/references.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import {PageTitle} from "./components/PageTitle";
+import {ReferenceDetail} from "./components/ReferenceDetail";
+
+ReactDOM.render(
+    <PageTitle title="References" />,
+    document.getElementById('title')
+);
+
+ReactDOM.render(
+    <ReferenceDetail />,
+    document.getElementById('references')
+);

--- a/core/trino-main/src/main/resources/webapp/src/webpack.config.js
+++ b/core/trino-main/src/main/resources/webapp/src/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
         'query': __dirname +'/query.jsx',
         'plan': __dirname +'/plan.jsx',
         'embedded_plan': __dirname +'/embedded_plan.jsx',
+        'references': __dirname +'/references.jsx',
         'stage': __dirname +'/stage.jsx',
         'worker': __dirname +'/worker.jsx',
         'workers': __dirname +'/workers.jsx',


### PR DESCRIPTION
## Description
This PR extends the Info endpoint on QueryResource - with the boolean parameter `pruned` which returns a lightweight version of QueryInfo, by pruning the StageInfo object graph.


## Additional context and related issues
The QueryInfo object returned by the QueryInfo endpoint can be very big and take a lot of memory, as it contains the entire plan, all the tasks, and all the buffers involved in the tasks, even though this data may not always be relevant.

On the `QueryStateMachine` class there is already a method available to prune the `QueryInfo` object, which this new endpoint leverages.

### Usage
An external system which is in charge of submitting queries to Trino can rely on this endpoint to understand which tables and routines have been used by each query, with a response that is manageable in terms of memory. This data powers analytical use cases e.g. understanding which are the most popular datasets, what is the adoption of a given function, etc. 
To showcase the utility of this endpoint, this PR also includes the implementation of a new page on Trino UI which shows Referenced Tables and Routines.

![image](https://github.com/trinodb/trino/assets/15678584/99e3a4b8-fa71-4c0a-ba84-2afbef56c3c3)

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( x ) Release notes are required, with the following suggested text:

```markdown
# General
* Add boolean query parameter to the QueryInfo endpoint that returns a lightweight response, by pruning the StageInfo object, with route `/v1/query/{queryId}?pruned=true` 
```
