### PR TITLE
Remove unnecessary test

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestEngineOnlyQueries.java
@@ -6708,22 +6708,6 @@ public abstract class AbstractTestEngineOnlyQueries
                 .failure().hasMessage("line 3:8: Recursive language functions are not supported: a(integer):integer");
     }
 
-    // ensure that JSON_TABLE runs properly in distributed mode (i.e., serialization of handles works correctly, etc)
-    @Test
-    public void testJsonTable()
-    {
-        assertThat(query("""
-                         SELECT first, last
-                          FROM (SELECT '{"a" : [1, 2, 3], "b" : [4, 5, 6]}') t(json_col), JSON_TABLE(
-                              json_col,
-                              'lax $.a'
-                              COLUMNS(
-                                  first bigint PATH 'lax $[0]',
-                                  last bigint PATH 'lax $[last]'))
-                         """))
-                .matches("VALUES (BIGINT '1', BIGINT '3')");
-    }
-
     private static ZonedDateTime zonedDateTime(String value)
     {
         return ZONED_DATE_TIME_FORMAT.parse(value, ZonedDateTime::from);


### PR DESCRIPTION
This testcase is covered by io.trino.sql.query.TestJsonTable now that it uses StandaloneQueryRunner.


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
