### PR TITLE
Implement `metadata_delete_after_commit_enabled `and `metadata_previous_versions_max` for Iceberg table.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -271,6 +271,8 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.DATA_LOCATION_PROPE
 import static io.trino.plugin.iceberg.IcebergTableProperties.EXTRA_PROPERTIES_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.OBJECT_STORE_LAYOUT_ENABLED_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.SORTED_BY_PROPERTY;
@@ -359,6 +361,8 @@ import static org.apache.iceberg.SnapshotSummary.TOTAL_RECORDS_PROP;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_ENABLED;
 import static org.apache.iceberg.TableProperties.WRITE_DATA_LOCATION;
 import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
@@ -383,6 +387,8 @@ public class IcebergMetadata
             .add(OBJECT_STORE_LAYOUT_ENABLED_PROPERTY)
             .add(DATA_LOCATION_PROPERTY)
             .add(PARTITIONING_PROPERTY)
+            .add(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)
+            .add(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)
             .add(SORTED_BY_PROPERTY)
             .build();
 
@@ -2176,6 +2182,17 @@ public class IcebergMetadata
                     Optional.of(Boolean.parseBoolean(icebergTable.properties().get(OBJECT_STORE_ENABLED)))).orElseThrow();
             if (!objectStoreEnabled) {
                 throw new TrinoException(INVALID_TABLE_PROPERTY, "Data location can only be set when object store layout is enabled");
+            }
+            if (properties.containsKey(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)) {
+                boolean commitEnabled = (boolean) properties.get(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)
+                        .orElseThrow(() -> new IllegalArgumentException("The metadata_delete_after_commit_enabled property cannot be empty"));
+                updateProperties.set(METADATA_DELETE_AFTER_COMMIT_ENABLED, String.valueOf(commitEnabled));
+            }
+
+            if (properties.containsKey(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)) {
+                int metadataPerviousVersionMax = (int) properties.get(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)
+                        .orElseThrow(() -> new IllegalArgumentException("The metadata_previous_versions_max property cannot be empty"));
+                updateProperties.set(METADATA_PREVIOUS_VERSIONS_MAX, Integer.toString(metadataPerviousVersionMax));
             }
             updateProperties.set(WRITE_DATA_LOCATION, dataLocation);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTableProperties.java
@@ -61,6 +61,8 @@ public class IcebergTableProperties
     public static final String PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY = "parquet_bloom_filter_columns";
     public static final String OBJECT_STORE_LAYOUT_ENABLED_PROPERTY = "object_store_layout_enabled";
     public static final String DATA_LOCATION_PROPERTY = "data_location";
+    public static final String METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY = "metadata_delete_after_commit_enabled";
+    public static final String METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY = "metadata_previous_versions_max";
     public static final String EXTRA_PROPERTIES_PROPERTY = "extra_properties";
 
     public static final Set<String> SUPPORTED_PROPERTIES = ImmutableSet.<String>builder()
@@ -73,6 +75,8 @@ public class IcebergTableProperties
             .add(ORC_BLOOM_FILTER_FPP_PROPERTY)
             .add(OBJECT_STORE_LAYOUT_ENABLED_PROPERTY)
             .add(DATA_LOCATION_PROPERTY)
+            .add(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)
+            .add(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)
             .add(EXTRA_PROPERTIES_PROPERTY)
             .add(PARQUET_BLOOM_FILTER_COLUMNS_PROPERTY)
             .build();
@@ -188,6 +192,15 @@ public class IcebergTableProperties
                 .add(stringProperty(
                         DATA_LOCATION_PROPERTY,
                         "File system location URI for the table's data files",
+                        null,
+                        false))
+                .add(booleanProperty(
+                        METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY,
+                        "Delete old tracked metadata files after each table commit",
+                        null,
+                        false))
+                .add(integerProperty(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY,
+                        "The number of old metadata files to keep",
                         null,
                         false))
                 .build();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -123,6 +123,8 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.DATA_LOCATION_PROPE
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FORMAT_VERSION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.OBJECT_STORE_LAYOUT_ENABLED_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_COLUMNS_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.ORC_BLOOM_FILTER_FPP_PROPERTY;
@@ -174,6 +176,8 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
+import static org.apache.iceberg.TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED;
+import static org.apache.iceberg.TableProperties.METADATA_PREVIOUS_VERSIONS_MAX;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_ENABLED;
 import static org.apache.iceberg.TableProperties.OBJECT_STORE_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.ORC_BLOOM_FILTER_COLUMNS;
@@ -342,6 +346,15 @@ public final class IcebergUtil
 
         Optional<String> dataLocation = Optional.ofNullable(icebergTable.properties().get(WRITE_DATA_LOCATION));
         dataLocation.ifPresent(location -> properties.put(DATA_LOCATION_PROPERTY, location));
+
+        String metadataDeleteAfterCommitEnabled = icebergTable.properties().get(METADATA_DELETE_AFTER_COMMIT_ENABLED);
+        if (metadataDeleteAfterCommitEnabled != null) {
+            properties.put(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY, Boolean.parseBoolean(metadataDeleteAfterCommitEnabled));
+        }
+        String metadataPreviousVersionsMax = icebergTable.properties().get(METADATA_PREVIOUS_VERSIONS_MAX);
+        if (metadataPreviousVersionsMax != null) {
+            properties.put(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY, Integer.parseInt(metadataPreviousVersionsMax));
+        }
 
         return properties.buildOrThrow();
     }
@@ -880,6 +893,13 @@ public final class IcebergUtil
             for (String column : parquetBloomFilterColumns) {
                 propertiesBuilder.put(PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + column, "true");
             }
+        }
+
+        if (tableMetadata.getProperties().containsKey(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)) {
+            propertiesBuilder.put(METADATA_DELETE_AFTER_COMMIT_ENABLED, ((Boolean) tableMetadata.getProperties().get(METADATA_DELETE_AFTER_COMMIT_ENABLED_PROPERTY)).toString());
+        }
+        if (tableMetadata.getProperties().containsKey(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)) {
+            propertiesBuilder.put(METADATA_PREVIOUS_VERSIONS_MAX, ((Integer) tableMetadata.getProperties().get(METADATA_PREVIOUS_VERSIONS_MAX_PROPERTY)).toString());
         }
 
         if (tableMetadata.getComment().isPresent()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
@@ -35,6 +35,7 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_CONCURRENT_MODIFICATION_DE
 import static io.trino.plugin.iceberg.IcebergTableName.tableNameFrom;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
+import static org.apache.iceberg.CatalogUtil.deleteRemovedMetadataFiles;
 
 @NotThreadSafe
 public class FileMetastoreTableOperations
@@ -56,7 +57,7 @@ public class FileMetastoreTableOperations
     protected void commitToExistingTable(TableMetadata base, TableMetadata metadata)
     {
         Table currentTable = getTable();
-        commitTableUpdate(currentTable, metadata, (table, newMetadataLocation) -> Table.builder(table)
+        commitTableUpdate(currentTable, base, metadata, (table, newMetadataLocation) -> Table.builder(table)
                 .apply(builder -> updateMetastoreTable(builder, metadata, newMetadataLocation, Optional.of(currentMetadataLocation)))
                 .build());
     }
@@ -65,12 +66,12 @@ public class FileMetastoreTableOperations
     protected void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
     {
         Table materializedView = getTable(database, tableNameFrom(tableName));
-        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> Table.builder(table)
+        commitTableUpdate(materializedView, base, metadata, (table, newMetadataLocation) -> Table.builder(table)
                 .apply(builder -> builder.setParameter(METADATA_LOCATION_PROP, newMetadataLocation).setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation))
                 .build());
     }
 
-    private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
+    private void commitTableUpdate(Table table, TableMetadata base, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
     {
         checkState(currentMetadataLocation != null, "No current metadata location for existing table");
         String metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
@@ -97,5 +98,6 @@ public class FileMetastoreTableOperations
             }
             throw new CommitStateUnknownException(e);
         }
+        deleteRemovedMetadataFiles(io(), base, metadata);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -39,6 +39,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.fixBrokenMetadataLocation;
 import static java.util.Objects.requireNonNull;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP;
+import static org.apache.iceberg.CatalogUtil.deleteRemovedMetadataFiles;
 
 @NotThreadSafe
 public class HiveMetastoreTableOperations
@@ -65,7 +66,7 @@ public class HiveMetastoreTableOperations
     protected void commitToExistingTable(TableMetadata base, TableMetadata metadata)
     {
         Table currentTable = getTable();
-        commitTableUpdate(currentTable, metadata, (table, newMetadataLocation) -> Table.builder(table)
+        commitTableUpdate(currentTable, base, metadata, (table, newMetadataLocation) -> Table.builder(table)
                 .apply(builder -> updateMetastoreTable(builder, metadata, newMetadataLocation, Optional.of(currentMetadataLocation)))
                 .build());
     }
@@ -74,14 +75,14 @@ public class HiveMetastoreTableOperations
     protected final void commitMaterializedViewRefresh(TableMetadata base, TableMetadata metadata)
     {
         Table materializedView = getTable(database, tableNameFrom(tableName));
-        commitTableUpdate(materializedView, metadata, (table, newMetadataLocation) -> Table.builder(table)
+        commitTableUpdate(materializedView, base, metadata, (table, newMetadataLocation) -> Table.builder(table)
                 .apply(builder -> builder
                         .setParameter(METADATA_LOCATION_PROP, newMetadataLocation)
                         .setParameter(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation))
                 .build());
     }
 
-    private void commitTableUpdate(Table table, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
+    private void commitTableUpdate(Table table, TableMetadata base, TableMetadata metadata, BiFunction<Table, String, Table> tableUpdateFunction)
     {
         String newMetadataLocation = writeNewMetadata(metadata, version.orElseThrow() + 1);
         long lockId = thriftMetastore.acquireTableExclusiveLock(
@@ -126,6 +127,7 @@ public class HiveMetastoreTableOperations
             }
         }
 
+        deleteRemovedMetadataFiles(io(), base, metadata);
         shouldRefresh = true;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/jdbc/IcebergJdbcTableOperations.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.CatalogUtil.deleteRemovedMetadataFiles;
 
 public class IcebergJdbcTableOperations
         extends AbstractIcebergTableOperations
@@ -65,6 +66,7 @@ public class IcebergJdbcTableOperations
         checkState(currentMetadataLocation != null, "No current metadata location for existing table");
         String newMetadataLocation = writeNewMetadata(metadata, version.orElseThrow() + 1);
         jdbcClient.alterTable(database, tableName, newMetadataLocation, currentMetadataLocation);
+        deleteRemovedMetadataFiles(io(), base, metadata);
         shouldRefresh = true;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/nessie/IcebergNessieTableOperations.java
@@ -38,6 +38,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_COMMIT_ERROR;
 import static io.trino.plugin.iceberg.catalog.nessie.IcebergNessieUtil.toIdentifier;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.CatalogUtil.deleteRemovedMetadataFiles;
 
 public class IcebergNessieTableOperations
         extends AbstractIcebergTableOperations
@@ -149,6 +150,7 @@ public class IcebergNessieTableOperations
             // CommitFailedException is handled as a special case in the Iceberg library. This commit will automatically retry
             throw new CommitFailedException(e, "Cannot commit: ref hash is out of date. Update the ref '%s' and try again", nessieClient.refName());
         }
+        deleteRemovedMetadataFiles(io(), base, metadata);
         shouldRefresh = true;
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Implement `metadata_delete_after_commit_enabled` and `metadata_previous_versions_max` for Iceberg table.
Without this feature, old metadata files (XXX.metadata.json files) will remains on the file system indefinitely after commit.

This corresponds to `write.metadata.delete-after-commit.enabled` and `write.metadata.previous-versions-max` properties (see: https://iceberg.apache.org/docs/latest/maintenance/#remove-old-metadata-files)

The following has been implemented:
```
CREATE TABLE foo (a bigint) WITH (
    metadata_delete_after_commit_enabled = true,
    metadata_previous_versions_max = 10);

ALTER TABLE foo SET PROPERTIES metadata_delete_after_commit_enabled = true;
ALTER TABLE foo SET PROPERTIES metadata_previous_versions_max = 10;
```



This PR depends on #20410 which implemented `$metadata_log_entries` system table for Iceberg table. This system table provides visibility on metadata file. Some testing codes are using `$metadata_log_entries`.
First 2 commits are from #20410. Only the last commit is for this PR.


Fix #19582
Fix #14128 
Supersede #20011

## Implementation of `metadata_previous_versions_max`
`metadata_previous_versions_max` is implemented by Iceberg's [TableMetadata](https://github.com/apache/iceberg/blob/6a3b2d7c153412b01c746debb018c544516f2bbd/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1679-L1695) which Trino is using for commit. Trino only needs to set Iceberg table's `write.metadata.previous-versions-max` property for this to work.

Below is the call stack of an INSERT into Iceberg table.
```
addPreviousFile:1638, TableMetadata$Builder (org.apache.iceberg)
build:1417, TableMetadata$Builder (org.apache.iceberg)
internalApply:70, SetStatistics (org.apache.iceberg)
commit:56, SetStatistics (org.apache.iceberg)
finishInsert:1163, IcebergMetadata (io.trino.plugin.iceberg)
finishCreateTable:1000, IcebergMetadata (io.trino.plugin.iceberg)
finishCreateTable:585, ClassLoaderSafeConnectorMetadata (io.trino.plugin.base.classloader)
finishCreateTable:658, TracingConnectorMetadata (io.trino.tracing)
finishCreateTable:1129, MetadataManager (io.trino.metadata)
finishCreateTable:610, TracingMetadata (io.trino.tracing)
lambda$createTableFinisher$4:4155, LocalExecutionPlanner (io.trino.sql.planner)
finishTable:-1, LocalExecutionPlanner$$Lambda/0x00007f55b0a068e0 (io.trino.sql.planner)
getOutput:319, TableFinishOperator (io.trino.operator)
```

## Implementation of `metadata_delete_after_commit_enabled`
Trino is doing TableOperations by itself. The required logic has been added to `*TableOperations`.
Reference implementation in Iceberg:
https://github.com/apache/iceberg/blob/6a3b2d7c153412b01c746debb018c544516f2bbd/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java#L412-L440

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes
(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Support the Iceberg table properties `metadata_delete_after_commit_enabled` and `metadata_previous_versions_max` ({issue}`issuenumber`)
```
