### PR TITLE
Remove unnecessary constructor from TrinoException

### DIFF
--- a/core/trino-spi/pom.xml
+++ b/core/trino-spi/pom.xml
@@ -437,6 +437,10 @@
                                     <code>java.method.addedToInterface</code>
                                     <new>method void io.trino.spi.block.BlockBuilder::resetTo(int)</new>
                                 </item>
+                                <item>
+                                    <code>java.method.removed</code>
+                                    <old>method void io.trino.spi.TrinoException::&lt;init&gt;(io.trino.spi.ErrorCode, java.lang.String, java.lang.Throwable)</old>
+                                </item>
                             </differences>
                         </revapi.differences>
                     </analysisConfiguration>

--- a/core/trino-spi/src/main/java/io/trino/spi/TrinoException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/TrinoException.java
@@ -39,20 +39,10 @@ public class TrinoException
         this(errorCode, Optional.empty(), message, cause);
     }
 
-    public TrinoException(ErrorCode errorCode, String message, Throwable cause)
-    {
-        this(errorCode, Optional.empty(), message, cause);
-    }
-
     public TrinoException(ErrorCodeSupplier errorCodeSupplier, Optional<Location> location, String message, Throwable cause)
     {
-        this(errorCodeSupplier.toErrorCode(), location, message, cause);
-    }
-
-    private TrinoException(ErrorCode errorCode, Optional<Location> location, String message, Throwable cause)
-    {
         super(message, cause);
-        this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        this.errorCode = errorCodeSupplier.toErrorCode();
         this.location = requireNonNull(location, "location is null");
     }
 

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/CorruptedDeltaLakeTableHandle.java
@@ -35,6 +35,6 @@ public record CorruptedDeltaLakeTableHandle(
     public TrinoException createException()
     {
         // Original exception originates from a different place. Create a new exception not to confuse reader with a stacktrace not matching call site.
-        return new TrinoException(originalException.getErrorCode(), originalException.getMessage(), originalException);
+        return new TrinoException(originalException::getErrorCode, originalException.getMessage(), originalException);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CorruptedIcebergTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CorruptedIcebergTableHandle.java
@@ -31,6 +31,6 @@ public record CorruptedIcebergTableHandle(SchemaTableName schemaTableName, Trino
     public TrinoException createException()
     {
         // Original exception originates from a different place. Create a new exception not to confuse reader with a stacktrace not matching call site.
-        return new TrinoException(originalException.getErrorCode(), originalException.getMessage(), originalException);
+        return new TrinoException(originalException::getErrorCode, originalException.getMessage(), originalException);
     }
 }


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
