### PR TITLE
Fix temporal predicates in MVs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -262,6 +262,7 @@ public class Analysis
     private final Map<NodeRef<TableFunctionInvocation>, TableFunctionInvocationAnalysis> tableFunctionAnalyses = new LinkedHashMap<>();
     private final Set<NodeRef<Relation>> aliasedRelations = new LinkedHashSet<>();
     private final Set<NodeRef<TableFunctionInvocation>> polymorphicTableFunctions = new LinkedHashSet<>();
+    private final Map<NodeRef<Table>, List<Field>> materializedViewStorageTableFields = new LinkedHashMap<>();
 
     public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, QueryType queryType)
     {
@@ -1381,6 +1382,16 @@ public class Analysis
     public void addResolvedLabels(Map<NodeRef<Identifier>, String> labels)
     {
         resolvedLabels.putAll(labels);
+    }
+
+    public List<Field> getMaterializedViewStorageTableFields(Table node)
+    {
+        return materializedViewStorageTableFields.get(NodeRef.of(node));
+    }
+
+    public void setMaterializedViewStorageTableFields(Table node, List<Field> fields)
+    {
+        materializedViewStorageTableFields.put(NodeRef.of(node), fields);
     }
 
     @Immutable

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2562,14 +2562,10 @@ class StatementAnalyzer
 
             if (storageTable.isPresent()) {
                 List<Field> storageTableFields = analyzeStorageTable(table, viewFields, storageTable.get());
-                Scope accessControlScope = Scope.builder()
-                        .withRelationType(RelationId.anonymous(), new RelationType(viewFields))
-                        .build();
-                analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
-                analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
-                analysis.addRelationCoercion(table, viewFields.stream().map(Field::getType).toArray(Type[]::new));
-                // use storage table output fields as they contain ColumnHandles
-                return createAndAssignScope(table, scope, storageTableFields);
+                analysis.setMaterializedViewStorageTableFields(table, storageTableFields);
+            }
+            else {
+                analysis.registerNamedQuery(table, query);
             }
 
             Scope accessControlScope = Scope.builder()
@@ -2578,7 +2574,6 @@ class StatementAnalyzer
             analyzeFiltersAndMasks(table, name, new RelationType(viewFields), accessControlScope);
             analysis.registerTable(table, storageTable, name, session.getIdentity().getUser(), accessControlScope, Optional.of(originalSql));
             viewFields.forEach(field -> analysis.addSourceColumns(field, ImmutableSet.of(new SourceColumn(name, field.getName().orElseThrow()))));
-            analysis.registerNamedQuery(table, query);
             return createAndAssignScope(table, scope, viewFields);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -151,6 +151,7 @@ import io.trino.sql.tree.Values;
 import io.trino.sql.tree.VariableDefinition;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -311,7 +312,13 @@ class RelationPlanner
 
             ImmutableList.Builder<Symbol> outputSymbolsBuilder = ImmutableList.builder();
             ImmutableMap.Builder<Symbol, ColumnHandle> columns = ImmutableMap.builder();
-            for (Field field : scope.getRelationType().getAllFields()) {
+
+            Collection<Field> fields = analysis.getMaterializedViewStorageTableFields(node);
+            boolean hasStorageTableFields = fields != null;
+            if (!hasStorageTableFields) {
+                fields = scope.getRelationType().getAllFields();
+            }
+            for (Field field : fields) {
                 Symbol symbol = symbolAllocator.newSymbol(field);
 
                 outputSymbolsBuilder.add(symbol);
@@ -324,8 +331,10 @@ class RelationPlanner
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);
 
-            List<Type> types = analysis.getRelationCoercion(node);
-            if (types != null) {
+            if (hasStorageTableFields) {
+                List<Type> types = scope.getRelationType().getAllFields().stream()
+                        .map(Field::getType)
+                        .collect(toImmutableList());
                 // apply required coercion and prune invisible fields from child outputs
                 NodeAndMappings coerced = coerce(plan, types, symbolAllocator, idAllocator);
                 plan = new RelationPlan(coerced.getNode(), scope, coerced.getFields(), outerContext);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Temporal predicates in some MVs work differently before and after refresh. This is because for some connectors, the storage table uses a varchar instead of the original temporal type. Before a refresh, we use the original `RelationType`, but after we use the storage table's `RelationType`.

This ensures we correct the `ResolvedField`'s type according to the registered `relationCoercion`, which was previously unused by the `ExpressionAnalyzer`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

This issue was raised as a starburst jira ticket.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
