### PR TITLE
Fix reading parquet statistics for long decimals

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -392,10 +392,13 @@ public class TupleDomainParquetPredicate
             }
             else {
                 for (int i = 0; i < minimums.size(); i++) {
-                    Int128 min = Int128.fromBigEndian(((Slice) minimums.get(i)).getBytes());
-                    Int128 max = Int128.fromBigEndian(((Slice) maximums.get(i)).getBytes());
+                    Object min = minimums.get(i);
+                    Object max = maximums.get(i);
 
-                    rangesBuilder.addRangeInclusive(min, max);
+                    Int128 minValue = min instanceof Slice ? Int128.fromBigEndian(((Slice) min).getBytes()) : Int128.valueOf(asLong(min));
+                    Int128 maxValue = max instanceof Slice ? Int128.fromBigEndian(((Slice) max).getBytes()) : Int128.valueOf(asLong(max));
+
+                    rangesBuilder.addRangeInclusive(minValue, maxValue);
                 }
             }
 

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/TestTupleDomainParquetPredicate.java
@@ -272,6 +272,8 @@ public class TestTupleDomainParquetPredicate
         assertThat(getDomain(columnDescriptor, type, 10, binaryColumnStats(maximum, maximum), ID, UTC)).isEqualTo(singleValue(type, max));
 
         assertThat(getDomain(columnDescriptor, type, 10, binaryColumnStats(0L, 100L), ID, UTC)).isEqualTo(create(ValueSet.ofRanges(range(type, zero, true, hundred, true)), false));
+        assertThat(getDomain(columnDescriptor, type, 10, intColumnStats(0, 100), ID, UTC)).isEqualTo(create(ValueSet.ofRanges(range(type, zero, true, hundred, true)), false));
+
         // fail on corrupted statistics
         assertThatExceptionOfType(ParquetCorruptionException.class)
                 .isThrownBy(() -> getDomain(columnDescriptor, type, 10, binaryColumnStats(100L, 10L), ID, UTC))

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -14,12 +14,10 @@ http-server.http.port=8080
 
 discovery.uri=http://localhost:8080
 
-exchange.http-client.max-connections=1000
 exchange.http-client.max-connections-per-server=1000
 exchange.http-client.connect-timeout=1m
 exchange.http-client.idle-timeout=1m
 
-scheduler.http-client.max-connections=1000
 scheduler.http-client.max-connections-per-server=1000
 scheduler.http-client.connect-timeout=1m
 scheduler.http-client.idle-timeout=1m


### PR DESCRIPTION
## Description
Fixes query failure when reading parquet statistics for a short decimal
in parquet file that is read as a long decimal in Trino


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Hive, Hudi, Delta, Iceberg
* Fix query failure due to "Corrupted statistics" when reading parquet files with a predicate on a long decimal column. ({issue}`20981`)
```
