### PR TITLE
Handle NaN and infinite values in Aggregation Window Function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorCompiler.java
@@ -26,6 +26,7 @@ import io.airlift.bytecode.control.ForLoop;
 import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.expression.BytecodeExpression;
 import io.airlift.bytecode.expression.BytecodeExpressions;
+import io.airlift.bytecode.instruction.LabelNode;
 import io.trino.operator.window.InternalWindowIndex;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -287,22 +288,20 @@ public final class AccumulatorCompiler
 
         // Generate methods
         generateCopy(definition, WindowAccumulator.class);
-        generateAddOrRemoveInputWindowIndex(
+        generateAddInputWindowIndex(
                 definition,
                 stateFields,
                 argumentNullable,
                 lambdaProviderFields,
                 implementation.getInputFunction(),
-                "addInput",
                 callSiteBinder);
         implementation.getRemoveInputFunction().ifPresent(
-                removeInputFunction -> generateAddOrRemoveInputWindowIndex(
+                removeInputFunction -> generateRemoveInputWindowIndex(
                         definition,
                         stateFields,
                         argumentNullable,
                         lambdaProviderFields,
                         removeInputFunction,
-                        "removeInput",
                         callSiteBinder));
 
         generateEvaluateFinal(definition, stateFields, implementation.getOutputFunction(), callSiteBinder);
@@ -417,13 +416,12 @@ public final class AccumulatorCompiler
         body.ret();
     }
 
-    private static void generateAddOrRemoveInputWindowIndex(
+    private static void generateAddInputWindowIndex(
             ClassDefinition definition,
             List<FieldDefinition> stateField,
             List<Boolean> argumentNullable,
             List<FieldDefinition> lambdaProviderFields,
             MethodHandle inputFunction,
-            String generatedFunctionName,
             CallSiteBinder callSiteBinder)
     {
         // TODO: implement masking based on maskChannel field once Window Functions support DISTINCT arguments to the functions.
@@ -434,7 +432,7 @@ public final class AccumulatorCompiler
 
         MethodDefinition method = definition.declareMethod(
                 a(PUBLIC),
-                generatedFunctionName,
+                "addInput",
                 type(void.class),
                 ImmutableList.of(index, startPosition, endPosition));
         Scope scope = method.getScope();
@@ -462,7 +460,7 @@ public final class AccumulatorCompiler
         invokeInputFunction.append(invokeDynamic(
                 BOOTSTRAP_METHOD,
                 ImmutableList.of(binding.getBindingId()),
-                generatedFunctionName,
+                "addInput",
                 binding.getType(),
                 getInvokeFunctionOnWindowIndexParameters(
                         scope.getThis(),
@@ -479,6 +477,75 @@ public final class AccumulatorCompiler
                                 .condition(anyParametersAreNull(argumentNullable, index, position))
                                 .ifFalse(invokeInputFunction)))
                 .ret();
+    }
+
+    private static void generateRemoveInputWindowIndex(
+            ClassDefinition definition,
+            List<FieldDefinition> stateField,
+            List<Boolean> argumentNullable,
+            List<FieldDefinition> lambdaProviderFields,
+            MethodHandle inputFunction,
+            CallSiteBinder callSiteBinder)
+    {
+        // TODO: implement masking based on maskChannel field once Window Functions support DISTINCT arguments to the functions.
+
+        Parameter index = arg("index", WindowIndex.class);
+        Parameter startPosition = arg("startPosition", int.class);
+        Parameter endPosition = arg("endPosition", int.class);
+
+        MethodDefinition method = definition.declareMethod(
+                a(PUBLIC),
+                "removeInput",
+                type(boolean.class),
+                ImmutableList.of(index, startPosition, endPosition));
+        Scope scope = method.getScope();
+        BytecodeBlock body = method.getBody();
+
+        Variable position = scope.declareVariable(int.class, "position");
+
+        // input parameters
+        Variable inputBlockPosition = scope.declareVariable(int.class, "inputBlockPosition");
+        List<Variable> inputBlockVariables = new ArrayList<>();
+        for (int i = 0; i < argumentNullable.size(); i++) {
+            inputBlockVariables.add(scope.declareVariable(Block.class, "inputBlock" + i));
+        }
+
+        Binding binding = callSiteBinder.bind(inputFunction);
+        BytecodeBlock invokeInputFunction = new BytecodeBlock();
+        // WindowIndex is built on PagesIndex, which simply wraps Blocks
+        // and currently does not understand ValueBlocks.
+        // Until PagesIndex is updated to understand ValueBlocks, the
+        // input function parameters must be directly unwrapped to ValueBlocks.
+        invokeInputFunction.append(inputBlockPosition.set(index.cast(InternalWindowIndex.class).invoke("getRawBlockPosition", int.class, position)));
+        for (int i = 0; i < inputBlockVariables.size(); i++) {
+            invokeInputFunction.append(inputBlockVariables.get(i).set(index.cast(InternalWindowIndex.class).invoke("getRawBlock", Block.class, constantInt(i), position)));
+        }
+        LabelNode returnFalse = new LabelNode("returnFalse");
+        invokeInputFunction.append(invokeDynamic(
+                BOOTSTRAP_METHOD,
+                ImmutableList.of(binding.getBindingId()),
+                "removeInput",
+                binding.getType(),
+                getInvokeFunctionOnWindowIndexParameters(
+                        scope.getThis(),
+                        stateField,
+                        inputBlockPosition,
+                        inputBlockVariables,
+                        lambdaProviderFields)));
+        invokeInputFunction.ifFalseGoto(returnFalse);
+
+        body.append(new ForLoop()
+                        .initialize(position.set(startPosition))
+                        .condition(BytecodeExpressions.lessThanOrEqual(position, endPosition))
+                        .update(position.increment())
+                        .body(new IfStatement()
+                                .condition(anyParametersAreNull(argumentNullable, index, position))
+                                .ifFalse(invokeInputFunction)))
+                .push(true)
+                .retBoolean()
+                .visitLabel(returnFalse)
+                .push(false)
+                .retBoolean();
     }
 
     private static BytecodeExpression anyParametersAreNull(

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AverageAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AverageAggregations.java
@@ -46,17 +46,23 @@ public final class AverageAggregations
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setLong(state.getLong() - 1);
         state.setDouble(state.getDouble() - value);
+        return true;
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        state.setLong(state.getLong() - 1);
-        state.setDouble(state.getDouble() - value);
+        double currentValue = state.getDouble();
+        if (Double.isFinite(currentValue)) {
+            state.setDouble(currentValue - value);
+            state.setLong(state.getLong() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountAggregation.java
@@ -37,9 +37,10 @@ public final class CountAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongState state)
+    public static boolean removeInput(@AggregationState LongState state)
     {
         state.setValue(state.getValue() - 1);
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountColumn.java
@@ -47,12 +47,13 @@ public final class CountColumn
     }
 
     @RemoveInputFunction
-    public static void removeInput(
+    public static boolean removeInput(
             @AggregationState LongState state,
             @BlockPosition @SqlType("T") ValueBlock block,
             @BlockIndex int position)
     {
         state.setValue(state.getValue() - 1);
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CountIfAggregation.java
@@ -40,11 +40,12 @@ public final class CountIfAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongState state, @SqlType(StandardTypes.BOOLEAN) boolean value)
+    public static boolean removeInput(@AggregationState LongState state, @SqlType(StandardTypes.BOOLEAN) boolean value)
     {
         if (value) {
             state.setValue(state.getValue() - 1);
         }
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DoubleSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DoubleSumAggregation.java
@@ -38,10 +38,15 @@ public final class DoubleSumAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
+    public static boolean removeInput(@AggregationState LongAndDoubleState state, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        state.setLong(state.getLong() - 1);
-        state.setDouble(state.getDouble() - value);
+        double currentValue = state.getDouble();
+        if (Double.isFinite(currentValue)) {
+            state.setDouble(currentValue - value);
+            state.setLong(state.getLong() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/LongSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/LongSumAggregation.java
@@ -38,10 +38,11 @@ public final class LongSumAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(@AggregationState LongLongState state, @SqlType(StandardTypes.BIGINT) long value)
+    public static boolean removeInput(@AggregationState LongLongState state, @SqlType(StandardTypes.BIGINT) long value)
     {
         state.setFirst(state.getFirst() - 1);
         state.setSecond(BigintOperators.subtract(state.getSecond(), value));
+        return true;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/RealAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/RealAverageAggregation.java
@@ -46,13 +46,18 @@ public final class RealAverageAggregation
     }
 
     @RemoveInputFunction
-    public static void removeInput(
+    public static boolean removeInput(
             @AggregationState LongState count,
             @AggregationState DoubleState sum,
             @SqlType("REAL") long value)
     {
-        count.setValue(count.getValue() - 1);
-        sum.setValue(sum.getValue() - intBitsToFloat((int) value));
+        double currentValue = sum.getValue();
+        if (Double.isFinite(currentValue)) {
+            sum.setValue(currentValue - intBitsToFloat((int) value));
+            count.setValue(count.getValue() - 1);
+            return true;
+        }
+        return false;
     }
 
     @CombineFunction

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/WindowAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/WindowAccumulator.java
@@ -24,7 +24,7 @@ public interface WindowAccumulator
 
     void addInput(WindowIndex index, int startPosition, int endPosition);
 
-    void removeInput(WindowIndex index, int startPosition, int endPosition);
+    boolean removeInput(WindowIndex index, int startPosition, int endPosition);
 
     void evaluateFinal(BlockBuilder blockBuilder);
 }

--- a/core/trino-main/src/test/java/io/trino/operator/window/AbstractTestWindowFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/AbstractTestWindowFunction.java
@@ -67,6 +67,16 @@ public abstract class AbstractTestWindowFunction
         return WindowAssertions.executeWindowQueryWithNulls(sql, queryRunner);
     }
 
+    protected void assertWindowQueryWithNan(@Language("SQL") String sql, MaterializedResult expected)
+    {
+        WindowAssertions.assertWindowQueryWithNan(sql, expected, queryRunner);
+    }
+
+    protected void assertWindowQueryWithInfinity(@Language("SQL") String sql, MaterializedResult expected)
+    {
+        WindowAssertions.assertWindowQueryWithInfinity(sql, expected, queryRunner);
+    }
+
     protected void assertUnboundedWindowQueryWithNulls(@Language("SQL") String sql, MaterializedResult expected)
     {
         assertWindowQueryWithNulls(unbounded(sql), expected);

--- a/core/trino-main/src/test/java/io/trino/operator/window/TestAggregateWindowFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/TestAggregateWindowFunction.java
@@ -595,4 +595,68 @@ public class TestAggregateWindowFunction
                         .row(null, null, null)
                         .build());
     }
+
+    @Test
+    public void testAverageRowsRollingWithNanAndInfinity()
+    {
+        assertWindowQueryWithNan("avg(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 4.5)
+                        .row(33.0, "F", 14.0)
+                        .row(Double.NaN, "F", Double.NaN)
+                        .row(32.0, "O", Double.NaN)
+                        .row(4.0, "O", Double.NaN)
+                        .row(1.0, "O", 12.333333333333334)
+                        .row(7.0, "O", 4.0)
+                        .row(2.0, "O", 3.3333333333333335)
+                        .row(34.0, "O", 14.333333333333334)
+                        .build());
+
+        assertWindowQueryWithInfinity("avg(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 4.5)
+                        .row(33.0, "F", 14.0)
+                        .row(Double.POSITIVE_INFINITY, "F", Double.POSITIVE_INFINITY)
+                        .row(32.0, "O", Double.POSITIVE_INFINITY)
+                        .row(4.0, "O", Double.POSITIVE_INFINITY)
+                        .row(1.0, "O", 12.333333333333334)
+                        .row(7.0, "O", 4.0)
+                        .row(2.0, "O", 3.3333333333333335)
+                        .row(34.0, "O", 14.333333333333334)
+                        .build());
+    }
+
+    @Test
+    public void testSumRowsRollingWithNanAndInfinity()
+    {
+        assertWindowQueryWithNan("sum(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 9.0)
+                        .row(33.0, "F", 42.0)
+                        .row(Double.NaN, "F", Double.NaN)
+                        .row(32.0, "O", Double.NaN)
+                        .row(4.0, "O", Double.NaN)
+                        .row(1.0, "O", 37.0)
+                        .row(7.0, "O", 12.0)
+                        .row(2.0, "O", 10.0)
+                        .row(34.0, "O", 43.0)
+                        .build());
+
+        assertWindowQueryWithInfinity("sum(orderkey) OVER (ORDER BY orderdate ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
+                resultBuilder(TEST_SESSION, BIGINT, VARCHAR, DOUBLE)
+                        .row(6.0, "F", 6.0)
+                        .row(3.0, "F", 9.0)
+                        .row(33.0, "F", 42.0)
+                        .row(Double.POSITIVE_INFINITY, "F", Double.POSITIVE_INFINITY)
+                        .row(32.0, "O", Double.POSITIVE_INFINITY)
+                        .row(4.0, "O", Double.POSITIVE_INFINITY)
+                        .row(1.0, "O", 37.0)
+                        .row(7.0, "O", 12.0)
+                        .row(2.0, "O", 10.0)
+                        .row(34.0, "O", 43.0)
+                        .build());
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/window/WindowAssertions.java
@@ -54,6 +54,38 @@ public final class WindowAssertions
             "    (CAST(NULL AS BIGINT), CAST(NULL AS VARCHAR), '1995-07-16')\n" +
             ") AS orders (orderkey, orderstatus, orderdate)";
 
+    private static final String VALUES_WITH_NAN = "" +
+            "SELECT *\n" +
+            "FROM (\n" +
+            "  VALUES\n" +
+            "    ( 1, 'O', '1996-01-02'),\n" +
+            "    ( 2, 'O', '1996-12-01'),\n" +
+            "    ( 3, 'F', '1993-10-14'),\n" +
+            "    ( 4, 'O', '1995-10-11'),\n" +
+            "    ( nan(), 'F', '1994-07-30'),\n" +
+            "    ( 6, 'F', '1992-02-21'),\n" +
+            "    ( 7, 'O', '1996-01-10'),\n" +
+            "    (32, 'O', '1995-07-16'),\n" +
+            "    (33, 'F', '1993-10-27'),\n" +
+            "    (34, 'O', '1998-07-21')\n" +
+            ") AS orders (orderkey, orderstatus, orderdate)";
+
+    private static final String VALUES_WITH_INFINITY = "" +
+            "SELECT *\n" +
+            "FROM (\n" +
+            "  VALUES\n" +
+            "    ( 1, 'O', '1996-01-02'),\n" +
+            "    ( 2, 'O', '1996-12-01'),\n" +
+            "    ( 3, 'F', '1993-10-14'),\n" +
+            "    ( 4, 'O', '1995-10-11'),\n" +
+            "    ( infinity(), 'F', '1994-07-30'),\n" +
+            "    ( 6, 'F', '1992-02-21'),\n" +
+            "    ( 7, 'O', '1996-01-10'),\n" +
+            "    (32, 'O', '1995-07-16'),\n" +
+            "    (33, 'F', '1993-10-27'),\n" +
+            "    (34, 'O', '1998-07-21')\n" +
+            ") AS orders (orderkey, orderstatus, orderdate)";
+
     private WindowAssertions() {}
 
     public static void assertWindowQuery(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
@@ -79,5 +111,25 @@ public final class WindowAssertions
                 "FROM (%s) x", sql, VALUES_WITH_NULLS);
 
         return queryRunner.execute(query);
+    }
+
+    public static void assertWindowQueryWithNan(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
+    {
+        @Language("SQL") String query = format("" +
+                "SELECT orderkey, orderstatus,\n%s\n" +
+                "FROM (%s) x", sql, VALUES_WITH_NAN);
+
+        MaterializedResult actual = queryRunner.execute(query);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+    }
+
+    public static void assertWindowQueryWithInfinity(@Language("SQL") String sql, MaterializedResult expected, QueryRunner queryRunner)
+    {
+        @Language("SQL") String query = format("" +
+                "SELECT orderkey, orderstatus,\n%s\n" +
+                "FROM (%s) x", sql, VALUES_WITH_INFINITY);
+
+        MaterializedResult actual = queryRunner.execute(query);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
If the input data to an aggregation window function contains Nan or infinite, the result for that window frame will be Nan/Infinite, which is expected. However, after that, the result of the window continues to be Nan/Infinite even if the input data in the window does not contain any invalid values. For the steps on reproduction, please refer to https://github.com/trinodb/trino/issues/20946.



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# General
* Fix incorrect window aggregation results over double values in the presence of NaN or Infinite inputs ({issue}`20946`)
```
