### PR TITLE
Fix Iceberg materialized view storage table cleanup

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/AbstractTrinoCatalog.java
@@ -25,6 +25,7 @@ import io.trino.plugin.iceberg.ColumnIdentity;
 import io.trino.plugin.iceberg.IcebergMaterializedViewDefinition;
 import io.trino.plugin.iceberg.IcebergUtil;
 import io.trino.plugin.iceberg.PartitionTransforms.ColumnTransform;
+import io.trino.plugin.iceberg.fileio.ForwardingFileIo;
 import io.trino.plugin.iceberg.fileio.ForwardingOutputFile;
 import io.trino.spi.TrinoException;
 import io.trino.spi.catalog.CatalogName;
@@ -334,6 +335,14 @@ public abstract class AbstractTrinoCatalog
         TableMetadataParser.write(metadata, new ForwardingOutputFile(fileSystem, metadataFileLocation));
 
         return metadataFileLocation;
+    }
+
+    protected void dropMaterializedViewStorage(TrinoFileSystem fileSystem, String storageMetadataLocation)
+            throws IOException
+    {
+        TableMetadata metadata = TableMetadataParser.read(new ForwardingFileIo(fileSystem), storageMetadataLocation);
+        String storageLocation = metadata.location();
+        fileSystem.deleteDirectory(Location.of(storageLocation));
     }
 
     protected SchemaTableName createMaterializedViewStorageTable(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/TrinoHiveCatalog.java
@@ -684,18 +684,19 @@ public class TrinoHiveCatalog
                 log.warn(e, "Failed to drop storage table '%s.%s' for materialized view '%s'", storageSchema, storageTableName, viewName);
             }
         }
+        else {
+            String storageMetadataLocation = view.getParameters().get(METADATA_LOCATION_PROP);
+            checkState(storageMetadataLocation != null, "Storage location missing in definition of materialized view " + viewName);
 
-        String storageMetadataLocation = view.getParameters().get(METADATA_LOCATION_PROP);
-        checkState(storageMetadataLocation != null, "Storage location missing in definition of materialized view " + viewName);
-
-        TrinoFileSystem fileSystem = fileSystemFactory.create(session);
-        TableMetadata metadata = TableMetadataParser.read(new ForwardingFileIo(fileSystem), storageMetadataLocation);
-        String storageLocation = metadata.location();
-        try {
-            fileSystem.deleteDirectory(Location.of(storageLocation));
-        }
-        catch (IOException e) {
-            log.warn(e, "Failed to delete storage location '%s' for materialized view '%s'", storageLocation, viewName);
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            TableMetadata metadata = TableMetadataParser.read(new ForwardingFileIo(fileSystem), storageMetadataLocation);
+            String storageLocation = metadata.location();
+            try {
+                fileSystem.deleteDirectory(Location.of(storageLocation));
+            }
+            catch (IOException e) {
+                log.warn(e, "Failed to delete storage location '%s' for materialized view '%s'", storageLocation, viewName);
+            }
         }
 
         metastore.dropTable(viewName.getSchemaName(), viewName.getTableName(), true);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedView.java
@@ -92,6 +92,12 @@ public class TestIcebergMaterializedView
                     .setCatalog("iceberg2")
                     .build();
 
+            queryRunner.createCatalog("iceberg_legacy_mv", "iceberg", Map.of(
+                    "iceberg.catalog.type", "TESTING_FILE_METASTORE",
+                    "hive.metastore.catalog.dir", queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toString(),
+                    "iceberg.hive-catalog-name", "hive",
+                    "iceberg.materialized-views.hide-storage-table", "false"));
+
             queryRunner.installPlugin(new MockConnectorPlugin(MockConnectorFactory.builder()
                     .withTableFunctions(ImmutableSet.of(new SequenceTableFunction()))
                     .withFunctionProvider(Optional.of(new FunctionProvider()
@@ -143,17 +149,17 @@ public class TestIcebergMaterializedView
         assertUpdate("CREATE MATERIALIZED VIEW " + viewName + " AS SELECT * FROM TABLE(mock.system.sequence_function())");
 
         assertFreshness(viewName, "STALE");
-        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue()).isNull();
+        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue()).isNull();
         int result1 = (int) computeActual("SELECT * FROM " + viewName).getOnlyValue();
 
         int result2 = (int) computeActual("SELECT * FROM " + viewName).getOnlyValue();
         assertThat(result2).isNotEqualTo(result1); // differs because PTF sequence_function is called directly as mv is considered stale
         assertFreshness(viewName, "STALE");
-        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue()).isNull();
+        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue()).isNull();
 
         assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 1);
         assertFreshness(viewName, "UNKNOWN");
-        ZonedDateTime lastFreshTime = (ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue();
+        ZonedDateTime lastFreshTime = (ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue();
         assertThat(lastFreshTime).isNotNull();
         int result3 = (int) computeActual("SELECT * FROM " + viewName).getOnlyValue();
         assertThat(result3).isNotEqualTo(result2);  // mv is not stale anymore so all selects until next refresh returns same result
@@ -163,7 +169,7 @@ public class TestIcebergMaterializedView
         assertThat(result4).isEqualTo(result5);
 
         assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 1);
-        assertThat((ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue()).isAfter(lastFreshTime);
+        assertThat((ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue()).isAfter(lastFreshTime);
         assertFreshness(viewName, "UNKNOWN");
         int result6 = (int) computeActual("SELECT * FROM " + viewName).getOnlyValue();
         assertThat(result6).isNotEqualTo(result5);
@@ -183,7 +189,7 @@ public class TestIcebergMaterializedView
         assertThat(materializedRows.get(0).getField(1)).isEqualTo(2);
         int valueFromPtf1 = (int) materializedRows.get(0).getField(0);
         assertFreshness(viewName, "STALE");
-        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue()).isNull();
+        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue()).isNull();
 
         materializedRows = computeActual("SELECT * FROM " + viewName).getMaterializedRows();
         assertThat(materializedRows.size()).isEqualTo(1);
@@ -191,11 +197,11 @@ public class TestIcebergMaterializedView
         int valueFromPtf2 = (int) materializedRows.get(0).getField(0);
         assertThat(valueFromPtf2).isNotEqualTo(valueFromPtf1); // differs because PTF sequence_function is called directly as mv is considered stale
         assertFreshness(viewName, "STALE");
-        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue()).isNull();
+        assertThat(computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue()).isNull();
 
         assertUpdate("REFRESH MATERIALIZED VIEW " + viewName, 1);
         assertFreshness(viewName, "UNKNOWN");
-        ZonedDateTime lastFreshTime = (ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE name = '" + viewName + "'").getOnlyValue();
+        ZonedDateTime lastFreshTime = (ZonedDateTime) computeActual("SELECT last_fresh_time FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'").getOnlyValue();
         assertThat(lastFreshTime).isNotNull();
         materializedRows = computeActual("SELECT * FROM " + viewName).getMaterializedRows();
         assertThat(materializedRows.size()).isEqualTo(1);
@@ -284,7 +290,7 @@ public class TestIcebergMaterializedView
 
     private void assertFreshness(String viewName, String expected)
     {
-        assertThat((String) computeScalar("SELECT freshness FROM system.metadata.materialized_views WHERE name = '" + viewName + "'")).isEqualTo(expected);
+        assertThat((String) computeScalar("SELECT freshness FROM system.metadata.materialized_views WHERE catalog_name = '" + ICEBERG_CATALOG + "' AND name = '" + viewName + "'")).isEqualTo(expected);
     }
 
     public static class SequenceTableFunction

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedView.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/catalog/glue/TestIcebergGlueCatalogMaterializedView.java
@@ -27,6 +27,7 @@ import io.trino.plugin.hive.metastore.glue.AwsApiCallStats;
 import io.trino.plugin.iceberg.BaseIcebergMaterializedViewTest;
 import io.trino.plugin.iceberg.IcebergQueryRunner;
 import io.trino.plugin.iceberg.SchemaInitializer;
+import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.QueryRunner;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestInstance;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import java.io.File;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -61,7 +63,7 @@ public class TestIcebergGlueCatalogMaterializedView
         this.schemaDirectory = Files.createTempDirectory("test_iceberg").toFile();
         schemaDirectory.deleteOnExit();
 
-        return IcebergQueryRunner.builder()
+        DistributedQueryRunner queryRunner = IcebergQueryRunner.builder()
                 .setIcebergProperties(
                         ImmutableMap.of(
                                 "iceberg.catalog.type", "glue",
@@ -72,6 +74,13 @@ public class TestIcebergGlueCatalogMaterializedView
                                 .withSchemaName(schemaName)
                                 .build())
                 .build();
+
+        queryRunner.createCatalog("iceberg_legacy_mv", "iceberg", Map.of(
+                "iceberg.catalog.type", "glue",
+                "hive.metastore.glue.default-warehouse-dir", schemaDirectory.getAbsolutePath(),
+                "iceberg.materialized-views.hide-storage-table", "false"));
+
+        return queryRunner;
     }
 
     @Override


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Fixes: https://github.com/trinodb/trino/issues/20837

As well as some other edge cases which can happen if a `CREATE MATERIALIZED VIEW` operation fails.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
(x) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Iceberg
* Fix dropping materialized views which were created before 433 when using a Hive catalog.
* Improve storage table cleanup when creating a materialized view fails.
```
