### PR TITLE
Add JDBC connection current catalog fallback parameter

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/ConnectionProperties.java
@@ -100,6 +100,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String, String> HOSTNAME_IN_CERTIFICATE = new HostnameInCertificate();
     public static final ConnectionProperty<String, ZoneId> TIMEZONE = new TimeZone();
     public static final ConnectionProperty<String, Boolean> EXPLICIT_PREPARE = new ExplicitPrepare();
+    public static final ConnectionProperty<String, Boolean> ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG = new AssumeNullCatalogMeansCurrentCatalog();
 
     private static final Set<ConnectionProperty<?, ?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?, ?>>builder()
             .add(USER)
@@ -146,6 +147,7 @@ final class ConnectionProperties
             .add(HOSTNAME_IN_CERTIFICATE)
             .add(TIMEZONE)
             .add(EXPLICIT_PREPARE)
+            .add(ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG)
             .build();
 
     private static final Map<String, ConnectionProperty<?, ?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -725,6 +727,15 @@ final class ConnectionProperties
         public ExplicitPrepare()
         {
             super(PropertyName.EXPLICIT_PREPARE, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class AssumeNullCatalogMeansCurrentCatalog
+            extends AbstractConnectionProperty<String, Boolean>
+    {
+        public AssumeNullCatalogMeansCurrentCatalog()
+        {
+            super(PropertyName.ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG, NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/PropertyName.java
@@ -62,6 +62,7 @@ public enum PropertyName
     SESSION_PROPERTIES("sessionProperties"),
     SOURCE("source"),
     EXPLICIT_PREPARE("explicitPrepare"),
+    ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG("assumeNullCatalogMeansCurrentCatalog"),
     DNS_RESOLVER("dnsResolver"),
     DNS_RESOLVER_CONTEXT("dnsResolverContext"),
     HOSTNAME_IN_CERTIFICATE("hostnameInCertificate"),

--- a/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
+++ b/client/trino-client/src/main/java/io/trino/client/uri/TrinoUri.java
@@ -66,6 +66,7 @@ import static io.trino.client.uri.ConnectionProperties.ACCESS_TOKEN;
 import static io.trino.client.uri.ConnectionProperties.APPLICATION_NAME_PREFIX;
 import static io.trino.client.uri.ConnectionProperties.ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS;
 import static io.trino.client.uri.ConnectionProperties.ASSUME_LITERAL_UNDERSCORE_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS;
+import static io.trino.client.uri.ConnectionProperties.ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG;
 import static io.trino.client.uri.ConnectionProperties.CLIENT_INFO;
 import static io.trino.client.uri.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.client.uri.ConnectionProperties.DISABLE_COMPRESSION;
@@ -170,6 +171,7 @@ public class TrinoUri
     private Optional<Map<String, String>> sessionProperties;
     private Optional<String> source;
     private Optional<Boolean> explicitPrepare;
+    private Optional<Boolean> assumeNullCatalogMeansCurrentCatalog;
 
     private Optional<String> catalog = Optional.empty();
     private Optional<String> schema = Optional.empty();
@@ -223,7 +225,8 @@ public class TrinoUri
             Optional<String> traceToken,
             Optional<Map<String, String>> sessionProperties,
             Optional<String> source,
-            Optional<Boolean> explicitPrepare)
+            Optional<Boolean> explicitPrepare,
+            Optional<Boolean> assumeNullCatalogMeansCurrentCatalog)
             throws SQLException
     {
         this.uri = requireNonNull(uri, "uri is null");
@@ -277,6 +280,7 @@ public class TrinoUri
         this.sessionProperties = SESSION_PROPERTIES.getValueOrDefault(urlProperties, sessionProperties);
         this.source = SOURCE.getValueOrDefault(urlProperties, source);
         this.explicitPrepare = EXPLICIT_PREPARE.getValueOrDefault(urlProperties, explicitPrepare);
+        this.assumeNullCatalogMeansCurrentCatalog = ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG.getValueOrDefault(urlProperties, assumeNullCatalogMeansCurrentCatalog);
 
         properties = buildProperties();
 
@@ -423,6 +427,7 @@ public class TrinoUri
         this.sessionProperties = SESSION_PROPERTIES.getValue(properties);
         this.source = SOURCE.getValue(properties);
         this.explicitPrepare = EXPLICIT_PREPARE.getValue(properties);
+        this.assumeNullCatalogMeansCurrentCatalog = ASSUME_NULL_CATALOG_MEANS_CURRENT_CATALOG.getValue(properties);
 
         // enable SSL by default for the trino schema and the standard port
         useSecureConnection = ssl.orElse(uri.getScheme().equals("https") || (uri.getScheme().equals("trino") && uri.getPort() == 443));
@@ -533,6 +538,11 @@ public class TrinoUri
     public Optional<Boolean> getExplicitPrepare()
     {
         return explicitPrepare;
+    }
+
+    public Optional<Boolean> getAssumeNullCatalogMeansCurrentCatalog()
+    {
+        return assumeNullCatalogMeansCurrentCatalog;
     }
 
     public boolean isCompressionDisabled()
@@ -941,6 +951,7 @@ public class TrinoUri
         private Map<String, String> sessionProperties;
         private String source;
         private Boolean explicitPrepare;
+        private Boolean assumeNullCatalogMeansCurrentCatalog;
 
         private Builder() {}
 
@@ -1235,6 +1246,12 @@ public class TrinoUri
             return this;
         }
 
+        public Builder setAssumeNullCatalogMeansCurrentCatalog(Boolean assumeNullCatalogMeansCurrentCatalog)
+        {
+            this.assumeNullCatalogMeansCurrentCatalog = requireNonNull(assumeNullCatalogMeansCurrentCatalog, "assumeNullCatalogMeansCurrentCatalog is null");
+            return this;
+        }
+
         public TrinoUri build()
                 throws SQLException
         {
@@ -1284,7 +1301,8 @@ public class TrinoUri
                     Optional.ofNullable(traceToken),
                     Optional.ofNullable(sessionProperties),
                     Optional.ofNullable(source),
-                    Optional.ofNullable(explicitPrepare));
+                    Optional.ofNullable(explicitPrepare),
+                    Optional.ofNullable(assumeNullCatalogMeansCurrentCatalog));
         }
     }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -113,6 +113,7 @@ public class TrinoConnection
     private final Call.Factory httpCallFactory;
     private final Set<TrinoStatement> statements = newSetFromMap(new ConcurrentHashMap<>());
     private boolean useExplicitPrepare = true;
+    private boolean assumeNullCatalogMeansCurrentCatalog;
 
     TrinoConnection(TrinoDriverUri uri, Call.Factory httpCallFactory)
     {
@@ -147,6 +148,7 @@ public class TrinoConnection
         sessionProperties.putAll(uri.getSessionProperties());
 
         uri.getExplicitPrepare().ifPresent(value -> this.useExplicitPrepare = value);
+        uri.getAssumeNullCatalogMeansCurrentCatalog().ifPresent(value -> this.assumeNullCatalogMeansCurrentCatalog = value);
     }
 
     @Override
@@ -918,5 +920,10 @@ public class TrinoConnection
     public boolean useExplicitPrepare()
     {
         return this.useExplicitPrepare;
+    }
+
+    public boolean getAssumeNullCatalogMeansCurrentCatalog()
+    {
+        return this.assumeNullCatalogMeansCurrentCatalog;
     }
 }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
@@ -953,7 +953,7 @@ public class TrinoDatabaseMetaData
                 "FROM system.jdbc.tables");
 
         List<String> filters = new ArrayList<>();
-        emptyStringEqualsFilter(filters, "TABLE_CAT", catalog);
+        emptyStringEqualsFilter(filters, "TABLE_CAT", effectiveCatalog(catalog));
         emptyStringLikeFilter(filters, "TABLE_SCHEM", schemaPattern);
         optionalStringLikeFilter(filters, "TABLE_NAME", tableNamePattern);
         optionalStringInFilter(filters, "TABLE_TYPE", types);
@@ -1011,7 +1011,7 @@ public class TrinoDatabaseMetaData
                 "FROM system.jdbc.columns");
 
         List<String> filters = new ArrayList<>();
-        emptyStringEqualsFilter(filters, "TABLE_CAT", catalog);
+        emptyStringEqualsFilter(filters, "TABLE_CAT", effectiveCatalog(catalog));
         emptyStringLikeFilter(filters, "TABLE_SCHEM", schemaPattern);
         optionalStringLikeFilter(filters, "TABLE_NAME", tableNamePattern);
         optionalStringLikeFilter(filters, "COLUMN_NAME", columnNamePattern);
@@ -1393,7 +1393,7 @@ public class TrinoDatabaseMetaData
                 "FROM system.jdbc.schemas");
 
         List<String> filters = new ArrayList<>();
-        emptyStringEqualsFilter(filters, "TABLE_CATALOG", catalog);
+        emptyStringEqualsFilter(filters, "TABLE_CATALOG", effectiveCatalog(catalog));
         optionalStringLikeFilter(filters, "TABLE_SCHEM", schemaPattern);
         buildFilters(query, filters);
 
@@ -1650,5 +1650,14 @@ public class TrinoDatabaseMetaData
             }
         }
         out.append('\'');
+    }
+
+    private String effectiveCatalog(String catalog)
+            throws SQLException
+    {
+        if (connection.getAssumeNullCatalogMeansCurrentCatalog() && catalog == null) {
+            return connection.getCatalog();
+        }
+        return catalog;
     }
 }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1100,6 +1100,71 @@ public class TestTrinoDatabaseMetaData
                     list(),
                     ImmutableMultiset.of());
         }
+
+        try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
+            // should list all schemas as the catalog is not set
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getSchemas(null, null),
+                            list("TABLE_CATALOG", "TABLE_SCHEM")),
+                    list(
+                            list("blackhole", "information_schema"),
+                            list("blackhole", "default"),
+                            list("blackhole", "blackhole"),
+                            list("hive", "information_schema"),
+                            list("hive", "default"),
+                            list(COUNTING_CATALOG, "information_schema"),
+                            list(COUNTING_CATALOG, "test_schema1"),
+                            list(COUNTING_CATALOG, "test_schema2"),
+                            list(COUNTING_CATALOG, "test_schema3_empty"),
+                            list(COUNTING_CATALOG, "test_schema4_empty"),
+                            list("system", "information_schema"),
+                            list("system", "jdbc"),
+                            list("system", "metadata"),
+                            list("system", "runtime"),
+                            list(TEST_CATALOG, "information_schema"),
+                            list(TEST_CATALOG, "sf1"),
+                            list(TEST_CATALOG, "sf100"),
+                            list(TEST_CATALOG, "sf1000"),
+                            list(TEST_CATALOG, "sf10000"),
+                            list(TEST_CATALOG, "sf100000"),
+                            list(TEST_CATALOG, "sf300"),
+                            list(TEST_CATALOG, "sf3000"),
+                            list(TEST_CATALOG, "sf30000"),
+                            list(TEST_CATALOG, "tiny")),
+                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+            // set a different catalog to check if current catalog is used
+            connection.setCatalog(COUNTING_CATALOG);
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getSchemas(null, null),
+                            list("TABLE_CATALOG", "TABLE_SCHEM")),
+                    list(
+                            list(COUNTING_CATALOG, "information_schema"),
+                            list(COUNTING_CATALOG, "test_schema1"),
+                            list(COUNTING_CATALOG, "test_schema2"),
+                            list(COUNTING_CATALOG, "test_schema3_empty"),
+                            list(COUNTING_CATALOG, "test_schema4_empty")),
+                    ImmutableMultiset.of("ConnectorMetadata.listSchemaNames"));
+
+            // change the catalog back using a statement on the connection
+            connection.createStatement().execute(String.format("USE %s.%s", "blackhole", "blackhole"));
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getSchemas(null, null),
+                            list("TABLE_CATALOG", "TABLE_SCHEM")),
+                    list(
+                            list("blackhole", "information_schema"),
+                            list("blackhole", "default"),
+                            list("blackhole", "blackhole")),
+                    ImmutableMultiset.of());
+        }
     }
 
     @Test
@@ -1250,6 +1315,38 @@ public class TestTrinoDatabaseMetaData
                     connection,
                     readMetaData(
                             databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, null, new String[0]),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
+                    list(),
+                    ImmutableMultiset.of());
+        }
+
+        try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getTables(null, null, null, new String[0]),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
+                    list(),
+                    ImmutableMultiset.of());
+
+            // set a different catalog to check if current catalog is used
+            connection.setCatalog(COUNTING_CATALOG);
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getTables(null, null, null, new String[0]),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
+                    list(),
+                    ImmutableMultiset.of());
+
+            // change the catalog back using a statement on the connection
+            connection.createStatement().execute(String.format("USE %s.%s", "blackhole", "blackhole"));
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getTables(null, null, null, new String[0]),
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                     list(),
                     ImmutableMultiset.of());
@@ -1494,6 +1591,38 @@ public class TestTrinoDatabaseMetaData
                             list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
                     list(),
                     ImmutableMultiset.of("ConnectorMetadata.streamRelationColumns"));
+        }
+
+        try (Connection connection = createConnectionWithNullCatalogMeansCurrent()) {
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getColumns(null, null, null, ""),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
+                    list(),
+                    ImmutableMultiset.of("ConnectorMetadata.streamRelationColumns"));
+
+            // set a different catalog to check if current catalog is used
+            connection.setCatalog(COUNTING_CATALOG);
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getColumns(null, null, null, ""),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
+                    list(),
+                    ImmutableMultiset.of("ConnectorMetadata.streamRelationColumns"));
+
+            // change the catalog back using a statement on the connection
+            connection.createStatement().execute(String.format("USE %s.%s", "blackhole", "blackhole"));
+
+            assertMetadataCalls(
+                    connection,
+                    readMetaData(
+                            databaseMetaData -> databaseMetaData.getColumns(null, null, null, ""),
+                            list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
+                    list(),
+                    ImmutableMultiset.of());
         }
     }
 
@@ -1820,6 +1949,13 @@ public class TestTrinoDatabaseMetaData
             throws SQLException
     {
         String url = format("jdbc:trino://%s/%s/%s", server.getAddress(), catalog, schema);
+        return DriverManager.getConnection(url, "admin", null);
+    }
+
+    private Connection createConnectionWithNullCatalogMeansCurrent()
+            throws SQLException
+    {
+        String url = format("jdbc:trino://%s?assumeNullCatalogMeansCurrentCatalog=true", server.getAddress());
         return DriverManager.getConnection(url, "admin", null);
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
This commit introduces fallback (disabled by default), which will try to use `catalog` value passed through JDBC connection when fetching Trino metadata like: `getTables`, `getColumns`, `getSchemas` with `catalog` set to `null`.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
- https://github.com/trinodb/trino/issues/16361
- https://github.com/trinodb/trino/issues/1173

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```
# JDBC Driver
* Add a new connection property `assumeNullCatalogMeansCurrent`. Enabling this makes a `null` value for
  `catalog` parameter in `DatabaseMetaData` methods to mean the current catalog. If no current catalog is
  set the behaviour is unmodified.
```
