### PR TITLE
Use DefaultAzureCredential by default for Azure file system

### DIFF
--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefault.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefault.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.filesystem.azure;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.identity.DefaultAzureCredentialBuilder;
+import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+
+public class AzureAuthDefault
+        implements AzureAuth
+{
+    private final TokenCredential credential = new DefaultAzureCredentialBuilder().build();
+
+    @Override
+    public void setAuth(String storageAccount, BlobContainerClientBuilder builder)
+    {
+        builder.credential(credential);
+    }
+
+    @Override
+    public void setAuth(String storageAccount, DataLakeServiceClientBuilder builder)
+    {
+        builder.credential(credential);
+    }
+}

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefaultModule.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureAuthDefaultModule.java
@@ -15,19 +15,13 @@ package io.trino.filesystem.azure;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import io.airlift.configuration.AbstractConfigurationAwareModule;
 
-public class AzureFileSystemModule
-        extends AbstractConfigurationAwareModule
+public class AzureAuthDefaultModule
+        implements Module
 {
     @Override
-    protected void setup(Binder binder)
+    public void configure(Binder binder)
     {
-        Module module = switch (buildConfigObject(AzureFileSystemConfig.class).getAuthType()) {
-            case ACCESS_KEY -> new AzureAuthAccessKeyModule();
-            case OAUTH -> new AzureAuthOAuthModule();
-            case DEFAULT -> new AzureAuthDefaultModule();
-        };
-        install(module);
+        binder.bind(AzureAuth.class).to(AzureAuthDefault.class);
     }
 }

--- a/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/main/java/io/trino/filesystem/azure/AzureFileSystemConfig.java
@@ -24,10 +24,10 @@ public class AzureFileSystemConfig
     {
         ACCESS_KEY,
         OAUTH,
-        NONE
+        DEFAULT,
     }
 
-    private AuthType authType = AuthType.NONE;
+    private AuthType authType = AuthType.DEFAULT;
 
     private DataSize readBlockSize = DataSize.of(4, Unit.MEGABYTE);
     private DataSize writeBlockSize = DataSize.of(4, Unit.MEGABYTE);

--- a/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
+++ b/lib/trino-filesystem-azure/src/test/java/io/trino/filesystem/azure/TestAzureFileSystemConfig.java
@@ -31,7 +31,7 @@ class TestAzureFileSystemConfig
     void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(AzureFileSystemConfig.class)
-                .setAuthType(AuthType.NONE)
+                .setAuthType(AuthType.DEFAULT)
                 .setReadBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setWriteBlockSize(DataSize.of(4, Unit.MEGABYTE))
                 .setMaxWriteConcurrency(8)


### PR DESCRIPTION
## Release notes

(x) This is not user-visible or is docs only, and no release notes are required.
