### PR TITLE
Introduce ClosingBinder

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -13,7 +13,6 @@
  */
 package io.trino.server;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
@@ -155,9 +154,7 @@ import io.trino.type.TypeSignatureDeserializer;
 import io.trino.type.TypeSignatureKeyDeserializer;
 import io.trino.util.EmbedVersion;
 import io.trino.util.FinalizerService;
-import jakarta.annotation.PreDestroy;
 
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -177,6 +174,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.NodeSchedulerPolicy.TOPOLOGY;
 import static io.trino.execution.scheduler.NodeSchedulerConfig.NodeSchedulerPolicy.UNIFORM;
 import static io.trino.operator.RetryPolicy.TASK;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 import static io.trino.server.InternalCommunicationHttpClientModule.internalHttpClientModule;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -501,7 +499,10 @@ public class ServerMainModule
         newOptionalBinder(binder, RuleStatsRecorder.class);
 
         // cleanup
-        binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);
+        closingBinder(binder)
+                .registerExecutor(ScheduledExecutorService.class, ForExchange.class)
+                .registerExecutor(ExecutorService.class, ForAsyncHttp.class)
+                .registerExecutor(ScheduledExecutorService.class, ForAsyncHttp.class);
     }
 
     private static class RegisterFunctionBundles
@@ -601,28 +602,5 @@ public class ServerMainModule
     public static ScheduledExecutorService createAsyncHttpTimeoutExecutor(TaskManagerConfig config)
     {
         return newScheduledThreadPool(config.getHttpTimeoutThreads(), daemonThreadsNamed("async-http-timeout-%s"));
-    }
-
-    public static class ExecutorCleanup
-    {
-        private final List<ExecutorService> executors;
-
-        @Inject
-        public ExecutorCleanup(
-                @ForExchange ScheduledExecutorService exchangeExecutor,
-                @ForAsyncHttp ExecutorService httpResponseExecutor,
-                @ForAsyncHttp ScheduledExecutorService httpTimeoutExecutor)
-        {
-            executors = ImmutableList.of(
-                    exchangeExecutor,
-                    httpResponseExecutor,
-                    httpTimeoutExecutor);
-        }
-
-        @PreDestroy
-        public void shutdown()
-        {
-            executors.forEach(ExecutorService::shutdownNow);
-        }
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ClosingBinder.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/ClosingBinder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Closer;
+import com.google.inject.Binder;
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Inject;
+import com.google.inject.Key;
+import com.google.inject.multibindings.Multibinder;
+import jakarta.annotation.PreDestroy;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+public class ClosingBinder
+{
+    public static ClosingBinder closingBinder(Binder binder)
+    {
+        return new ClosingBinder(binder);
+    }
+
+    private final Multibinder<ExecutorService> executors;
+    private final Multibinder<Closeable> closeables;
+
+    private ClosingBinder(Binder binder)
+    {
+        executors = newSetBinder(binder, ExecutorService.class, ForCleanup.class);
+        closeables = newSetBinder(binder, Closeable.class, ForCleanup.class);
+        binder.bind(Cleanup.class).asEagerSingleton();
+    }
+
+    public ClosingBinder registerExecutor(Class<? extends ExecutorService> type)
+    {
+        executors.addBinding().to(type);
+        return this;
+    }
+
+    public ClosingBinder registerExecutor(Class<? extends ExecutorService> type, Class<? extends Annotation> annotation)
+    {
+        executors.addBinding().to(Key.get(type, annotation));
+        return this;
+    }
+
+    public ClosingBinder registerCloseable(Class<? extends Closeable> type)
+    {
+        closeables.addBinding().to(type);
+        return this;
+    }
+
+    public ClosingBinder registerCloseable(Class<? extends Closeable> type, Class<? extends Annotation> annotation)
+    {
+        closeables.addBinding().to(Key.get(type, annotation));
+        return this;
+    }
+
+    private static class Cleanup
+    {
+        private final Set<ExecutorService> executors;
+        private final Set<Closeable> closeables;
+
+        @Inject
+        public Cleanup(
+                @ForCleanup Set<ExecutorService> executors,
+                @ForCleanup Set<Closeable> closeables)
+        {
+            this.executors = ImmutableSet.copyOf(executors);
+            this.closeables = ImmutableSet.copyOf(closeables);
+        }
+
+        @PreDestroy
+        public void shutdown()
+                throws IOException
+        {
+            executors.forEach(ExecutorService::shutdownNow);
+            try (Closer closer = Closer.create()) {
+                closeables.forEach(closer::register);
+            }
+        }
+    }
+
+    @Retention(RUNTIME)
+    @Target({FIELD, PARAMETER, METHOD})
+    @BindingAnnotation
+    private @interface ForCleanup {}
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/TestClosingBinder.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/TestClosingBinder.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.bootstrap.LifeCycleManager;
+import org.junit.jupiter.api.Test;
+
+import java.io.Closeable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestClosingBinder
+{
+    @Test
+    public void testExecutorShutdown()
+    {
+        Module module = binder -> {
+            binder.bind(ExecutorService.class).toInstance(newCachedThreadPool());
+            closingBinder(binder).registerExecutor(ExecutorService.class);
+        };
+        Injector injector = getInjector(module);
+
+        ExecutorService executorService = injector.getInstance(ExecutorService.class);
+        assertThat(executorService.isShutdown()).isFalse();
+        stop(injector);
+        assertThat(executorService.isShutdown()).isTrue();
+    }
+
+    @Test
+    public void testCloseableShutdown()
+    {
+        AtomicBoolean closed = new AtomicBoolean();
+        Injector injector = getInjector(binder -> {
+            binder.bind(Closeable.class).toInstance(() -> closed.set(true));
+            closingBinder(binder).registerCloseable(Closeable.class);
+        });
+
+        assertThat(closed.get()).isFalse();
+        stop(injector);
+        assertThat(closed.get()).isTrue();
+    }
+
+    private static Injector getInjector(Module module)
+    {
+        Bootstrap app = new Bootstrap(module);
+
+        return app.doNotInitializeLogging()
+                .quiet()
+                .initialize();
+    }
+
+    private static void stop(Injector injector)
+    {
+        LifeCycleManager lifeCycleManager = injector.getInstance(LifeCycleManager.class);
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -31,7 +31,6 @@ import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.function.table.ConnectorTableFunction;
 import io.trino.spi.procedure.Procedure;
-import jakarta.annotation.PreDestroy;
 
 import java.util.concurrent.ExecutorService;
 
@@ -39,6 +38,7 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class JdbcModule
@@ -103,6 +103,9 @@ public class JdbcModule
                 .in(Scopes.SINGLETON);
 
         newSetBinder(binder, JdbcQueryEventListener.class);
+
+        closingBinder(binder)
+                .registerExecutor(ExecutorService.class, ForRecordCursor.class);
     }
 
     public static Multibinder<SessionPropertiesProvider> sessionPropertiesProviderBinder(Binder binder)
@@ -133,11 +136,5 @@ public class JdbcModule
     public static void bindTablePropertiesProvider(Binder binder, Class<? extends TablePropertiesProvider> type)
     {
         tablePropertiesProviderBinder(binder).addBinding().to(type).in(Scopes.SINGLETON);
-    }
-
-    @PreDestroy
-    public void shutdownRecordCursorExecutor(@ForRecordCursor ExecutorService executor)
-    {
-        executor.shutdownNow();
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreModule.java
@@ -26,13 +26,13 @@ import io.trino.plugin.hive.AllowHiveTableRename;
 import io.trino.plugin.hive.ForHiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreFactory;
 import io.trino.plugin.hive.metastore.RawHiveMetastoreFactory;
-import jakarta.annotation.PreDestroy;
 
 import java.util.concurrent.ExecutorService;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.threadsNamed;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.base.ClosingBinder.closingBinder;
 import static io.trino.plugin.base.security.UserNameProvider.SIMPLE_USER_NAME_PROVIDER;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newFixedThreadPool;
@@ -91,12 +91,9 @@ public class ThriftMetastoreModule
                 .setDefault()
                 .toInstance(SIMPLE_USER_NAME_PROVIDER);
         binder.bind(Key.get(boolean.class, AllowHiveTableRename.class)).toInstance(true);
-    }
 
-    @PreDestroy
-    public void shutdownsWriteStatisticExecutor(@ThriftHiveWriteStatisticsExecutor ExecutorService executor)
-    {
-        executor.shutdownNow();
+        closingBinder(binder)
+                .registerExecutor(ExecutorService.class, ThriftHiveWriteStatisticsExecutor.class);
     }
 
     private static class ThriftHiveMetastoreStatisticExecutorProvider


### PR DESCRIPTION
    Introduce ClosingBinder

    It is easy to make a mistake when closing a resource on a
    method in the guice module annotated with @PreDestroy. Such method won't
    be called and resource may leak. This does not affect
    production, but it may leak resources during the test.

    ClosingBinder is created in order to help mitigate this problem by introducing
    simple utility to close resources in guice modules.
