### PR TITLE
Adjust default caching behavior in CI's setup 

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 21
   cache:
     description: "Cache Maven repo (true/false/restore)"
-    default: true
+    default: restore
   cleanup-node:
     description: "Clean up node (true/false) to increase free disk space"
     default: false # Disabled by default as it adds ~4 minutes of test runtime. Should be enabled case by case.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -47,6 +47,7 @@ runs:
         if: ${{ format('{0}', inputs.cache) == 'true' }}
         uses: actions/cache@v4
         with:
+          # Note: must be same set of paths as for cache:restore mode
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
@@ -56,6 +57,7 @@ runs:
         if: ${{ format('{0}', inputs.cache) == 'restore' }}
         uses: actions/cache/restore@v4
         with:
+          # Note: must be same set of paths as for cache:true mode
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,6 +994,7 @@ jobs:
                 format('refs/pull/{0}/head', github.event.client_payload.pull_request.number) || '' }}
       - uses: ./.github/actions/setup
         with:
+          # The job doesn't build anything, so the ~/.m2/repository cache isn't useful
           cache: 'false'
       - name: Product tests artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The CI cache setup is designed so that only one chosen job populates the
cache (currently the maven-checks). Adjust the default to convey the
intent.