### PR TITLE
Allow loading of dynamic agents

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -15,3 +15,5 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -14,3 +14,5 @@
 # Reduce starvation of threads by GClocker, recommend to set about the number of cpu cores (JDK-8192647)
 -XX:+UnlockDiagnosticVMOptions
 -XX:GCLockerRetryAllocationCount=32
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-all/jvm.config
@@ -15,3 +15,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode-ignite/jvm.config
@@ -15,3 +15,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -14,3 +14,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -13,3 +13,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -14,3 +14,5 @@
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=Asia/Kathmandu
 -XX:ErrorFile=/docker/logs/product-tests-presto-jvm-error-file.log
+# Allow loading dynamic agent used by JOL
+-XX:+EnableDynamicAgentLoading


### PR DESCRIPTION
This suppresses startup warnings generated by JOL library:

```
WARNING: A Java agent has been loaded dynamically (/tmp/jolAgent15371107136115023174.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```