### PR TITLE
Allow a custom header name for the authorization in Prometheus connector

### DIFF
--- a/docs/src/main/sphinx/connector/prometheus.md
+++ b/docs/src/main/sphinx/connector/prometheus.md
@@ -42,13 +42,14 @@ prometheus.read-timeout=10s
 The following configuration properties are available:
 
 | Property name                               | Description                                                                                  |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------- |
+|---------------------------------------------|----------------------------------------------------------------------------------------------|
 | `prometheus.uri`                            | Where to find Prometheus coordinator host                                                    |
 | `prometheus.query.chunk.size.duration`      | The duration of each query to Prometheus                                                     |
 | `prometheus.max.query.range.duration`       | Width of overall query to Prometheus, will be divided into query-chunk-size-duration queries |
 | `prometheus.cache.ttl`                      | How long values from this config file are cached                                             |
 | `prometheus.auth.user`                      | Username for basic authentication                                                            |
 | `prometheus.auth.password`                  | Password for basic authentication                                                            |
+| `prometheus.auth.http.header.name`          | Name of the header to use for authorization                                                  |
 | `prometheus.bearer.token.file`              | File holding bearer token if needed for access to Prometheus                                 |
 | `prometheus.read-timeout`                   | How much time a query to Prometheus has before timing out                                    |
 | `prometheus.case-insensitive-name-matching` | Match Prometheus metric names case insensitively. Defaults to `false`                        |
@@ -79,7 +80,8 @@ settings are meant to protect against an unlimited query.
 
 Prometheus can be setup to require a Authorization header with every query. The value in
 `prometheus.bearer.token.file` allows for a bearer token to be read from the configured file. This file
-is optional and not required unless your Prometheus setup requires it.
+is optional and not required unless your Prometheus setup requires it.  
+`prometheus.auth.http.header.name` allows you to use a custom header name for bearer token. Default value is `Authorization`.
 
 (prometheus-type-mapping)=
 

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusConnectorConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.net.HttpHeaders;
 import com.google.inject.ConfigurationException;
 import com.google.inject.spi.Message;
 import io.airlift.configuration.Config;
@@ -36,6 +37,7 @@ public class PrometheusConnectorConfig
     private Duration maxQueryRangeDuration = new Duration(21, TimeUnit.DAYS);
     private Duration cacheDuration = new Duration(30, TimeUnit.SECONDS);
     private Duration readTimeout = new Duration(10, TimeUnit.SECONDS);
+    private String httpAuthHeaderName = HttpHeaders.AUTHORIZATION;
     private File bearerTokenFile;
     private String user;
     private String password;
@@ -94,6 +96,19 @@ public class PrometheusConnectorConfig
     public PrometheusConnectorConfig setCacheDuration(Duration cacheConfigDuration)
     {
         this.cacheDuration = cacheConfigDuration;
+        return this;
+    }
+
+    public String getHttpAuthHeaderName()
+    {
+        return httpAuthHeaderName;
+    }
+
+    @Config("prometheus.auth.http.header.name")
+    @ConfigDescription("Name of the HTTP header to use for authorization")
+    public PrometheusConnectorConfig setHttpAuthHeaderName(String httpHeaderName)
+    {
+        this.httpAuthHeaderName = httpHeaderName;
         return this;
     }
 

--- a/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/plugin/trino-prometheus/src/test/java/io/trino/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.prometheus;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HttpHeaders;
 import com.google.inject.ConfigurationException;
 import io.airlift.units.Duration;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ public class TestPrometheusConnectorConfig
                 .setMaxQueryRangeDuration(new Duration(21, DAYS))
                 .setCacheDuration(new Duration(30, SECONDS))
                 .setBearerTokenFile(null)
+                .setHttpAuthHeaderName(HttpHeaders.AUTHORIZATION)
                 .setUser(null)
                 .setPassword(null)
                 .setReadTimeout(new Duration(10, SECONDS))
@@ -54,6 +56,7 @@ public class TestPrometheusConnectorConfig
                 .put("prometheus.query.chunk.size.duration", "365d")
                 .put("prometheus.max.query.range.duration", "1095d")
                 .put("prometheus.cache.ttl", "60s")
+                .put("prometheus.auth.http.header.name", "X-team-auth")
                 .put("prometheus.bearer.token.file", "/tmp/bearer_token.txt")
                 .put("prometheus.auth.user", "admin")
                 .put("prometheus.auth.password", "password")
@@ -67,6 +70,7 @@ public class TestPrometheusConnectorConfig
         expected.setQueryChunkSizeDuration(new Duration(365, DAYS));
         expected.setMaxQueryRangeDuration(new Duration(1095, DAYS));
         expected.setCacheDuration(new Duration(60, SECONDS));
+        expected.setHttpAuthHeaderName("X-team-auth");
         expected.setBearerTokenFile(new File("/tmp/bearer_token.txt"));
         expected.setUser("admin");
         expected.setPassword("password");


### PR DESCRIPTION
## Description
Allowing users to use a custom header for authorization of prometheus endpoint

Current code only support Authorization http header, just adding a new configuration property to allow a custom header name

Fixes #20659

## Release notes

(X) Release notes are required, with the following suggested text:

```markdown
# Prometheus
* Add support for a custom authorization header name. ({issue}`20659`)
```
