### PR TITLE
Improve type mapping for Snowflake Connector

### DIFF
--- a/docs/src/main/sphinx/connector/snowflake.md
+++ b/docs/src/main/sphinx/connector/snowflake.md
@@ -49,30 +49,163 @@ multiple instances of the Snowflake connector.
 
 ## Type mapping
 
-Trino supports the following Snowflake data types:
+Because Trino and Snowflake each support types that the other does not, this
+connector {ref}`modifies some types <type-mapping-overview>` when reading or
+writing data. Data types may not map the same way in both directions between
+Trino and the data source. Refer to the following sections for type mapping in
+each direction.
 
-| Snowflake Type | Trino Type     |
-| -------------- | -------------- |
-| `boolean`      | `boolean`      |
-| `tinyint`      | `bigint`       |
-| `smallint`     | `bigint`       |
-| `byteint`      | `bigint`       |
-| `int`          | `bigint`       |
-| `integer`      | `bigint`       |
-| `bigint`       | `bigint`       |
-| `float`        | `real`         |
-| `real`         | `real`         |
-| `double`       | `double`       |
-| `decimal`      | `decimal(P,S)` |
-| `varchar(n)`   | `varchar(n)`   |
-| `char(n)`      | `varchar(n)`   |
-| `binary(n)`    | `varbinary`    |
-| `varbinary`    | `varbinary`    |
-| `date`         | `date`         |
-| `time`         | `time`         |
-| `timestampntz` | `timestamp`    |
+List of [Snowflake data types](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html).
 
-Complete list of [Snowflake data types](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types.html).
+### Snowflake type to Trino type mapping
+
+The connector maps Snowflake types to the corresponding Trino types following
+this table:
+
+:::{list-table} Snowflake type to Trino type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - Snowflake type
+  - Trino type
+  - Notes
+* - `NUMBER`
+  - `DECIMAL`
+  - Default precision and scale are (38,0).
+* - `DECIMAL`, `NUMERIC`
+  - `DECIMAL`
+  - Synonymous with `NUMBER`. See Snowflake 
+    [data types for fixed point numbers](https://docs.snowflake.com/en/sql-reference/data-types-numeric#data-types-for-fixed-point-numbers)
+    for more information.
+* - `INT`, `INTEGER`, `BIGINT`, `SMALLINT`, `TINYINT`, `BYTEINT`
+  - `DECIMAL(38,0)`
+  - Synonymous with `NUMBER(38,0)`. See Snowflake 
+    [data types for fixed point numbers](https://docs.snowflake.com/en/sql-reference/data-types-numeric#data-types-for-fixed-point-numbers)
+    for more information.
+* - `FLOAT`, `FLOAT4`, `FLOAT8`
+  - `DOUBLE`
+  - The names `FLOAT`, `FLOAT4`, and `FLOAT8` are for compatibility with other systems; Snowflake treats all three as
+    64-bit floating-point numbers. See Snowflake 
+    [data types for floating point numbers](https://docs.snowflake.com/en/sql-reference/data-types-numeric#data-types-for-floating-point-numbers)
+    for more information.
+* - `DOUBLE`, `DOUBLE PRECISION`, `REAL`
+  - `DOUBLE`
+  - Synonymous with `FLOAT`. See Snowflake 
+    [data types for floating point numbers](https://docs.snowflake.com/en/sql-reference/data-types-numeric#data-types-for-floating-point-numbers)
+    for more information.
+* - `VARCHAR`
+  - `VARCHAR`
+  -
+* - `CHAR`, `CHARACTER`
+  - `VARCHAR`
+  - Synonymous with `VARCHAR` except default length is `VARCHAR(1)`. See Snowflake 
+    [String & Binary Data Types](https://docs.snowflake.com/en/sql-reference/data-types-text)
+    for more information.
+* - `STRING`, `TEXT`
+  - `VARCHAR`
+  - Synonymous with `VARCHAR`. See Snowflake 
+    [String & Binary Data Types](https://docs.snowflake.com/en/sql-reference/data-types-text)
+    for more information.
+* - `BINARY`
+  - `VARBINARY`
+  - 
+* - `VARBINARY`
+  - `VARBINARY`
+  - Synonymous with `BINARY`. See Snowflake 
+    [String & Binary Data Types](https://docs.snowflake.com/en/sql-reference/data-types-text)
+    for more information.
+* - `BOOLEAN`
+  - `BOOLEAN`
+  - 
+* - `DATE`
+  - `DATE`
+  -
+* - `TIME`
+  - `TIME`
+  -
+* - `TIMESTAMP_NTZ`
+  - `TIMESTAMP`
+  - TIMESTAMP with no time zone; time zone, if provided, is not stored. See Snowflake 
+    [Date & Time Data Types](https://docs.snowflake.com/en/sql-reference/data-types-datetime)
+    for more information.
+* - `DATETIME`
+  - `TIMESTAMP`
+  - Alias for `TIMESTAMP_NTZ`. See Snowflake 
+    [Date & Time Data Types](https://docs.snowflake.com/en/sql-reference/data-types-datetime)
+    for more information.
+* - `TIMESTAMP`
+  - `TIMESTAMP`
+  - Alias for one of the `TIMESTAMP` variations (`TIMESTAMP_NTZ` by default). This connector always sets `TIMESTAMP_NTZ` as the variant.
+* - `TIMESTAMP_TZ`
+  - `TIMESTAMP WITH TIME ZONE`
+  - TIMESTAMP with time zone.
+:::
+
+No other types are supported.
+
+### Trino type to Snowflake type mapping
+
+The connector maps Trino types to the corresponding Snowflake types following
+this table:
+
+:::{list-table} Trino type to Snowflake type mapping
+:widths: 30, 30, 40
+:header-rows: 1
+
+* - Trino type
+  - Snowflake type
+  - Notes
+* - `TINYINT`
+  - `NUMBER(3, 0)`
+  -
+* - `SMALLINT`
+  - `NUMBER(5, 0)`
+  -
+* - `INTEGER`
+  - `NUMBER(10, 0)`
+  -
+* - `BIGINT`
+  - `NUMBER(19, 0)`
+  -
+* - `DECIMAL`
+  - `NUMBER`
+  -
+* - `REAL`
+  - `DOUBLE`
+  -
+* - `DOUBLE`
+  - `DOUBLE`
+  -
+* - `VARCHAR`
+  - `VARCHAR`
+  -
+* - `CHAR`
+  - `VARCHAR`
+  -
+* - `VARBINARY`
+  - `BINARY`
+  -
+* - `VARBINARY`
+  - `VARBINARY`
+  -
+* - `BOOLEAN`
+  - `BOOLEAN`
+  -
+* - `DATE`
+  - `DATE`
+  -
+* - `TIME`
+  - `TIME`
+  -
+* - `TIMESTAMP`
+  - `TIMESTAMP_NTZ`
+  -
+* - `TIMESTAMP WITH TIME ZONE`
+  - `TIMESTAMP_TZ`
+  -
+::::
+
+No other types are supported.
 
 (snowflake-sql-support)=
 

--- a/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClientModule.java
+++ b/plugin/trino-snowflake/src/main/java/io/trino/plugin/snowflake/SnowflakeClientModule.java
@@ -69,6 +69,7 @@ public class SnowflakeClientModule
         properties.setProperty("TIMESTAMP_TZ_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
         properties.setProperty("TIMESTAMP_LTZ_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
         properties.setProperty("TIME_OUTPUT_FORMAT", "HH24:MI:SS.FF9");
+        properties.setProperty("JDBC_TREAT_DECIMAL_AS_INT", "FALSE");
 
         // Support for Corporate proxies
         if (snowflakeConfig.getHttpProxy().isPresent()) {

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -142,14 +142,14 @@ public class TestSnowflakeConnectorTest
     {
         // Override this test because the type of row "shippriority" should be bigint rather than integer for snowflake case
         return resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "", "")
-                .row("custkey", "bigint", "", "")
+                .row("orderkey", "decimal(19,0)", "", "")
+                .row("custkey", "decimal(19,0)", "", "")
                 .row("orderstatus", "varchar(1)", "", "")
                 .row("totalprice", "double", "", "")
                 .row("orderdate", "date", "", "")
                 .row("orderpriority", "varchar(15)", "", "")
                 .row("clerk", "varchar(15)", "", "")
-                .row("shippriority", "bigint", "", "")
+                .row("shippriority", "decimal(10,0)", "", "")
                 .row("comment", "varchar(79)", "", "")
                 .build();
     }
@@ -159,6 +159,20 @@ public class TestSnowflakeConnectorTest
     public void testShowColumns()
     {
         assertThat(query("SHOW COLUMNS FROM orders")).result().matches(getDescribeOrdersResult());
+    }
+
+    @Test
+    @Override
+    public void testInformationSchemaFiltering()
+    {
+        assertQuery(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
+                "SELECT 'orders' table_name");
+        // Overriding this method to change "data_type" from "bigint" to "decimal(19,0)". When creating a Trino BIGINT
+        // column using Trino Snowflake Connector, a "decimal(19,0)" column is created under the hood.
+        assertQuery(
+                "SELECT table_name FROM information_schema.columns WHERE data_type = 'decimal(19,0)' AND table_name = 'nation' and column_name = 'nationkey' LIMIT 1",
+                "SELECT 'nation' table_name");
     }
 
     @Test
@@ -177,14 +191,14 @@ public class TestSnowflakeConnectorTest
         // Override this test because the type of row "shippriority" should be bigint rather than integer for snowflake case
         assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
                 .isEqualTo("CREATE TABLE snowflake.tpch.orders (\n" +
-                        "   orderkey bigint,\n" +
-                        "   custkey bigint,\n" +
+                        "   orderkey decimal(19, 0),\n" +
+                        "   custkey decimal(19, 0),\n" +
                         "   orderstatus varchar(1),\n" +
                         "   totalprice double,\n" +
                         "   orderdate date,\n" +
                         "   orderpriority varchar(15),\n" +
                         "   clerk varchar(15),\n" +
-                        "   shippriority bigint,\n" +
+                        "   shippriority decimal(10, 0),\n" +
                         "   comment varchar(79)\n" +
                         ")");
     }

--- a/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestingSnowflakeServer.java
+++ b/plugin/trino-snowflake/src/test/java/io/trino/plugin/snowflake/TestingSnowflakeServer.java
@@ -60,6 +60,12 @@ public final class TestingSnowflakeServer
         properties.setProperty("schema", TEST_SCHEMA);
         properties.setProperty("warehouse", TEST_WAREHOUSE);
         properties.setProperty("role", TEST_ROLE);
+        properties.setProperty("TIMESTAMP_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
+        properties.setProperty("TIMESTAMP_NTZ_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
+        properties.setProperty("TIMESTAMP_TZ_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
+        properties.setProperty("TIMESTAMP_LTZ_OUTPUT_FORMAT", "YYYY-MM-DD\"T\"HH24:MI:SS.FF9TZH:TZM");
+        properties.setProperty("TIME_OUTPUT_FORMAT", "HH24:MI:SS.FF9");
+        properties.setProperty("JDBC_TREAT_DECIMAL_AS_INT", "FALSE");
         return properties;
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description
For https://github.com/trinodb/trino/issues/20977

Please reference `snowflake.md` diff for the exact type conversion behavior.

References for source-of-truths:

- https://docs.snowflake.com/en/sql-reference/intro-summary-data-types
- https://docs.snowflake.com/en/sql-reference/sql/show-columns#output
- https://github.com/snowflakedb/snowflake-jdbc/blob/d4ca9f0e99b142fa0c1a3dffe5cc7bde4fdfaf61/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

- [ ] TODO: Make it configurable whether SF session property `JDBC_TREAT_DECIMAL_AS_INT` is set to `FALSE`


<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
(x) Release notes are required, with the following suggested text:

```markdown
# Snowflake Connector
* Improve type mapping for Snowflake Connector. ({issue}`20977`)
```
