### PR TITLE
Allow to define multiple retry strategies for JDBC connection

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionFactoryModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RetryingConnectionFactoryModule.java
@@ -18,7 +18,7 @@ import com.google.inject.Scopes;
 import io.trino.plugin.jdbc.RetryingConnectionFactory.DefaultRetryStrategy;
 import io.trino.plugin.jdbc.RetryingConnectionFactory.RetryStrategy;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 
 public class RetryingConnectionFactoryModule
         extends AbstractModule
@@ -27,9 +27,6 @@ public class RetryingConnectionFactoryModule
     public void configure()
     {
         bind(RetryingConnectionFactory.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder(), RetryStrategy.class)
-                .setDefault()
-                .to(DefaultRetryStrategy.class)
-                .in(Scopes.SINGLETON);
+        newSetBinder(binder(), RetryStrategy.class).addBinding().to(DefaultRetryStrategy.class).in(Scopes.SINGLETON);
     }
 }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClientModule.java
@@ -55,7 +55,7 @@ public class OracleClientModule
         configBinder(binder).bindConfig(OracleConfig.class);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class)).setBinding().toInstance(ORACLE_MAX_LIST_EXPRESSIONS);
         newSetBinder(binder, ConnectorTableFunction.class).addBinding().toProvider(Query.class).in(Scopes.SINGLETON);
-        newOptionalBinder(binder, RetryStrategy.class).setBinding().to(OracleRetryStrategy.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, RetryStrategy.class).addBinding().to(OracleRetryStrategy.class).in(Scopes.SINGLETON);
     }
 
     @Provides

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.oracle;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
@@ -128,7 +129,7 @@ public class TestingOracleServer
     {
         StatisticsAwareConnectionFactory connectionFactory = new StatisticsAwareConnectionFactory(
                 DriverConnectionFactory.builder(new OracleDriver(), connectionUrl, StaticCredentialProvider.of(username, password)).build());
-        return new RetryingConnectionFactory(connectionFactory, new DefaultRetryStrategy());
+        return new RetryingConnectionFactory(connectionFactory, ImmutableSet.of(new DefaultRetryStrategy()));
     }
 
     @Override


### PR DESCRIPTION
Allow to define multiple retry strategies for JDBC connection

Thanks to that now Oracle connector will retry opening a JDBC connection on
any SQLRecoverableException or SQLTransientException. Previously it
retried only on the former.
