### PR TITLE
Fix incorrect result when filtering clustering key in Cassandra

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -244,7 +244,9 @@ public class CassandraMetadata
 
         String clusteringKeyPredicates = "";
         TupleDomain<ColumnHandle> unenforcedConstraint;
-        if (partitionResult.isUnpartitioned()) {
+        if (partitionResult.isUnpartitioned() || partitionResult.isIndexedColumnPredicatePushdown()) {
+            // When the filter is missing at least one of the partition keys or when the table is not partitioned,
+            // use the raw unenforced constraint of the partitionResult
             unenforcedConstraint = partitionResult.getUnenforcedConstraint();
         }
         else {

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -87,7 +87,7 @@ public class CassandraPartitionManager
             }
         }
 
-        // push down indexed column fixed value predicates only for unpartitioned partition which uses token range query
+        // Cassandra allows pushing down indexed column fixed value predicates along with token range SELECT
         if ((partitions.size() == 1) && partitions.get(0).isUnpartitioned()) {
             Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().get();
             List<ColumnHandle> indexedColumns = new ArrayList<>();
@@ -108,9 +108,9 @@ public class CassandraPartitionManager
             if (sb.length() > 0) {
                 CassandraPartition partition = partitions.get(0);
                 TupleDomain<ColumnHandle> filterIndexedColumn = TupleDomain.withColumnDomains(Maps.filterKeys(remainingTupleDomain.getDomains().get(), not(in(indexedColumns))));
-                partitions = new ArrayList<>();
-                partitions.add(new CassandraPartition(partition.getKey(), sb.toString(), filterIndexedColumn, true));
-                return new CassandraPartitionResult(partitions, filterIndexedColumn);
+                return new CassandraPartitionResult(
+                        ImmutableList.of(new CassandraPartition(partition.getKey(), sb.toString(), filterIndexedColumn, true)),
+                        filterIndexedColumn);
             }
         }
         return new CassandraPartitionResult(partitions, remainingTupleDomain);

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionResult.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionResult.java
@@ -46,4 +46,9 @@ public class CassandraPartitionResult
     {
         return partitions.size() == 1 && getOnlyElement(partitions).isUnpartitioned();
     }
+
+    public boolean isIndexedColumnPredicatePushdown()
+    {
+        return partitions.size() == 1 && getOnlyElement(partitions).isIndexedColumnPredicatePushdown();
+    }
 }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -861,12 +861,7 @@ public class TestCassandraConnectorTest
         // Execute a query on Trino with where clause having all the secondary key columns and another column (potentially a cluster key column)
         assertQuery("SELECT * FROM tpch." + table + " WHERE idx1_col = 'value1' AND idx2_col = 'value21' AND cluster_col = 1", "VALUES ('v11', 'v21', 1, 'value1', 'value21')");
         // Execute a query on Trino with where clause not having all the secondary key columns and another column (potentially a cluster key column)
-        if (withClusteringKey) {
-            assertQuery("SELECT * FROM tpch." + table + " WHERE idx1_col = 'value1' AND cluster_col = 1", "VALUES ('v11', 'v21', 1, 'value1', 'value21'), ('v11', 'v22', 2, 'value1', 'value22')");
-        }
-        else {
-            assertQuery("SELECT * FROM tpch." + table + " WHERE idx1_col = 'value1' AND cluster_col = 1", "VALUES ('v11', 'v21', 1, 'value1', 'value21')");
-        }
+        assertQuery("SELECT * FROM tpch." + table + " WHERE idx1_col = 'value1' AND cluster_col = 1", "VALUES ('v11', 'v21', 1, 'value1', 'value21')");
 
         onCassandra("DROP INDEX tpch." + table + "_idx1_col_idx");
         onCassandra("DROP INDEX tpch." + table + "_idx2_col_idx");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
Clustering key constraints are ignored when there are secondary key and clustering key defined and not all the secondary keys are part of the `WHERE` clause.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Diagnosis - `clusteringKeyPredicates` is not considered when splits are created based on the token range.

https://github.com/trinodb/trino/blob/3d3a0f0a9ce1cef3acab4a3355f12be715324c78/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java#L93-L102

https://github.com/trinodb/trino/blob/3d3a0f0a9ce1cef3acab4a3355f12be715324c78/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplitManager.java#L110-L118

Proposed fix - Keep `clusteringKeyPredicates` empty and the cluster key constraint will remain part of `unenforcedConstraint` 

https://github.com/trinodb/trino/blob/3d3a0f0a9ce1cef3acab4a3355f12be715324c78/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java#L246-L249

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Cassandra
* Fix incorrect result when query contains predicates on clustering columns. ({issue}`20963`)
```
