### PR TITLE
Fix Azure filesystem hierarchical namespaces check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,13 +572,13 @@ jobs:
         env:
           ABFS_FLAT_ACCOUNT: todo
           ABFS_FLAT_ACCESS_KEY: todo
-          ABFS_ACCOUNT: todo
-          ABFS_ACCESS_KEY: todo
+          ABFS_HIERARCHICAL_ACCOUNT: todo
+          ABFS_HIERARCHICAL_ACCESS_KEY: todo
         # todo(https://github.com/trinodb/trino/issues/18998) Enable when we have env variables in place
         if: >-
           false &&
           contains(matrix.modules, 'trino-filesystem-azure') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCOUNT != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_ACCOUNT != '' || env.ABFS_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCOUNT != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_HIERARCHICAL_ACCOUNT != '' || env.ABFS_HIERARCHICAL_ACCESS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl ${{ matrix.modules }} ${{ format('-P {0}', matrix.profile) }}
       - name: GCS FileSystem Cloud Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,10 +575,11 @@ jobs:
           ABFS_HIERARCHICAL_ACCOUNT: todo
           ABFS_HIERARCHICAL_ACCESS_KEY: todo
         # todo(https://github.com/trinodb/trino/issues/18998) Enable when we have env variables in place
+        # Run tests only if any of the secrets are present
         if: >-
           false &&
           contains(matrix.modules, 'trino-filesystem-azure') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCOUNT != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_HIERARCHICAL_ACCOUNT != '' || env.ABFS_HIERARCHICAL_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_HIERARCHICAL_ACCESS_KEY != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl ${{ matrix.modules }} ${{ format('-P {0}', matrix.profile) }}
       - name: GCS FileSystem Cloud Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,12 +574,15 @@ jobs:
           ABFS_FLAT_ACCESS_KEY: todo
           ABFS_HIERARCHICAL_ACCOUNT: todo
           ABFS_HIERARCHICAL_ACCESS_KEY: todo
+          ABFS_OAUTH_TENANT_ID: todo
+          ABFS_OAUTH_CLIENT_ID: todo
+          ABFS_OAUTH_CLIENT_SECRET: todo
         # todo(https://github.com/trinodb/trino/issues/18998) Enable when we have env variables in place
         # Run tests only if any of the secrets are present
         if: >-
           false &&
           contains(matrix.modules, 'trino-filesystem-azure') && contains(matrix.profile, 'cloud-tests') &&
-          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_HIERARCHICAL_ACCESS_KEY != '')
+          (env.CI_SKIP_SECRETS_PRESENCE_CHECKS != '' || env.ABFS_FLAT_ACCESS_KEY != '' || env.ABFS_HIERARCHICAL_ACCESS_KEY != '' || env.ABFS_OAUTH_CLIENT_SECRET != '')
         run: |
           $MAVEN test ${MAVEN_TEST} -pl ${{ matrix.modules }} ${{ format('-P {0}', matrix.profile) }}
       - name: GCS FileSystem Cloud Tests

--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -189,6 +189,8 @@
                             <excludes>
                                 <exclude>**/TestAzureFileSystemGen2Flat.java</exclude>
                                 <exclude>**/TestAzureFileSystemGen2Hierarchical.java</exclude>
+                                <exclude>**/TestAzureFileSystemOAuthGen2Flat.java</exclude>
+                                <exclude>**/TestAzureFileSystemOAuthGen2Hierarchical.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -207,6 +209,8 @@
                             <includes>
                                 <include>**/TestAzureFileSystemGen2Flat.java</include>
                                 <include>**/TestAzureFileSystemGen2Hierarchical.java</include>
+                                <include>**/TestAzureFileSystemOAuthGen2Flat.java</include>
+                                <include>**/TestAzureFileSystemOAuthGen2Hierarchical.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/lib/trino-filesystem-azure/pom.xml
+++ b/lib/trino-filesystem-azure/pom.xml
@@ -141,6 +141,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+            <classifier>jdk11</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>junit-extensions</artifactId>
             <scope>test</scope>

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystem.java
@@ -20,10 +20,8 @@ import com.azure.core.util.TracingOptions;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
-import com.azure.storage.blob.models.AccountKind;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.ListBlobsOptions;
-import com.azure.storage.blob.models.StorageAccountInfo;
 import com.azure.storage.common.Utility;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
@@ -456,13 +454,13 @@ public class AzureFileSystem
     private boolean isHierarchicalNamespaceEnabled(AzureLocation location)
             throws IOException
     {
-        StorageAccountInfo accountInfo = createBlobContainerClient(location).getServiceClient().getAccountInfo();
-
-        AccountKind accountKind = accountInfo.getAccountKind();
-        if (accountKind != AccountKind.STORAGE_V2) {
-            throw new IOException("Unsupported account kind '%s': %s".formatted(accountKind, location));
+        try {
+            DataLakeFileSystemClient fileSystemClient = createFileSystemClient(location);
+            return fileSystemClient.getDirectoryClient("/").exists();
         }
-        return accountInfo.isHierarchicalNamespaceEnabled();
+        catch (RuntimeException e) {
+            throw new IOException("Checking whether hierarchical namespace is enabled for the location %s failed".formatted(location), e);
+        }
     }
 
     private BlobClient createBlobClient(AzureLocation location)

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -14,12 +14,10 @@
 package io.trino.filesystem.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.blob.models.StorageAccountInfo;
-import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
-import com.azure.storage.file.datalake.DataLakeFileSystemClientBuilder;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.options.DataLakePathDeleteOptions;
 import io.opentelemetry.api.OpenTelemetry;
@@ -51,65 +49,73 @@ public abstract class AbstractTestAzureFileSystem
         return requireNonNull(System.getenv(name), "Environment variable not set: " + name);
     }
 
-    enum AccountKind
+    protected enum AccountKind
     {
         HIERARCHICAL, FLAT
     }
 
     private String account;
-    private StorageSharedKeyCredential credential;
+    private AzureAuth azureAuth;
     private AccountKind accountKind;
     private String containerName;
     private Location rootLocation;
     private BlobContainerClient blobContainerClient;
     private TrinoFileSystem fileSystem;
 
-    protected void initialize(String account, String accountKey, AccountKind expectedAccountKind)
+    protected void initializeWithAccessKey(String account, String accountKey, AccountKind accountKind)
             throws IOException
     {
-        this.account = account;
-        credential = new StorageSharedKeyCredential(account, accountKey);
+        initialize(account, new AzureAuthAccessKey(accountKey), accountKind);
+    }
 
-        String blobEndpoint = "https://%s.blob.core.windows.net".formatted(account);
-        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder()
-                .endpoint(blobEndpoint)
-                .credential(credential)
-                .buildClient();
-        accountKind = getAccountKind(blobServiceClient);
-        checkState(accountKind == expectedAccountKind, "Expected %s account, but found %s".formatted(expectedAccountKind, accountKind));
-
+    private void initialize(String account, AzureAuth azureAuth, AccountKind accountKind)
+            throws IOException
+    {
+        this.account = requireNonNull(account, "account is null");
+        this.azureAuth = requireNonNull(azureAuth, "azureAuth is null");
+        this.accountKind = requireNonNull(accountKind, "accountKind is null");
         containerName = "test-%s-%s".formatted(accountKind.name().toLowerCase(ROOT), randomUUID());
         rootLocation = Location.of("abfs://%s@%s.dfs.core.windows.net/".formatted(containerName, account));
 
-        blobContainerClient = blobServiceClient.getBlobContainerClient(containerName);
+        BlobContainerClientBuilder builder = new BlobContainerClientBuilder()
+                .endpoint("https://%s.blob.core.windows.net".formatted(account))
+                .containerName(containerName);
+        azureAuth.setAuth(account, builder);
+        blobContainerClient = builder.buildClient();
         // this will fail if the container already exists, which is what we want
         blobContainerClient.create();
+        boolean isHierarchicalNamespaceEnabled = isHierarchicalNamespaceEnabled();
+        if (accountKind == AccountKind.HIERARCHICAL) {
+            checkState(isHierarchicalNamespaceEnabled, "Expected hierarchical namespaces to be enabled for storage account %s and container %s with account kind %s".formatted(account, containerName, accountKind));
+        }
+        else {
+            checkState(!isHierarchicalNamespaceEnabled, "Expected hierarchical namespaces to not be enabled for storage account %s and container %s with account kind %s".formatted(account, containerName, accountKind));
+        }
 
         fileSystem = new AzureFileSystemFactory(
                 OpenTelemetry.noop(),
-                new AzureAuthAccessKey(accountKey),
+                azureAuth,
                 new AzureFileSystemConfig()).create(ConnectorIdentity.ofUser("test"));
 
         cleanupFiles();
     }
 
-    private static AccountKind getAccountKind(BlobServiceClient blobServiceClient)
+    private boolean isHierarchicalNamespaceEnabled()
             throws IOException
     {
-        StorageAccountInfo accountInfo = blobServiceClient.getAccountInfo();
-        if (accountInfo.getAccountKind() == com.azure.storage.blob.models.AccountKind.STORAGE_V2) {
-            if (accountInfo.isHierarchicalNamespaceEnabled()) {
-                return AccountKind.HIERARCHICAL;
-            }
-            return AccountKind.FLAT;
+        DataLakeFileSystemClient fileSystemClient = createDataLakeFileSystemClient();
+        try {
+            return fileSystemClient.getDirectoryClient("/").exists();
         }
-        throw new IOException("Unsupported account kind '%s'".formatted(accountInfo.getAccountKind()));
+        catch (RuntimeException e) {
+            throw new IOException("Failed to check whether hierarchical namespaces is enabled for the storage account %s and container %s".formatted(account, containerName));
+        }
     }
 
     @AfterAll
     void tearDown()
     {
-        credential = null;
+        azureAuth = null;
         fileSystem = null;
         if (blobContainerClient != null) {
             blobContainerClient.deleteIfExists();
@@ -126,12 +132,7 @@ public abstract class AbstractTestAzureFileSystem
     private void cleanupFiles()
     {
         if (accountKind == AccountKind.HIERARCHICAL) {
-            DataLakeFileSystemClient fileSystemClient = new DataLakeFileSystemClientBuilder()
-                    .endpoint("https://%s.dfs.core.windows.net".formatted(account))
-                    .fileSystemName(containerName)
-                    .credential(credential)
-                    .buildClient();
-
+            DataLakeFileSystemClient fileSystemClient = createDataLakeFileSystemClient();
             DataLakePathDeleteOptions deleteRecursiveOptions = new DataLakePathDeleteOptions().setIsRecursive(true);
             for (PathItem pathItem : fileSystemClient.listPaths()) {
                 if (pathItem.isDirectory()) {
@@ -145,6 +146,15 @@ public abstract class AbstractTestAzureFileSystem
         else {
             blobContainerClient.listBlobs().forEach(item -> blobContainerClient.getBlobClient(urlEncode(item.getName())).deleteIfExists());
         }
+    }
+
+    private DataLakeFileSystemClient createDataLakeFileSystemClient()
+    {
+        DataLakeServiceClientBuilder serviceClientBuilder = new DataLakeServiceClientBuilder()
+                .endpoint("https://%s.dfs.core.windows.net".formatted(account));
+        azureAuth.setAuth(account, serviceClientBuilder);
+        DataLakeServiceClient serviceClient = serviceClientBuilder.buildClient();
+        return serviceClient.getFileSystemClient(containerName);
     }
 
     @Override

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/AbstractTestAzureFileSystem.java
@@ -68,6 +68,13 @@ public abstract class AbstractTestAzureFileSystem
         initialize(account, new AzureAuthAccessKey(accountKey), accountKind);
     }
 
+    protected void initializeWithOAuth(String account, String tenantId, String clientId, String clientSecret, AccountKind accountKind)
+            throws IOException
+    {
+        String clientEndpoint = "https://login.microsoftonline.com/%s/oauth2/v2.0/token".formatted(tenantId);
+        initialize(account, new AzureAuthOauth(clientEndpoint, tenantId, clientId, clientSecret), accountKind);
+    }
+
     private void initialize(String account, AzureAuth azureAuth, AccountKind accountKind)
             throws IOException
     {

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Flat.java
@@ -29,6 +29,6 @@ class TestAzureFileSystemGen2Flat
     void setup()
             throws IOException
     {
-        initialize(getRequiredEnvironmentVariable("ABFS_FLAT_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_FLAT_ACCESS_KEY"), FLAT);
+        initializeWithAccessKey(getRequiredEnvironmentVariable("ABFS_FLAT_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_FLAT_ACCESS_KEY"), FLAT);
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
@@ -29,6 +29,6 @@ class TestAzureFileSystemGen2Hierarchical
     void setup()
             throws IOException
     {
-        initialize(getRequiredEnvironmentVariable("ABFS_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_ACCESS_KEY"), HIERARCHICAL);
+        initialize(getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCESS_KEY"), HIERARCHICAL);
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemGen2Hierarchical.java
@@ -29,6 +29,6 @@ class TestAzureFileSystemGen2Hierarchical
     void setup()
             throws IOException
     {
-        initialize(getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCESS_KEY"), HIERARCHICAL);
+        initializeWithAccessKey(getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCOUNT"), getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCESS_KEY"), HIERARCHICAL);
     }
 }

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemOAuthGen2Flat.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemOAuthGen2Flat.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.IOException;
+
+import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.FLAT;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestAzureFileSystemOAuthGen2Flat
+        extends AbstractTestAzureFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        String account = getRequiredEnvironmentVariable("ABFS_FLAT_ACCOUNT");
+        String tenantId = getRequiredEnvironmentVariable("ABFS_OAUTH_TENANT_ID");
+        String clientId = getRequiredEnvironmentVariable("ABFS_OAUTH_CLIENT_ID");
+        String clientSecret = getRequiredEnvironmentVariable("ABFS_OAUTH_CLIENT_SECRET");
+        initializeWithOAuth(account, tenantId, clientId, clientSecret, FLAT);
+    }
+}

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemOAuthGen2Hierarchical.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemOAuthGen2Hierarchical.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import java.io.IOException;
+
+import static io.trino.filesystem.azure.AbstractTestAzureFileSystem.AccountKind.HIERARCHICAL;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class TestAzureFileSystemOAuthGen2Hierarchical
+        extends AbstractTestAzureFileSystem
+{
+    @BeforeAll
+    void setup()
+            throws IOException
+    {
+        String account = getRequiredEnvironmentVariable("ABFS_HIERARCHICAL_ACCOUNT");
+        String tenantId = getRequiredEnvironmentVariable("ABFS_OAUTH_TENANT_ID");
+        String clientId = getRequiredEnvironmentVariable("ABFS_OAUTH_CLIENT_ID");
+        String clientSecret = getRequiredEnvironmentVariable("ABFS_OAUTH_CLIENT_SECRET");
+        initializeWithOAuth(account, tenantId, clientId, clientSecret, HIERARCHICAL);
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
The hierarchical namespaces check in the native Azure filesystem is not compatible with authentication via OAuth tokens. The existing check uses the "Get Account Information" blob service account REST API endpoint. As stated in the documentation for this endpoint, it does not support OAuth based access token authentication:

https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures#authorization

In order to fix the Azure filesystem OAuth integration we have figured out an alternate method of checking if hierarchical namespaces are enabled for an account using other apis made available in the azure-sdk-for-java. The method used in this PR checks if the root directory exists on the account. If it exists, then HNS is enabled for the account, if it does not exist then HNS is not enabled for the account.

An issue has been opened in the azure-sdk-for-java repo in order to get feedback on this approach and to see if they are planning to add support for OAuth token based authentication to the "Get Account Information" API. https://github.com/Azure/azure-sdk-for-java/issues/38912

Additionally, as part of these changes I have refactored some of the testing infrastructure for the Azure filesystem in order to support tests using OAuth. All that needs to be done is to add the env variables/secrets to CI. https://github.com/trinodb/trino/issues/18998

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(X) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
