### PR TITLE
Use createOrOverwrite to create transaction log files on s3

### DIFF
--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/writer/S3NativeTransactionLogSynchronizer.java
@@ -140,10 +140,8 @@ public class S3NativeTransactionLogSynchronizer
                 throw new TransactionConflictException("Target file was created during locking: " + newLogEntryPath);
             }
 
-            // write transaction log entry
-            try (OutputStream outputStream = fileSystem.newOutputFile(newLogEntryPath).create()) {
-                outputStream.write(entryContents);
-            }
+            // write transaction log entry atomically by keeping in mind that S3 does not support creating files exclusively
+            fileSystem.newOutputFile(newLogEntryPath).createOrOverwrite(entryContents);
         }
         catch (IOException e) {
             throw new UncheckedIOException("Internal error while writing " + newLogEntryPath, e);


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

Follow-up work for e1784943 to ensure that transaction log files are written atomically on S3 for Delta Lake in order to avoid to end up on the storage half-baked (leading to table corruption).

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues


https://github.com/trinodb/trino/pull/20913

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
