### PR TITLE
Run minimum test for BigQuery proxy

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -527,7 +527,7 @@
                                 <exclude>**/TestBigQueryInstanceCleaner.java</exclude>
                                 <exclude>**/TestBigQueryCaseInsensitiveMapping.java</exclude>
                                 <exclude>**/TestBigQuery*FailureRecoveryTest.java</exclude>
-                                <exclude>**/TestBigQueryWithProxyConnectorSmokeTest.java</exclude>
+                                <exclude>**/TestBigQueryWithProxyTest.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -596,7 +596,7 @@
                             <includes>
                                 <include>**/TestBigQueryArrowConnectorSmokeTest.java</include>
                                 <include>**/TestBigQueryWithDifferentProjectIdConnectorSmokeTest.java</include>
-                                <include>**/TestBigQueryWithProxyConnectorSmokeTest.java</include>
+                                <include>**/TestBigQueryWithProxyTest.java</include>
                                 <include>**/TestBigQueryArrowTypeMapping.java</include>
                                 <include>**/TestBigQueryAvroTypeMapping.java</include>
                                 <include>**/TestBigQueryMetadataCaching.java</include>

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithProxyTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryWithProxyTest.java
@@ -14,15 +14,19 @@
 package io.trino.plugin.bigquery;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
+import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.containers.MitmProxy;
+import io.trino.testing.sql.TestTable;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.net.URISyntaxException;
 
-public class TestBigQueryWithProxyConnectorSmokeTest
-        extends BaseBigQueryConnectorSmokeTest
+public class TestBigQueryWithProxyTest
+        extends AbstractTestQueryFramework
 {
     @Override
     protected QueryRunner createQueryRunner()
@@ -39,9 +43,18 @@ public class TestBigQueryWithProxyConnectorSmokeTest
                         "bigquery.rpc-proxy.uri", proxy.getProxyEndpoint(),
                         "bigquery.rpc-proxy.truststore-path", fromResources("proxy/truststore.jks").getAbsolutePath(),
                         "bigquery.rpc-proxy.truststore-password", "123456"),
-                REQUIRED_TPCH_TABLES);
+                ImmutableSet.of());
 
         return queryRunner;
+    }
+
+    @Test
+    void testCreateTableAsSelect()
+    {
+        // This test covers all client (BigQuery, BigQueryReadClient and BigQueryWriteClient)
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test.test_ctas", "AS SELECT 42 x")) {
+            assertQuery("SELECT * FROM " + table.getName(), "VALUES 42");
+        }
     }
 
     private static File fromResources(String filename)


### PR DESCRIPTION
## Description

This reduces the number of CreateWriteStreamRequest to 6 from 42 in the test. 
