### PR TITLE
Improve performance of arrays_overlap

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraysOverlapFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraysOverlapFunction.java
@@ -21,170 +21,67 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlNullable;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
-import io.trino.spi.function.TypeParameterSpecialization;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
-import io.trino.type.BlockTypeOperators.BlockPositionComparison;
-import it.unimi.dsi.fastutil.ints.IntArrays;
-import it.unimi.dsi.fastutil.ints.IntComparator;
-import it.unimi.dsi.fastutil.longs.LongArrays;
+import io.trino.type.BlockTypeOperators;
 
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION_NOT_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
+import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.spi.function.OperatorType.IS_DISTINCT_FROM;
 
 @ScalarFunction("arrays_overlap")
 @Description("Returns true if arrays have common elements")
 public final class ArraysOverlapFunction
 {
-    private int[] leftPositions = new int[0];
-    private int[] rightPositions = new int[0];
-
-    private long[] leftLongArray = new long[0];
-    private long[] rightLongArray = new long[0];
-
-    @TypeParameter("E")
-    public ArraysOverlapFunction(@TypeParameter("E") Type elementType) {}
-
-    @SqlNullable
-    @TypeParameter("E")
-    @TypeParameterSpecialization(name = "E", nativeContainerType = long.class)
-    @SqlType(StandardTypes.BOOLEAN)
-    public Boolean arraysOverlapInt(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_LAST,
-                    argumentTypes = {"E", "E"},
-                    convention = @Convention(arguments = {NEVER_NULL, NEVER_NULL}, result = FAIL_ON_NULL)) LongComparison comparisonOperator,
-            @TypeParameter("E") Type type,
-            @SqlType("array(E)") Block leftArray,
-            @SqlType("array(E)") Block rightArray)
-    {
-        int leftSize = leftArray.getPositionCount();
-        int rightSize = rightArray.getPositionCount();
-
-        if (leftSize == 0 || rightSize == 0) {
-            return false;
-        }
-
-        if (leftLongArray.length < leftSize) {
-            leftLongArray = new long[leftSize * 2];
-        }
-        if (rightLongArray.length < rightSize) {
-            rightLongArray = new long[rightSize * 2];
-        }
-
-        int leftNonNullSize = sortLongArray(leftArray, leftLongArray, type, comparisonOperator);
-        int rightNonNullSize = sortLongArray(rightArray, rightLongArray, type, comparisonOperator);
-
-        int leftPosition = 0;
-        int rightPosition = 0;
-        while (leftPosition < leftNonNullSize && rightPosition < rightNonNullSize) {
-            long compareValue = comparisonOperator.compare(leftLongArray[leftPosition], rightLongArray[rightPosition]);
-            if (compareValue > 0) {
-                rightPosition++;
-            }
-            else if (compareValue < 0) {
-                leftPosition++;
-            }
-            else {
-                return true;
-            }
-        }
-        return (leftNonNullSize < leftSize) || (rightNonNullSize < rightSize) ? null : false;
-    }
-
-    // Assumes buffer is long enough, returns count of non-null elements.
-    private static int sortLongArray(Block array, long[] buffer, Type type, LongComparison comparisonOperator)
-    {
-        int arraySize = array.getPositionCount();
-        int nonNullSize = 0;
-        for (int i = 0; i < arraySize; i++) {
-            if (!array.isNull(i)) {
-                buffer[nonNullSize++] = type.getLong(array, i);
-            }
-        }
-
-        LongArrays.unstableSort(buffer, 0, nonNullSize, (left, right) -> (int) comparisonOperator.compare(left, right));
-
-        return nonNullSize;
-    }
+    private ArraysOverlapFunction() {}
 
     @SqlNullable
     @TypeParameter("E")
     @SqlType(StandardTypes.BOOLEAN)
-    public Boolean arraysOverlap(
-            @OperatorDependency(
-                    operator = COMPARISON_UNORDERED_LAST,
-                    argumentTypes = {"E", "E"},
-                    convention = @Convention(arguments = {BLOCK_POSITION_NOT_NULL, BLOCK_POSITION_NOT_NULL}, result = FAIL_ON_NULL)) BlockPositionComparison comparisonOperator,
+    public static Boolean arraysOverlap(
             @TypeParameter("E") Type type,
+            @OperatorDependency(
+                    operator = IS_DISTINCT_FROM,
+                    argumentTypes = {"E", "E"},
+                    convention = @Convention(arguments = {BLOCK_POSITION,
+                            BLOCK_POSITION}, result = FAIL_ON_NULL)) BlockTypeOperators.BlockPositionIsDistinctFrom elementIsDistinctFrom,
+            @OperatorDependency(
+                    operator = HASH_CODE,
+                    argumentTypes = "E",
+                    convention = @Convention(arguments = BLOCK_POSITION, result = FAIL_ON_NULL)) BlockTypeOperators.BlockPositionHashCode elementHashCode,
             @SqlType("array(E)") Block leftArray,
             @SqlType("array(E)") Block rightArray)
     {
-        int leftPositionCount = leftArray.getPositionCount();
-        int rightPositionCount = rightArray.getPositionCount();
+        Block smaller = rightArray;
+        Block larger = leftArray;
+        if (leftArray.getPositionCount() < rightArray.getPositionCount()) {
+            smaller = leftArray;
+            larger = rightArray;
+        }
 
-        if (leftPositionCount == 0 || rightPositionCount == 0) {
+        int largerPositionCount = larger.getPositionCount();
+        int smallerPositionCount = smaller.getPositionCount();
+
+        if (largerPositionCount == 0 || smallerPositionCount == 0) {
             return false;
         }
 
-        if (leftPositions.length < leftPositionCount) {
-            leftPositions = new int[leftPositionCount * 2];
+        BlockSet smallerSet = new BlockSet(type, elementIsDistinctFrom, elementHashCode, smallerPositionCount);
+        for (int position = 0; position < smallerPositionCount; position++) {
+            smallerSet.add(smaller, position);
         }
 
-        if (rightPositions.length < rightPositionCount) {
-            rightPositions = new int[rightPositionCount * 2];
-        }
-
-        for (int i = 0; i < leftPositionCount; i++) {
-            leftPositions[i] = i;
-        }
-        for (int i = 0; i < rightPositionCount; i++) {
-            rightPositions[i] = i;
-        }
-        IntArrays.quickSort(leftPositions, 0, leftPositionCount, intBlockCompare(comparisonOperator, leftArray));
-        IntArrays.quickSort(rightPositions, 0, rightPositionCount, intBlockCompare(comparisonOperator, rightArray));
-
-        int leftPosition = 0;
-        int rightPosition = 0;
-        while (leftPosition < leftPositionCount && rightPosition < rightPositionCount) {
-            if (leftArray.isNull(leftPositions[leftPosition]) || rightArray.isNull(rightPositions[rightPosition])) {
-                // Nulls are in the end of the array. Non-null elements do not overlap.
-                return null;
+        boolean largerContainsNull = false;
+        for (int position = 0; position < largerPositionCount; position++) {
+            if (larger.isNull(position)) {
+                largerContainsNull = true;
+                continue;
             }
-            long compareValue = comparisonOperator.compare(leftArray, leftPositions[leftPosition], rightArray, rightPositions[rightPosition]);
-            if (compareValue > 0) {
-                rightPosition++;
-            }
-            else if (compareValue < 0) {
-                leftPosition++;
-            }
-            else {
+            if (smallerSet.contains(larger, position)) {
                 return true;
             }
         }
-        return leftArray.isNull(leftPositions[leftPositionCount - 1]) || rightArray.isNull(rightPositions[rightPositionCount - 1]) ? null : false;
-    }
-
-    private static IntComparator intBlockCompare(BlockPositionComparison comparisonOperator, Block block)
-    {
-        return (left, right) -> {
-            if (block.isNull(left) && block.isNull(right)) {
-                return 0;
-            }
-            if (block.isNull(left)) {
-                return 1;
-            }
-            if (block.isNull(right)) {
-                return -1;
-            }
-            return (int) comparisonOperator.compare(block, left, block, right);
-        };
-    }
-
-    public interface LongComparison
-    {
-        long compare(long left, long right);
+        return largerContainsNull || smallerSet.containsNullElement() ? null : false;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/BlockSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/BlockSet.java
@@ -137,6 +137,14 @@ public class BlockSet
     }
 
     /**
+     * Returns whether this set contains a NULL element
+     */
+    public boolean containsNullElement()
+    {
+        return containsNullElement;
+    }
+
+    /**
      * Return the position of the value within this set, or -1 if the value is not in this set.
      * This method can not get the position of a null value, and an exception will be thrown in that case.
      *

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraysOverlap.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkArraysOverlap.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+import io.trino.jmh.Benchmarks;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.DriverYieldSignal;
+import io.trino.operator.project.PageProcessor;
+import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.Type;
+import io.trino.sql.gen.ExpressionCompiler;
+import io.trino.sql.relational.CallExpression;
+import io.trino.sql.relational.RowExpression;
+import org.junit.jupiter.api.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.relational.Expressions.field;
+import static io.trino.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArraysOverlap
+{
+    private static final int POSITIONS = 1_000;
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
+    public List<Optional<Page>> benchmark(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(data.getPageProcessor().process(
+                SESSION,
+                new DriverYieldSignal(),
+                newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                data.getPage()));
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private String name = "arrays_overlap";
+
+        @Param({"BIGINT", "VARCHAR"})
+        private String type = "BIGINT";
+
+        @Param({"10", "100", "1000"})
+        private int arraySize = 10;
+
+        private Page page;
+        private PageProcessor pageProcessor;
+
+        @Setup
+        public void setup()
+        {
+            Type elementType = switch (type) {
+                case "BIGINT" -> BIGINT;
+                case "VARCHAR" -> VARCHAR;
+                default -> throw new UnsupportedOperationException();
+            };
+
+            TestingFunctionResolution functionResolution = new TestingFunctionResolution();
+            ArrayType arrayType = new ArrayType(elementType);
+            ImmutableList<RowExpression> projections = ImmutableList.of(new CallExpression(
+                    functionResolution.resolveFunction(name, fromTypes(arrayType, arrayType)),
+                    ImmutableList.of(field(0, arrayType), field(1, arrayType))));
+
+            ExpressionCompiler compiler = functionResolution.getExpressionCompiler();
+            pageProcessor = compiler.compilePageProcessor(Optional.empty(), projections).get();
+
+            page = new Page(createChannel(POSITIONS, arraySize, elementType), createChannel(POSITIONS, arraySize, elementType));
+        }
+
+        private static Block createChannel(int positionCount, int arraySize, Type elementType)
+        {
+            ArrayType arrayType = new ArrayType(elementType);
+            ArrayBlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
+            for (int position = 0; position < positionCount; position++) {
+                blockBuilder.buildEntry(elementBuilder -> {
+                    for (int i = 0; i < arraySize; i++) {
+                        if (elementType.getJavaType() == long.class) {
+                            elementType.writeLong(elementBuilder, ThreadLocalRandom.current().nextLong() % arraySize);
+                        }
+                        else if (elementType.equals(VARCHAR)) {
+                            // make sure the size of a varchar is rather small; otherwise the aggregated slice may overflow
+                            elementType.writeSlice(elementBuilder, Slices.utf8Slice(Long.toString(ThreadLocalRandom.current().nextLong() % arraySize)));
+                        }
+                        else {
+                            throw new UnsupportedOperationException();
+                        }
+                    }
+                });
+            }
+            return blockBuilder.build();
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getPage()
+        {
+            return page;
+        }
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArraysOverlap().benchmark(data);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArraysOverlap().benchmark(data);
+
+        Benchmarks.benchmark(BenchmarkArraysOverlap.class).run();
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Use a set instead of sorted arrays for a faster implementation

```
BenchmarkArraysOverlap
    (arraySize)           (name)   (type)  Mode  Cnt      Before                  After             Units
             10   arrays_overlap   BIGINT  avgt   20    1833.452 ±    39.165   1130.388 ±  112.507  ns/op
             10   arrays_overlap  VARCHAR  avgt   20    3507.608 ±   146.911   1476.905 ±  164.377  ns/op
            100   arrays_overlap   BIGINT  avgt   20   31971.624 ±   660.772   8473.338 ±  768.726  ns/op
            100   arrays_overlap  VARCHAR  avgt   20   66072.713 ±  5309.456  10928.315 ±  336.211  ns/op
           1000   arrays_overlap   BIGINT  avgt   20  500618.664 ± 17615.978  79698.191 ± 5276.151  ns/op
           1000   arrays_overlap  VARCHAR  avgt   20  908004.836 ± 29334.310  99256.412 ± 1329.540  ns/op
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Supersedes https://github.com/trinodb/trino/pull/17579


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Improve performance of arrays_overlap. ({issue}`20900`)
```
