### PR TITLE
Use BigQuery storage read API when reading external reading BigLake tables

### DIFF
--- a/plugin/trino-bigquery/README.md
+++ b/plugin/trino-bigquery/README.md
@@ -22,9 +22,16 @@ You can follow the steps below to be able to run the integration tests locally.
   **BigQuery Admin** role assigned.
 * Get the base64 encoded text of the service account credentials file using `base64
   /path/to/service_account_credentials.json`.
+* Create a new BigQuery `CLOUD_RESOURCE` connection and grant the connection service account GCS permissions.
+  [Documentation](https://cloud.google.com/bigquery/docs/create-cloud-resource-connection).
+   * `bq mk --connection --location=us --project_id=$PROJECT_ID --connection_type=CLOUD_RESOURCE $CONNECTION_ID`
+   * Now we need to grant the new connection's service account the GCS permissions.
+   * To do this, run `bq show --connection $PROJECT_ID.us.$CONNECTION_ID`, which will display the service account ID.
+   * Grant the service account GCS Object Viewer permissions. e.g.: `gsutil iam ch serviceAccount:bqcx-xxxx@gcp-sa-bigquery-condel.iam.gserviceaccount.com:objectViewer gs://DESTINATION_BUCKET_NAME`
+
 * The `TestBigQueryWithDifferentProjectIdConnectorSmokeTest` requires an alternate project ID which is different from the
   project ID attached to the service account but the service account still has access to.
-* Set the VM options `bigquery.credentials-key`, `testing.gcp-storage-bucket`, and `testing.alternate-bq-project-id` in the IntelliJ "Run Configuration"
-  (or on the CLI if using Maven directly). It should look something like
-  `-Dbigquery.credentials-key=base64-text -Dtesting.gcp-storage-bucket=DESTINATION_BUCKET_NAME -Dtesting.alternate-bq-project-id=bigquery-cicd-alternate`.
+  * Set the VM options `bigquery.credentials-key`, `testing.gcp-storage-bucket`, `testing.alternate-bq-project-id` and `testing.bigquery-connection-id` in the IntelliJ "Run Configuration"
+    (or on the CLI if using Maven directly). It should look something like
+        `-Dbigquery.credentials-key=base64-text -Dtesting.gcp-storage-bucket=DESTINATION_BUCKET_NAME -Dtesting.alternate-bq-project-id=bigquery-cicd-alternate -testing.bigquery-connection-id=my_project.us.connection-id`.
 * Run any test of your choice.

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.ExternalTableDefinition;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.QueryJobConfiguration;
@@ -258,12 +259,19 @@ public class BigQueryMetadata
             columns.add(PARTITION_DATE.getColumnHandle());
             columns.add(PARTITION_TIME.getColumnHandle());
         }
+        Optional<String> connectionId = Optional.empty();
+        if (tableInfo.get().getDefinition() instanceof ExternalTableDefinition externalTableDefinition) {
+            if (externalTableDefinition.getConnectionId() != null && !externalTableDefinition.getConnectionId().isEmpty()) {
+                connectionId = Optional.of(externalTableDefinition.getConnectionId());
+            }
+        }
         return new BigQueryTableHandle(new BigQueryNamedRelationHandle(
                 schemaTableName,
                 new RemoteTableName(tableInfo.get().getTableId()),
                 tableInfo.get().getDefinition().getType().toString(),
                 partitionType,
-                Optional.ofNullable(tableInfo.get().getDescription())))
+                Optional.ofNullable(tableInfo.get().getDescription()),
+                connectionId))
                 .withProjectedColumns(columns.build());
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryNamedRelationHandle.java
@@ -32,6 +32,7 @@ public class BigQueryNamedRelationHandle
     private final String type;
     private final Optional<BigQueryPartitionType> partitionType;
     private final Optional<String> comment;
+    private final Optional<String> connectionId;
 
     @JsonCreator
     public BigQueryNamedRelationHandle(
@@ -39,13 +40,15 @@ public class BigQueryNamedRelationHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName,
             @JsonProperty("type") String type,
             @JsonProperty("partitionType") Optional<BigQueryPartitionType> partitionType,
-            @JsonProperty("comment") Optional<String> comment)
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("connectionId") Optional<String> connectionId)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
         this.type = requireNonNull(type, "type is null");
         this.partitionType = requireNonNull(partitionType, "partitionType is null");
         this.comment = requireNonNull(comment, "comment is null");
+        this.connectionId = requireNonNull(connectionId, "connectionId is null");
     }
 
     @JsonProperty
@@ -78,6 +81,12 @@ public class BigQueryNamedRelationHandle
         return comment;
     }
 
+    @JsonProperty
+    public boolean hasConnection()
+    {
+        return connectionId.isPresent();
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -93,13 +102,14 @@ public class BigQueryNamedRelationHandle
         return Objects.equals(schemaTableName, that.schemaTableName) &&
                 Objects.equals(type, that.type) &&
                 Objects.equals(partitionType, that.partitionType) &&
-                Objects.equals(comment, that.comment);
+                Objects.equals(comment, that.comment) &&
+                Objects.equals(connectionId, that.connectionId);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaTableName, type, partitionType, comment);
+        return Objects.hash(schemaTableName, type, partitionType, comment, connectionId);
     }
 
     @Override
@@ -110,6 +120,7 @@ public class BigQueryNamedRelationHandle
                 .add("schemaTableName", schemaTableName)
                 .add("type", type)
                 .add("comment", comment)
+                .add("connectionId", connectionId)
                 .toString();
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryTableHandle.java
@@ -19,11 +19,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.cloud.bigquery.RangePartitioning;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.TableDefinition;
-import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
-import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.predicate.TupleDomain;
 
 import java.util.List;
@@ -50,12 +48,6 @@ public class BigQueryTableHandle
         this.relationHandle = requireNonNull(relationHandle, "relationHandle is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
         this.projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null");
-    }
-
-    @Deprecated
-    public BigQueryTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName, TableInfo tableInfo)
-    {
-        this(new BigQueryNamedRelationHandle(schemaTableName, remoteTableName, tableInfo.getDefinition().getType().toString(), getPartitionType(tableInfo.getDefinition()), Optional.ofNullable(tableInfo.getDescription())));
     }
 
     public BigQueryTableHandle(BigQueryRelationHandle relationHandle)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -38,6 +38,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.cloud.bigquery.TableDefinition.Type.EXTERNAL;
 import static com.google.cloud.bigquery.TableDefinition.Type.SNAPSHOT;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
@@ -149,7 +150,7 @@ public class ReadSessionCreator
     {
         TableDefinition tableDefinition = remoteTable.getDefinition();
         TableDefinition.Type tableType = tableDefinition.getType();
-        if (tableType == TABLE || tableType == SNAPSHOT) {
+        if (tableType == TABLE || tableType == SNAPSHOT || tableType == EXTERNAL) {
             return remoteTable;
         }
         if (tableType == VIEW) {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -121,7 +121,7 @@ public final class BigQueryQueryRunner
     {
         return testSessionBuilder()
                 .setCatalog("bigquery")
-                .setSchema(TPCH_SCHEMA)
+                .setSchema(TEST_SCHEMA)
                 .build();
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

BigQuery storage APIs support reading BigLake external tables (ie external tables with a connection). But the current implementation uses views which can be expensive, because it requires Trino issuing a SQL query against BigQuery. This PR adds support to read BigLake tables directly using the storage API.

There are no behavior changes for external tables and BQ native tables - they use the view and storage APIs respectively. Added a new test for BigLake tables.

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues

Fixes https://github.com/trinodb/trino/issues/21016
https://cloud.google.com/bigquery/docs/biglake-intro

<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

(x) Release notes are required, with the following suggested text:

```markdown
# BigQuery
* Improve performance when reading external BigLake tables. ({issue}`21016`)
```
