### PR TITLE
Trino FS Write API

### DIFF
--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/TrinoOutputFile.java
@@ -61,6 +61,12 @@ public interface TrinoOutputFile
     OutputStream create(AggregatedMemoryContext memoryContext)
             throws IOException;
 
+    default Write write(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        throw new UnsupportedOperationException("write() not supported by " + getClass());
+    }
+
     OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
             throws IOException;
 

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/Write.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/Write.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Represents ongoing write operation.
+ */
+public interface Write
+        extends AutoCloseable
+{
+    /**
+     * The output stream to write to. The caller is not responsible for closing the stream.
+     *
+     * @see #close()
+     */
+    OutputStream stream();
+
+    /**
+     * Marks the write as finished. No more data can be written after this method is called.
+     * It is an error to call this method after {@link #abort()} has been called.
+     * The write operation is not guaranteed to be made visible when this method returns,
+     * it will be made visible at the latest when {@link #close()} is called.
+     */
+    void finish();
+
+    /**
+     * Marks the write as aborted. No more data can be written after this method is called.
+     * It is an error to call this method after {@link #finish()} has been called.
+     * <p>
+     * The effect of calling this method followed by {@link #close()} is the same as calling
+     * {@link #close()} directly. Calling this method is useful for documenting the intent
+     * and verify the {@link #finish()} has not been called.
+     */
+    void abort();
+
+    /**
+     * Releases any resources associated with this write operation, committing it if and only
+     * if {@link #finish()} has not been called. It is an error to call this method if neither
+     * {@link #finish()} nor {@link #abort()} has been called. In such case, it behaves as if
+     * #abort() has been called, but throws an exception instead of returning.
+     *
+     * @throws IllegalStateException if the write has not been finished nor explicitly aborted
+     *
+     * @apiNote IllegalStateException is thrown when {@link #finish()}/{@link #close()} has not
+     * been called to make it easier to use the Write API correctly.
+     */
+    @Override
+    void close()
+            throws IOException;
+}

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryOutputFile.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryOutputFile.java
@@ -57,6 +57,13 @@ class MemoryOutputFile
     }
 
     @Override
+    public MemoryWrite write(AggregatedMemoryContext memoryContext)
+            throws IOException
+    {
+        return null;
+    }
+
+    @Override
     public OutputStream createOrOverwrite(AggregatedMemoryContext memoryContext)
             throws IOException
     {

--- a/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryWrite.java
+++ b/lib/trino-filesystem/src/main/java/io/trino/filesystem/memory/MemoryWrite.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.memory;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.Write;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.checkFromIndexSize;
+import static java.util.Objects.requireNonNull;
+
+public class MemoryWrite
+        implements Write
+{
+    private enum State
+    {
+        READY,
+        ABORTED,
+        FINISHED,
+        CLOSED,
+        /**/;
+    }
+
+    public interface OnStreamClose
+    {
+        void onCommit(Slice data)
+                throws IOException;
+    }
+
+    private final Object lock = new Object();
+    private final OnStreamClose onCommit;
+    @GuardedBy("lock")
+    private ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    @GuardedBy("lock")
+    private State state = State.READY;
+    private final MemoryOutputStream outputStream;
+
+    public MemoryWrite(Location location, OnStreamClose onCommit)
+    {
+        this.onCommit = requireNonNull(onCommit, "onCommit is null");
+        this.outputStream = new MemoryOutputStream(location);
+    }
+
+    @Override
+    public OutputStream stream()
+    {
+        return outputStream;
+    }
+
+    @Override
+    public void finish()
+    {
+        synchronized (lock) {
+            checkState(state == State.READY, "Cannot finish in state %s", state);
+            state = State.FINISHED;
+        }
+    }
+
+    @Override
+    public void abort()
+    {
+        synchronized (lock) {
+            checkState(state == State.READY, "Cannot abort in state %s", state);
+            state = State.ABORTED;
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        synchronized (lock) {
+            switch (state) {
+                case READY, ABORTED -> {
+                    boolean wasAborted = state == State.ABORTED;
+                    state = State.CLOSED;
+                    buffer = null;
+                    if (!wasAborted) {
+                        throw new IllegalStateException("Neither finish() nor abort() was called before close()");
+                    }
+                }
+
+                case FINISHED -> {
+                    state = State.CLOSED;
+                    byte[] data = buffer.toByteArray();
+                    buffer = null;
+                    onCommit.onCommit(Slices.wrappedBuffer(data));
+                }
+
+                case CLOSED -> {
+                    // Already closed
+                }
+            }
+        }
+    }
+
+    private class MemoryOutputStream
+            extends OutputStream
+    {
+        private final Location location;
+        private boolean closed;
+
+        public MemoryOutputStream(Location location)
+        {
+            this.location = requireNonNull(location, "location is null");
+        }
+
+        @Override
+        public void write(int b)
+                throws IOException
+        {
+            synchronized (lock) {
+                ensureOpen();
+                buffer.write(b);
+            }
+        }
+
+        @Override
+        public void write(byte[] bytes, int offset, int length)
+                throws IOException
+        {
+            checkFromIndexSize(offset, length, bytes.length);
+
+            synchronized (lock) {
+                ensureOpen();
+                buffer.write(bytes, offset, length);
+            }
+        }
+
+        @Override
+        public void flush()
+                throws IOException
+        {
+            synchronized (lock) {
+                ensureOpen();
+            }
+        }
+
+        @GuardedBy("lock")
+        private void ensureOpen()
+                throws IOException
+        {
+            if (closed || state != State.READY) {
+                throw new IOException("Output stream closed: " + location);
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            closed = true;
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/avro/AvroFileWriterFactory.java
@@ -117,7 +117,7 @@ public class AvroFileWriterFactory
             Closeable rollbackAction = () -> fileSystem.deleteFile(location);
 
             return Optional.of(new AvroHiveFileWriter(
-                    outputFile.create(outputStreamMemoryContext),
+                    outputFile.write(outputStreamMemoryContext),
                     outputStreamMemoryContext,
                     fileSchema,
                     new HiveAvroTypeManager(hiveTimestampPrecision),


### PR DESCRIPTION
Introduce `Write` interface for managing write operations. Existing pattern is to use `OutputStream` and commit write on the `close()` operation. `OutputStream` is `Closeable`, so it is often used with try-with-resources. As a result exception during write still results in partial data flushed to the storage, which is undesirable.

Alternative solution could be to use `OutputStream` without try-with-resources. This has two important disadvantages:

- is against what IDE will often suggest, so too easy to forget.
- makes it impossible to cleanup resources associated with write being aborted (e.g. abort multi-part S3 upload)

The new `Write` API solves those problems. It should be used with try-with-resources to allow resource disposal on both successful and failed write. It requires explicit `finish()` to mark the write as successful, otherwise the write is aborted,
