### PR TITLE
WIP: Test Upcoming Iceberg and Nessie versions

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <!-- Nessie version (matching to Iceberg release) must be bumped along with Iceberg version bump to avoid compatibility issues -->
-        <dep.nessie.version>0.71.1</dep.nessie.version>
+        <dep.nessie.version>0.77.1</dep.nessie.version>
     </properties>
 
     <dependencies>
@@ -239,12 +239,32 @@
             <groupId>org.projectnessie.nessie</groupId>
             <artifactId>nessie-client</artifactId>
             <version>${dep.nessie.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.projectnessie.nessie</groupId>
             <artifactId>nessie-model</artifactId>
             <version>${dep.nessie.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -332,7 +352,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.2.3</version>
+            <version>5.3.1</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieCatalogModule.java
@@ -22,9 +22,9 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.iceberg.catalog.IcebergTableOperationsProvider;
 import io.trino.plugin.iceberg.catalog.TrinoCatalogFactory;
 import org.apache.iceberg.nessie.NessieIcebergClient;
+import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.auth.BearerAuthenticationProvider;
-import org.projectnessie.client.http.HttpClientBuilder;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.lang.Math.toIntExact;
@@ -47,7 +47,7 @@ public class IcebergNessieCatalogModule
     @Singleton
     public static NessieIcebergClient createNessieIcebergClient(IcebergNessieCatalogConfig icebergNessieCatalogConfig)
     {
-        HttpClientBuilder builder = HttpClientBuilder.builder()
+        NessieClientBuilder builder = NessieClientBuilder.createClientBuilderFromSystemSettings()
                 .withUri(icebergNessieCatalogConfig.getServerUri())
                 .withDisableCompression(!icebergNessieCatalogConfig.isCompressionEnabled())
                 .withReadTimeout(toIntExact(icebergNessieCatalogConfig.getReadTimeout().toMillis()))

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergFileOperations.java
@@ -183,6 +183,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "OutputFile.createOrOverwrite"))
                         .add(new FileOperation(MANIFEST, "OutputFile.createOrOverwrite"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .add(new FileOperation(STATS, "OutputFile.create"))
                         .build());
     }
@@ -197,6 +198,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -223,6 +225,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), min(icebergManifestPrefetching, numberOfFiles))
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), min(icebergManifestPrefetching, numberOfFiles))
                         .build());
 
         assertFileSystemAccesses("EXPLAIN SELECT * FROM test_select_with_limit LIMIT 3",
@@ -231,6 +234,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), numberOfFiles)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), numberOfFiles)
                         .build());
 
         assertFileSystemAccesses("EXPLAIN ANALYZE SELECT * FROM test_select_with_limit LIMIT 3",
@@ -239,6 +243,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), numberOfFiles + min(icebergManifestPrefetching, numberOfFiles))
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), numberOfFiles + min(icebergManifestPrefetching, numberOfFiles))
                         .build());
 
         assertUpdate("DROP TABLE test_select_with_limit");
@@ -271,6 +276,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -283,6 +289,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -294,6 +301,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -305,6 +313,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -319,6 +328,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -355,6 +365,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -367,6 +378,7 @@ public class TestIcebergFileOperations
                 ALL_FILES,
                 ImmutableMultiset.<FileOperation>builder()
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .add(new FileOperation(METADATA_JSON, "InputFile.newStream"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
@@ -397,6 +409,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
         assertFileSystemAccesses("SELECT * FROM " + tableName + " FOR VERSION AS OF " + v3SnapshotId,
                 ImmutableMultiset.<FileOperation>builder()
@@ -404,6 +417,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .build());
         assertFileSystemAccesses("SELECT * FROM " + tableName,
                 ImmutableMultiset.<FileOperation>builder()
@@ -411,6 +425,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .build());
     }
 
@@ -437,6 +452,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
         assertFileSystemAccesses("SELECT * FROM " + tableName + " FOR VERSION AS OF " + v3SnapshotId,
                 ImmutableMultiset.<FileOperation>builder()
@@ -444,6 +460,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .build());
         assertFileSystemAccesses("SELECT * FROM " + tableName,
                 ImmutableMultiset.<FileOperation>builder()
@@ -451,6 +468,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .build());
     }
 
@@ -464,6 +482,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -479,6 +498,7 @@ public class TestIcebergFileOperations
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 2)
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 2)
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 4)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 4)
                         .build());
     }
 
@@ -496,6 +516,7 @@ public class TestIcebergFileOperations
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 2)
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 2)
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 4)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 4)
                         .build());
     }
 
@@ -510,6 +531,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -524,6 +546,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -540,6 +563,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -554,6 +578,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream"))
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
     }
 
@@ -570,6 +595,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 2)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 2)
                         .build());
 
         // CAST to date and comparison
@@ -579,6 +605,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream")) // fewer than without filter
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
 
         // CAST to date and BETWEEN
@@ -588,6 +615,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream")) // fewer than without filter
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
 
         // conversion to date as a date function
@@ -597,6 +625,7 @@ public class TestIcebergFileOperations
                         .add(new FileOperation(SNAPSHOT, "InputFile.length"))
                         .add(new FileOperation(SNAPSHOT, "InputFile.newStream"))
                         .add(new FileOperation(MANIFEST, "InputFile.newStream")) // fewer than without filter
+                        .add(new FileOperation(MANIFEST, "InputFile.length"))
                         .build());
 
         assertUpdate("DROP TABLE test_varchar_as_date_predicate");
@@ -622,6 +651,7 @@ public class TestIcebergFileOperations
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.length"), 4)
                         .addCopies(new FileOperation(SNAPSHOT, "InputFile.newStream"), 4)
                         .addCopies(new FileOperation(MANIFEST, "InputFile.newStream"), 5)
+                        .addCopies(new FileOperation(MANIFEST, "InputFile.length"), 5)
                         .build());
 
         assertUpdate("DROP TABLE " + tableName);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/nessie/TestTrinoNessieCatalog.java
@@ -36,8 +36,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
+import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.api.NessieApiV1;
-import org.projectnessie.client.http.HttpClientBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,7 +94,7 @@ public class TestTrinoNessieCatalog
         TrinoFileSystemFactory fileSystemFactory = new HdfsFileSystemFactory(HDFS_ENVIRONMENT, HDFS_FILE_SYSTEM_STATS);
         IcebergNessieCatalogConfig icebergNessieCatalogConfig = new IcebergNessieCatalogConfig()
                 .setServerUri(URI.create(nessieContainer.getRestApiUri()));
-        NessieApiV1 nessieApi = HttpClientBuilder.builder()
+        NessieApiV1 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
                 .withUri(nessieContainer.getRestApiUri())
                 .build(NessieApiV1.class);
         NessieIcebergClient nessieClient = new NessieIcebergClient(nessieApi, icebergNessieCatalogConfig.getDefaultReferenceName(), null, ImmutableMap.of());
@@ -118,7 +118,7 @@ public class TestTrinoNessieCatalog
         IcebergNessieCatalogConfig icebergNessieCatalogConfig = new IcebergNessieCatalogConfig()
                 .setDefaultWarehouseDir(tmpDirectory.toAbsolutePath().toString())
                 .setServerUri(URI.create(nessieContainer.getRestApiUri()));
-        NessieApiV1 nessieApi = HttpClientBuilder.builder()
+        NessieApiV1 nessieApi = NessieClientBuilder.createClientBuilderFromSystemSettings()
                 .withUri(nessieContainer.getRestApiUri())
                 .build(NessieApiV1.class);
         NessieIcebergClient nessieClient = new NessieIcebergClient(nessieApi, icebergNessieCatalogConfig.getDefaultReferenceName(), null, ImmutableMap.of());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/rest/TestIcebergTrinoRestCatalogConnectorSmokeTest.java
@@ -185,14 +185,6 @@ public class TestIcebergTrinoRestCatalogConnectorSmokeTest
 
     @Test
     @Override
-    public void testDropTableWithMissingDataFile()
-    {
-        assertThatThrownBy(super::testDropTableWithMissingDataFile)
-                .hasMessageContaining("Table location should not exist");
-    }
-
-    @Test
-    @Override
     public void testDropTableWithNonExistentTableLocation()
     {
         assertThatThrownBy(super::testDropTableWithNonExistentTableLocation)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/containers/NessieContainer.java
@@ -28,9 +28,9 @@ public class NessieContainer
 {
     private static final Logger log = Logger.get(NessieContainer.class);
 
-    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.71.1";
+    public static final String DEFAULT_IMAGE = "ghcr.io/projectnessie/nessie:0.77.1";
     public static final String DEFAULT_HOST_NAME = "nessie";
-    public static final String VERSION_STORE_TYPE = "INMEMORY";
+    public static final String VERSION_STORE_TYPE = "IN_MEMORY";
 
     public static final int PORT = 19121;
 

--- a/plugin/trino-iceberg/src/test/java/org/apache/iceberg/jdbc/TestingTrinoIcebergJdbcUtil.java
+++ b/plugin/trino-iceberg/src/test/java/org/apache/iceberg/jdbc/TestingTrinoIcebergJdbcUtil.java
@@ -16,8 +16,8 @@ package org.apache.iceberg.jdbc;
 
 public final class TestingTrinoIcebergJdbcUtil
 {
-    public static final String CREATE_CATALOG_TABLE = JdbcUtil.CREATE_CATALOG_TABLE;
-    public static final String CREATE_NAMESPACE_PROPERTIES_TABLE = JdbcUtil.CREATE_NAMESPACE_PROPERTIES_TABLE;
+    public static final String CREATE_CATALOG_TABLE = JdbcUtil.V0_CREATE_CATALOG_SQL;
+    public static final String CREATE_NAMESPACE_PROPERTIES_TABLE = JdbcUtil.CREATE_NAMESPACE_PROPERTIES_TABLE_SQL;
 
     private TestingTrinoIcebergJdbcUtil() {}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,8 @@
         <dep.errorprone.version>2.25.0</dep.errorprone.version>
         <dep.flyway.version>10.8.1</dep.flyway.version>
         <dep.google.http.client.version>1.44.1</dep.google.http.client.version>
-        <dep.iceberg.version>1.4.3</dep.iceberg.version>
+        <!-- Uses the RC4 (1158) from the repository -->
+        <dep.iceberg.version>1.5.0</dep.iceberg.version>
         <dep.jna.version>5.14.0</dep.jna.version>
         <dep.joda.version>2.12.7</dep.joda.version>
         <dep.jsonwebtoken.version>0.12.5</dep.jsonwebtoken.version>
@@ -2260,6 +2261,14 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <repositories>
+        <repository>
+            <id>iceberg-release-candidate</id>
+            <name>Iceberg Release Candidate</name>
+            <url>https://repository.apache.org/content/repositories/orgapacheiceberg-1158/</url>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement>

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/EnvSinglenodeSparkIcebergNessie.java
@@ -43,7 +43,7 @@ public class EnvSinglenodeSparkIcebergNessie
 
     private static final int SPARK_THRIFT_PORT = 10213;
     private static final int NESSIE_PORT = 19120;
-    private static final String NESSIE_VERSION = "0.71.1";
+    private static final String NESSIE_VERSION = "0.77.1";
     private static final String SPARK = "spark";
 
     private final DockerFiles dockerFiles;
@@ -99,8 +99,8 @@ public class EnvSinglenodeSparkIcebergNessie
 
     private DockerContainer createNessieContainer()
     {
-        DockerContainer container = new DockerContainer("projectnessie/nessie:" + NESSIE_VERSION, "nessie-server")
-                .withEnv("NESSIE_VERSION_STORE_TYPE", "INMEMORY")
+        DockerContainer container = new DockerContainer("ghcr.io/projectnessie/nessie:" + NESSIE_VERSION, "nessie-server")
+                .withEnv("NESSIE_VERSION_STORE_TYPE", "IN_MEMORY")
                 .withEnv("QUARKUS_HTTP_PORT", Integer.valueOf(NESSIE_PORT).toString())
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
                 .waitingFor(forSelectedPorts(NESSIE_PORT));


### PR DESCRIPTION
- Testing with Iceberg 1.5.0 RC4 and Nessie 0.77.1
- Remove deprecated usage
- InputFile.length is being called since https://github.com/apache/iceberg/pull/9592
- Handle JDBC catalog test failures

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:
