### PR TITLE
Clean up planning of json expressions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -1353,12 +1353,8 @@ class RelationPlanner
 
         // apply the input functions to the JSON path parameters having FORMAT,
         // and collect all JSON path parameters in a Row
-        List<JsonPathParameter> coercedParameters = pathParameters.stream()
-                .map(parameter -> new JsonPathParameter(
-                        parameter.getLocation(),
-                        parameter.getName(),
-                        coerced.get(parameter.getParameter()).toSymbolReference(),
-                        parameter.getFormat()))
+        List<Expression> coercedParameters = pathParameters.stream()
+                .map(parameter -> coerced.get(parameter.getParameter()).toSymbolReference())
                 .collect(toImmutableList());
         JsonTableAnalysis jsonTableAnalysis = analysis.getJsonTableAnalysis(jsonTable);
         RowType parametersType = jsonTableAnalysis.parametersType();


### PR DESCRIPTION


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
