### PR TITLE
Move dynamic catalog mgt

### DIFF
--- a/docs/src/main/sphinx/language/sql-support.md
+++ b/docs/src/main/sphinx/language/sql-support.md
@@ -46,6 +46,15 @@ any connector:
 - {doc}`/sql/use`
 - {doc}`/sql/values`
 
+(sql-catalog-management)=
+### Catalog management
+
+The following statements are used to [manage dynamic
+catalogs](/admin/properties-catalog):
+
+- {doc}`/sql/create-catalog`
+- {doc}`/sql/drop-catalog`
+
 (sql-read-operations)=
 ## Read operations
 
@@ -81,15 +90,6 @@ connector to connector:
 - {doc}`/sql/delete`
 - {doc}`/sql/truncate`
 - {doc}`/sql/merge`
-
-(sql-catalog-management)=
-### Catalog management
-
-The following statements are used to [manage dynamic
-catalogs](/admin/properties-catalog):
-
-- {doc}`/sql/create-catalog`
-- {doc}`/sql/drop-catalog`
 
 (sql-schema-table-management)=
 ### Schema and table management


### PR DESCRIPTION
## Description

- To globally available statements
- but as separate section to preserve links

Reasoning is that these operations are not traditional write operations to the data source / database as all others, and it also does not depend on what connector is used .. and basically is supported by all connectors.

## Additional context and related issues

All connectors docs already link to the globally supported section and this move therefore fixes a docs issue. Alternative would be to add an explicit link to all connectors.. but thats kinda misleading in my opinion.

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
