### PR TITLE
Support basic iso date type partition key for Hudi table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -168,6 +168,7 @@ public final class HiveUtil
 
     static {
         DateTimeParser[] timestampWithoutTimeZoneParser = {
+                DateTimeFormat.forPattern("yyyyMd").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),

--- a/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
+++ b/plugin/trino-hudi/src/main/java/io/trino/plugin/hudi/HudiPageSourceProvider.java
@@ -318,7 +318,14 @@ public class HudiPageSourceProvider
                 case VARBINARY:
                     return Optional.of(utf8Slice(partitionValue));
                 case DATE:
-                    return Optional.of(LocalDate.parse(partitionValue, DateTimeFormatter.ISO_LOCAL_DATE).toEpochDay());
+                    LocalDate localDate;
+                    try {
+                        localDate = LocalDate.parse(partitionValue, DateTimeFormatter.ISO_LOCAL_DATE);
+                    }
+                    catch (DateTimeParseException e) {
+                        localDate = LocalDate.parse(partitionValue, DateTimeFormatter.BASIC_ISO_DATE);
+                    }
+                    return Optional.of(localDate.toEpochDay());
                 case TIMESTAMP:
                     return Optional.of(Timestamp.valueOf(partitionValue).toLocalDateTime().toEpochSecond(ZoneOffset.UTC) * 1_000);
                 case BOOLEAN:


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
When trino reads hudi partitioned key which is yyyyMMdd format type, it encounters error,.
This PR supports trino reads hudi table with partition key of yyyyMMdd.

Error message:
![image](https://github.com/trinodb/trino/assets/19464348/60b71833-3a2b-4a44-a86b-4ae978204183)
After PR,  trino can read the table:
![image](https://github.com/trinodb/trino/assets/19464348/159120cc-9a2f-4a3b-a492-52a1a3a1ba18)


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
![image](https://github.com/trinodb/trino/assets/19464348/9b4a1584-d82d-43be-8a52-b21e830a1d40)
![image](https://github.com/trinodb/trino/assets/19464348/0f7e23e1-b1b6-4188-9d0d-b62b6df6f862)

**I also use spark to read the table, it can work.**
![image](https://github.com/trinodb/trino/assets/19464348/ca774dd7-317e-4319-8970-07ea53d75702)

Fixes #20975

## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`20975`) 
```
