### PR TITLE
Handle NaN and infinite values in Aggregation Window Function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AverageAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AverageAggregations.java
@@ -46,17 +46,23 @@ public final class AverageAggregations
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setLong(state.getLong() - 1);
         state.setDouble(state.getDouble() - value);
+        return true;
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        state.setLong(state.getLong() - 1);
-        state.setDouble(state.getDouble() - value);
+        double currentValue = state.getDouble();
+        if (Double.isFinite(currentValue)) {
+            state.setDouble(currentValue - value);
+            state.setLong(state.getLong() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
@@ -37,9 +37,10 @@ public final class CountAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongState state)
+    public static boolean removeInput(@AggregationState LongState state)
     {
         state.setValue(state.getValue() - 1);
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
@@ -47,12 +47,13 @@ public final class CountColumn
     }
 
     @RemoveInputFunction
-    public static void removeInput(
+    public static boolean removeInput(
             @AggregationState LongState state,
             @BlockPosition @SqlType("T") ValueBlock block,
             @BlockIndex int position)
     {
         state.setValue(state.getValue() - 1);
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
@@ -40,11 +40,12 @@ public final class CountIfAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongState state, @SqlType(StandardTypes.BOOLEAN) boolean value)
+    public static boolean removeInput(@AggregationState LongState state, @SqlType(StandardTypes.BOOLEAN) boolean value)
     {
         if (value) {
             state.setValue(state.getValue() - 1);
         }
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DoubleSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DoubleSumAggregation.java
@@ -38,10 +38,15 @@ public final class DoubleSumAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        state.setLong(state.getLong() - 1);
-        state.setDouble(state.getDouble() - value);
+        double currentValue = state.getDouble();
+        if (Double.isFinite(currentValue)) {
+            state.setDouble(currentValue - value);
+            state.setLong(state.getLong() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LongSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LongSumAggregation.java
@@ -38,10 +38,11 @@ public final class LongSumAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongLongState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static boolean removeInput(@AggregationState LongLongState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setFirst(state.getFirst() - 1);
         state.setSecond(BigintOperators.subtract(state.getSecond(), value));
+        return true; // This should always return true as the state cannot be infinite or NaN for long input values.
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/RealAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/RealAverageAggregation.java
@@ -46,13 +46,18 @@ public final class RealAverageAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(
+    public static boolean removeInput(
             @AggregationState LongState count,
             @AggregationState DoubleState sum,
             @SqlType("REAL") long value)
     {
-        count.setValue(count.getValue() - 1);
-        sum.setValue(sum.getValue() - intBitsToFloat((int) value));
+        double currentValue = sum.getValue();
+        if (Double.isFinite(currentValue)) {
+            sum.setValue(currentValue - intBitsToFloat((int) value));
+            count.setValue(count.getValue() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/WindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/WindowAccumulator.java
@@ -24,7 +24,11 @@ public interface WindowAccumulator
 
     void addInput(WindowIndex index, int startPosition, int endPosition);
 
-    void removeInput(WindowIndex index, int startPosition, int endPosition);
+    /**
+     * @return Returns false when an NaN or Infinite input double value is
+     * encountered, true otherwise.
+     */
+    boolean removeInput(WindowIndex index, int startPosition, int endPosition);
 
     void evaluateFinal(BlockBuilder blockBuilder);
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestRealAverageAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRealAverageAggregation.java
@@ -14,9 +14,16 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.block.BlockAssertions;
+import io.trino.metadata.ResolvedFunction;
 import io.trino.operator.aggregation.AbstractTestAggregationFunction;
+import io.trino.operator.aggregation.WindowAccumulator;
+import io.trino.operator.window.PagesWindowIndex;
+import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationImplementation;
+import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Type;
 import org.junit.jupiter.api.Test;
 
@@ -24,9 +31,11 @@ import java.util.List;
 
 import static io.trino.block.BlockAssertions.createBlockOfReals;
 import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static io.trino.operator.aggregation.AggregationTestUtils.makeValidityAssertion;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static java.lang.Float.floatToRawIntBits;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestRealAverageAggregation
         extends AbstractTestAggregationFunction
@@ -98,5 +107,137 @@ public class TestRealAverageAggregation
             sum += i;
         }
         return sum / length;
+    }
+
+    protected Block[] getSequenceBlocksForRealNaNTest(int start, int length)
+    {
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, length);
+        for (int i = start; i < start + length - 5; i++) {
+            REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        REAL.writeLong(blockBuilder, floatToRawIntBits(Float.NaN));
+        for (int i = start + length - 4; i < start + length; i++) {
+            REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    protected Block[] getSequenceBlocksForRealInfinityTest(int start, int length)
+    {
+        BlockBuilder blockBuilder = REAL.createBlockBuilder(null, length);
+        for (int i = start; i < start + length - 5; i++) {
+            REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        REAL.writeLong(blockBuilder, floatToRawIntBits(Float.POSITIVE_INFINITY));
+        for (int i = start + length - 4; i < start + length; i++) {
+            REAL.writeLong(blockBuilder, floatToRawIntBits((float) i));
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Test
+    public void testSlidingWindowForNaNAndInfinity()
+    {
+        int totalPositions = 12;
+        int[] windowWidths = new int[totalPositions];
+        Object[] expectedValues = new Object[totalPositions];
+        Object[] expectedValues2 = new Object[totalPositions];
+
+        for (int i = 0; i < totalPositions; ++i) {
+            int windowWidth = Integer.min(i, totalPositions - 1 - i);
+            windowWidths[i] = windowWidth;
+            if (i >= 4) {
+                expectedValues[i] = Float.NaN;
+                expectedValues2[i] = Float.POSITIVE_INFINITY;
+            }
+            else {
+                expectedValues[i] = getExpectedValue(i, windowWidth);
+                expectedValues2[i] = getExpectedValue(i, windowWidth);
+            }
+        }
+        Page inputPage = new Page(totalPositions, getSequenceBlocksForRealNaNTest(0, totalPositions));
+
+        PagesIndex pagesIndex = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex.addPage(inputPage);
+        WindowIndex windowIndex = new PagesWindowIndex(pagesIndex, 0, totalPositions - 1);
+
+        ResolvedFunction resolvedFunction = functionResolution.resolveFunction(getFunctionName(), fromTypes(getFunctionParameterTypes()));
+        AggregationImplementation aggregationImplementation = functionResolution.getPlannerContext().getFunctionManager().getAggregationImplementation(resolvedFunction);
+        WindowAccumulator aggregation = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        assertThat(resolvedFunction.getSignature().getReturnType().toString().contains("real")).isTrue();
+        assertThat(resolvedFunction.getSignature().getName().toString().contains("avg")).isTrue();
+        int oldStart = 0;
+        int oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation.removeInput(windowIndex, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation.addInput(windowIndex, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues[start]))
+                    .isTrue();
+        }
+
+        Page inputPage2 = new Page(totalPositions, getSequenceBlocksForRealInfinityTest(0, totalPositions));
+
+        PagesIndex pagesIndex2 = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex2.addPage(inputPage2);
+        WindowIndex windowIndex2 = new PagesWindowIndex(pagesIndex2, 0, totalPositions - 1);
+        WindowAccumulator aggregation2 = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        oldStart = 0;
+        oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation2.removeInput(windowIndex2, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation2.addInput(windowIndex2, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation2.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues2[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues2[start]))
+                    .isTrue();
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
@@ -156,7 +156,8 @@ public abstract class AbstractTestAggregationFunction
             if (aggregationImplementation.getRemoveInputFunction().isPresent()) {
                 for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
                     if (oldi < start || oldi >= start + width) {
-                        aggregation.removeInput(windowIndex, oldi, oldi);
+                        boolean res = aggregation.removeInput(windowIndex, oldi, oldi);
+                        assertThat(res).isTrue();
                     }
                 }
                 for (int newi = start; newi < start + width; ++newi) {
@@ -184,7 +185,7 @@ public abstract class AbstractTestAggregationFunction
         }
     }
 
-    private static WindowAccumulator createWindowAccumulator(ResolvedFunction resolvedFunction, AggregationImplementation aggregationImplementation)
+    protected static WindowAccumulator createWindowAccumulator(ResolvedFunction resolvedFunction, AggregationImplementation aggregationImplementation)
     {
         try {
             Constructor<? extends WindowAccumulator> constructor = generateWindowAccumulatorClass(

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleAverageAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleAverageAggregation.java
@@ -14,13 +14,24 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.block.BlockAssertions;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.window.PagesWindowIndex;
+import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationImplementation;
+import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.trino.operator.aggregation.AggregationTestUtils.makeValidityAssertion;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDoubleAverageAggregation
         extends AbstractTestAggregationFunction
@@ -59,5 +70,111 @@ public class TestDoubleAverageAggregation
     protected List<Type> getFunctionParameterTypes()
     {
         return ImmutableList.of(DOUBLE);
+    }
+
+    @Test
+    public void testSlidingWindowForNaNAndInfinity()
+    {
+        int totalPositions = 12;
+        int[] windowWidths = new int[totalPositions];
+        Object[] expectedValues = new Object[totalPositions];
+        Object[] expectedValues2 = new Object[totalPositions];
+
+        for (int i = 0; i < totalPositions; ++i) {
+            int windowWidth = Integer.min(i, totalPositions - 1 - i);
+            windowWidths[i] = windowWidth;
+            if (i >= 4) {
+                expectedValues[i] = Double.NaN;
+                expectedValues2[i] = Double.POSITIVE_INFINITY;
+            }
+            else {
+                expectedValues[i] = getExpectedValue(i, windowWidth);
+                expectedValues2[i] = getExpectedValue(i, windowWidth);
+            }
+        }
+        Page inputPage = new Page(totalPositions, TestDoubleSumAggregation.getSequenceBlocksForDoubleNaNTest(0, totalPositions));
+
+        PagesIndex pagesIndex = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex.addPage(inputPage);
+        WindowIndex windowIndex = new PagesWindowIndex(pagesIndex, 0, totalPositions - 1);
+
+        ResolvedFunction resolvedFunction = functionResolution.resolveFunction(getFunctionName(), fromTypes(getFunctionParameterTypes()));
+        AggregationImplementation aggregationImplementation = functionResolution.getPlannerContext().getFunctionManager().getAggregationImplementation(resolvedFunction);
+        WindowAccumulator aggregation = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        assertThat(resolvedFunction.getSignature().getReturnType().toString().contains("double")).isTrue();
+        assertThat(resolvedFunction.getSignature().getName().toString().contains("avg")).isTrue();
+        int oldStart = 0;
+        int oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation.removeInput(windowIndex, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation.addInput(windowIndex, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues[start]))
+                    .isTrue();
+        }
+
+        Page inputPage2 = new Page(totalPositions, TestDoubleSumAggregation.getSequenceBlocksForDoubleInfinityTest(0, totalPositions));
+
+        PagesIndex pagesIndex2 = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex2.addPage(inputPage2);
+        WindowIndex windowIndex2 = new PagesWindowIndex(pagesIndex2, 0, totalPositions - 1);
+        WindowAccumulator aggregation2 = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        oldStart = 0;
+        oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation2.removeInput(windowIndex2, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation2.addInput(windowIndex2, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation2.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues2[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues2[start]))
+                    .isTrue();
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleSumAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleSumAggregation.java
@@ -14,13 +14,24 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.block.BlockAssertions;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.PagesIndex;
+import io.trino.operator.window.PagesWindowIndex;
+import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AggregationImplementation;
+import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Type;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static io.trino.operator.aggregation.AggregationTestUtils.makeValidityAssertion;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDoubleSumAggregation
         extends AbstractTestAggregationFunction
@@ -59,5 +70,137 @@ public class TestDoubleSumAggregation
     protected List<Type> getFunctionParameterTypes()
     {
         return ImmutableList.of(DOUBLE);
+    }
+
+    protected static Block[] getSequenceBlocksForDoubleNaNTest(int start, int length)
+    {
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
+        for (int i = start; i < start + length - 5; i++) {
+            DOUBLE.writeDouble(blockBuilder, i);
+        }
+        DOUBLE.writeDouble(blockBuilder, Double.NaN);
+        for (int i = start + length - 4; i < start + length; i++) {
+            DOUBLE.writeDouble(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    protected static Block[] getSequenceBlocksForDoubleInfinityTest(int start, int length)
+    {
+        BlockBuilder blockBuilder = DOUBLE.createBlockBuilder(null, length);
+        for (int i = start; i < start + length - 5; i++) {
+            DOUBLE.writeDouble(blockBuilder, i);
+        }
+        DOUBLE.writeDouble(blockBuilder, Double.POSITIVE_INFINITY);
+        for (int i = start + length - 4; i < start + length; i++) {
+            DOUBLE.writeDouble(blockBuilder, i);
+        }
+        return new Block[] {blockBuilder.build()};
+    }
+
+    @Test
+    public void testSlidingWindowForNaNAndInfinity()
+    {
+        int totalPositions = 12;
+        int[] windowWidths = new int[totalPositions];
+        Object[] expectedValues = new Object[totalPositions];
+        Object[] expectedValues2 = new Object[totalPositions];
+
+        for (int i = 0; i < totalPositions; ++i) {
+            int windowWidth = Integer.min(i, totalPositions - 1 - i);
+            windowWidths[i] = windowWidth;
+            if (i >= 4) {
+                expectedValues[i] = Double.NaN;
+                expectedValues2[i] = Double.POSITIVE_INFINITY;
+            }
+            else {
+                expectedValues[i] = getExpectedValue(i, windowWidth);
+                expectedValues2[i] = getExpectedValue(i, windowWidth);
+            }
+        }
+        Page inputPage = new Page(totalPositions, getSequenceBlocksForDoubleNaNTest(0, totalPositions));
+
+        PagesIndex pagesIndex = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex.addPage(inputPage);
+        WindowIndex windowIndex = new PagesWindowIndex(pagesIndex, 0, totalPositions - 1);
+
+        ResolvedFunction resolvedFunction = functionResolution.resolveFunction(getFunctionName(), fromTypes(getFunctionParameterTypes()));
+        AggregationImplementation aggregationImplementation = functionResolution.getPlannerContext().getFunctionManager().getAggregationImplementation(resolvedFunction);
+        WindowAccumulator aggregation = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        assertThat(resolvedFunction.getSignature().getReturnType().toString().contains("double")).isTrue();
+        assertThat(resolvedFunction.getSignature().getName().toString().contains("sum")).isTrue();
+        int oldStart = 0;
+        int oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation.removeInput(windowIndex, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation.addInput(windowIndex, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues[start]))
+                    .isTrue();
+        }
+
+        Page inputPage2 = new Page(totalPositions, getSequenceBlocksForDoubleInfinityTest(0, totalPositions));
+
+        PagesIndex pagesIndex2 = new PagesIndex.TestingFactory(false).newPagesIndex(getFunctionParameterTypes(), totalPositions);
+        pagesIndex2.addPage(inputPage2);
+        WindowIndex windowIndex2 = new PagesWindowIndex(pagesIndex2, 0, totalPositions - 1);
+        WindowAccumulator aggregation2 = createWindowAccumulator(resolvedFunction, aggregationImplementation);
+        oldStart = 0;
+        oldWidth = 0;
+        for (int start = 0; start < totalPositions; ++start) {
+            int width = windowWidths[start];
+            for (int oldi = oldStart; oldi < oldStart + oldWidth; ++oldi) {
+                if (oldi < start || oldi >= start + width) {
+                    boolean res = aggregation2.removeInput(windowIndex2, oldi, oldi);
+                    if (oldi >= 4) {
+                        assertThat(res).isFalse();
+                    }
+                    else {
+                        assertThat(res).isTrue();
+                    }
+                }
+            }
+            for (int newi = start; newi < start + width; ++newi) {
+                if (newi < oldStart || newi >= oldStart + oldWidth) {
+                    aggregation2.addInput(windowIndex2, newi, newi);
+                }
+            }
+            oldStart = start;
+            oldWidth = width;
+
+            Type outputType = resolvedFunction.getSignature().getReturnType();
+            BlockBuilder blockBuilder = outputType.createBlockBuilder(null, 1000);
+            aggregation2.evaluateFinal(blockBuilder);
+            Block block = blockBuilder.build();
+
+            assertThat(makeValidityAssertion(expectedValues2[start]).apply(
+                    BlockAssertions.getOnlyValue(outputType, block),
+                    expectedValues2[start]))
+                    .isTrue();
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/window/AbstractTestWindowFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/AbstractTestWindowFunction.java
@@ -67,6 +67,16 @@ public abstract class AbstractTestWindowFunction
         return WindowAssertions.executeWindowQueryWithNulls(sql, queryRunner);
     }
 
+    protected void assertWindowQueryWithNan(@Language("SQL") String sql, MaterializedResult expected)
+    {
+        WindowAssertions.assertWindowQueryWithNan(sql, expected, queryRunner);
+    }
+
+    protected void assertWindowQueryWithInfinity(@Language("SQL") String sql, MaterializedResult expected)
+    {
+        WindowAssertions.assertWindowQueryWithInfinity(sql, expected, queryRunner);
+    }
+
     protected void assertUnboundedWindowQueryWithNulls(@Language("SQL") String sql, MaterializedResult expected)
     {
         assertWindowQueryWithNulls(unbounded(sql), expected);

--- a/core/trino-main/src/test/java/io/trino/operator/window/TestAggregateWindowFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/TestAggregateWindowFunction.java
@@ -595,4 +595,68 @@ public class TestAggregateWindowFunction
                         .row(null, null, null)
                         .build());
     }
+
+    @Test
+    public void testAverageRowsRollingWithNanAndInfinity()
+    {
+        assertWindowQueryWithNan("avg(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 4.5)
+                        .row(33.0, "F", 14.0)
+                        .row(Double.NaN, "F", Double.NaN)
+                        .row(32.0, "O", Double.NaN)
+                        .row(4.0, "O", Double.NaN)
+                        .row(1.0, "O", 12.333333333333334)
+                        .row(7.0, "O", 4.0)
+                        .row(2.0, "O", 3.3333333333333335)
+                        .row(34.0, "O", 14.333333333333334)
+                        .build());
+
+        assertWindowQueryWithInfinity("avg(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 4.5)
+                        .row(33.0, "F", 14.0)
+                        .row(Double.POSITIVE_INFINITY, "F", Double.POSITIVE_INFINITY)
+                        .row(32.0, "O", Double.POSITIVE_INFINITY)
+                        .row(4.0, "O", Double.POSITIVE_INFINITY)
+                        .row(1.0, "O", 12.333333333333334)
+                        .row(7.0, "O", 4.0)
+                        .row(2.0, "O", 3.3333333333333335)
+                        .row(34.0, "O", 14.333333333333334)
+                        .build());
+    }
+
+    @Test
+    public void testSumRowsRollingWithNanAndInfinity()
+    {
+        assertWindowQueryWithNan("sum(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 9.0)
+                        .row(33.0, "F", 42.0)
+                        .row(Double.NaN, "F", Double.NaN)
+                        .row(32.0, "O", Double.NaN)
+                        .row(4.0, "O", Double.NaN)
+                        .row(1.0, "O", 37.0)
+                        .row(7.0, "O", 12.0)
+                        .row(2.0, "O", 10.0)
+                        .row(34.0, "O", 43.0)
+                        .build());
+
+        assertWindowQueryWithInfinity("sum(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 9.0)
+                        .row(33.0, "F", 42.0)
+                        .row(Double.POSITIVE_INFINITY, "F", Double.POSITIVE_INFINITY)
+                        .row(32.0, "O", Double.POSITIVE_INFINITY)
+                        .row(4.0, "O", Double.POSITIVE_INFINITY)
+                        .row(1.0, "O", 37.0)
+                        .row(7.0, "O", 12.0)
+                        .row(2.0, "O", 10.0)
+                        .row(34.0, "O", 43.0)
+                        .build());
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
@@ -54,6 +54,38 @@ public final class WindowAssertions
             "    (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), '1995-07-16')\n" +
             ") AS orders (orderkey, orderstatus, orderdate)";
 
+    private static final String VALUES_WITH_NAN = "" +
+            "SELECT *\n" +
+            "FROM (\n" +
+            "  VALUES\n" +
+            "    ( 1, 'O', '1996-01-02'),\n" +
+            "    ( 2, 'O', '1996-12-01'),\n" +
+            "    ( 3, 'F', '1993-10-14'),\n" +
+            "    ( 4, 'O', '1995-10-11'),\n" +
+            "    ( nan(), 'F', '1994-07-30'),\n" +
+            "    ( 6, 'F', '1992-02-21'),\n" +
+            "    ( 7, 'O', '1996-01-10'),\n" +
+            "    (32, 'O', '1995-07-16'),\n" +
+            "    (33, 'F', '1993-10-27'),\n" +
+            "    (34, 'O', '1998-07-21')\n" +
+            ") AS orders (orderkey, orderstatus, orderdate)";
+
+    private static final String VALUES_WITH_INFINITY = "" +
+            "SELECT *\n" +
+            "FROM (\n" +
+            "  VALUES\n" +
+            "    ( 1, 'O', '1996-01-02'),\n" +
+            "    ( 2, 'O', '1996-12-01'),\n" +
+            "    ( 3, 'F', '1993-10-14'),\n" +
+            "    ( 4, 'O', '1995-10-11'),\n" +
+            "    ( infinity(), 'F', '1994-07-30'),\n" +
+            "    ( 6, 'F', '1992-02-21'),\n" +
+            "    ( 7, 'O', '1996-01-10'),\n" +
+            "    (32, 'O', '1995-07-16'),\n" +
+            "    (33, 'F', '1993-10-27'),\n" +
+            "    (34, 'O', '1998-07-21')\n" +
+            ") AS orders (orderkey, orderstatus, orderdate)";
+
     private WindowAssertions() {}
 
     public static void assertWindowQuery(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
@@ -79,5 +111,25 @@ public final class WindowAssertions
                 "FROM (%s) x", sql, VALUES_WITH_NULLS);
 
         return queryRunner.execute(query);
+    }
+
+    public static void assertWindowQueryWithNan(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
+    {
+        @Language("SQL") String query = format("" +
+                "SELECT orderkey, orderstatus,\n%s\n" +
+                "FROM (%s) x", sql, VALUES_WITH_NAN);
+
+        MaterializedResult actual = queryRunner.execute(query);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    public static void assertWindowQueryWithInfinity(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
+    {
+        @Language("SQL") String query = format("" +
+                "SELECT orderkey, orderstatus,\n%s\n" +
+                "FROM (%s) x", sql, VALUES_WITH_INFINITY);
+
+        MaterializedResult actual = queryRunner.execute(query);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If the input data to an aggregation window function contains Nan or infinite, the result for that window frame will be Nan/Infinite, which is expected. However, after that, the result of the window continues to be Nan/Infinite even if the input data in the window does not contain any invalid values. For the steps on reproduction, please refer to https://github.com/trinodb/trino/issues/20946.

## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect window aggregation results over double values in the presence of NaN or Infinite inputs ({issue}`20946`)
```