### PR TITLE
Add constructor of RenameColumn without NodeLocation

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/RenameColumn.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/RenameColumn.java
@@ -31,9 +31,19 @@ public class RenameColumn
     private final boolean tableExists;
     private final boolean columnExists;
 
+    public RenameColumn(QualifiedName table, QualifiedName source, Identifier target, boolean tableExists, boolean columnExists)
+    {
+        this(Optional.empty(), table, source, target, tableExists, columnExists);
+    }
+
     public RenameColumn(NodeLocation location, QualifiedName table, QualifiedName source, Identifier target, boolean tableExists, boolean columnExists)
     {
-        super(Optional.of(location));
+        this(Optional.of(location), table, source, target, tableExists, columnExists);
+    }
+
+    private RenameColumn(Optional<NodeLocation> location, QualifiedName table, QualifiedName source, Identifier target, boolean tableExists, boolean columnExists)
+    {
+        super(location);
         this.table = requireNonNull(table, "table is null");
         this.source = requireNonNull(source, "source is null");
         this.target = requireNonNull(target, "target is null");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Add constructor of `RenameColumn` which doesn't take `NodeLocation` as other tree nodes.


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
