### PR TITLE
Fix 'Multiple entries with same key' error with dynamic filters

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
+++ b/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
@@ -452,7 +452,8 @@ public class DynamicFilterService
                                 return applySaturatedCasts(metadata, functionManager, typeOperators, session, updatedSummary, targetType);
                             }
                             return updatedSummary;
-                        })));
+                        },
+                        Domain::intersect)));
     }
 
     private static Set<DynamicFilterId> getLazyDynamicFilters(PlanFragment plan)


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Trino will throw Exceptions "Multiple entries with same key", when the same dynamic filter applies to the same partitions key column multiple times under different conditions. E.g.
```
SELECT *
FROM tbl_a a
JOIN tbl_b b ON b.partition_key_date >= a.start_date AND b.partition_key_date <= a.start_date
```


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix query failures with "Multiple entries with same key" error encountered with joins on partitioned tables. ({issue}`20917`)
```
