### PR TITLE
Include file statistics domain in IcebergSplit

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTypes.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergTypes.java
@@ -165,7 +165,7 @@ public final class IcebergTypes
         if (icebergType instanceof Types.StringType) {
             // Partition values are passed as String, but min/max values are passed as a CharBuffer
             if (value instanceof CharBuffer) {
-                value = new String(((CharBuffer) value).array());
+                value = ((CharBuffer) value).toString();
             }
             return utf8Slice(((String) value));
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/functions/tablechanges/TableChangesFunctionProcessor.java
@@ -120,6 +120,7 @@ public class TableChangesFunctionProcessor
                 ImmutableList.of(),
                 DynamicFilter.EMPTY,
                 TupleDomain.all(),
+                TupleDomain.all(),
                 split.path(),
                 split.start(),
                 split.length(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -61,6 +61,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -72,6 +73,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.createPerTransactionCache;
 import static io.trino.plugin.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static io.trino.plugin.iceberg.IcebergSplitSource.createFileStatisticsDomain;
 import static io.trino.plugin.iceberg.IcebergTestUtils.getFileSystemFactory;
 import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -146,26 +148,7 @@ public class TestIcebergSplitSource
         long startMillis = System.currentTimeMillis();
         SchemaTableName schemaTableName = new SchemaTableName("tpch", "nation");
         Table nationTable = catalog.loadTable(SESSION, schemaTableName);
-        IcebergTableHandle tableHandle = new IcebergTableHandle(
-                CatalogHandle.fromId("iceberg:NORMAL:v12345"),
-                schemaTableName.getSchemaName(),
-                schemaTableName.getTableName(),
-                TableType.DATA,
-                Optional.empty(),
-                SchemaParser.toJson(nationTable.schema()),
-                Optional.of(PartitionSpecParser.toJson(nationTable.spec())),
-                1,
-                TupleDomain.all(),
-                TupleDomain.all(),
-                OptionalLong.empty(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                nationTable.location(),
-                nationTable.properties(),
-                false,
-                Optional.empty(),
-                ImmutableSet.of(),
-                Optional.of(false));
+        IcebergTableHandle tableHandle = createTableHandle(schemaTableName, nationTable, TupleDomain.all());
 
         try (IcebergSplitSource splitSource = new IcebergSplitSource(
                 new DefaultIcebergFileSystemFactory(fileSystemFactory),
@@ -236,6 +219,74 @@ public class TestIcebergSplitSource
     }
 
     @Test
+    public void testFileStatisticsDomain()
+            throws Exception
+    {
+        SchemaTableName schemaTableName = new SchemaTableName("tpch", "nation");
+        Table nationTable = catalog.loadTable(SESSION, schemaTableName);
+        IcebergTableHandle tableHandle = createTableHandle(schemaTableName, nationTable, TupleDomain.all());
+
+        IcebergSplit split = generateSplit(nationTable, tableHandle, DynamicFilter.EMPTY);
+        assertThat(split.getFileStatisticsDomain()).isEqualTo(TupleDomain.all());
+
+        IcebergColumnHandle nationKey = new IcebergColumnHandle(
+                new ColumnIdentity(1, "nationkey", ColumnIdentity.TypeCategory.PRIMITIVE, ImmutableList.of()),
+                BIGINT,
+                ImmutableList.of(),
+                BIGINT,
+                true,
+                Optional.empty());
+        tableHandle = createTableHandle(schemaTableName, nationTable, TupleDomain.fromFixedValues(ImmutableMap.of(nationKey, NullableValue.of(BIGINT, 1L))));
+        split = generateSplit(nationTable, tableHandle, DynamicFilter.EMPTY);
+        assertThat(split.getFileStatisticsDomain()).isEqualTo(TupleDomain.withColumnDomains(
+                ImmutableMap.of(nationKey, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, true, 24L, true)), false))));
+
+        IcebergColumnHandle regionKey = new IcebergColumnHandle(
+                new ColumnIdentity(3, "regionkey", ColumnIdentity.TypeCategory.PRIMITIVE, ImmutableList.of()),
+                BIGINT,
+                ImmutableList.of(),
+                BIGINT,
+                true,
+                Optional.empty());
+        split = generateSplit(nationTable, tableHandle, new DynamicFilter()
+        {
+            @Override
+            public Set<ColumnHandle> getColumnsCovered()
+            {
+                return ImmutableSet.of(regionKey);
+            }
+
+            @Override
+            public CompletableFuture<?> isBlocked()
+            {
+                return NOT_BLOCKED;
+            }
+
+            @Override
+            public boolean isComplete()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isAwaitable()
+            {
+                return true;
+            }
+
+            @Override
+            public TupleDomain<ColumnHandle> getCurrentPredicate()
+            {
+                return TupleDomain.all();
+            }
+        });
+        assertThat(split.getFileStatisticsDomain()).isEqualTo(TupleDomain.withColumnDomains(
+                ImmutableMap.of(
+                        nationKey, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, true, 24L, true)), false),
+                        regionKey, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, true, 4L, true)), false))));
+    }
+
+    @Test
     public void testBigintPartitionPruning()
     {
         IcebergColumnHandle bigintColumn = new IcebergColumnHandle(
@@ -272,93 +323,17 @@ public class TestIcebergSplitSource
         Map<Integer, Type.PrimitiveType> primitiveTypes = ImmutableMap.of(1, Types.LongType.get());
         Map<Integer, ByteBuffer> lowerBound = ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), 1000L));
         Map<Integer, ByteBuffer> upperBound = ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), 2000L));
+        TupleDomain<IcebergColumnHandle> domainLowerUpperBound = TupleDomain.withColumnDomains(
+                ImmutableMap.of(bigintColumn, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1000L, true, 2000L, true)), false)));
+        List<IcebergColumnHandle> predicatedColumns = ImmutableList.of(bigintColumn);
 
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 0L))),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isFalse();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 1000L))),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 1500L))),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 2000L))),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 3000L))),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isFalse();
+        assertThat(createFileStatisticsDomain(primitiveTypes, lowerBound, upperBound, ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(domainLowerUpperBound);
 
-        Domain outsideStatisticsRangeAllowNulls = Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, true, 100L, true)), true);
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, outsideStatisticsRangeAllowNulls)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isFalse();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, outsideStatisticsRangeAllowNulls)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 1L))).isTrue();
-
-        Domain outsideStatisticsRangeNoNulls = Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 0L, true, 100L, true)), false);
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, outsideStatisticsRangeNoNulls)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isFalse();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, outsideStatisticsRangeNoNulls)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 1L))).isFalse();
-
-        Domain insideStatisticsRange = Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1001L, true, 1002L, true)), false);
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, insideStatisticsRange)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, insideStatisticsRange)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 1L))).isTrue();
-
-        Domain overlappingStatisticsRange = Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 990L, true, 1010L, true)), false);
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, overlappingStatisticsRange)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, overlappingStatisticsRange)),
-                lowerBound,
-                upperBound,
-                ImmutableMap.of(1, 1L))).isTrue();
+        TupleDomain<IcebergColumnHandle> domainLowerUpperBoundAllowNulls = TupleDomain.withColumnDomains(
+                ImmutableMap.of(bigintColumn, Domain.create(ValueSet.ofRanges(Range.range(BIGINT, 1000L, true, 2000L, true)), true)));
+        assertThat(createFileStatisticsDomain(primitiveTypes, lowerBound, upperBound, ImmutableMap.of(1, 1L), predicatedColumns))
+                .isEqualTo(domainLowerUpperBoundAllowNulls);
     }
 
     @Test
@@ -374,46 +349,87 @@ public class TestIcebergSplitSource
         Map<Integer, Type.PrimitiveType> primitiveTypes = ImmutableMap.of(1, Types.LongType.get());
         Map<Integer, ByteBuffer> lowerBound = ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), -1000L));
         Map<Integer, ByteBuffer> upperBound = ImmutableMap.of(1, Conversions.toByteBuffer(Types.LongType.get(), 2000L));
-        TupleDomain<IcebergColumnHandle> domainOfZero = TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 0L)));
+        TupleDomain<IcebergColumnHandle> domainLessThanUpperBound = TupleDomain.withColumnDomains(
+                ImmutableMap.of(bigintColumn, Domain.create(ValueSet.ofRanges(Range.lessThanOrEqual(BIGINT, 2000L)), false)));
+        List<IcebergColumnHandle> predicatedColumns = ImmutableList.of(bigintColumn);
 
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                domainOfZero,
-                null,
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                domainOfZero,
-                ImmutableMap.of(),
-                upperBound,
-                ImmutableMap.of(1, 0L))).isTrue();
+        assertThat(createFileStatisticsDomain(primitiveTypes, null, upperBound, ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(domainLessThanUpperBound);
+        assertThat(createFileStatisticsDomain(primitiveTypes, ImmutableMap.of(), upperBound, ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(domainLessThanUpperBound);
 
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                domainOfZero,
-                lowerBound,
-                null,
-                ImmutableMap.of(1, 0L))).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                domainOfZero,
-                lowerBound,
-                ImmutableMap.of(),
-                ImmutableMap.of(1, 0L))).isTrue();
+        TupleDomain<IcebergColumnHandle> domainGreaterThanLessBound = TupleDomain.withColumnDomains(
+                ImmutableMap.of(bigintColumn, Domain.create(ValueSet.ofRanges(Range.greaterThanOrEqual(BIGINT, -1000L)), false)));
+        assertThat(createFileStatisticsDomain(primitiveTypes, lowerBound, null, ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(domainGreaterThanLessBound);
+        assertThat(createFileStatisticsDomain(primitiveTypes, lowerBound, ImmutableMap.of(), ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(domainGreaterThanLessBound);
 
-        TupleDomain<IcebergColumnHandle> onlyNull = TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, Domain.onlyNull(BIGINT)));
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                onlyNull,
+        assertThat(createFileStatisticsDomain(primitiveTypes, ImmutableMap.of(), ImmutableMap.of(), null, predicatedColumns))
+                .isEqualTo(TupleDomain.all());
+        assertThat(createFileStatisticsDomain(primitiveTypes, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), predicatedColumns))
+                .isEqualTo(TupleDomain.all());
+        assertThat(createFileStatisticsDomain(primitiveTypes, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(1, 1L), predicatedColumns))
+                .isEqualTo(TupleDomain.all());
+
+        assertThat(createFileStatisticsDomain(primitiveTypes, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(1, 0L), predicatedColumns))
+                .isEqualTo(TupleDomain.withColumnDomains(ImmutableMap.of(bigintColumn, Domain.notNull(BIGINT))));
+    }
+
+    private IcebergSplit generateSplit(Table nationTable, IcebergTableHandle tableHandle, DynamicFilter dynamicFilter)
+            throws Exception
+    {
+        try (IcebergSplitSource splitSource = new IcebergSplitSource(
+                new DefaultIcebergFileSystemFactory(fileSystemFactory),
+                SESSION,
+                tableHandle,
                 ImmutableMap.of(),
-                ImmutableMap.of(),
-                null)).isTrue();
-        assertThat(IcebergSplitSource.fileMatchesPredicate(
-                primitiveTypes,
-                onlyNull,
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableMap.of())).isTrue();
+                nationTable.newScan(),
+                Optional.empty(),
+                dynamicFilter,
+                new Duration(0, SECONDS),
+                alwaysTrue(),
+                new TestingTypeManager(),
+                false,
+                new IcebergConfig().getMinimumAssignedSplitWeight(),
+                new DefaultCachingHostAddressProvider())) {
+            ImmutableList.Builder<IcebergSplit> builder = ImmutableList.builder();
+            while (!splitSource.isFinished()) {
+                splitSource.getNextBatch(100).get()
+                        .getSplits()
+                        .stream()
+                        .map(IcebergSplit.class::cast)
+                        .forEach(builder::add);
+            }
+            List<IcebergSplit> splits = builder.build();
+            assertThat(splits.size()).isEqualTo(1);
+            assertThat(splitSource.isFinished()).isTrue();
+
+            return splits.getFirst();
+        }
+    }
+
+    private static IcebergTableHandle createTableHandle(SchemaTableName schemaTableName, Table nationTable, TupleDomain<IcebergColumnHandle> unenforcedPredicate)
+    {
+        return new IcebergTableHandle(
+                CatalogHandle.fromId("iceberg:NORMAL:v12345"),
+                schemaTableName.getSchemaName(),
+                schemaTableName.getTableName(),
+                TableType.DATA,
+                Optional.empty(),
+                SchemaParser.toJson(nationTable.schema()),
+                Optional.of(PartitionSpecParser.toJson(nationTable.spec())),
+                1,
+                unenforcedPredicate,
+                TupleDomain.all(),
+                OptionalLong.empty(),
+                ImmutableSet.of(),
+                Optional.empty(),
+                nationTable.location(),
+                nationTable.properties(),
+                false,
+                Optional.empty(),
+                ImmutableSet.of(),
+                Optional.of(false));
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Allows pruning splits on workers using late arriving dynamic filters without opening file format footers
Also helps in avoiding unnecessary predicate pushdown into ORC/parquet

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Matches delta lake connector approach of including `statisticsPredicate` in DeltaLakeSplit


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
