### PR TITLE
Cleanup test containers on retries

### DIFF
--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -80,8 +80,15 @@ public class TestingOracleServer
                 .withCopyFileToContainer(MountableFile.forClasspathResource("restart.sh"), "/container-entrypoint-initdb.d/02-restart.sh")
                 .withCopyFileToContainer(MountableFile.forHostPath(createConfigureScript()), "/container-entrypoint-initdb.d/03-create-users.sql")
                 .usingSid();
-        this.cleanup = startOrReuse(container);
-        this.container = container;
+        try {
+            this.cleanup = startOrReuse(container);
+            this.container = container;
+        }
+        catch (Throwable e) {
+            try (container) {
+                throw e;
+            }
+        }
     }
 
     private Path createConfigureScript()

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -141,16 +141,23 @@ public final class TestingSqlServer
         // to be disabled for tests.
         container.withUrlParam("encrypt", "false");
 
-        Closeable cleanup = startOrReuse(container);
         try {
-            setUpDatabase(sqlExecutorForContainer(container), databaseName, databaseSetUp);
-        }
-        catch (Exception e) {
-            closeAllSuppress(e, cleanup);
-            throw e;
-        }
+            Closeable cleanup = startOrReuse(container);
+            try {
+                setUpDatabase(sqlExecutorForContainer(container), databaseName, databaseSetUp);
+            }
+            catch (Exception e) {
+                closeAllSuppress(e, cleanup);
+                throw e;
+            }
 
-        return new InitializedState(container, databaseName, cleanup);
+            return new InitializedState(container, databaseName, cleanup);
+        }
+        catch (Throwable e) {
+            try (container) {
+                throw e;
+            }
+        }
     }
 
     private static void setUpDatabase(SqlExecutor executor, String databaseName, BiConsumer<SqlExecutor, String> databaseSetUp)


### PR DESCRIPTION
Container start may fail and leave a container running behind.
When container creation/start is not retried, this is not an issue,
since the failure is propagated and leads to test failures anyway.
If creation/start is retried, the leaked container may be running in the
background (resource leak), and also will be reported by
`ReportLeakedContainers` (test failure, even though the start was
retried and successful in the end). Therefore containers needs to be
explicitly cleaned up (stopped) upon retries.