### PR TITLE
Remove filter from UnnestNode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -292,14 +292,7 @@ public class EffectivePredicateExtractor
         @Override
         public Expression visitUnnest(UnnestNode node, Void context)
         {
-            Expression sourcePredicate = node.getSource().accept(this, context);
-
-            return switch (node.getJoinType()) {
-                case INNER, LEFT -> pullExpressionThroughSymbols(
-                        combineConjuncts(metadata, node.getFilter().orElse(TRUE_LITERAL), sourcePredicate),
-                        node.getOutputSymbols());
-                case RIGHT, FULL -> TRUE_LITERAL;
-            };
+            return TRUE_LITERAL;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionExtractor.java
@@ -22,7 +22,6 @@ import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.ProjectNode;
-import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.tree.Expression;
 
@@ -122,13 +121,6 @@ public final class ExpressionExtractor
         {
             node.getFilter().ifPresent(consumer);
             return super.visitJoin(node, context);
-        }
-
-        @Override
-        public Void visitUnnest(UnnestNode node, Void context)
-        {
-            node.getFilter().ifPresent(consumer);
-            return super.visitUnnest(node, context);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
@@ -232,7 +232,7 @@ public final class PlanCopier
         @Override
         public PlanNode visitUnnest(UnnestNode node, RewriteContext<Void> context)
         {
-            return new UnnestNode(idAllocator.getNextId(), context.rewrite(node.getSource()), node.getReplicateSymbols(), node.getMappings(), node.getOrdinalitySymbol(), node.getJoinType(), node.getFilter());
+            return new UnnestNode(idAllocator.getNextId(), context.rewrite(node.getSource()), node.getReplicateSymbols(), node.getMappings(), node.getOrdinalitySymbol(), node.getJoinType());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateInnerUnnestWithGlobalAggregation.java
@@ -183,8 +183,7 @@ public class DecorrelateInnerUnnestWithGlobalAggregation
                 input.getOutputSymbols(),
                 unnestNode.getMappings(),
                 Optional.of(ordinalitySymbol),
-                LEFT,
-                Optional.empty());
+                LEFT);
 
         // append mask symbol based on ordinality to distinguish between the unnested rows and synthetic null rows
         Symbol mask = context.getSymbolAllocator().newSymbol("mask", BOOLEAN);
@@ -258,8 +257,7 @@ public class DecorrelateInnerUnnestWithGlobalAggregation
         return isScalar(unnestNode.getSource(), lookup) &&
                 unnestNode.getReplicateSymbols().isEmpty() &&
                 basedOnCorrelation &&
-                unnestNode.getJoinType() == INNER &&
-                (unnestNode.getFilter().isEmpty() || unnestNode.getFilter().get().equals(TRUE_LITERAL));
+                unnestNode.getJoinType() == INNER;
     }
 
     private static PlanNode rewriteNodeSequence(PlanNode root, List<Symbol> leftOutputs, Symbol mask, PlanNode sequenceSource, PlanNodeId reducingAggregationId, PlanNodeId correlatedUnnestId, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateLeftUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateLeftUnnestWithGlobalAggregation.java
@@ -163,8 +163,7 @@ public class DecorrelateLeftUnnestWithGlobalAggregation
                 input.getOutputSymbols(),
                 unnestNode.getMappings(),
                 unnestNode.getOrdinalitySymbol(),
-                LEFT,
-                Optional.empty());
+                LEFT);
 
         // restore all projections, grouped aggregations and global aggregations from the subquery
         PlanNode result = rewriteNodeSequence(
@@ -223,8 +222,7 @@ public class DecorrelateLeftUnnestWithGlobalAggregation
         return isScalar(unnestNode.getSource(), lookup) &&
                 unnestNode.getReplicateSymbols().isEmpty() &&
                 basedOnCorrelation &&
-                unnestNode.getJoinType() == LEFT &&
-                (unnestNode.getFilter().isEmpty() || unnestNode.getFilter().get().equals(TRUE_LITERAL));
+                unnestNode.getJoinType() == LEFT;
     }
 
     private static PlanNode rewriteNodeSequence(PlanNode root, List<Symbol> leftOutputs, PlanNode sequenceSource, PlanNodeId correlatedUnnestId, Lookup lookup)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DecorrelateUnnest.java
@@ -232,8 +232,7 @@ public class DecorrelateUnnest
                 input.getOutputSymbols(),
                 unnestNode.getMappings(),
                 Optional.of(ordinalitySymbol),
-                unnestJoinType,
-                Optional.empty());
+                unnestJoinType);
 
         // restore all nodes from the subquery
         PlanNode rewrittenPlan = Rewriter.rewriteNodeSequence(
@@ -301,8 +300,7 @@ public class DecorrelateUnnest
         return isScalar(unnestNode.getSource(), lookup) &&
                 unnestNode.getReplicateSymbols().isEmpty() &&
                 basedOnCorrelation &&
-                (unnestNode.getJoinType() == INNER || unnestNode.getJoinType() == LEFT) &&
-                (unnestNode.getFilter().isEmpty() || unnestNode.getFilter().get().equals(TRUE_LITERAL));
+                (unnestNode.getJoinType() == INNER || unnestNode.getJoinType() == LEFT);
     }
 
     private static class Rewriter

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -615,8 +615,7 @@ public class ExtractSpatialJoins
                 node.getOutputSymbols(),
                 ImmutableList.of(new UnnestNode.Mapping(partitionsSymbol, ImmutableList.of(partitionSymbol))),
                 Optional.empty(),
-                INNER,
-                Optional.empty());
+                INNER);
     }
 
     private static boolean containsNone(Collection<Symbol> values, Collection<Symbol> testValues)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUnnestColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUnnestColumns.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolsExtractor;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.UnnestNode;
 
@@ -70,7 +69,6 @@ public class PruneUnnestColumns
     {
         ImmutableSet.Builder<Symbol> referencedAndFilterSymbolsBuilder = ImmutableSet.<Symbol>builder()
                 .addAll(referencedOutputs);
-        unnestNode.getFilter().ifPresent(expression -> referencedAndFilterSymbolsBuilder.addAll(SymbolsExtractor.extractUnique(expression)));
         Set<Symbol> referencedAndFilterSymbols = referencedAndFilterSymbolsBuilder.build();
 
         List<Symbol> prunedReplicateSymbols = unnestNode.getReplicateSymbols().stream()
@@ -90,7 +88,6 @@ public class PruneUnnestColumns
                 prunedReplicateSymbols,
                 unnestNode.getMappings(),
                 prunedOrdinalitySymbol,
-                unnestNode.getJoinType(),
-                unnestNode.getFilter()));
+                unnestNode.getJoinType()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownDereferenceThroughUnnest.java
@@ -85,7 +85,6 @@ public class PushDownDereferenceThroughUnnest
         // Extract dereferences from project node's assignments and unnest node's filter
         ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.builder();
         expressionsBuilder.addAll(projectNode.getAssignments().getExpressions());
-        unnestNode.getFilter().ifPresent(expressionsBuilder::add);
 
         // Extract dereferences for pushdown
         Set<SubscriptExpression> dereferences = extractRowSubscripts(expressionsBuilder.build(), false, context.getSession(), typeAnalyzer, context.getSymbolAllocator().getTypes());
@@ -131,8 +130,7 @@ public class PushDownDereferenceThroughUnnest
                                         .build(),
                                 unnestNode.getMappings(),
                                 unnestNode.getOrdinalitySymbol(),
-                                unnestNode.getJoinType(),
-                                unnestNode.getFilter().map(filter -> replaceExpression(filter, mappings))),
+                                unnestNode.getJoinType()),
                         newAssignments));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -666,8 +666,7 @@ public class HashGenerationOptimizer
                                     .build(),
                             node.getMappings(),
                             node.getOrdinalitySymbol(),
-                            node.getJoinType(),
-                            node.getFilter()),
+                            node.getJoinType()),
                     hashSymbols);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -1537,7 +1537,7 @@ public class PredicatePushDown
 
             PlanNode output = node;
             if (rewrittenSource != node.getSource()) {
-                output = new UnnestNode(node.getId(), rewrittenSource, node.getReplicateSymbols(), node.getMappings(), node.getOrdinalitySymbol(), node.getJoinType(), node.getFilter());
+                output = new UnnestNode(node.getId(), rewrittenSource, node.getReplicateSymbols(), node.getMappings(), node.getOrdinalitySymbol(), node.getJoinType());
             }
             if (!postUnnestConjuncts.isEmpty()) {
                 output = new FilterNode(idAllocator.getNextId(), output, combineConjuncts(metadata, postUnnestConjuncts));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -275,7 +275,6 @@ public class UnaliasSymbolReferences
             }
 
             Optional<Symbol> newOrdinalitySymbol = node.getOrdinalitySymbol().map(mapper::map);
-            Optional<Expression> newFilter = node.getFilter().map(mapper::map);
 
             return new PlanAndMappings(
                     new UnnestNode(
@@ -284,8 +283,7 @@ public class UnaliasSymbolReferences
                             newReplicateSymbols,
                             newMappings.build(),
                             newOrdinalitySymbol,
-                            node.getJoinType(),
-                            newFilter),
+                            node.getJoinType()),
                     mapping);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/UnnestNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/UnnestNode.java
@@ -16,17 +16,13 @@ package io.trino.sql.planner.plan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.annotations.Immutable;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.SymbolsExtractor;
-import io.trino.sql.tree.Expression;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -41,7 +37,6 @@ public class UnnestNode
     private final List<Mapping> mappings;
     private final Optional<Symbol> ordinalitySymbol;
     private final JoinType joinType;
-    private final Optional<Expression> filter;
 
     @JsonCreator
     public UnnestNode(
@@ -50,8 +45,7 @@ public class UnnestNode
             @JsonProperty("replicateSymbols") List<Symbol> replicateSymbols,
             @JsonProperty("mappings") List<Mapping> mappings,
             @JsonProperty("ordinalitySymbol") Optional<Symbol> ordinalitySymbol,
-            @JsonProperty("joinType") JoinType joinType,
-            @JsonProperty("filter") Optional<Expression> filter)
+            @JsonProperty("joinType") JoinType joinType)
     {
         super(id);
         this.source = requireNonNull(source, "source is null");
@@ -62,11 +56,6 @@ public class UnnestNode
         this.mappings = ImmutableList.copyOf(mappings);
         this.ordinalitySymbol = requireNonNull(ordinalitySymbol, "ordinalitySymbol is null");
         this.joinType = requireNonNull(joinType, "joinType is null");
-        this.filter = requireNonNull(filter, "filter is null");
-        if (filter.isPresent()) {
-            Set<Symbol> outputs = ImmutableSet.copyOf(getOutputSymbols());
-            checkArgument(outputs.containsAll(SymbolsExtractor.extractUnique(filter.get())), "Outputs do not contain all filter symbols");
-        }
     }
 
     @Override
@@ -113,12 +102,6 @@ public class UnnestNode
         return joinType;
     }
 
-    @JsonProperty
-    public Optional<Expression> getFilter()
-    {
-        return filter;
-    }
-
     @Override
     public List<PlanNode> getSources()
     {
@@ -134,7 +117,7 @@ public class UnnestNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, mappings, ordinalitySymbol, joinType, filter);
+        return new UnnestNode(getId(), Iterables.getOnlyElement(newChildren), replicateSymbols, mappings, ordinalitySymbol, joinType);
     }
 
     public static class Mapping

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/GraphvizPrinter.java
@@ -406,11 +406,7 @@ public final class GraphvizPrinter
         public Void visitUnnest(UnnestNode node, Void context)
         {
             StringBuilder label = new StringBuilder();
-            if (node.getFilter().isPresent()) {
-                label.append(node.getJoinType().getJoinLabel())
-                        .append(" Unnest");
-            }
-            else if (!node.getReplicateSymbols().isEmpty()) {
+            if (!node.getReplicateSymbols().isEmpty()) {
                 label.append("CrossJoin Unnest");
             }
             else {
@@ -424,9 +420,7 @@ public final class GraphvizPrinter
             label.append(format(" [%s", unnestInputs))
                     .append(node.getOrdinalitySymbol().isPresent() ? " (ordinality)]" : "]");
 
-            String details = node.getFilter().isPresent() ? " filter " + node.getFilter().get().toString() : "";
-
-            printNode(node, label.toString(), details, NODE_COLORS.get(NodeType.UNNEST));
+            printNode(node, label.toString(), "", NODE_COLORS.get(NodeType.UNNEST));
             return node.getSource().accept(this, context);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -1407,19 +1407,11 @@ public class PlanPrinter
         public Void visitUnnest(UnnestNode node, Context context)
         {
             String name;
-            if (node.getFilter().isPresent()) {
-                name = node.getJoinType().getJoinLabel() + " Unnest";
-            }
-            else if (!node.getReplicateSymbols().isEmpty()) {
-                if (node.getJoinType() == INNER) {
-                    name = "CrossJoin Unnest";
-                }
-                else {
-                    name = node.getJoinType().getJoinLabel() + " Unnest";
-                }
+            if (node.getJoinType() == INNER) {
+                name = "CrossJoin Unnest";
             }
             else {
-                name = "Unnest";
+                name = node.getJoinType().getJoinLabel() + " Unnest";
             }
 
             List<Symbol> unnestInputs = node.getMappings().stream()
@@ -1431,7 +1423,6 @@ public class PlanPrinter
                 descriptor.put("replicate", formatOutputs(getTypes(context), node.getReplicateSymbols()));
             }
             descriptor.put("unnest", formatOutputs(getTypes(context), unnestInputs));
-            node.getFilter().ifPresent(filter -> descriptor.put("filter", formatFilter(filter)));
             addNode(node, name, descriptor.buildOrThrow(), context);
             return processChildren(node, new Context(context.types()));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.sanity;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.sql.PlannerContext;
@@ -93,7 +92,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.sql.planner.SymbolsExtractor.extractUnique;
 import static io.trino.sql.planner.optimizations.IndexJoinOptimizer.IndexKeyTracer;
-import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 /**
  * Ensures that all dependencies (i.e., symbols in expressions) for a plan node are provided by its source nodes
@@ -713,13 +711,6 @@ public final class ValidateDependenciesChecker
                     .map(UnnestNode.Mapping::getInput)
                     .forEach(required::add);
 
-            Set<Symbol> unnestedSymbols = node.getMappings().stream()
-                    .map(UnnestNode.Mapping::getOutputs)
-                    .flatMap(Collection::stream)
-                    .collect(toImmutableSet());
-
-            Set<Symbol> expectedFilterSymbols = Sets.difference(extractUnique(node.getFilter().orElse(TRUE_LITERAL)), unnestedSymbols);
-            required.addAll(expectedFilterSymbols);
             checkDependencies(source.getOutputSymbols(), required.build(), "Invalid node. Dependencies (%s) not in source plan output (%s)", required, source.getOutputSymbols());
 
             return null;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -539,7 +539,7 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern unnest(List<String> replicateSymbols, List<UnnestMapping> mappings, PlanMatchPattern source)
     {
-        return unnest(replicateSymbols, mappings, Optional.empty(), INNER, Optional.empty(), source);
+        return unnest(replicateSymbols, mappings, Optional.empty(), INNER, source);
     }
 
     public static PlanMatchPattern unnest(
@@ -547,7 +547,6 @@ public final class PlanMatchPattern
             List<UnnestMapping> mappings,
             Optional<String> ordinalitySymbol,
             JoinType type,
-            Optional<String> filter,
             PlanMatchPattern source)
     {
         PlanMatchPattern result = node(UnnestNode.class, source)
@@ -555,8 +554,7 @@ public final class PlanMatchPattern
                         replicateSymbols,
                         mappings,
                         ordinalitySymbol,
-                        type,
-                        filter.map(predicate -> PlanBuilder.expression(predicate))));
+                        type));
 
         mappings.forEach(mapping -> {
             for (int i = 0; i < mapping.getOutputs().size(); i++) {

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/UnnestMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/UnnestMatcher.java
@@ -21,7 +21,6 @@ import io.trino.sql.planner.plan.JoinType;
 import io.trino.sql.planner.plan.PlanNode;
 import io.trino.sql.planner.plan.UnnestNode;
 import io.trino.sql.planner.plan.UnnestNode.Mapping;
-import io.trino.sql.tree.Expression;
 
 import java.util.List;
 import java.util.Optional;
@@ -40,15 +39,13 @@ final class UnnestMatcher
     private final List<PlanMatchPattern.UnnestMapping> unnestMappings;
     private final Optional<String> ordinalitySymbol;
     private final JoinType type;
-    private final Optional<Expression> filter;
 
-    public UnnestMatcher(List<String> replicateSymbols, List<PlanMatchPattern.UnnestMapping> unnestMappings, Optional<String> ordinalitySymbol, JoinType type, Optional<Expression> filter)
+    public UnnestMatcher(List<String> replicateSymbols, List<PlanMatchPattern.UnnestMapping> unnestMappings, Optional<String> ordinalitySymbol, JoinType type)
     {
         this.replicateSymbols = requireNonNull(replicateSymbols, "replicateSymbols is null");
         this.unnestMappings = requireNonNull(unnestMappings, "unnestMappings is null");
         this.ordinalitySymbol = requireNonNull(ordinalitySymbol, "ordinalitySymbol is null");
         this.type = requireNonNull(type, "type is null");
-        this.filter = requireNonNull(filter, "filter is null");
     }
 
     @Override
@@ -99,16 +96,6 @@ final class UnnestMatcher
             return NO_MATCH;
         }
 
-        if (filter.isPresent() != unnestNode.getFilter().isPresent()) {
-            return NO_MATCH;
-        }
-        if (filter.isEmpty()) {
-            return MatchResult.match();
-        }
-        if (!new ExpressionVerifier(symbolAliases).process(unnestNode.getFilter().get(), filter.get())) {
-            return NO_MATCH;
-        }
-
         return MatchResult.match();
     }
 
@@ -121,7 +108,6 @@ final class UnnestMatcher
                 .add("replicateSymbols", replicateSymbols)
                 .add("unnestMappings", unnestMappings)
                 .add("ordinalitySymbol", ordinalitySymbol.orElse(null))
-                .add("filter", filter.orElse(null))
                 .toString();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateInnerUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateInnerUnnestWithGlobalAggregation.java
@@ -60,7 +60,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values())))))
                 .doesNotFire();
     }
@@ -94,7 +93,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                 new UnnestNode.Mapping(p.symbol("a"), ImmutableList.of(p.symbol("unnested_a")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(p.symbol("a"), p.symbol("b")))))))
                 .doesNotFire();
     }
@@ -114,7 +112,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -132,7 +129,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -153,7 +149,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                 new UnnestNode.Mapping(p.symbol("old_masks"), ImmutableList.of(p.symbol("old_mask")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -175,7 +170,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                                         unnestMapping("old_masks", ImmutableList.of("old_mask"))),
                                                                 Optional.of("ordinality"),
                                                                 LEFT,
-                                                                Optional.empty(),
                                                                 assignUniqueId("unique", values("corr", "old_masks"))))))));
     }
 
@@ -194,7 +188,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.of(p.symbol("ordinality")),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -212,7 +205,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -236,7 +228,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                                         Optional.empty(),
                                                         INNER,
-                                                        Optional.empty(),
                                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))))
                 .matches(
                         project(
@@ -261,7 +252,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                                 Optional.of("ordinality"),
                                                                 LEFT,
-                                                                Optional.empty(),
                                                                 assignUniqueId("unique", values("corr"))))))));
     }
 
@@ -282,7 +272,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                                 Optional.empty(),
                                                 INNER,
-                                                Optional.empty(),
                                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))))
                 .matches(
                         project(
@@ -302,7 +291,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                                 Optional.of("ordinality"),
                                                                 LEFT,
-                                                                Optional.empty(),
                                                                 assignUniqueId("unique", values("corr"))))))));
     }
 
@@ -327,7 +315,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                             ImmutableList.of(new UnnestNode.Mapping(p.symbol("char_array"), ImmutableList.of(p.symbol("unnested_corr")))),
                                             Optional.empty(),
                                             INNER,
-                                            Optional.empty(),
                                             p.project(
                                                     Assignments.of(p.symbol("char_array"), regexpExtractAll),
                                                     p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))));
@@ -348,7 +335,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                         ImmutableList.of(unnestMapping("char_array", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         project(
                                                                 ImmutableMap.of("char_array", expression("regexp_extract_all(corr, '.')")),
                                                                 assignUniqueId("unique", values("corr"))))))));
@@ -388,7 +374,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                                                         new UnnestNode.Mapping(p.symbol("numbers"), ImmutableList.of(p.symbol("number")))),
                                                                                 Optional.empty(),
                                                                                 INNER,
-                                                                                Optional.empty(),
                                                                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))))))))
                 .matches(
                         project(
@@ -421,7 +406,6 @@ public class TestDecorrelateInnerUnnestWithGlobalAggregation
                                                                                                 unnestMapping("numbers", ImmutableList.of("number"))),
                                                                                         Optional.of("ordinality"),
                                                                                         LEFT,
-                                                                                        Optional.empty(),
                                                                                         assignUniqueId("unique", values("groups", "numbers")))))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateLeftUnnestWithGlobalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateLeftUnnestWithGlobalAggregation.java
@@ -59,7 +59,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values())))))
                 .doesNotFire();
     }
@@ -93,7 +92,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 new UnnestNode.Mapping(p.symbol("a"), ImmutableList.of(p.symbol("unnested_a")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(p.symbol("a"), p.symbol("b")))))))
                 .doesNotFire();
     }
@@ -113,7 +111,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -128,7 +125,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                 Optional.empty(),
                                                 LEFT,
-                                                Optional.empty(),
                                                 assignUniqueId("unique", values("corr"))))));
     }
 
@@ -149,7 +145,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 new UnnestNode.Mapping(p.symbol("masks"), ImmutableList.of(p.symbol("mask")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -167,7 +162,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                         unnestMapping("masks", ImmutableList.of("mask"))),
                                                 Optional.empty(),
                                                 LEFT,
-                                                Optional.empty(),
                                                 assignUniqueId("unique", values("corr", "masks"))))));
     }
 
@@ -186,7 +180,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.of(p.symbol("ordinality")),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))
                 .matches(
                         project(
@@ -201,7 +194,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                 Optional.of("ordinality"),
                                                 LEFT,
-                                                Optional.empty(),
                                                 assignUniqueId("unique", values("corr"))))));
     }
 
@@ -224,7 +216,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                                         Optional.empty(),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))))))
                 .matches(
                         project(
@@ -245,7 +236,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.empty(),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -266,7 +256,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                                 Optional.empty(),
                                                 LEFT,
-                                                Optional.empty(),
                                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))))
                 .matches(
                         project(
@@ -283,7 +272,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.empty(),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -308,7 +296,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                             ImmutableList.of(new UnnestNode.Mapping(p.symbol("char_array"), ImmutableList.of(p.symbol("unnested_char")))),
                                             Optional.empty(),
                                             LEFT,
-                                            Optional.empty(),
                                             p.project(
                                                     Assignments.of(p.symbol("char_array"), regexpExtractAll),
                                                     p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))));
@@ -326,7 +313,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                 ImmutableList.of(unnestMapping("char_array", ImmutableList.of("unnested_char"))),
                                                 Optional.empty(),
                                                 LEFT,
-                                                Optional.empty(),
                                                 project(
                                                         ImmutableMap.of("char_array", expression("regexp_extract_all(corr, '.')")),
                                                         assignUniqueId("unique", values("corr")))))));
@@ -366,7 +352,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                                                         new UnnestNode.Mapping(p.symbol("numbers"), ImmutableList.of(p.symbol("number")))),
                                                                                 Optional.empty(),
                                                                                 LEFT,
-                                                                                Optional.empty(),
                                                                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))))))))
                 .matches(
                         project(
@@ -396,7 +381,6 @@ public class TestDecorrelateLeftUnnestWithGlobalAggregation
                                                                                         unnestMapping("numbers", ImmutableList.of("number"))),
                                                                                 Optional.empty(),
                                                                                 LEFT,
-                                                                                Optional.empty(),
                                                                                 assignUniqueId("unique", values("groups", "numbers"))))))))));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateUnnest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDecorrelateUnnest.java
@@ -90,7 +90,6 @@ public class TestDecorrelateUnnest
                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                 Optional.empty(),
                                 LEFT,
-                                Optional.empty(),
                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))
                 .matches(
                         project(
@@ -99,7 +98,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                         Optional.of("ordinality"),
                                         LEFT,
-                                        Optional.empty(),
                                         assignUniqueId("unique", values("corr")))));
     }
 
@@ -117,7 +115,6 @@ public class TestDecorrelateUnnest
                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                 Optional.empty(),
                                 LEFT,
-                                Optional.empty(),
                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))
                 .matches(
                         project(
@@ -126,7 +123,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                         Optional.of("ordinality"),
                                         LEFT,
-                                        Optional.empty(),
                                         assignUniqueId("unique", values("corr")))));
     }
 
@@ -144,7 +140,6 @@ public class TestDecorrelateUnnest
                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                 Optional.empty(),
                                 INNER,
-                                Optional.empty(),
                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))
                 .matches(
                         project(
@@ -153,7 +148,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                         Optional.of("ordinality"),
                                         INNER,
-                                        Optional.empty(),
                                         assignUniqueId("unique", values("corr")))));
     }
 
@@ -171,7 +165,6 @@ public class TestDecorrelateUnnest
                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                 Optional.empty(),
                                 INNER,
-                                Optional.empty(),
                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))
                 .matches(
                         project(
@@ -181,7 +174,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                         Optional.of("ordinality"),
                                         LEFT,
-                                        Optional.empty(),
                                         assignUniqueId("unique", values("corr")))));
     }
 
@@ -200,7 +192,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(// restore semantics of INNER unnest after it was rewritten to LEFT
@@ -216,7 +207,6 @@ public class TestDecorrelateUnnest
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr"))))
                                                 .withAlias("row_number", new RowNumberSymbolMatcher()))));
     }
@@ -237,7 +227,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(
@@ -252,7 +241,6 @@ public class TestDecorrelateUnnest
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr"))))
                                                 .withAlias("row_number", new RowNumberSymbolMatcher()))));
     }
@@ -274,7 +262,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(
@@ -291,7 +278,6 @@ public class TestDecorrelateUnnest
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -312,7 +298,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(
@@ -329,7 +314,6 @@ public class TestDecorrelateUnnest
                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                         Optional.of("ordinality"),
                                                         LEFT,
-                                                        Optional.empty(),
                                                         assignUniqueId("unique", values("corr")))))));
     }
 
@@ -349,7 +333,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         LEFT,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(
@@ -360,7 +343,6 @@ public class TestDecorrelateUnnest
                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                 Optional.of("ordinality"),
                                                 LEFT,
-                                                Optional.empty(),
                                                 assignUniqueId("unique", values("corr"))))));
 
         tester().assertThat(new DecorrelateUnnest(tester().getMetadata()))
@@ -376,7 +358,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))
                 .matches(
                         project(// restore semantics of INNER unnest after it was rewritten to LEFT
@@ -388,7 +369,6 @@ public class TestDecorrelateUnnest
                                                 ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                 Optional.of("ordinality"),
                                                 LEFT,
-                                                Optional.empty(),
                                                 assignUniqueId("unique", values("corr"))))));
     }
 
@@ -416,7 +396,6 @@ public class TestDecorrelateUnnest
                                                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                                                         Optional.empty(),
                                                                         LEFT,
-                                                                        Optional.empty(),
                                                                         p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of()))))))))))
                 .matches(
                         project(
@@ -441,7 +420,6 @@ public class TestDecorrelateUnnest
                                                                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                                                                         Optional.of("ordinality"),
                                                                                         LEFT,
-                                                                                        Optional.empty(),
                                                                                         assignUniqueId("unique", values("corr")))))))))));
     }
 
@@ -459,7 +437,6 @@ public class TestDecorrelateUnnest
                                 ImmutableList.of(new UnnestNode.Mapping(p.symbol("corr"), ImmutableList.of(p.symbol("unnested_corr")))),
                                 Optional.of(p.symbol("ordinality")),
                                 INNER,
-                                Optional.empty(),
                                 p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))))
                 .matches(
                         project(
@@ -469,7 +446,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("corr", ImmutableList.of("unnested_corr"))),
                                         Optional.of("ordinality"),
                                         LEFT,
-                                        Optional.empty(),
                                         assignUniqueId("unique", values("corr")))));
     }
 
@@ -493,7 +469,6 @@ public class TestDecorrelateUnnest
                                     ImmutableList.of(new UnnestNode.Mapping(p.symbol("char_array"), ImmutableList.of(p.symbol("unnested_char")))),
                                     Optional.empty(),
                                     LEFT,
-                                    Optional.empty(),
                                     p.project(
                                             Assignments.of(p.symbol("char_array"), regexpExtractAll),
                                             p.values(ImmutableList.of(), ImmutableList.of(ImmutableList.of())))));
@@ -505,7 +480,6 @@ public class TestDecorrelateUnnest
                                         ImmutableList.of(unnestMapping("char_array", ImmutableList.of("unnested_char"))),
                                         Optional.of("ordinality"),
                                         LEFT,
-                                        Optional.empty(),
                                         project(
                                                 ImmutableMap.of("char_array", expression("regexp_extract_all(corr, '.')")),
                                                 assignUniqueId("unique", values("corr"))))));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneUnnestColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneUnnestColumns.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
-import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.UnnestNode.Mapping;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,6 @@ public class TestPruneUnnestColumns
                                     ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
                                     Optional.of(ordinalitySymbol),
                                     INNER,
-                                    Optional.empty(),
                                     p.values(replicateSymbol, unnestSymbol)));
                 })
                 .matches(
@@ -61,7 +59,6 @@ public class TestPruneUnnestColumns
                                         ImmutableList.of(unnestMapping("unnest_symbol", ImmutableList.of("unnested_symbol"))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         values("replicate_symbol", "unnest_symbol"))));
     }
 
@@ -81,7 +78,6 @@ public class TestPruneUnnestColumns
                                     ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
                                     Optional.of(ordinalitySymbol),
                                     INNER,
-                                    Optional.empty(),
                                     p.values(replicateSymbol, unnestSymbol)));
                 })
                 .matches(
@@ -92,52 +88,7 @@ public class TestPruneUnnestColumns
                                         ImmutableList.of(unnestMapping("unnest_symbol", ImmutableList.of("unnested_symbol"))),
                                         Optional.of("ordinality_symbol"),
                                         INNER,
-                                        Optional.empty(),
                                         values("replicate_symbol", "unnest_symbol"))));
-    }
-
-    @Test
-    public void testDoNotPruneOrdinalitySymbolUsedInFilter()
-    {
-        tester().assertThat(new PruneUnnestColumns())
-                .on(p -> {
-                    Symbol replicateSymbol = p.symbol("replicate_symbol");
-                    Symbol unnestSymbol = p.symbol("unnest_symbol");
-                    Symbol unnestedSymbol = p.symbol("unnested_symbol");
-                    Symbol ordinalitySymbol = p.symbol("ordinality_symbol");
-                    return p.project(
-                            Assignments.identity(replicateSymbol, unnestedSymbol),
-                            p.unnest(
-                                    ImmutableList.of(replicateSymbol),
-                                    ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
-                                    Optional.of(ordinalitySymbol),
-                                    INNER,
-                                    Optional.of(PlanBuilder.expression("ordinality_symbol < BIGINT '5'")),
-                                    p.values(replicateSymbol, unnestSymbol)));
-                })
-                .doesNotFire();
-    }
-
-    @Test
-    public void testDoNotPruneReplicateSymbolUsedInFilter()
-    {
-        tester().assertThat(new PruneUnnestColumns())
-                .on(p -> {
-                    Symbol replicateSymbol = p.symbol("replicate_symbol");
-                    Symbol unnestSymbol = p.symbol("unnest_symbol");
-                    Symbol unnestedSymbol = p.symbol("unnested_symbol");
-                    Symbol ordinalitySymbol = p.symbol("ordinality_symbol");
-                    return p.project(
-                            Assignments.identity(unnestedSymbol, ordinalitySymbol),
-                            p.unnest(
-                                    ImmutableList.of(replicateSymbol),
-                                    ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
-                                    Optional.of(ordinalitySymbol),
-                                    INNER,
-                                    Optional.of(PlanBuilder.expression("replicate_symbol < BIGINT '5'")),
-                                    p.values(replicateSymbol, unnestSymbol)));
-                })
-                .doesNotFire();
     }
 
     @Test
@@ -156,7 +107,6 @@ public class TestPruneUnnestColumns
                                     ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
                                     Optional.of(ordinalitySymbol),
                                     INNER,
-                                    Optional.empty(),
                                     p.values(replicateSymbol, unnestSymbol)));
                 })
                 .doesNotFire();
@@ -178,7 +128,6 @@ public class TestPruneUnnestColumns
                                     ImmutableList.of(new Mapping(unnestSymbol, ImmutableList.of(unnestedSymbol))),
                                     Optional.of(ordinalitySymbol),
                                     INNER,
-                                    Optional.empty(),
                                     p.values(replicateSymbol, unnestSymbol)));
                 })
                 .doesNotFire();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -251,7 +251,6 @@ public class TestPushDownDereferencesRules
                                         ImmutableList.of(new UnnestNode.Mapping(p.symbol("arr", arrayType), ImmutableList.of(p.symbol("field")))),
                                         Optional.empty(),
                                         INNER,
-                                        Optional.empty(),
                                         p.values(p.symbol("msg", ROW_TYPE), p.symbol("arr", arrayType)))))
                 .matches(
                         strictProject(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -1328,10 +1328,10 @@ public class PlanBuilder
 
     public UnnestNode unnest(List<Symbol> replicateSymbols, List<UnnestNode.Mapping> mappings, PlanNode source)
     {
-        return unnest(replicateSymbols, mappings, Optional.empty(), INNER, Optional.empty(), source);
+        return unnest(replicateSymbols, mappings, Optional.empty(), INNER, source);
     }
 
-    public UnnestNode unnest(List<Symbol> replicateSymbols, List<UnnestNode.Mapping> mappings, Optional<Symbol> ordinalitySymbol, JoinType type, Optional<Expression> filter, PlanNode source)
+    public UnnestNode unnest(List<Symbol> replicateSymbols, List<UnnestNode.Mapping> mappings, Optional<Symbol> ordinalitySymbol, JoinType type, PlanNode source)
     {
         return new UnnestNode(
                 idAllocator.getNextId(),
@@ -1339,8 +1339,7 @@ public class PlanBuilder
                 replicateSymbols,
                 mappings,
                 ordinalitySymbol,
-                type,
-                filter);
+                type);
     }
 
     public WindowNode window(DataOrganizationSpecification specification, Map<Symbol, WindowNode.Function> functions, PlanNode source)


### PR DESCRIPTION
Only TRUE is supported. There's no point in carrying the complexity until arbitrary filters are supported.

## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
